### PR TITLE
fix: configure rector to preserve filament importer lifecycle hooks

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -16,6 +18,14 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,
+        RemoveUnusedPrivateMethodRector::class => [
+            // Skip Filament importer lifecycle hooks - they're called dynamically via callHook()
+            __DIR__.'/app/Filament/Imports/*',
+        ],
+        PrivatizeFinalClassMethodRector::class => [
+            // Filament expects protected visibility for lifecycle hooks
+            __DIR__.'/app/Filament/Imports/*',
+        ],
     ])
     ->withPreparedSets(
         deadCode: true,


### PR DESCRIPTION
Rector was incorrectly removing lifecycle hooks (afterSave, beforeFill, etc) from Filament importers because they're called dynamically via callHook(). Added path-specific exclusions for RemoveUnusedPrivateMethodRector and PrivatizeFinalClassMethodRector to preserve these essential methods.