### PR TITLE
perf: use native ARM runners for parallel multi-platform builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
@@ -31,6 +30,7 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -99,6 +99,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Prepare
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Problem

Multi-platform Docker builds using QEMU emulation are extremely slow (20-60+ minutes) because the x86 runner has to emulate ARM instructions.

## Solution

Use matrix strategy with native runners for each platform:

| Platform | Runner | Build Method |
|----------|--------|--------------|
| `linux/amd64` | `ubuntu-latest` | Native |
| `linux/arm64` | `ubuntu-24.04-arm` | Native |

Both platforms build **in parallel** on their native architecture, then merge into a single multi-platform manifest.

## Expected Results

- Build time reduced from 20-60 min → ~5-8 min
- Both platforms build simultaneously
- Final image supports both amd64 and arm64

## Architecture

```
┌─────────────────┐     ┌─────────────────┐
│  Build (amd64)  │     │  Build (arm64)  │
│  ubuntu-latest  │     │ ubuntu-24.04-arm│
└────────┬────────┘     └────────┬────────┘
         │                       │
         └───────────┬───────────┘
                     ▼
            ┌─────────────────┐
            │  Merge Manifest │
            │  ubuntu-latest  │
            └─────────────────┘
```