### PR TITLE
fix: pin phpstan to 2.1.33 for rector compatibility

### DIFF
--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -24,7 +24,7 @@ final readonly class GitHubService
     {
         $cacheKey = "github_stars_{$owner}_{$repo}";
 
-        $cachedValue = Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), function () use ($owner, $repo): int {
+        return Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), function () use ($owner, $repo): int {
             try {
                 /** @var Response $response */
                 $response = Http::withHeaders([
@@ -44,8 +44,6 @@ final readonly class GitHubService
                 return 0;
             }
         });
-
-        return is_null($cachedValue) ? 0 : (int) $cachedValue;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-livewire": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
+        "phpstan/phpstan": "2.1.33",
         "rector/rector": "^2.0",
         "spatie/laravel-horizon-watcher": "^1.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7039c77cf264055f5e732c527918adef",
+    "content-hash": "1cc4574ba2f8973c49d3e6e062120afa",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -14583,11 +14583,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.34",
+            "version": "2.1.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/070ba754a949fcade788e16e8dc5a5935b7cf2ee",
-                "reference": "070ba754a949fcade788e16e8dc5a5935b7cf2ee",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
                 "shasum": ""
             },
             "require": {
@@ -14632,7 +14632,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-19T19:52:16+00:00"
+            "time": "2025-12-05T10:24:31+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
phpstan 2.1.34 breaks rector 2.3.1 causing parallel processing crashes and "Service name must be a non-empty string" errors on php 8.4. also simplify GitHubService by returning directly from Cache::remember.