### PR TITLE
fix: cast cache result to int in getStarsCount

### DIFF
--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -24,7 +24,7 @@ final readonly class GitHubService
     {
         $cacheKey = "github_stars_{$owner}_{$repo}";
 
-        return Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), function () use ($owner, $repo): int {
+        return (int) Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), function () use ($owner, $repo): int {
             try {
                 /** @var Response $response */
                 $response = Http::withHeaders([


### PR DESCRIPTION
Cache::remember returns mixed, causing type error when cached value is stored as string