### PR TITLE
feat: use team slug instead of ULID in panel URLs

### DIFF
--- a/app/Actions/Jetstream/UpdateTeamName.php
+++ b/app/Actions/Jetstream/UpdateTeamName.php
@@ -23,10 +23,12 @@ final readonly class UpdateTeamName implements UpdatesTeamNames
 
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', 'min:3', 'regex:' . Team::SLUG_REGEX, "unique:teams,slug,{$team->id}"],
         ])->validateWithBag('updateTeamName');
 
-        $team->forceFill([
+        $team->update([
             'name' => $input['name'],
-        ])->save();
+            'slug' => $input['slug'],
+        ]);
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Observers\TeamObserver;
 use App\Services\AvatarService;
 use Database\Factories\TeamFactory;
 use Filament\Models\Contracts\HasAvatar;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -17,13 +19,17 @@ use Laravel\Jetstream\Team as JetstreamTeam;
 
 /**
  * @property string $name
+ * @property string $slug
  */
+#[ObservedBy(TeamObserver::class)]
 final class Team extends JetstreamTeam implements HasAvatar
 {
     /** @use HasFactory<TeamFactory> */
     use HasFactory;
 
     use HasUlids;
+
+    public const string SLUG_REGEX = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
 
     /**
      * The attributes that are mass assignable.
@@ -32,6 +38,7 @@ final class Team extends JetstreamTeam implements HasAvatar
      */
     protected $fillable = [
         'name',
+        'slug',
         'personal_team',
     ];
 

--- a/app/Observers/TeamObserver.php
+++ b/app/Observers/TeamObserver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\Team;
+use Illuminate\Support\Str;
+
+final readonly class TeamObserver
+{
+    public function creating(Team $team): void
+    {
+        if (blank($team->slug)) {
+            $team->slug = self::generateUniqueSlug($team->name);
+        }
+    }
+
+    private static function generateUniqueSlug(string $name): string
+    {
+        $baseSlug = Str::slug($name);
+
+        if ($baseSlug === '') {
+            $baseSlug = Str::lower(Str::random(8));
+        }
+
+        $slug = $baseSlug;
+        $counter = 2;
+
+        while (Team::query()->where('slug', $slug)->exists()) {
+            $slug = "{$baseSlug}-{$counter}";
+            $counter++;
+        }
+
+        return $slug;
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -79,7 +79,7 @@ final class AppPanelProvider extends PanelProvider
             ->domain('app.'.parse_url((string) config('app.url'))['host'])
             ->homeUrl(fn (): string => CompanyResource::getUrl())
             ->brandName('Relaticle')
-            ->brandLogo(fn (): \Illuminate\Contracts\View\View|\Illuminate\Contracts\View\Factory => Auth::check() ? view('filament.app.logo-empty') : view('filament.app.logo'))
+            ->brandLogo(fn (): View|Factory => Auth::check() ? view('filament.app.logo-empty') : view('filament.app.logo'))
             ->brandLogoHeight('2.6rem')
             ->login(Login::class)
             ->registration(Register::class)
@@ -118,7 +118,6 @@ final class AppPanelProvider extends PanelProvider
             ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
-            ->discoverPages(in: base_path('app-modules/ImportWizard/src/Filament/Pages'), for: 'Relaticle\\ImportWizard\\Filament\\Pages')
             ->discoverPages(in: base_path('app-modules/ImportWizard/src/Filament/Pages'), for: 'Relaticle\\ImportWizard\\Filament\\Pages')
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters')
@@ -191,7 +190,7 @@ final class AppPanelProvider extends PanelProvider
 
         if (Features::hasTeamFeatures()) {
             $panel
-                ->tenant(Team::class, ownershipRelationship: 'team')
+                ->tenant(Team::class, slugAttribute: 'slug', ownershipRelationship: 'team')
                 ->tenantRegistration(CreateTeam::class)
                 ->tenantProfile(EditTeam::class);
         }

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Team>
@@ -27,9 +29,13 @@ final class TeamFactory extends Factory
         ];
     }
 
-    public function configure(): Factory
+    public function configure(): static
     {
-        return $this->sequence(fn (Sequence $sequence): array => [
+        return $this->afterMaking(function (Team $team): void {
+            if (blank($team->slug)) {
+                $team->slug = Str::slug($team->name) . '-' . Str::lower(Str::random(5));
+            }
+        })->sequence(fn (Sequence $sequence): array => [
             'created_at' => now()->subMinutes($sequence->index),
             'updated_at' => now()->subMinutes($sequence->index),
         ]);

--- a/database/migrations/2026_02_11_232804_add_slug_to_teams_table.php
+++ b/database/migrations/2026_02_11_232804_add_slug_to_teams_table.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table): void {
+            $table->string('slug')->nullable()->after('name');
+        });
+
+        $this->backfillSlugs();
+
+        Schema::table('teams', function (Blueprint $table): void {
+            $table->string('slug')->nullable(false)->unique()->change();
+        });
+    }
+
+    private function backfillSlugs(): void
+    {
+        $teams = DB::table('teams')->orderBy('created_at')->get();
+        $usedSlugs = [];
+
+        foreach ($teams as $team) {
+            $baseSlug = Str::slug($team->name);
+
+            if ($baseSlug === '') {
+                $baseSlug = Str::lower(Str::random(8));
+            }
+
+            $slug = $baseSlug;
+            $counter = 2;
+
+            while (in_array($slug, $usedSlugs, true)) {
+                $slug = "{$baseSlug}-{$counter}";
+                $counter++;
+            }
+
+            $usedSlugs[] = $slug;
+
+            DB::table('teams')->where('id', $team->id)->update(['slug' => $slug]);
+        }
+    }
+};

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -7,6 +7,10 @@ return [
         'team_name' => [
             'label' => 'Team Name',
         ],
+        'team_slug' => [
+            'label' => 'Team Slug',
+            'helper_text' => 'Only lowercase letters, numbers, and hyphens. This appears in your team URL.',
+        ],
         'email' => [
             'label' => 'Email',
         ],

--- a/tests/Feature/Teams/UpdateTeamNameTest.php
+++ b/tests/Feature/Teams/UpdateTeamNameTest.php
@@ -3,17 +3,93 @@
 declare(strict_types=1);
 
 use App\Livewire\App\Teams\UpdateTeamName;
+use App\Models\Team;
 use App\Models\User;
 use Livewire\Livewire;
 
-test('team names can be updated', function () {
+test('team name and slug can be updated', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
     Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
-        ->fillForm(['name' => 'Test Team'])
+        ->fillForm(['name' => 'New Name', 'slug' => 'new-name'])
+        ->call('updateTeamName', $user->currentTeam)
+        ->assertHasNoFormErrors();
+
+    $team = $user->currentTeam->fresh();
+
+    expect($team->name)->toBe('New Name')
+        ->and($team->slug)->toBe('new-name');
+});
+
+test('slug is required', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->fillForm(['name' => 'Test Team', 'slug' => ''])
+        ->call('updateTeamName', $user->currentTeam)
+        ->assertHasFormErrors(['slug' => 'required']);
+});
+
+test('slug must be at least 3 characters', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->fillForm(['name' => 'Test Team', 'slug' => 'ab'])
+        ->call('updateTeamName', $user->currentTeam)
+        ->assertHasFormErrors(['slug']);
+});
+
+test('slug must match valid format', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->fillForm(['name' => 'Test Team', 'slug' => 'Invalid Slug!'])
+        ->call('updateTeamName', $user->currentTeam)
+        ->assertHasFormErrors(['slug']);
+});
+
+test('slug must be unique across teams', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    Team::factory()->create(['slug' => 'taken-slug']);
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->fillForm(['name' => 'Test Team', 'slug' => 'taken-slug'])
+        ->call('updateTeamName', $user->currentTeam)
+        ->assertHasFormErrors(['slug']);
+});
+
+test('team can keep its own slug on update', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $currentSlug = $user->currentTeam->slug;
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->fillForm(['name' => 'Different Name', 'slug' => $currentSlug])
         ->call('updateTeamName', $user->currentTeam)
         ->assertHasNoFormErrors()
         ->assertNotified();
+});
 
-    expect($user->currentTeam->fresh()->name)->toEqual('Test Team');
+test('slug change triggers redirect', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->fillForm(['name' => 'New Name', 'slug' => 'completely-new-slug'])
+        ->call('updateTeamName', $user->currentTeam)
+        ->assertHasNoFormErrors()
+        ->assertRedirect();
+});
+
+test('same slug does not trigger redirect', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
+
+    $currentSlug = $user->currentTeam->slug;
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->fillForm(['name' => 'Different Name', 'slug' => $currentSlug])
+        ->call('updateTeamName', $user->currentTeam)
+        ->assertHasNoFormErrors()
+        ->assertNotified()
+        ->assertNoRedirect();
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -19,8 +19,11 @@ use Illuminate\Support\Facades\Event;
 pest()->extend(Tests\TestCase::class)
     ->use(RefreshDatabase::class)
     ->beforeEach(function () {
-        // Globally disable events to prevent demo record creation during tests
-        Event::fake();
+        // Globally disable events to prevent demo record creation during tests.
+        // Allow the Team creating event so the TeamObserver can generate slugs.
+        Event::fake()->except([
+            'eloquent.creating: App\\Models\\Team',
+        ]);
     })
     ->in('Feature', 'Unit');
 


### PR DESCRIPTION
Add slug column to teams table with migration backfill for existing records. TeamObserver auto-generates unique slugs on creation. Filament tenant resolution now uses slug attribute. Team settings form supports editing slug with auto-generation from name, validation, and redirect on slug change.