### PR TITLE
fix: use team slug instead of ULID for tenant URL resolution

### DIFF
--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -24,7 +24,7 @@ final readonly class LoginResponse implements \Filament\Auth\Http\Responses\Cont
         // For app panel, redirect to companies with tenant
         $user = $request->user('web');
         if ($user && $user->currentTeam) {
-            return redirect()->intended(CompanyResource::getUrl('index', ['tenant' => $user->currentTeam->getKey()]));
+            return redirect()->intended(CompanyResource::getUrl('index', ['tenant' => $user->currentTeam]));
         }
 
         return redirect()->intended(Filament::getUrl());

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -173,7 +173,7 @@ final class AppPanelProvider extends PanelProvider
             ])
             ->renderHook(
                 PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
-                fn (): string => Blade::render('@env(\'local\')<x-login-link email="manuk.minasyan1@gmail.com" redirect-url="'.url('/').'" />@endenv'),
+                fn (): string => Blade::render('@env(\'local\')<x-login-link email="manuk.minasyan1@gmail.com" redirect-url="'.url()->getAppUrl().'" />@endenv'),
             )
             ->renderHook(
                 PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -13,7 +13,7 @@ test('login screen can be rendered', function () {
 
 test('users can authenticate using the login screen', function () {
     $user = User::factory()->withPersonalTeam()->create();
-    $teamId = $user->ownedTeams()->first()->id;
+    $team = $user->ownedTeams()->first();
 
     livewire(Login::class)
         ->fillForm([
@@ -21,7 +21,7 @@ test('users can authenticate using the login screen', function () {
             'password' => 'password',
         ])
         ->call('authenticate')
-        ->assertRedirect(url()->getAppUrl($teamId.'/companies'));
+        ->assertRedirect(url()->getAppUrl("{$team->slug}/companies"));
 
     $this->assertAuthenticated();
 });


### PR DESCRIPTION
## Summary

- **LoginResponse**: Pass the team model instead of `->getKey()` (ULID) when building the post-login redirect URL, so Filament resolves the `slug` attribute correctly
- **AppPanelProvider**: Developer login link `redirect-url` changed from `url('/')` (marketing homepage) to `url()->getAppUrl()` (app panel)
- **AuthenticationTest**: Fix assertion to use `$team->slug` instead of `$team->id`

## Root cause

The app panel is configured with `slugAttribute: 'slug'` for tenant routing, but `LoginResponse` was passing `$user->currentTeam->getKey()` (the ULID primary key) as the tenant parameter. Filament generated a URL with the ULID, then tried to resolve it against the `slug` column — resulting in a 404.

## Test plan

- [x] All 686 tests passing
- [x] Login with email/password redirects to `/app/{team-slug}/companies`
- [x] Developer login link (local env) redirects to app panel