### PR TITLE
fix: handle multi-value custom fields in AI context builder

### DIFF
--- a/app/Services/AI/RecordContextBuilder.php
+++ b/app/Services/AI/RecordContextBuilder.php
@@ -138,8 +138,10 @@ final readonly class RecordContextBuilder
      */
     private function getCompanyBasicInfo(Company $company): array
     {
+        $domains = $this->getCustomFieldValue($company, CompanyField::DOMAINS->value);
+
         return collect([
-            'domain' => $this->getCustomFieldValue($company, CompanyField::DOMAINS->value),
+            'domain' => is_array($domains) ? implode(', ', $domains) : $domains,
             'is_icp' => (bool) $this->getCustomFieldValue($company, CompanyField::ICP->value),
             'account_owner' => $company->accountOwner?->name,
         ])->filter(fn (mixed $value): bool => filled($value))->all();

--- a/app/Services/AI/RecordSummaryService.php
+++ b/app/Services/AI/RecordSummaryService.php
@@ -122,7 +122,8 @@ PROMPT;
 
         $parts->push('', 'Basic Information:');
         foreach ($context['basic_info'] as $key => $value) {
-            $parts->push("- {$this->formatLabel($key)}: {$value}");
+            $displayValue = is_array($value) ? implode(', ', $value) : $value;
+            $parts->push("- {$this->formatLabel($key)}: {$displayValue}");
         }
 
         if (filled($context['company'] ?? null)) {


### PR DESCRIPTION
## Summary
- Prevent "Array to string conversion" when `RecordContextBuilder` returns array values for multi-value fields like `domains`
- Add `implode()` handling in both `RecordContextBuilder::getCompanyBasicInfo()` and `RecordSummaryService::addBasicInfo()`
- Add regression test covering multi-value custom fields in context builder output

## Test plan
- [x] `php artisan test --compact tests/Feature/AI/RecordSummaryServiceTest.php` — 17 passed