### PR TITLE
fix: update custom-fields to v3.0.0-beta12

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7122,16 +7122,16 @@
         },
         {
             "name": "relaticle/custom-fields",
-            "version": "v3.0.0-beta11",
+            "version": "3.0.0-beta12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Relaticle/custom-fields.git",
-                "reference": "2a715970fd11c405b0a31dd5dec8d7ae95c7fc48"
+                "reference": "2e59afccdabdba5fa6e115f9ad1bb4b9713834fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Relaticle/custom-fields/zipball/2a715970fd11c405b0a31dd5dec8d7ae95c7fc48",
-                "reference": "2a715970fd11c405b0a31dd5dec8d7ae95c7fc48",
+                "url": "https://api.github.com/repos/Relaticle/custom-fields/zipball/2e59afccdabdba5fa6e115f9ad1bb4b9713834fb",
+                "reference": "2e59afccdabdba5fa6e115f9ad1bb4b9713834fb",
                 "shasum": ""
             },
             "require": {
@@ -7217,7 +7217,7 @@
                 "issues": "https://github.com/relaticle/custom-fields/issues",
                 "source": "https://github.com/relaticle/custom-fields"
             },
-            "time": "2026-02-15T15:48:25+00:00"
+            "time": "2026-02-16T19:50:45+00:00"
         },
         {
             "name": "relaticle/flowforge",


### PR DESCRIPTION
## Summary
- Updates `relaticle/custom-fields` to `v3.0.0-beta12`
- Fixes `str_starts_with(): Argument #1 ($haystack) must be of type string, array given` TypeError on multi-value field types (link, email, phone)
- Removes `starts_with` and `url` from `LinkFieldType` available validation rules since these are string-only rules incompatible with array storage
- Adds upgrade step (`CleanMultiValueValidationRulesStep`) to clean existing DB records

Fixes RELATICLE-CRM-2E

## Test plan
- [x] All 341 custom-fields package tests pass
- [x] Bug reproduced locally via Tinkerwell before fix
- [x] 7 affected production fields identified via Tinkerwell audit
- [x] Run step 2 cleanup script on production after deploy
- [x] Run `php artisan custom-fields:upgrade` on production