### PR TITLE
feat: align opportunity view actions with people and companies

### DIFF
--- a/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\CompanyResource;
 use App\Filament\Resources\OpportunityResource;
 use App\Filament\Resources\PeopleResource;
 use App\Models\Opportunity;
+use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
@@ -27,8 +28,38 @@ final class ViewOpportunity extends ViewRecord
     {
         return [
             GenerateRecordSummaryAction::make(),
+            EditAction::make()->icon('heroicon-o-pencil-square')->label('Edit'),
             ActionGroup::make([
-                EditAction::make(),
+                ActionGroup::make([
+                    Action::make('copyPageUrl')
+                        ->label('Copy page URL')
+                        ->icon('heroicon-o-clipboard-document')
+                        ->action(function (Opportunity $record): void {
+                            $url = OpportunityResource::getUrl('view', [$record]);
+                            $this->js("
+                            navigator.clipboard.writeText('{$url}').then(() => {
+                                new FilamentNotification()
+                                    .title('URL copied to clipboard')
+                                    .success()
+                                    .send()
+                            })
+                        ");
+                        }),
+                    Action::make('copyRecordId')
+                        ->label('Copy record ID')
+                        ->icon('heroicon-o-clipboard-document')
+                        ->action(function (Opportunity $record): void {
+                            $id = $record->getKey();
+                            $this->js("
+                            navigator.clipboard.writeText('{$id}').then(() => {
+                                new FilamentNotification()
+                                    .title('Record ID copied to clipboard')
+                                    .success()
+                                    .send()
+                            })
+                        ");
+                        }),
+                ])->dropdown(false),
                 DeleteAction::make(),
             ]),
         ];


### PR DESCRIPTION
Move Edit button outside the dropdown as a standalone action and add Copy Page URL / Copy Record ID actions inside the dropdown, matching the existing pattern in ViewPeople and ViewCompany.