### PR TITLE
Fix N+1 query in opportunities board

### DIFF
--- a/app/Filament/Pages/OpportunitiesBoard.php
+++ b/app/Filament/Pages/OpportunitiesBoard.php
@@ -56,6 +56,7 @@ final class OpportunitiesBoard extends BoardPage
                     })
                     ->select('opportunities.*', 'cfv.'.$valueColumn)
                     ->with(['company', 'contact'])
+                    ->withCustomFieldValues()
             )
             ->recordTitleAttribute('name')
             ->columnIdentifier($valueColumn)


### PR DESCRIPTION
## Problem

Sentry detected an N+1 query issue (RELATICLE-CRM-38) when loading the opportunities board. The board was loading custom field values individually for each opportunity card.

## Solution

Added `->withCustomFieldValues()` to the board query to eager load all custom field relationships in a single query.

## Performance Impact

- **Before:** 10-20+ queries per page load (one per opportunity)
- **After:** 1-3 queries total (batch loaded)

## Related Issues

- Sentry: https://relaticle.sentry.io/issues/RELATICLE-CRM-38
- Similar to PR #146 (PeopleResource fix)

## Testing

- Board still loads correctly
- Opportunities display with custom fields
- No test regressions