### PR TITLE
fix: handle null owner in TopTeamsTableWidget URL generation

### DIFF
--- a/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
@@ -44,7 +44,7 @@ final class TopTeamsTableWidget extends BaseWidget
                 TextColumn::make('owner.name')
                     ->label('Owner')
                     ->sortable()
-                    ->url(fn (Team $record): string => UserResource::getUrl('view', ['record' => $record->owner])),
+                    ->url(fn (Team $record): ?string => $record->owner ? UserResource::getUrl('view', ['record' => $record->owner]) : null),
 
                 TextColumn::make('members_count')
                     ->label('Members')


### PR DESCRIPTION
## Summary

- Fix `UrlGenerationException` in `TopTeamsTableWidget` when a team's owner is null
- The `owner.name` column's `->url()` closure now returns `null` instead of crashing when `$record->owner` is missing (deleted user or broken relationship)

## Context

Production error (Flare #110555022): `Missing required parameter for [Route: filament.sysadmin.resources.users.view] [URI: users/{record}] [Missing parameter: record]` — triggered when rendering the sysadmin dashboard widget for a team with no owner.

## Test plan

- [ ] Verify sysadmin dashboard loads without errors when teams exist with null owners
- [ ] Verify owner column still links correctly for teams with valid owners