### PR TITLE
chore(deps): replace spatie/boost-spatie-guidelines with spatie/guidelines-skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,10 @@ This project has domain-specific skills available. You MUST activate the relevan
 - `custom-fields-development` — Adds dynamic custom fields to Eloquent models without migrations using Filament integration. Use when adding the UsesCustomFields trait to models, integrating custom fields in Filament forms/tables/infolists, configuring field types, working with field validation, or managing feature flags for conditional visibility, encryption, and multi-tenancy.
 - `flowforge-development` — Builds Kanban board interfaces for Eloquent models with drag-and-drop functionality. Use when creating board pages, configuring columns and cards, implementing drag-and-drop positioning, working with Filament board pages or standalone Livewire boards, or troubleshooting position-related issues.
 - `laravel-query-builder` — Build filtered, sorted, and included API endpoints using spatie/laravel-query-builder. Activates when working with QueryBuilder, AllowedFilter, AllowedSort, AllowedInclude, or when the user mentions query parameters, API filtering, sorting, includes, or spatie/laravel-query-builder.
-- `spatie-laravel-php-standards` — Apply Spatie's Laravel and PHP coding standards for any task that creates, edits, reviews, refactors, or formats Laravel/PHP code or Blade templates; use for controllers, Eloquent models, routes, config, validation, migrations, tests, and related files to align with Laravel conventions and PSR-12.
+- `spatie-javascript` — Apply Spatie's JavaScript coding standards for any task that creates, edits, reviews, refactors, or formats JavaScript or TypeScript code; use for variable declarations, comparisons, functions, destructuring, and Prettier configuration to align with Spatie's JS conventions.
+- `spatie-laravel-php` — Apply Spatie's Laravel and PHP coding standards for any task that creates, edits, reviews, refactors, or formats Laravel/PHP code or Blade templates; use for controllers, Eloquent models, routes, config, validation, migrations, tests, and related files to align with Laravel conventions and PSR-12.
+- `spatie-security` — Apply Spatie's security guidelines when configuring applications, databases, or servers, or when reviewing code for security concerns; use for SSL setup, CSRF protection, password hashing, database permissions, and server hardening.
+- `spatie-version-control` — Apply Spatie's version control conventions when creating commits, branches, pull requests, or managing Git repositories; use for naming repos, writing commit messages, choosing branch strategies, and merging code.
 
 ## Conventions
 
@@ -541,16 +544,15 @@ livewire(ListUsers::class)
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
-- **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
-  - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
-  - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
-  - `$view`: `protected string` (not `protected static string`) on Page and Widget classes
 
-=== spatie/boost-spatie-guidelines rules ===
+=== spatie/guidelines-skills rules ===
 
 # Project Coding Guidelines
 
-- This codebase follows Spatie's Laravel & PHP guidelines.
-- Always activate the `spatie-laravel-php-standards` skill whenever writing, editing, reviewing, or formatting Laravel or PHP code.
+- This codebase follows Spatie's coding guidelines.
+- Always activate the `spatie-laravel-php` skill when writing, editing, reviewing, or formatting Laravel or PHP code.
+- Always activate the `spatie-javascript` skill when writing, editing, reviewing, or formatting JavaScript or TypeScript code.
+- Always activate the `spatie-version-control` skill when creating commits, branches, or managing Git operations.
+- Always activate the `spatie-security` skill when configuring security, reviewing authentication, or setting up servers and databases.
 
 </laravel-boost-guidelines>

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "rector/rector": "^2.0",
-        "spatie/boost-spatie-guidelines": "^1.1",
+        "spatie/guidelines-skills": "dev-main",
         "spatie/pest-plugin-route-testing": "^1.1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b242fceef183fbd3be4dbddec3d9ed25",
+    "content-hash": "1c86c5e64cb30e2d65114a04f883cac7",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -16278,16 +16278,16 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v2.4.0",
+            "version": "v2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "a09bebcff238ed92fd123e460b27bd58bed22520"
+                "reference": "841d52905728cfac9f93c778a1758e740ce9a367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/a09bebcff238ed92fd123e460b27bd58bed22520",
-                "reference": "a09bebcff238ed92fd123e460b27bd58bed22520",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/841d52905728cfac9f93c778a1758e740ce9a367",
+                "reference": "841d52905728cfac9f93c778a1758e740ce9a367",
                 "shasum": ""
             },
             "require": {
@@ -16340,7 +16340,7 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-03-23T16:01:08+00:00"
+            "time": "2026-04-10T15:59:10+00:00"
         },
         {
             "name": "laravel/pail",
@@ -19268,34 +19268,35 @@
             "time": "2026-03-11T22:59:30+00:00"
         },
         {
-            "name": "spatie/boost-spatie-guidelines",
-            "version": "1.1.0",
+            "name": "spatie/guidelines-skills",
+            "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spatie/boost-spatie-guidelines.git",
-                "reference": "1d15ddcd4077f7f7230fa9550fad16b6d78d0493"
+                "url": "https://github.com/spatie/guidelines-skills.git",
+                "reference": "0fb11f5cd3607db70a7c7503b8f437c8adeeeba5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/boost-spatie-guidelines/zipball/1d15ddcd4077f7f7230fa9550fad16b6d78d0493",
-                "reference": "1d15ddcd4077f7f7230fa9550fad16b6d78d0493",
+                "url": "https://api.github.com/repos/spatie/guidelines-skills/zipball/0fb11f5cd3607db70a7c7503b8f437c8adeeeba5",
+                "reference": "0fb11f5cd3607db70a7c7503b8f437c8adeeeba5",
                 "shasum": ""
             },
             "require": {
                 "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
                     "providers": [
-                        "Spatie\\BoostSpatieGuidelines\\BoostSpatieGuidelinesServiceProvider"
+                        "Spatie\\Guidelines\\GuidelinesServiceProvider"
                     ]
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Spatie\\BoostSpatieGuidelines\\": "src"
+                    "Spatie\\Guidelines\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -19310,20 +19311,22 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Spatie's Laravel & PHP coding guidelines for Laravel Boost",
-            "homepage": "https://github.com/spatie/boost-spatie-guidelines",
+            "description": "Spatie's coding guidelines as AI skills for Laravel Boost and skills.sh",
+            "homepage": "https://github.com/spatie/guidelines-skills",
             "keywords": [
+                "ai",
                 "boost",
                 "coding-standards",
                 "guidelines",
                 "laravel",
+                "skills",
                 "spatie"
             ],
             "support": {
-                "issues": "https://github.com/spatie/boost-spatie-guidelines/issues",
-                "source": "https://github.com/spatie/boost-spatie-guidelines/tree/1.1.0"
+                "issues": "https://github.com/spatie/guidelines-skills/issues",
+                "source": "https://github.com/spatie/guidelines-skills/tree/main"
             },
-            "time": "2026-03-06T08:25:49+00:00"
+            "time": "2026-03-16T14:11:29+00:00"
         },
         {
             "name": "spatie/pest-plugin-route-testing",
@@ -19626,7 +19629,9 @@
     ],
     "aliases": [],
     "minimum-stability": "beta",
-    "stability-flags": {},
+    "stability-flags": {
+        "spatie/guidelines-skills": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
## Summary

- Replaced `spatie/boost-spatie-guidelines` (single skill) with the new `spatie/guidelines-skills` package (4 skills: laravel-php, javascript, version-control, security)
- Updated `laravel/boost` from v2.4.0 to v2.4.3
- CLAUDE.md regenerated by `boost:install` to reflect the new skills and guidelines

## Context

Spatie released a standalone [guidelines-skills](https://spatie.be/blog/spatie-guidelines-as-ai-skills) package that replaces the older `boost-spatie-guidelines`. The new package expands coverage from just Laravel/PHP to also include JavaScript, version control, and security guidelines.

## Test plan

- [x] `composer install` succeeds
- [x] `php artisan boost:install` runs without errors
- [ ] CI passes