### PR TITLE
docs: README, MCP, field types, and core-model diagram fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">The Open-Source CRM Built for AI Agents</h1>
 
 <p align="center">
-  <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/deploy.yml?style=for-the-badge&label=tests" alt="Tests"></a>
+  <a href="https://github.com/Relaticle/relaticle/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/tests.yml?style=for-the-badge&label=tests" alt="Tests"></a>
   <a href="https://relaticle.com/docs/mcp"><img src="https://img.shields.io/badge/MCP_Tools-30-8A2BE2?style=for-the-badge" alt="30 MCP Tools"></a>
   <a href="https://laravel.com/docs/12.x"><img src="https://img.shields.io/badge/Laravel-12.x-FF2D20?style=for-the-badge&logo=laravel" alt="Laravel 12"></a>
   <a href="https://php.net"><img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4"></a>
@@ -43,15 +43,6 @@ Relaticle is a self-hosted CRM with a production-grade MCP server. Connect any A
 - **Multi-Team Isolation** - 5-layer authorization with team-scoped data and workspaces
 - **Modern Tech Stack** - Laravel 12, Filament 5, PHP 8.4, 1,100+ automated tests
 - **Privacy-First** - Self-hosted, AGPL-3.0, your data stays on your server
-
-**vs Other CRMs:**
-
-| | Self-Hosted | Open Source | MCP Tools | Custom Fields | Per-Seat Pricing |
-|---|---|---|---|---|---|
-| **Relaticle** | Yes | AGPL-3.0 | 30 | 22 types | No |
-| **HubSpot** | No | No | 9 | Limited | Yes |
-| **Salesforce** | No | No | 0 | Yes (complex) | Yes |
-| **Attio** | No | No | 0 | Yes | Yes |
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">The Open-Source CRM Built for AI Agents</h1>
 
 <p align="center">
-  <a href="https://github.com/Relaticle/relaticle/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/tests.yml?style=for-the-badge&label=tests" alt="Tests"></a>
+  <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/deploy.yml?style=for-the-badge&label=tests" alt="Tests"></a>
   <a href="https://relaticle.com/docs/mcp"><img src="https://img.shields.io/badge/MCP_Tools-30-8A2BE2?style=for-the-badge" alt="30 MCP Tools"></a>
   <a href="https://laravel.com/docs/12.x"><img src="https://img.shields.io/badge/Laravel-12.x-FF2D20?style=for-the-badge&logo=laravel" alt="Laravel 12"></a>
   <a href="https://php.net"><img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4"></a>

--- a/packages/Documentation/resources/markdown/developer-guide.md
+++ b/packages/Documentation/resources/markdown/developer-guide.md
@@ -39,7 +39,7 @@ Visit `http://localhost:8000` to access the application.
 ```
 Team ─┬─ User (via Membership)
       ├─ Company ─┬─ People
-      │           └─ Opportunity ─── Contact (People)
+      │           └─ Opportunity ─── People
       ├─ Task (many-to-many with Company, People, Opportunity)
       └─ Note (many-to-many with Company, People, Opportunity)
 ```

--- a/packages/Documentation/resources/markdown/getting-started.md
+++ b/packages/Documentation/resources/markdown/getting-started.md
@@ -93,10 +93,14 @@ Every entity supports custom fields for tracking data specific to your business.
 3. Choose the entity type (Companies, People, etc.)
 4. Add, edit, or reorder fields
 
-**Field types available:**
-- Text, Number, Date, Email, URL
-- Select (dropdown), Multi-select
-- Boolean (yes/no)
+**22 field types available**, including:
+- Text, Textarea, Number, Date, Date & Time
+- Email, Phone, Link, Color Picker
+- Select, Multi-select, Radio, Checkbox, Checkbox List
+- Toggle, Toggle Buttons, Tags Input
+- Currency, Rich Editor, Markdown Editor
+- File Upload
+- Record (link to another entity)
 
 ---
 

--- a/packages/Documentation/resources/markdown/mcp-guide.md
+++ b/packages/Documentation/resources/markdown/mcp-guide.md
@@ -9,9 +9,11 @@ MCP (Model Context Protocol) lets AI assistants like Claude work directly with y
 With the Relaticle MCP server, your AI assistant can:
 
 - **List and search** companies, people, opportunities, tasks, and notes
+- **Get a single record** with full details and relationships
 - **Create new records** directly from a conversation
 - **Update existing records** -- rename a company, reassign a task
 - **Delete records** you no longer need
+- **Attach or detach** tasks and notes to companies, people, and opportunities
 - **Read entity schemas** to understand your custom fields
 - **Get a CRM overview** with record counts and recent activity
 
@@ -104,13 +106,20 @@ Add this to your VS Code settings (`.vscode/mcp.json`):
 
 ## Available Tools
 
-The server provides 30 tools across five CRM entities:
+The server provides 30 tools: one account tool plus full CRUD across five CRM entities, with link management for tasks and notes.
+
+### Account
+
+| Tool | Description |
+|------|-------------|
+| `whoami` | Get the authenticated user, current team, team members, and token abilities |
 
 ### Companies
 
 | Tool | Description |
 |------|-------------|
 | `list_companies` | List companies with optional search by name and pagination |
+| `get_company` | Get a single company by ID with full details and relationships |
 | `create_company` | Create a new company (requires `name`) |
 | `update_company` | Update a company by ID |
 | `delete_company` | Soft-delete a company by ID |
@@ -120,6 +129,7 @@ The server provides 30 tools across five CRM entities:
 | Tool | Description |
 |------|-------------|
 | `list_people` | List contacts with optional search, filter by company |
+| `get_people` | Get a single person by ID with full details and relationships |
 | `create_people` | Create a new contact (requires `name`, optional `company_id`) |
 | `update_people` | Update a contact by ID |
 | `delete_people` | Soft-delete a contact by ID |
@@ -129,6 +139,7 @@ The server provides 30 tools across five CRM entities:
 | Tool | Description |
 |------|-------------|
 | `list_opportunities` | List deals with optional search, filter by company |
+| `get_opportunity` | Get a single opportunity by ID with full details and relationships |
 | `create_opportunity` | Create a new deal (requires `name`, optional `company_id`, `contact_id`) |
 | `update_opportunity` | Update a deal by ID |
 | `delete_opportunity` | Soft-delete a deal by ID |
@@ -138,18 +149,24 @@ The server provides 30 tools across five CRM entities:
 | Tool | Description |
 |------|-------------|
 | `list_tasks` | List tasks with optional search by title |
+| `get_task` | Get a single task by ID with full details and relationships |
 | `create_task` | Create a new task (requires `title`) |
 | `update_task` | Update a task by ID |
 | `delete_task` | Soft-delete a task by ID |
+| `attach_task_to_entities` | Link a task to companies, people, opportunities, or assign users. Adds without removing existing links. |
+| `detach_task_from_entities` | Unlink a task from companies, people, opportunities, or unassign users |
 
 ### Notes
 
 | Tool | Description |
 |------|-------------|
 | `list_notes` | List notes with optional search by title |
+| `get_note` | Get a single note by ID with full details and relationships |
 | `create_note` | Create a new note (requires `title`) |
 | `update_note` | Update a note by ID |
 | `delete_note` | Soft-delete a note by ID |
+| `attach_note_to_entities` | Link a note to companies, people, or opportunities. Adds without removing existing links. |
+| `detach_note_from_entities` | Unlink a note from companies, people, or opportunities |
 
 All list tools support `search`, `per_page` (default 15), and `page` parameters. Create and update tools accept `custom_fields` as key-value pairs when your team has custom fields configured.
 


### PR DESCRIPTION
## Summary

Docs accuracy pass across README and the customer-facing guides at `/docs/*`.

**README**
- Remove the "vs Other CRMs" comparison table. The MCP tool counts for HubSpot (9), Salesforce (0), and Attio (0) are unverifiable from those vendors' public docs and age poorly. Competitor positioning belongs on relaticle.com where dedicated `/vs/*` pages can be kept accurate.

**MCP guide** (`/docs/mcp`)
- The page claimed "30 tools across five CRM entities" but listed only 20 (5 entities × 4 CRUD). Added the missing 10:
  - `whoami` (new Account section)
  - `get_company`, `get_people`, `get_opportunity`, `get_task`, `get_note` — single-record retrieval
  - `attach_task_to_entities`, `detach_task_from_entities`, `attach_note_to_entities`, `detach_note_from_entities` — link management
- Updated the "What You Can Do" bullets so the narrative matches the new tool coverage.

**Getting Started** (`/docs/getting-started`)
- Upgraded custom-fields listing from 7 types to the actual 22, matching the product's marketing claim and `FieldTypeSystem/Definitions/` source of truth.

**Developer guide** (`/docs/developer`)
- Core-model ASCII diagram referenced a non-existent `Contact` model. There is no Contact model in `app/Models/`; People is the contacts model. Replaced `Contact (People)` with `People`.

## Verified against source

- MCP tool count: 30 registered in `app/Mcp/Servers/RelaticleServer.php` (1 + 5 + 5 + 5 + 7 + 7 = 30)
- Custom field types: 22 classes in `vendor/relaticle/custom-fields/src/FieldTypeSystem/Definitions/`
- Dual-license claim on the dev guide's Custom Fields section is correct — `relaticle/custom-fields` package LICENSE and README confirm AGPL-3.0 + Commercial

## Test plan

- [ ] Visual check of rendered `/docs/mcp`, `/docs/getting-started`, `/docs/developer` on the PR's preview
- [ ] Confirm new tool names (`whoami`, `get_*`, `attach_*`, `detach_*`) render in the MCP tool tables