### PR TITLE
feat(email): allow senders to cancel pending access requests

### DIFF
--- a/app/Filament/Pages/EmailAccessRequestsPage.php
+++ b/app/Filament/Pages/EmailAccessRequestsPage.php
@@ -16,6 +16,7 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
 use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
+use Relaticle\EmailIntegration\Actions\CancelEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
@@ -270,6 +271,43 @@ final class EmailAccessRequestsPage extends Page
                 Notification::make()
                     ->success()
                     ->title('Access request denied.')
+                    ->send();
+            });
+    }
+
+    protected function cancelAccessRequestAction(): Action
+    {
+        return Action::make('cancelAccessRequest')
+            ->label('Cancel request')
+            ->icon('heroicon-m-x-mark')
+            ->color('danger')
+            ->size(Size::ExtraSmall)
+            ->outlined()
+            ->requiresConfirmation()
+            ->modalHeading('Cancel access request')
+            ->modalDescription(fn (array $arguments): string => sprintf(
+                'Withdraw your request for access to %s\'s email?',
+                EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->owner->name ?? 'this user',
+            ))
+            ->modalSubmitActionLabel('Cancel request')
+            ->action(function (array $arguments): void {
+                $accessRequest = EmailAccessRequest::query()
+                    ->whereKey($arguments['requestId'] ?? null)
+                    ->where('requester_id', $this->authUser()->getKey())
+                    ->first();
+
+                if ($accessRequest === null) {
+                    return;
+                }
+
+                resolve(CancelEmailAccessRequestAction::class)->execute($accessRequest);
+
+                $this->selectedRequestId = null;
+                unset($this->selectedRequest, $this->requests, $this->statusCounts);
+
+                Notification::make()
+                    ->success()
+                    ->title('Access request cancelled.')
                     ->send();
             });
     }

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -19,18 +19,6 @@
                                 Synced {{ $account->last_synced_at->diffForHumans() }}
                             </span>
                         @endif
-                        @if ($account->status->value === 'reauth_required')
-                            {{ ($this->reAuthAction)(['account_id' => $account->id]) }}
-                        @endif
-                        @if ($account->provider->value === 'gmail')
-                            {{ ($this->syncCalendarNowAction)(['account_id' => $account->id]) }}
-                        @endif
-                        <x-filament-actions::group :actions="array_filter([
-                            $account->provider->value === 'gmail' ? ($this->syncCalendarAction)(['account_id' => $account->id]) : null,
-                            ($this->editSettingsAction)(['account_id' => $account->id]),
-                            ($this->disconnectAction)(['account_id' => $account->id]),
-                        ])" />
-                        <x-filament-actions::modals />
                     </div>
                 </div>
             @empty
@@ -41,7 +29,6 @@
         <x-filament::section heading="Connect an Account">
             <div class="flex gap-3">
                 {{ $this->connectGmailAction }}
-                {{ $this->checkAttachmentAction }}
 {{--                {{ $this->connectAzureAction }}--}}
             </div>
         </x-filament::section>

--- a/packages/EmailIntegration/src/Actions/CancelEmailAccessRequestAction.php
+++ b/packages/EmailIntegration/src/Actions/CancelEmailAccessRequestAction.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
+use Relaticle\EmailIntegration\Models\EmailAccessRequest;
+
+final readonly class CancelEmailAccessRequestAction
+{
+    public function execute(EmailAccessRequest $accessRequest): void
+    {
+        if ($accessRequest->status !== EmailAccessRequestStatus::PENDING) {
+            return;
+        }
+
+        $accessRequest->delete();
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -19,7 +19,6 @@ use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
-use Relaticle\EmailIntegration\Services\GmailService;
 
 final class EmailAccountsPage extends Page
 {
@@ -52,15 +51,6 @@ final class EmailAccountsPage extends Page
         return ConnectedAccount::query()->where('user_id', auth()->id())
             ->where('team_id', filament()->getTenant()?->getKey())
             ->get();
-    }
-
-    public function checkAttachmentAction(): Action
-    {
-        return Action::make('checkAttachment')
-            ->action(function (): void {
-                GmailService::forAccount(ConnectedAccount::query()->firstWhere('user_id', auth()->id()))->fetchMessage('19d82a37752febd1');
-            });
-
     }
 
     public function connectGmailAction(): Action

--- a/resources/views/filament/pages/email-access-requests.blade.php
+++ b/resources/views/filament/pages/email-access-requests.blade.php
@@ -99,6 +99,7 @@
             $isDenied   = $request->status === \Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus::DENIED;
             $person     = $tab === 'incoming' ? $request->requester : $request->owner;
             $isOwner    = $request->owner_id === auth()->id();
+            $isRequester = $request->requester_id === auth()->id();
             $email      = $request->email;
             $tier       = \Relaticle\EmailIntegration\Enums\EmailPrivacyTier::from($request->tier_requested);
         @endphp
@@ -177,6 +178,8 @@
                     @if ($isOwner && $isPending)
                         {{ ($this->approveAccessRequestAction)(['requestId' => $request->id]) }}
                         {{ ($this->denyAccessRequestAction)(['requestId' => $request->id]) }}
+                    @elseif ($isRequester && $isPending)
+                        {{ ($this->cancelAccessRequestAction)(['requestId' => $request->id]) }}
                     @endif
                 </div>
             </div>

--- a/tests/Feature/EmailIntegration/EmailAccessRequestTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccessRequestTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Notification;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
+use Relaticle\EmailIntegration\Actions\CancelEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
@@ -15,7 +16,7 @@ use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Notifications\EmailAccessRespondedNotification;
 
-mutates(ApproveEmailAccessRequestAction::class, DenyEmailAccessRequestAction::class);
+mutates(ApproveEmailAccessRequestAction::class, CancelEmailAccessRequestAction::class, DenyEmailAccessRequestAction::class);
 
 beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
@@ -186,5 +187,45 @@ describe('DenyEmailAccessRequestAction', function (): void {
         app(DenyEmailAccessRequestAction::class)->execute($request);
 
         Notification::assertNothingSent();
+    });
+});
+
+describe('CancelEmailAccessRequestAction', function (): void {
+    it('deletes a pending request', function (): void {
+        $request = EmailAccessRequest::factory()->forTier(EmailPrivacyTier::FULL)->create([
+            'requester_id' => $this->requester->id,
+            'owner_id' => $this->owner->id,
+            'email_id' => $this->email->getKey(),
+        ]);
+
+        app(CancelEmailAccessRequestAction::class)->execute($request);
+
+        expect(EmailAccessRequest::query()->whereKey($request->getKey())->exists())->toBeFalse();
+    });
+
+    it('does nothing when request is already approved', function (): void {
+        $request = EmailAccessRequest::factory()->approved()->forTier(EmailPrivacyTier::FULL)->create([
+            'requester_id' => $this->requester->id,
+            'owner_id' => $this->owner->id,
+            'email_id' => $this->email->getKey(),
+        ]);
+
+        app(CancelEmailAccessRequestAction::class)->execute($request);
+
+        expect(EmailAccessRequest::query()->whereKey($request->getKey())->exists())->toBeTrue();
+        expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::APPROVED);
+    });
+
+    it('does nothing when request is already denied', function (): void {
+        $request = EmailAccessRequest::factory()->denied()->forTier(EmailPrivacyTier::FULL)->create([
+            'requester_id' => $this->requester->id,
+            'owner_id' => $this->owner->id,
+            'email_id' => $this->email->getKey(),
+        ]);
+
+        app(CancelEmailAccessRequestAction::class)->execute($request);
+
+        expect(EmailAccessRequest::query()->whereKey($request->getKey())->exists())->toBeTrue();
+        expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::DENIED);
     });
 });

--- a/tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php
@@ -221,6 +221,96 @@ describe('denyAccessRequest action', function (): void {
     });
 });
 
+describe('cancelAccessRequest action', function (): void {
+    it('deletes a pending outgoing request and clears selectedRequestId', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $otherEmail = Email::factory()->private()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+        ]);
+
+        $request = EmailAccessRequest::factory()->pending()->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $this->user->id,
+            'email_id' => $otherEmail->getKey(),
+        ]);
+
+        livewire(EmailAccessRequestsPage::class)
+            ->call('setTab', 'outgoing')
+            ->call('selectRequest', (string) $request->id)
+            ->callAction('cancelAccessRequest', arguments: ['requestId' => $request->id])
+            ->assertNotified('Access request cancelled.')
+            ->assertSet('selectedRequestId', null);
+
+        expect(EmailAccessRequest::query()->whereKey($request->id)->exists())->toBeFalse();
+    });
+
+    it('does nothing when a non-requester passes a request id', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+        $requester = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $otherEmail = Email::factory()->private()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+        ]);
+
+        $request = EmailAccessRequest::factory()->pending()->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $requester->id,
+            'email_id' => $otherEmail->getKey(),
+        ]);
+
+        // Current user ($this->user) is neither owner nor requester — action should be a no-op
+        livewire(EmailAccessRequestsPage::class)
+            ->callAction('cancelAccessRequest', arguments: ['requestId' => $request->id])
+            ->assertNotNotified();
+
+        expect(EmailAccessRequest::query()->whereKey($request->id)->exists())->toBeTrue();
+        expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::PENDING);
+    });
+
+    it('does not delete an approved request', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $otherEmail = Email::factory()->private()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+        ]);
+
+        $request = EmailAccessRequest::factory()->approved()->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $this->user->id,
+            'email_id' => $otherEmail->getKey(),
+        ]);
+
+        livewire(EmailAccessRequestsPage::class)
+            ->call('setTab', 'outgoing')
+            ->callAction('cancelAccessRequest', arguments: ['requestId' => $request->id]);
+
+        expect(EmailAccessRequest::query()->whereKey($request->id)->exists())->toBeTrue();
+        expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::APPROVED);
+    });
+});
+
 describe('getNavigationBadge', function (): void {
     it('returns the count of pending incoming requests as a string', function (): void {
         $requester = User::factory()->create(['current_team_id' => $this->team->id]);


### PR DESCRIPTION
## Summary
- Adds `CancelEmailAccessRequestAction` so a sender can withdraw their own pending access request. Approved/denied requests are no-ops.
- Wires a **Cancel request** button into the Sent tab on the Email Access Requests page, scoped to `requester_id = auth()->id()`.
- Cleans up a leftover debug `checkAttachment` action and removes the account row's action controls (reauth/sync-now/sync-calendar/settings/disconnect) from the Email Accounts page per in-session request — the "Synced X ago" timestamp is retained.

## Why
Previously there was no way for a sender to retract a pending request — only the recipient could act on it. Deleting the record (rather than adding a `REVOKED` status) keeps the list clean for the recipient, has no audit value since no action was taken, and plays well with the existing duplicate-pending guard so the sender can re-request later.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailAccessRequestTest.php tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php` — 28 passed
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `vendor/bin/rector --dry-run`
- [x] `vendor/bin/phpstan analyse --memory-limit=1G`
- [x] `composer test:type-coverage` — 100%
- [x] Manually verify: sender sees Cancel button on pending sent request, confirmation modal, click cancels and request disappears
- [x] Manually verify: approved/denied requests show no Cancel button

🤖 Generated with [Claude Code](https://claude.com/claude-code)