### PR TITLE
Bump access request page size to 20 and drop activity infolist on People view

### DIFF
--- a/app/Filament/Pages/EmailAccessRequestsPage.php
+++ b/app/Filament/Pages/EmailAccessRequestsPage.php
@@ -25,7 +25,7 @@ final class EmailAccessRequestsPage extends Page
 {
     use WithPagination;
 
-    private const int PER_PAGE = 2;
+    private const int PER_PAGE = 20;
 
     protected string $view = 'filament.pages.email-access-requests';
 

--- a/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
+++ b/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
@@ -22,7 +22,6 @@ use Filament\Support\Enums\TextSize;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
 use Relaticle\ActivityLog\Filament\Actions\ActivityLogAction;
-use Relaticle\ActivityLog\Filament\Infolists\Components\ActivityLog;
 use Relaticle\CustomFields\Facades\CustomFields;
 
 final class ViewPeople extends ViewRecord
@@ -131,16 +130,6 @@ final class ViewPeople extends ViewRecord
                 ->columnSpanFull()
                 ->collapsible()
                 ->collapsed(fn (People $record): bool => ($record->email_count ?? 0) === 0),
-
-            Section::make('Activity log')
-                ->icon(Heroicon::Bars3BottomLeft)
-                ->description('All activity for this record, grouped by week.')
-                ->schema([
-                    ActivityLog::make('activityLog')
-                        ->groupByDate(),
-                ])
-                ->columnSpanFull()
-                ->collapsible(),
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- Raise pagination on the Email Access Requests page from 2 to 20 per page so users no longer have to click through every couple of rows.
- Remove the "Activity log" Section from the People view infolist; activity already lives in the `ActivityLogRelationManager` tab, so the infolist version was duplicate UI.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php tests/Feature/Filament/App/Resources/PeopleResourceTest.php`
- [x] Manually verify the People view page no longer renders an activity log section, while the relation manager tab still shows it.
- [x] Manually verify the Email Access Requests page paginates 20 rows at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)