### PR TITLE
chore: merge main into feat/email-calendar-integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,12 @@ FATHOM_ANALYTICS_SITE_ID=
 # HEALTH_CHECKS_ENABLED=false
 # OH_DEAR_HEALTH_CHECK_SECRET=
 
+# Feature Flags (for forks and custom deployments)
+# Set to false to disable specific features
+# RELATICLE_FEATURE_ONBOARD_SEED=true
+# RELATICLE_FEATURE_SOCIAL_AUTH=true
+# RELATICLE_FEATURE_DOCUMENTATION=true
+
 # Community Links
 DISCORD_INVITE_URL=https://discord.gg/b9WxzUce4Q
 

--- a/.env.testing
+++ b/.env.testing
@@ -1,7 +1,7 @@
 APP_NAME=Relaticle
 APP_ENV=testing
 APP_KEY=base64:mtvstFRAXZAZlcVw0PdhkGZxTTdns7kJdIgPa72O9h8=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_URL=http://relaticle.test
 
 LOG_CHANNEL=daily

--- a/.github/skills/livewire-development/SKILL.md
+++ b/.github/skills/livewire-development/SKILL.md
@@ -18,15 +18,29 @@ Use `search-docs` for detailed Livewire 4 patterns and documentation.
 
 ```bash
 
-# Single-file component (default in v4)
+# Single-file component (SFC - default in v4)
+
+# Creates: resources/views/components/⚡create-post.blade.php
 
 php artisan make:livewire create-post
 
-# Multi-file component
+# Page component (SFC - Full Page in v4)
+
+# Creates: resources/views/pages/⚡create-post.blade.php
+
+php artisan make:livewire pages::create-post
+
+# Multi-file component (MFC)
+
+# Creates: resources/views/components/⚡create-post/create-post.php
+
+#          resources/views/components/⚡create-post/create-post.blade.php
 
 php artisan make:livewire create-post --mfc
 
 # Class-based component (v3 style)
+
+# Creates: app/Livewire/CreatePost.php AND resources/views/livewire/create-post.blade.php
 
 php artisan make:livewire create-post --class
 
@@ -41,18 +55,23 @@ Use `php artisan livewire:convert create-post` to convert between single-file, m
 
 ### Choosing a Component Format
 
-Before creating a component, check `config/livewire.php` for directory overrides, which change where files are stored. Then, look at existing files in those directories (defaulting to `app/Livewire/` and `resources/views/livewire/`) to match the established convention.
+> **Always follow the project's existing conventions first.** Before creating any component, inspect the project's existing Livewire components to determine the established format (SFC, MFC, or class-based) and directory structure. Check `app/Livewire/`, `resources/views/components/`, and `resources/views/livewire/` for existing components. If the project already uses a consistent format, **use that same format** — even if it differs from the Livewire v4 defaults below. Only fall back to the v4 defaults (SFC in `resources/views/components/`) when no existing convention is established.
+
+Also check `config/livewire.php` for `make_command.type`, `make_command.emoji`, `component_locations`, and `component_namespaces` overrides, which change the default format and where files are stored.
 
 ### Component Format Reference
 
 | Format | Flag | Class Path | View Path |
 |--------|------|------------|-----------|
-| Single-file (SFC) | default | — | `resources/views/livewire/create-post.blade.php` (PHP + Blade in one file) |
-| Multi-file (MFC) | `--mfc` | `app/Livewire/CreatePost.php` | `resources/views/livewire/create-post.blade.php` |
+| Single-file (SFC) | default | — | `resources/views/components/⚡create-post.blade.php` (PHP + Blade in one file) |
+| Full Page SFC | `pages::name` | — | `resources/views/pages/⚡create-post.blade.php` |
+| Multi-file (MFC) | `--mfc` | `resources/views/components/⚡create-post/create-post.php` | `resources/views/components/⚡create-post/create-post.blade.php` |
 | Class-based | `--class` | `app/Livewire/CreatePost.php` | `resources/views/livewire/create-post.blade.php` |
-| View-based | ⚡ prefix | — | `resources/views/livewire/create-post.blade.php` (Blade-only with functional state) |
+| View-based | default (Blade-only) | — | `resources/views/components/⚡create-post.blade.php` (Blade-only with functional state) |
 
-Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates files at `app/Livewire/Posts/CreatePost.php` and `resources/views/livewire/posts/create-post.blade.php`.
+> **Important:** The ⚡ prefix shown above is the **default** behavior in Livewire v4 — it is **configurable**. Check `config/livewire.php` for the `make_command.emoji` setting. When `true` (default), always include the ⚡ prefix in filenames you create. When `false`, omit the ⚡ prefix from all paths above.
+
+Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates `resources/views/components/posts/⚡create-post.blade.php` (single-file by default). Use `make:livewire Posts/CreatePost --mfc` for multi-file output at `resources/views/components/posts/⚡create-post/create-post.php` and `resources/views/components/posts/⚡create-post/create-post.blade.php`.
 
 ### Single-File Component Example
 
@@ -68,7 +87,7 @@ new class extends Component {
     {
         $this->count++;
     }
-}
+};
 ?>
 
 <div>

--- a/.github/skills/pest-testing/SKILL.md
+++ b/.github/skills/pest-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pest-testing
-description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
+description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
 license: MIT
 metadata:
   author: laravel
@@ -25,6 +25,8 @@ All tests must be written using Pest. Use `php artisan make:test --pest {name}`.
 - Do NOT remove tests without approval - these are core application code.
 
 ### Basic Test Structure
+
+Pest supports both `test()` and `it()` functions. Before writing new tests, check existing test files in the same directory to match the project's convention. Use `test()` if existing tests use `test()`, or `it()` if they use `it()`.
 
 <!-- Basic Pest Test Example -->
 ```php

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,11 @@
-name: Tests
+name: Deploy
 
-on: [pull_request]
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
 
 jobs:
   lint-and-static-analysis:
@@ -221,3 +226,13 @@ jobs:
 
       - name: Browser Tests
         run: vendor/bin/pest tests/Browser/ --configuration phpunit.ci.xml
+
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to Forge
+    if: github.event.release.prerelease == false
+    needs: [lint-and-static-analysis, tests, browser-tests]
+
+    steps:
+      - name: Trigger Forge Deploy
+        run: curl --fail --silent --show-error --location "${{ secrets.FORGE_DEPLOY_WEBHOOK }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,238 @@
+name: Deploy
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-static-analysis:
+    runs-on: ubuntu-latest
+    name: Code Quality Checks
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-composer-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: json, dom, curl, libxml, mbstring, zip
+          tools: composer:v2
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --no-progress --ansi --prefer-dist --optimize-autoloader
+
+      - name: Prepare Laravel Application
+        run: |
+          cp .env.ci .env
+          php artisan key:generate
+
+      - name: Run Lint
+        run: composer test:lint
+
+      - name: Run Refactor Check
+        run: composer test:refactor
+
+      - name: Run Type Coverage
+        run: composer test:type-coverage
+
+      - name: Run Static Analysis
+        run: composer test:types
+
+      - name: Architecture Tests
+        run: composer test:arch
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.4]
+        shard: [1, 2, 3, 4, 5]
+
+    name: Tests (Shard ${{ matrix.shard }}/5)
+
+    services:
+      postgres:
+        image: postgres:alpine
+        env:
+          POSTGRES_DB: relaticle_testing
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-composer-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, dom, curl, libxml, mbstring, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Set up Node & NPM
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22.x'
+
+      - name: Setup Problem Matches
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --no-progress --ansi --prefer-dist --optimize-autoloader
+
+      - name: Get NPM cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
+      - name: Cache dependencies
+        id: npm-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dependencies
+        run: npm run build
+
+      - name: Prepare Laravel
+        run: |
+          cp .env.ci .env
+          php artisan key:generate
+
+      - name: Tests
+        run: composer test:pest:ci
+        env:
+          SHARD: ${{ matrix.shard }}/5
+
+  browser-tests:
+    runs-on: ubuntu-latest
+    name: Browser Tests
+
+    services:
+      postgres:
+        image: postgres:alpine
+        env:
+          POSTGRES_DB: relaticle_testing
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-composer-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: json, dom, curl, libxml, mbstring, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Set up Node & NPM
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22.x'
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --no-progress --ansi --prefer-dist --optimize-autoloader
+
+      - name: Get NPM cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
+      - name: Cache NPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Prepare Laravel
+        run: |
+          cp .env.ci .env
+          php artisan key:generate
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser Tests
+        run: vendor/bin/pest tests/Browser/ --configuration phpunit.ci.xml
+
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy to Forge
+    if: github.event.release.prerelease == false
+    needs: [lint-and-static-analysis, tests, browser-tests]
+
+    steps:
+      - name: Trigger Forge Deploy
+        run: curl --fail --silent --show-error --location "${{ secrets.FORGE_DEPLOY_WEBHOOK }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [pull_request]
 
 jobs:
   lint-and-static-analysis:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ api.json
 polyscope.json
 /bin/setup-preview.sh
 .gstack/
+test-results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ polyscope.json
 /bin/setup-preview.sh
 /packages/filament
 .gstack/
+test-results.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/framework (LARAVEL) - v12
 - laravel/horizon (HORIZON) - v5
 - laravel/mcp (MCP) - v0
+- laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0
 - laravel/sanctum (SANCTUM) - v4
 - laravel/socialite (SOCIALITE) - v5
@@ -98,16 +99,17 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
+- `fortify-development` — ACTIVATE when the user works on authentication in Laravel. This includes login, registration, password reset, email verification, two-factor authentication (2FA/TOTP/QR codes/recovery codes), profile updates, password confirmation, or any auth-related routes and controllers. Activate when the user mentions Fortify, auth, authentication, login, register, signup, forgot password, verify email, 2FA, or references app/Actions/Fortify/, CreateNewUser, UpdateUserProfileInformation, FortifyServiceProvider, config/fortify.php, or auth guards. Fortify is the frontend-agnostic authentication backend for Laravel that registers all auth routes and controllers. Also activate when building SPA or headless authentication, customizing login redirects, overriding response contracts like LoginResponse, or configuring login throttling. Do NOT activate for Laravel Passport (OAuth2 API tokens), Socialite (OAuth social login), or non-auth Laravel features.
 - `laravel-best-practices` — Apply this skill whenever writing, reviewing, or refactoring Laravel PHP code. This includes creating or modifying controllers, models, migrations, form requests, policies, jobs, scheduled commands, service classes, and Eloquent queries. Triggers for N+1 and query performance issues, caching strategies, authorization and security patterns, validation, error handling, queue and job configuration, route definitions, and architectural decisions. Also use for Laravel code reviews and refactoring existing Laravel code to follow best practices. Covers any task involving Laravel backend PHP code patterns.
 - `configuring-horizon` — Use this skill whenever the user mentions Horizon by name in a Laravel context. Covers the full Horizon lifecycle: installing Horizon (horizon:install, Sail setup), configuring config/horizon.php (supervisor blocks, queue assignments, balancing strategies, minProcesses/maxProcesses), fixing the dashboard (authorization via Gate::define viewHorizon, blank metrics, horizon:snapshot scheduling), and troubleshooting production issues (worker crashes, timeout chain ordering, LongWaitDetected notifications, waits config). Also covers job tagging and silencing. Do not use for generic Laravel queues without Horizon, SQS or database drivers, standalone Redis setup, Linux supervisord, Telescope, or job batching.
 - `mcp-development` — Use this skill for Laravel MCP development only. Trigger when creating or editing MCP tools, resources, prompts, or servers in Laravel projects. Covers: artisan make:mcp-* generators, mcp:inspector, routes/ai.php, Tool/Resource/Prompt classes, schema validation, shouldRegister(), OAuth setup, URI templates, read-only attributes, and MCP debugging. Do not use for non-Laravel MCP projects or generic AI features without MCP.
+- `pennant-development` — Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems.
 - `socialite-development` — Manages OAuth social authentication with Laravel Socialite. Activate when adding social login providers; configuring OAuth redirect/callback flows; retrieving authenticated user details; customizing scopes or parameters; setting up community providers; testing with Socialite fakes; or when the user mentions social login, OAuth, Socialite, or third-party authentication.
 - `livewire-development` — Use for any task or question involving Livewire. Activate if user mentions Livewire, wire: directives, or Livewire-specific concepts like wire:model, wire:click, wire:sort, or islands, invoke this skill. Covers building new components, debugging reactivity issues, real-time form validation, drag-and-drop, loading states, migrating from Livewire 3 to 4, converting component formats (SFC/MFC/class-based), and performance optimization. Do not use for non-Livewire reactive UI (React, Vue, Alpine-only, Inertia.js) or standard Laravel forms without Livewire.
-- `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
+- `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
 - `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
 - `custom-fields-development` — Adds dynamic custom fields to Eloquent models without migrations using Filament integration. Use when adding the UsesCustomFields trait to models, integrating custom fields in Filament forms/tables/infolists, configuring field types, working with field validation, or managing feature flags for conditional visibility, encryption, and multi-tenancy.
 - `laravel-query-builder` — Build filtered, sorted, and included API endpoints using spatie/laravel-query-builder. Activates when working with QueryBuilder, AllowedFilter, AllowedSort, AllowedInclude, or when the user mentions query parameters, API filtering, sorting, includes, or spatie/laravel-query-builder.
-- `spatie-laravel-php-standards` — Apply Spatie's Laravel and PHP coding standards for any task that creates, edits, reviews, refactors, or formats Laravel/PHP code or Blade templates; use for controllers, Eloquent models, routes, config, validation, migrations, tests, and related files to align with Laravel conventions and PSR-12.
 
 ## Conventions
 
@@ -186,6 +188,19 @@ This project has domain-specific skills available. You MUST activate the relevan
 - Use TitleCase for Enum keys: `FavoritePerson`, `BestLake`, `Monthly`.
 - Prefer PHPDoc blocks over inline comments. Only add inline comments for exceptionally complex logic.
 - Use array shape type definitions in PHPDoc blocks.
+
+=== deployments rules ===
+
+# Deployment
+
+- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
+
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd at `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs. Never run commands to serve the site. It is always available.
+- Use the `herd` CLI to manage services, PHP versions, and sites (e.g. `herd sites`, `herd services:start <service>`, `herd php:list`). Run `herd list` to discover all available commands.
 
 === tests rules ===
 
@@ -421,12 +436,9 @@ livewire(ListUsers::class)
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
-
-=== spatie/boost-spatie-guidelines rules ===
-
-# Project Coding Guidelines
-
-- This codebase follows Spatie's Laravel & PHP guidelines.
-- Always activate the `spatie-laravel-php-standards` skill whenever writing, editing, reviewing, or formatting Laravel or PHP code.
+- **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
+  - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
+  - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
+  - `$view`: `protected string` (not `protected static string`) on Page and Widget classes
 
 </laravel-boost-guidelines>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,10 @@ This project has domain-specific skills available. You MUST activate the relevan
 - `custom-fields-development` — Adds dynamic custom fields to Eloquent models without migrations using Filament integration. Use when adding the UsesCustomFields trait to models, integrating custom fields in Filament forms/tables/infolists, configuring field types, working with field validation, or managing feature flags for conditional visibility, encryption, and multi-tenancy.
 - `flowforge-development` — Builds Kanban board interfaces for Eloquent models with drag-and-drop functionality. Use when creating board pages, configuring columns and cards, implementing drag-and-drop positioning, working with Filament board pages or standalone Livewire boards, or troubleshooting position-related issues.
 - `laravel-query-builder` — Build filtered, sorted, and included API endpoints using spatie/laravel-query-builder. Activates when working with QueryBuilder, AllowedFilter, AllowedSort, AllowedInclude, or when the user mentions query parameters, API filtering, sorting, includes, or spatie/laravel-query-builder.
-- `spatie-laravel-php-standards` — Apply Spatie's Laravel and PHP coding standards for any task that creates, edits, reviews, refactors, or formats Laravel/PHP code or Blade templates; use for controllers, Eloquent models, routes, config, validation, migrations, tests, and related files to align with Laravel conventions and PSR-12.
+- `spatie-javascript` — Apply Spatie's JavaScript coding standards for any task that creates, edits, reviews, refactors, or formats JavaScript or TypeScript code; use for variable declarations, comparisons, functions, destructuring, and Prettier configuration to align with Spatie's JS conventions.
+- `spatie-laravel-php` — Apply Spatie's Laravel and PHP coding standards for any task that creates, edits, reviews, refactors, or formats Laravel/PHP code or Blade templates; use for controllers, Eloquent models, routes, config, validation, migrations, tests, and related files to align with Laravel conventions and PSR-12.
+- `spatie-security` — Apply Spatie's security guidelines when configuring applications, databases, or servers, or when reviewing code for security concerns; use for SSL setup, CSRF protection, password hashing, database permissions, and server hardening.
+- `spatie-version-control` — Apply Spatie's version control conventions when creating commits, branches, pull requests, or managing Git repositories; use for naming repos, writing commit messages, choosing branch strategies, and merging code.
 
 ## Conventions
 
@@ -541,16 +544,15 @@ livewire(ListUsers::class)
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
-- **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
-  - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
-  - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
-  - `$view`: `protected string` (not `protected static string`) on Page and Widget classes
 
-=== spatie/boost-spatie-guidelines rules ===
+=== spatie/guidelines-skills rules ===
 
 # Project Coding Guidelines
 
-- This codebase follows Spatie's Laravel & PHP guidelines.
-- Always activate the `spatie-laravel-php-standards` skill whenever writing, editing, reviewing, or formatting Laravel or PHP code.
+- This codebase follows Spatie's coding guidelines.
+- Always activate the `spatie-laravel-php` skill when writing, editing, reviewing, or formatting Laravel or PHP code.
+- Always activate the `spatie-javascript` skill when writing, editing, reviewing, or formatting JavaScript or TypeScript code.
+- Always activate the `spatie-version-control` skill when creating commits, branches, or managing Git operations.
+- Always activate the `spatie-security` skill when configuring security, reviewing authentication, or setting up servers and databases.
 
 </laravel-boost-guidelines>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/framework (LARAVEL) - v12
 - laravel/horizon (HORIZON) - v5
 - laravel/mcp (MCP) - v0
+- laravel/pennant (PENNANT) - v1
 - laravel/prompts (PROMPTS) - v0
 - laravel/sanctum (SANCTUM) - v4
 - laravel/socialite (SOCIALITE) - v5
@@ -196,18 +197,21 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - pestphp/pest (PEST) - v4
 - phpunit/phpunit (PHPUNIT) - v12
 - rector/rector (RECTOR) - v2
+- alpinejs (ALPINEJS) - v3
 - tailwindcss (TAILWINDCSS) - v4
 
 ## Skills Activation
 
 This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
+- `fortify-development` — ACTIVATE when the user works on authentication in Laravel. This includes login, registration, password reset, email verification, two-factor authentication (2FA/TOTP/QR codes/recovery codes), profile updates, password confirmation, or any auth-related routes and controllers. Activate when the user mentions Fortify, auth, authentication, login, register, signup, forgot password, verify email, 2FA, or references app/Actions/Fortify/, CreateNewUser, UpdateUserProfileInformation, FortifyServiceProvider, config/fortify.php, or auth guards. Fortify is the frontend-agnostic authentication backend for Laravel that registers all auth routes and controllers. Also activate when building SPA or headless authentication, customizing login redirects, overriding response contracts like LoginResponse, or configuring login throttling. Do NOT activate for Laravel Passport (OAuth2 API tokens), Socialite (OAuth social login), or non-auth Laravel features.
 - `laravel-best-practices` — Apply this skill whenever writing, reviewing, or refactoring Laravel PHP code. This includes creating or modifying controllers, models, migrations, form requests, policies, jobs, scheduled commands, service classes, and Eloquent queries. Triggers for N+1 and query performance issues, caching strategies, authorization and security patterns, validation, error handling, queue and job configuration, route definitions, and architectural decisions. Also use for Laravel code reviews and refactoring existing Laravel code to follow best practices. Covers any task involving Laravel backend PHP code patterns.
 - `configuring-horizon` — Use this skill whenever the user mentions Horizon by name in a Laravel context. Covers the full Horizon lifecycle: installing Horizon (horizon:install, Sail setup), configuring config/horizon.php (supervisor blocks, queue assignments, balancing strategies, minProcesses/maxProcesses), fixing the dashboard (authorization via Gate::define viewHorizon, blank metrics, horizon:snapshot scheduling), and troubleshooting production issues (worker crashes, timeout chain ordering, LongWaitDetected notifications, waits config). Also covers job tagging and silencing. Do not use for generic Laravel queues without Horizon, SQS or database drivers, standalone Redis setup, Linux supervisord, Telescope, or job batching.
 - `mcp-development` — Use this skill for Laravel MCP development only. Trigger when creating or editing MCP tools, resources, prompts, or servers in Laravel projects. Covers: artisan make:mcp-* generators, mcp:inspector, routes/ai.php, Tool/Resource/Prompt classes, schema validation, shouldRegister(), OAuth setup, URI templates, read-only attributes, and MCP debugging. Do not use for non-Laravel MCP projects or generic AI features without MCP.
+- `pennant-development` — Use when working with Laravel Pennant the official Laravel feature flag package. Trigger whenever the query mentions Pennant by name or involves feature flags or feature toggles in a Laravel project. Tasks include defining feature flags checking whether features are active creating class based features in `app/Features` using Blade `@feature` directives scoping flags to users or teams building custom Pennant storage drivers protecting routes with feature flags testing feature flags with Pest or PHPUnit and implementing A B testing or gradual rollouts with feature flags. Do not trigger for generic Laravel configuration authorization policies authentication or non Pennant feature management systems.
 - `socialite-development` — Manages OAuth social authentication with Laravel Socialite. Activate when adding social login providers; configuring OAuth redirect/callback flows; retrieving authenticated user details; customizing scopes or parameters; setting up community providers; testing with Socialite fakes; or when the user mentions social login, OAuth, Socialite, or third-party authentication.
 - `livewire-development` — Use for any task or question involving Livewire. Activate if user mentions Livewire, wire: directives, or Livewire-specific concepts like wire:model, wire:click, wire:sort, or islands, invoke this skill. Covers building new components, debugging reactivity issues, real-time form validation, drag-and-drop, loading states, migrating from Livewire 3 to 4, converting component formats (SFC/MFC/class-based), and performance optimization. Do not use for non-Livewire reactive UI (React, Vue, Alpine-only, Inertia.js) or standard Laravel forms without Livewire.
-- `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
+- `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code.
 - `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
 - `custom-fields-development` — Adds dynamic custom fields to Eloquent models without migrations using Filament integration. Use when adding the UsesCustomFields trait to models, integrating custom fields in Filament forms/tables/infolists, configuring field types, working with field validation, or managing feature flags for conditional visibility, encryption, and multi-tenancy.
 - `flowforge-development` — Builds Kanban board interfaces for Eloquent models with drag-and-drop functionality. Use when creating board pages, configuring columns and cards, implementing drag-and-drop positioning, working with Filament board pages or standalone Livewire boards, or troubleshooting position-related issues.
@@ -335,6 +339,10 @@ This project has domain-specific skills available. You MUST activate the relevan
 ## Vite Error
 
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
+
+## Deployment
+
+- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
 === laravel/v12 rules ===
 
@@ -533,6 +541,10 @@ livewire(ListUsers::class)
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
+- **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
+  - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
+  - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
+  - `$view`: `protected string` (not `protected static string`) on Page and Widget classes
 
 === spatie/boost-spatie-guidelines rules ===
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,10 +216,6 @@ This project has domain-specific skills available. You MUST activate the relevan
 - `custom-fields-development` — Adds dynamic custom fields to Eloquent models without migrations using Filament integration. Use when adding the UsesCustomFields trait to models, integrating custom fields in Filament forms/tables/infolists, configuring field types, working with field validation, or managing feature flags for conditional visibility, encryption, and multi-tenancy.
 - `flowforge-development` — Builds Kanban board interfaces for Eloquent models with drag-and-drop functionality. Use when creating board pages, configuring columns and cards, implementing drag-and-drop positioning, working with Filament board pages or standalone Livewire boards, or troubleshooting position-related issues.
 - `laravel-query-builder` — Build filtered, sorted, and included API endpoints using spatie/laravel-query-builder. Activates when working with QueryBuilder, AllowedFilter, AllowedSort, AllowedInclude, or when the user mentions query parameters, API filtering, sorting, includes, or spatie/laravel-query-builder.
-- `spatie-javascript` — Apply Spatie's JavaScript coding standards for any task that creates, edits, reviews, refactors, or formats JavaScript or TypeScript code; use for variable declarations, comparisons, functions, destructuring, and Prettier configuration to align with Spatie's JS conventions.
-- `spatie-laravel-php` — Apply Spatie's Laravel and PHP coding standards for any task that creates, edits, reviews, refactors, or formats Laravel/PHP code or Blade templates; use for controllers, Eloquent models, routes, config, validation, migrations, tests, and related files to align with Laravel conventions and PSR-12.
-- `spatie-security` — Apply Spatie's security guidelines when configuring applications, databases, or servers, or when reviewing code for security concerns; use for SSL setup, CSRF protection, password hashing, database permissions, and server hardening.
-- `spatie-version-control` — Apply Spatie's version control conventions when creating commits, branches, pull requests, or managing Git repositories; use for naming repos, writing commit messages, choosing branch strategies, and merging code.
 
 ## Conventions
 
@@ -299,6 +295,12 @@ This project has domain-specific skills available. You MUST activate the relevan
 - Prefer PHPDoc blocks over inline comments. Only add inline comments for exceptionally complex logic.
 - Use array shape type definitions in PHPDoc blocks.
 
+=== deployments rules ===
+
+# Deployment
+
+- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
+
 === herd rules ===
 
 # Laravel Herd
@@ -342,10 +344,6 @@ This project has domain-specific skills available. You MUST activate the relevan
 ## Vite Error
 
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
-
-## Deployment
-
-- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
 === laravel/v12 rules ===
 
@@ -544,15 +542,9 @@ livewire(ListUsers::class)
 
 - **Never assume public file visibility.** File visibility is `private` by default. Always use `->visibility('public')` when public access is needed.
 - **Never assume full-width layout.** `Grid`, `Section`, and `Fieldset` do not span all columns by default. Explicitly set column spans when needed.
-
-=== spatie/guidelines-skills rules ===
-
-# Project Coding Guidelines
-
-- This codebase follows Spatie's coding guidelines.
-- Always activate the `spatie-laravel-php` skill when writing, editing, reviewing, or formatting Laravel or PHP code.
-- Always activate the `spatie-javascript` skill when writing, editing, reviewing, or formatting JavaScript or TypeScript code.
-- Always activate the `spatie-version-control` skill when creating commits, branches, or managing Git operations.
-- Always activate the `spatie-security` skill when configuring security, reviewing authentication, or setting up servers and databases.
+- **Use correct property types when overriding Page, Resource, and Widget properties.** These properties have union types or changed modifiers that must be preserved:
+  - `$navigationIcon`: `protected static string | BackedEnum | null` (not `?string`)
+  - `$navigationGroup`: `protected static string | UnitEnum | null` (not `?string`)
+  - `$view`: `protected string` (not `protected static string`) on Page and Widget classes
 
 </laravel-boost-guidelines>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">The Open-Source CRM Built for AI Agents</h1>
 
 <p align="center">
-  <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/tests.yml?branch=main&style=for-the-badge&label=tests" alt="Tests"></a>
+  <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/deploy.yml?style=for-the-badge&label=tests" alt="Tests"></a>
   <a href="https://relaticle.com/docs/mcp"><img src="https://img.shields.io/badge/MCP_Tools-30-8A2BE2?style=for-the-badge" alt="30 MCP Tools"></a>
   <a href="https://laravel.com/docs/12.x"><img src="https://img.shields.io/badge/Laravel-12.x-FF2D20?style=for-the-badge&logo=laravel" alt="Laravel 12"></a>
   <a href="https://php.net"><img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4"></a>

--- a/README.md
+++ b/README.md
@@ -44,15 +44,6 @@ Relaticle is a self-hosted CRM with a production-grade MCP server. Connect any A
 - **Modern Tech Stack** - Laravel 12, Filament 5, PHP 8.4, 1,100+ automated tests
 - **Privacy-First** - Self-hosted, AGPL-3.0, your data stays on your server
 
-**vs Other CRMs:**
-
-| | Self-Hosted | Open Source | MCP Tools | Custom Fields | Per-Seat Pricing |
-|---|---|---|---|---|---|
-| **Relaticle** | Yes | AGPL-3.0 | 30 | 22 types | No |
-| **HubSpot** | No | No | 9 | Limited | Yes |
-| **Salesforce** | No | No | 0 | Yes (complex) | Yes |
-| **Attio** | No | No | 0 | Yes | Yes |
-
 # Requirements
 
 - PHP 8.4+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">The Open-Source CRM Built for AI Agents</h1>
 
 <p align="center">
-  <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/tests.yml?branch=main&style=for-the-badge&label=tests" alt="Tests"></a>
+  <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/deploy.yml?style=for-the-badge&label=tests" alt="Tests"></a>
   <a href="https://relaticle.com/docs/mcp"><img src="https://img.shields.io/badge/MCP_Tools-30-8A2BE2?style=for-the-badge" alt="30 MCP Tools"></a>
   <a href="https://laravel.com/docs/12.x"><img src="https://img.shields.io/badge/Laravel-12.x-FF2D20?style=for-the-badge&logo=laravel" alt="Laravel 12"></a>
   <a href="https://php.net"><img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4"></a>
@@ -43,15 +43,6 @@ Relaticle is a self-hosted CRM with a production-grade MCP server. Connect any A
 - **Multi-Team Isolation** - 5-layer authorization with team-scoped data and workspaces
 - **Modern Tech Stack** - Laravel 12, Filament 5, PHP 8.4, 1,100+ automated tests
 - **Privacy-First** - Self-hosted, AGPL-3.0, your data stays on your server
-
-**vs Other CRMs:**
-
-| | Self-Hosted | Open Source | MCP Tools | Custom Fields | Per-Seat Pricing |
-|---|---|---|---|---|---|
-| **Relaticle** | Yes | AGPL-3.0 | 30 | 22 types | No |
-| **HubSpot** | No | No | 9 | Limited | Yes |
-| **Salesforce** | No | No | 0 | Yes (complex) | Yes |
-| **Attio** | No | No | 0 | Yes | Yes |
 
 # Requirements
 

--- a/app/Actions/Jetstream/CancelTeamDeletion.php
+++ b/app/Actions/Jetstream/CancelTeamDeletion.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Jetstream;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\TeamDeletionCancelledNotification;
+use Illuminate\Auth\Access\AuthorizationException;
+
+final readonly class CancelTeamDeletion
+{
+    public function cancel(User $user, Team $team): void
+    {
+        throw_unless($user->ownsTeam($team), AuthorizationException::class);
+
+        $team->forceFill(['scheduled_deletion_at' => null])->save();
+
+        /** @var User $owner */
+        $owner = $team->owner;
+
+        $owner->notify(new TeamDeletionCancelledNotification($team));
+    }
+}

--- a/app/Actions/Jetstream/CancelUserDeletion.php
+++ b/app/Actions/Jetstream/CancelUserDeletion.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Jetstream;
+
+use App\Models\User;
+use App\Notifications\UserDeletionCancelledNotification;
+use Illuminate\Support\Facades\DB;
+
+final readonly class CancelUserDeletion
+{
+    public function cancel(User $user): void
+    {
+        DB::transaction(function () use ($user): void {
+            $user->forceFill(['scheduled_deletion_at' => null])->save();
+
+            $user->ownedTeams()
+                ->where('personal_team', true)
+                ->update(['scheduled_deletion_at' => null]);
+        });
+
+        $user->notify(new UserDeletionCancelledNotification($user));
+    }
+}

--- a/app/Actions/Jetstream/RemoveTeamMember.php
+++ b/app/Actions/Jetstream/RemoveTeamMember.php
@@ -6,6 +6,7 @@ namespace App\Actions\Jetstream;
 
 use App\Models\Team;
 use App\Models\User;
+use App\Notifications\TeamMemberRemovedNotification;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\ValidationException;
@@ -26,6 +27,8 @@ final readonly class RemoveTeamMember implements RemovesTeamMembers
         $team->removeUser($teamMember);
 
         event(new TeamMemberRemoved($team, $teamMember));
+
+        $teamMember->notify(new TeamMemberRemovedNotification($team));
     }
 
     /**

--- a/app/Actions/Jetstream/ScheduleTeamDeletion.php
+++ b/app/Actions/Jetstream/ScheduleTeamDeletion.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Jetstream;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\TeamDeletionScheduledNotification;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+final readonly class ScheduleTeamDeletion
+{
+    public function schedule(User $user, Team $team): void
+    {
+        throw_unless($user->ownsTeam($team), AuthorizationException::class);
+
+        if ($team->isPersonalTeam()) {
+            throw ValidationException::withMessages([
+                'team' => ['Personal teams cannot be deleted directly.'],
+            ]);
+        }
+
+        DB::transaction(function () use ($team): void {
+            $team->forceFill(['scheduled_deletion_at' => now()->addDays(config('relaticle.deletion.grace_period_days'))])->save();
+
+            $team->teamInvitations()->delete();
+        });
+
+        /** @var User $owner */
+        $owner = $team->owner;
+
+        $owner->notify(new TeamDeletionScheduledNotification($team));
+    }
+}

--- a/app/Actions/Jetstream/ScheduleUserDeletion.php
+++ b/app/Actions/Jetstream/ScheduleUserDeletion.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Jetstream;
+
+use App\Models\User;
+use App\Notifications\UserDeletionScheduledNotification;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+final readonly class ScheduleUserDeletion
+{
+    public function schedule(User $user): void
+    {
+        $this->ensureUserCanBeDeleted($user);
+
+        DB::transaction(function () use ($user): void {
+            $deletionDate = now()->addDays(config('relaticle.deletion.grace_period_days'));
+
+            $user->forceFill(['scheduled_deletion_at' => $deletionDate])->save();
+
+            $user->ownedTeams()
+                ->where('personal_team', true)
+                ->update(['scheduled_deletion_at' => $deletionDate]);
+        });
+
+        $user->notify(new UserDeletionScheduledNotification($user));
+    }
+
+    private function ensureUserCanBeDeleted(User $user): void
+    {
+        $teamsWithMembers = $user->ownedTeams()
+            ->where('personal_team', false)
+            ->whereHas('users')
+            ->pluck('name');
+
+        if ($teamsWithMembers->isNotEmpty()) {
+            throw ValidationException::withMessages([
+                'team' => ["Transfer ownership of these teams before deleting your account: {$teamsWithMembers->implode(', ')}"],
+            ]);
+        }
+    }
+}

--- a/app/Console/Commands/PurgeScheduledDeletionsCommand.php
+++ b/app/Console/Commands/PurgeScheduledDeletionsCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\TeamDeletionReminderNotification;
+use App\Notifications\UserDeletionReminderNotification;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Laravel\Jetstream\Contracts\DeletesTeams;
+use Laravel\Jetstream\Contracts\DeletesUsers;
+
+final class PurgeScheduledDeletionsCommand extends Command
+{
+    protected $signature = 'app:purge-scheduled-deletions';
+
+    protected $description = 'Permanently delete users and teams past their scheduled deletion date, and send reminders ahead of purge';
+
+    public function handle(DeletesUsers $deletesUsers, DeletesTeams $deletesTeams): int
+    {
+        $this->purgeExpiredUsers($deletesUsers);
+        $this->purgeExpiredTeams($deletesTeams);
+        $this->sendReminders();
+
+        return self::SUCCESS;
+    }
+
+    private function purgeExpiredUsers(DeletesUsers $deletesUsers): void
+    {
+        $count = 0;
+
+        User::query()
+            ->expiredDeletion()
+            ->chunkById(100, function (Collection $users) use ($deletesUsers, &$count): void {
+                $users->each(function (User $user) use ($deletesUsers, &$count): void {
+                    DB::transaction(fn () => $deletesUsers->delete($user));
+
+                    Log::info('Purged user account', ['user_id' => $user->id, 'email' => $user->email]);
+                    $this->info("Purged user: {$user->email}");
+                    $count++;
+                });
+            });
+
+        $this->info("Purged {$count} user(s).");
+    }
+
+    private function purgeExpiredTeams(DeletesTeams $deletesTeams): void
+    {
+        $count = 0;
+
+        Team::query()
+            ->expiredDeletion()
+            ->chunkById(100, function (Collection $teams) use ($deletesTeams, &$count): void {
+                $teams->each(function (Team $team) use ($deletesTeams, &$count): void {
+                    DB::transaction(fn () => $deletesTeams->delete($team));
+
+                    Log::info('Purged team', ['team_id' => $team->id, 'name' => $team->name]);
+                    $this->info("Purged team: {$team->name}");
+                    $count++;
+                });
+            });
+
+        $this->info("Purged {$count} team(s).");
+    }
+
+    private function sendReminders(): void
+    {
+        $reminderDays = config('relaticle.deletion.reminder_days_before');
+        $reminderDate = now()->addDays($reminderDays);
+        $reminderStart = $reminderDate->copy()->startOfDay();
+        $reminderEnd = $reminderDate->copy()->endOfDay();
+
+        User::query()
+            ->scheduledForDeletion()
+            ->whereBetween('scheduled_deletion_at', [$reminderStart, $reminderEnd])
+            ->chunkById(100, function (Collection $users): void {
+                $users->each(fn (User $user) => $user->notify(new UserDeletionReminderNotification($user)));
+            });
+
+        Team::query()
+            ->scheduledForDeletion()
+            ->whereBetween('scheduled_deletion_at', [$reminderStart, $reminderEnd])
+            ->with('owner')
+            ->chunkById(100, function (Collection $teams): void {
+                $teams->each(function (Team $team): void {
+                    /** @var User $owner */
+                    $owner = $team->owner;
+
+                    $owner->notify(new TeamDeletionReminderNotification($team));
+                });
+            });
+    }
+}

--- a/app/Features/Documentation.php
+++ b/app/Features/Documentation.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Features;
+
+final readonly class Documentation
+{
+    public function resolve(): bool
+    {
+        return (bool) config('relaticle.features.documentation', true);
+    }
+}

--- a/app/Features/OnboardSeed.php
+++ b/app/Features/OnboardSeed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Features;
+
+final readonly class OnboardSeed
+{
+    public function resolve(): bool
+    {
+        return (bool) config('relaticle.features.onboard_seed', true);
+    }
+}

--- a/app/Features/SocialAuth.php
+++ b/app/Features/SocialAuth.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Features;
+
+final readonly class SocialAuth
+{
+    public function resolve(): bool
+    {
+        return (bool) config('relaticle.features.social_auth', true);
+    }
+}

--- a/app/Http/Controllers/AcceptTeamInvitationController.php
+++ b/app/Http/Controllers/AcceptTeamInvitationController.php
@@ -27,14 +27,19 @@ final readonly class AcceptTeamInvitationController
             return view('teams.invitation-expired');
         }
 
-        if ($request->user()->email !== $invitation->email) {
+        /** @var User $user */
+        $user = $request->user();
+
+        if ($user->email !== $invitation->email) {
             Log::warning('Invitation email mismatch', [
                 'invitation_id' => $invitation->id,
-                'user_id' => $request->user()->id,
+                'user_id' => $user->id,
             ]);
 
             abort(403, __('This invitation was sent to a different email address.'));
         }
+
+        abort_if($user->isScheduledForDeletion(), 403, __('You cannot accept team invitations while your account is scheduled for deletion.'));
 
         /** @var User $owner */
         $owner = $invitation->team->owner;
@@ -48,8 +53,6 @@ final readonly class AcceptTeamInvitationController
 
         $invitation->delete();
 
-        /** @var User $user */
-        $user = $request->user();
         $user->switchTeam($invitation->team);
 
         return redirect(config('fortify.home'))

--- a/app/Http/Middleware/CheckScheduledDeletion.php
+++ b/app/Http/Middleware/CheckScheduledDeletion.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final readonly class CheckScheduledDeletion
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if ($user?->isScheduledForDeletion() && ! $request->routeIs('*.scheduled-deletion', 'scheduled-deletion', 'logout', '*.auth.logout')) {
+            return to_route('filament.app.scheduled-deletion');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Listeners/CreateTeamCustomFields.php
+++ b/app/Listeners/CreateTeamCustomFields.php
@@ -9,6 +9,7 @@ use App\Enums\CustomFields\NoteField as NoteCustomField;
 use App\Enums\CustomFields\OpportunityField as OpportunityCustomField;
 use App\Enums\CustomFields\PeopleField as PeopleCustomField;
 use App\Enums\CustomFields\TaskField as TaskCustomField;
+use App\Features\OnboardSeed;
 use App\Models\Company;
 use App\Models\Note;
 use App\Models\Opportunity;
@@ -17,6 +18,7 @@ use App\Models\Task;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\DB;
 use Laravel\Jetstream\Events\TeamCreated;
+use Laravel\Pennant\Feature;
 use Relaticle\CustomFields\Contracts\CustomsFieldsMigrators;
 use Relaticle\CustomFields\Data\CustomFieldData;
 use Relaticle\CustomFields\Data\CustomFieldOptionSettingsData;
@@ -57,7 +59,7 @@ final readonly class CreateTeamCustomFields
             }
         });
 
-        if ($team->isPersonalTeam()) {
+        if ($team->isPersonalTeam() && Feature::active(OnboardSeed::class)) {
             $team->loadMissing('owner');
 
             /** @var Authenticatable $owner */

--- a/app/Livewire/App/Profile/DeleteAccount.php
+++ b/app/Livewire/App/Profile/DeleteAccount.php
@@ -4,19 +4,16 @@ declare(strict_types=1);
 
 namespace App\Livewire\App\Profile;
 
-use App\Actions\Jetstream\DeleteTeam;
+use App\Actions\Jetstream\ScheduleUserDeletion;
 use App\Livewire\BaseLivewireComponent;
-use App\Models\Team;
 use Filament\Actions\Action;
 use Filament\Forms;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
@@ -60,7 +57,7 @@ final class DeleteAccount extends BaseLivewireComponent
     }
 
     /**
-     * Delete the current user.
+     * Schedule deletion for the current user.
      *
      * @throws ValidationException
      */
@@ -74,26 +71,9 @@ final class DeleteAccount extends BaseLivewireComponent
             ]);
         }
 
-        // Logout before deleting to prevent SessionGuard::logout() from
-        // re-inserting the user when it updates the remember token.
+        resolve(ScheduleUserDeletion::class)->schedule($user);
+
         filament()->auth()->logout();
-
-        DB::transaction(function () use ($user): void {
-            if (config('jetstream.features.teams', false)) {
-                $user->teams()->detach();
-
-                /** @var Collection<int, Team> $ownedTeams */
-                $ownedTeams = $user->ownedTeams;
-                $ownedTeams->each(function (Team $team): void {
-                    resolve(DeleteTeam::class)->delete($team);
-                });
-            }
-
-            $user->deleteProfilePhoto();
-            $user->tokens->each->delete();
-
-            $user->delete();
-        });
 
         return redirect(filament()->getLoginUrl());
     }

--- a/app/Livewire/App/Profile/ScheduledDeletionInterstitial.php
+++ b/app/Livewire/App/Profile/ScheduledDeletionInterstitial.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\App\Profile;
+
+use App\Actions\Jetstream\CancelUserDeletion;
+use App\Livewire\BaseLivewireComponent;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
+use Illuminate\View\View;
+use Livewire\Attributes\Layout;
+
+#[Layout('layouts.filament-standalone')]
+final class ScheduledDeletionInterstitial extends BaseLivewireComponent
+{
+    public function mount(): Redirector|RedirectResponse|null
+    {
+        $user = auth()->user();
+
+        if (! $user instanceof User || ! $user->isScheduledForDeletion()) {
+            $tenant = Filament::getTenant() ?? ($user instanceof User ? $user->currentTeam : null);
+
+            if ($tenant) {
+                Filament::setTenant($tenant);
+
+                return redirect(Filament::getHomeUrl());
+            }
+
+            return redirect(Filament::getLoginUrl());
+        }
+
+        return null;
+    }
+
+    public function cancelDeletion(): Redirector|RedirectResponse
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        resolve(CancelUserDeletion::class)->cancel($user);
+
+        $this->sendNotification('Account deletion cancelled');
+
+        $tenant = Filament::getTenant() ?? $user->currentTeam;
+
+        if ($tenant) {
+            Filament::setTenant($tenant);
+
+            return redirect(Filament::getHomeUrl());
+        }
+
+        return redirect(Filament::getLoginUrl());
+    }
+
+    public function logout(): Redirector|RedirectResponse
+    {
+        filament()->auth()->logout();
+
+        return redirect(Filament::getLoginUrl());
+    }
+
+    public function cancelDeletionAction(): Action
+    {
+        return Action::make('cancelDeletion')
+            ->label('Keep my account')
+            ->color('primary')
+            ->extraAttributes(['class' => 'w-full justify-center'])
+            ->requiresConfirmation()
+            ->modalHeading('Keep your account?')
+            ->modalDescription('Your scheduled deletion will be cancelled and all your data will be preserved.')
+            ->modalSubmitActionLabel('Yes, keep my account')
+            ->action(fn (): Redirector|RedirectResponse => $this->cancelDeletion());
+    }
+
+    public function logoutAction(): Action
+    {
+        return Action::make('logout')
+            ->label('Sign out')
+            ->color('gray')
+            ->link()
+            ->action(fn (): Redirector|RedirectResponse => $this->logout());
+    }
+
+    public function render(): View
+    {
+        return view('livewire.app.profile.scheduled-deletion-interstitial');
+    }
+}

--- a/app/Livewire/App/Teams/DeleteTeam.php
+++ b/app/Livewire/App/Teams/DeleteTeam.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace App\Livewire\App\Teams;
 
-use App\Actions\Jetstream\DeleteTeam as DeleteTeamAction;
+use App\Actions\Jetstream\CancelTeamDeletion;
+use App\Actions\Jetstream\ScheduleTeamDeletion;
 use App\Livewire\BaseLivewireComponent;
 use App\Models\Team;
 use Filament\Actions\Action;
-use Filament\Facades\Filament;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 
 final class DeleteTeam extends BaseLivewireComponent
@@ -37,9 +38,11 @@ final class DeleteTeam extends BaseLivewireComponent
                     ->schema([
                         TextEntry::make('notice')
                             ->hiddenLabel()
-                            ->state(__('teams.sections.delete_team.notice')),
+                            ->state(fn (): string => $this->team->isScheduledForDeletion()
+                                ? __('teams.sections.delete_team.scheduled_notice', ['date' => $this->team->scheduled_deletion_at->format('F j, Y')])
+                                : __('teams.sections.delete_team.notice')),
                         Actions::make([
-                            Action::make('deleteAccountAction')
+                            Action::make('scheduleTeamDeletionAction')
                                 ->label(__('teams.actions.delete_team'))
                                 ->color('danger')
                                 ->requiresConfirmation()
@@ -47,7 +50,16 @@ final class DeleteTeam extends BaseLivewireComponent
                                 ->modalDescription(__('teams.modals.delete_team.notice'))
                                 ->modalSubmitActionLabel(__('teams.actions.delete_team'))
                                 ->modalCancelAction(false)
+                                ->visible(fn (): bool => ! $this->team->isScheduledForDeletion())
                                 ->action(fn () => $this->deleteTeam($this->team)),
+                            Action::make('cancelDeletionAction')
+                                ->label(__('teams.actions.cancel_deletion'))
+                                ->color('gray')
+                                ->requiresConfirmation()
+                                ->modalHeading(__('teams.modals.cancel_deletion.heading'))
+                                ->modalDescription(__('teams.modals.cancel_deletion.notice'))
+                                ->visible(fn (): bool => $this->team->isScheduledForDeletion())
+                                ->action(fn () => $this->cancelTeamDeletion($this->team)),
                         ]),
                     ]),
             ]);
@@ -60,12 +72,31 @@ final class DeleteTeam extends BaseLivewireComponent
 
     public function deleteTeam(Team $team): void
     {
-        resolve(DeleteTeamAction::class)->delete($team);
+        try {
+            resolve(ScheduleTeamDeletion::class)->schedule($this->authUser(), $team);
 
-        Filament::setTenant(Auth::guard('web')->user()->personalTeam());
+            $this->sendNotification("Team scheduled for deletion on {$team->refresh()->scheduled_deletion_at->format('F j, Y')}");
+        } catch (AuthorizationException) {
+            $this->sendNotification(
+                __('teams.notifications.permission_denied.cannot_delete_team'),
+                type: 'danger'
+            );
+        } catch (ValidationException $e) {
+            $this->addError('team', $e->validator->errors()->first());
+        }
+    }
 
-        $this->sendNotification(__('teams.notifications.team_deleted.success'));
+    public function cancelTeamDeletion(Team $team): void
+    {
+        try {
+            resolve(CancelTeamDeletion::class)->cancel($this->authUser(), $team);
 
-        redirect()->to(Filament::getCurrentPanel()?->getHomeUrl());
+            $this->sendNotification('Team deletion cancelled');
+        } catch (AuthorizationException) {
+            $this->sendNotification(
+                __('teams.notifications.permission_denied.cannot_cancel_team_deletion'),
+                type: 'danger'
+            );
+        }
     }
 }

--- a/app/Models/Concerns/HasCreator.php
+++ b/app/Models/Concerns/HasCreator.php
@@ -38,7 +38,7 @@ trait HasCreator
         return Attribute::make(
             get: fn (): string => $this->creation_source === CreationSource::SYSTEM ?
                 '⊙ System' :
-                $this->creator->name ?? 'Unknown',
+                $this->creator?->name ?? 'Former Member', // @phpstan-ignore nullsafe.neverNull (creator_id can reference a deleted user)
         );
     }
 }

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -7,9 +7,12 @@ namespace App\Models;
 use App\Services\AvatarService;
 use Database\Factories\TeamFactory;
 use Filament\Models\Contracts\HasAvatar;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamDeleted;
@@ -21,6 +24,7 @@ use Spatie\Sluggable\SlugOptions;
 /**
  * @property string $name
  * @property string $slug
+ * @property Carbon|null $scheduled_deletion_at
  */
 final class Team extends JetstreamTeam implements HasAvatar
 {
@@ -57,7 +61,7 @@ final class Team extends JetstreamTeam implements HasAvatar
 
         // App routes
         'companies', 'people', 'tasks', 'opportunities', 'notes',
-        'api-tokens', 'import-history', 'profile',
+        'api-tokens', 'import-history', 'profile', 'scheduled-deletion',
         'opportunities-board', 'tasks-board',
 
         // Content & info pages
@@ -120,6 +124,7 @@ final class Team extends JetstreamTeam implements HasAvatar
     {
         return [
             'personal_team' => 'boolean',
+            'scheduled_deletion_at' => 'datetime',
         ];
     }
 
@@ -159,6 +164,32 @@ final class Team extends JetstreamTeam implements HasAvatar
     public function isPersonalTeam(): bool
     {
         return $this->personal_team;
+    }
+
+    public function isScheduledForDeletion(): bool
+    {
+        return $this->scheduled_deletion_at !== null;
+    }
+
+    /**
+     * @param  Builder<Team>  $query
+     * @return Builder<Team>
+     */
+    #[Scope]
+    protected function scheduledForDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at');
+    }
+
+    /**
+     * @param  Builder<Team>  $query
+     * @return Builder<Team>
+     */
+    #[Scope]
+    protected function expiredDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at')
+            ->where('scheduled_deletion_at', '<=', now());
     }
 
     public function getFilamentAvatarUrl(): string

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -7,9 +7,12 @@ namespace App\Models;
 use App\Services\AvatarService;
 use Database\Factories\TeamFactory;
 use Filament\Models\Contracts\HasAvatar;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamDeleted;
@@ -23,6 +26,7 @@ use Spatie\Sluggable\SlugOptions;
  * @property string $name
  * @property string $slug
  * @property EmailPrivacyTier|null $default_email_sharing_tier
+ * @property Carbon|null $scheduled_deletion_at
  */
 final class Team extends JetstreamTeam implements HasAvatar
 {
@@ -59,7 +63,7 @@ final class Team extends JetstreamTeam implements HasAvatar
 
         // App routes
         'companies', 'people', 'tasks', 'opportunities', 'notes',
-        'api-tokens', 'import-history', 'profile',
+        'api-tokens', 'import-history', 'profile', 'scheduled-deletion',
         'opportunities-board', 'tasks-board',
 
         // Content & info pages
@@ -127,6 +131,7 @@ final class Team extends JetstreamTeam implements HasAvatar
         return [
             'personal_team' => 'boolean',
             'default_email_sharing_tier' => EmailPrivacyTier::class,
+            'scheduled_deletion_at' => 'datetime',
         ];
     }
 
@@ -166,6 +171,32 @@ final class Team extends JetstreamTeam implements HasAvatar
     public function isPersonalTeam(): bool
     {
         return $this->personal_team;
+    }
+
+    public function isScheduledForDeletion(): bool
+    {
+        return $this->scheduled_deletion_at !== null;
+    }
+
+    /**
+     * @param  Builder<Team>  $query
+     * @return Builder<Team>
+     */
+    #[Scope]
+    protected function scheduledForDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at');
+    }
+
+    /**
+     * @param  Builder<Team>  $query
+     * @return Builder<Team>
+     */
+    #[Scope]
+    protected function expiredDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at')
+            ->where('scheduled_deletion_at', '<=', now());
     }
 
     public function getFilamentAvatarUrl(): string

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,8 @@ use Filament\Models\Contracts\HasDefaultTenant;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -34,6 +36,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read string $profile_photo_url
  * @property Carbon|null $email_verified_at
  * @property string|null $remember_token
+ * @property Carbon|null $scheduled_deletion_at
  * @property string|null $two_factor_recovery_codes
  * @property string|null $two_factor_secret
  * @property-read Team|null $currentTeam
@@ -93,6 +96,7 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'scheduled_deletion_at' => 'datetime',
         ];
     }
 
@@ -107,6 +111,32 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
     public function hasPassword(): bool
     {
         return $this->password !== null;
+    }
+
+    public function isScheduledForDeletion(): bool
+    {
+        return $this->scheduled_deletion_at !== null;
+    }
+
+    /**
+     * @param  Builder<User>  $query
+     * @return Builder<User>
+     */
+    #[Scope]
+    protected function scheduledForDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at');
+    }
+
+    /**
+     * @param  Builder<User>  $query
+     * @return Builder<User>
+     */
+    #[Scope]
+    protected function expiredDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at')
+            ->where('scheduled_deletion_at', '<=', now());
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -13,6 +13,8 @@ use Filament\Models\Contracts\HasDefaultTenant;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -35,6 +37,7 @@ use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
  * @property-read string $profile_photo_url
  * @property Carbon|null $email_verified_at
  * @property string|null $remember_token
+ * @property Carbon|null $scheduled_deletion_at
  * @property string|null $two_factor_recovery_codes
  * @property string|null $two_factor_secret
  * @property EmailPrivacyTier|null $default_email_sharing_tier
@@ -97,6 +100,7 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'default_email_sharing_tier' => EmailPrivacyTier::class,
+            'scheduled_deletion_at' => 'datetime',
         ];
     }
 
@@ -111,6 +115,32 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
     public function hasPassword(): bool
     {
         return $this->password !== null;
+    }
+
+    public function isScheduledForDeletion(): bool
+    {
+        return $this->scheduled_deletion_at !== null;
+    }
+
+    /**
+     * @param  Builder<User>  $query
+     * @return Builder<User>
+     */
+    #[Scope]
+    protected function scheduledForDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at');
+    }
+
+    /**
+     * @param  Builder<User>  $query
+     * @return Builder<User>
+     */
+    #[Scope]
+    protected function expiredDeletion(Builder $query): Builder
+    {
+        return $query->whereNotNull('scheduled_deletion_at')
+            ->where('scheduled_deletion_at', '<=', now());
     }
 
     /**

--- a/app/Notifications/TeamDeletionCancelledNotification.php
+++ b/app/Notifications/TeamDeletionCancelledNotification.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Team;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+final class TeamDeletionCancelledNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly Team $team,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("{$this->team->name} deletion has been cancelled")
+            ->line("The scheduled deletion of {$this->team->name} has been cancelled.")
+            ->line('The team and all its data are safe. No further action is needed.')
+            ->salutation('Thank you for using Relaticle.');
+    }
+}

--- a/app/Notifications/TeamDeletionReminderNotification.php
+++ b/app/Notifications/TeamDeletionReminderNotification.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Team;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
+
+final class TeamDeletionReminderNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly Team $team,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $days = (int) config('relaticle.deletion.reminder_days_before');
+
+        return (new MailMessage)
+            ->subject("{$this->team->name} will be deleted in {$days} ".Str::plural('day', $days))
+            ->line("{$this->team->name} is scheduled for permanent deletion on {$this->team->scheduled_deletion_at->format('F j, Y')}.")
+            ->line('This is your final reminder. All data will be permanently removed after this date.')
+            ->line('You can cancel the deletion from your team settings at any time before that date.')
+            ->salutation('Thank you for using Relaticle.');
+    }
+}

--- a/app/Notifications/TeamDeletionScheduledNotification.php
+++ b/app/Notifications/TeamDeletionScheduledNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Team;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+final class TeamDeletionScheduledNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly Team $team,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("{$this->team->name} is scheduled for deletion")
+            ->line("{$this->team->name} has been scheduled for deletion on {$this->team->scheduled_deletion_at->format('F j, Y')}.")
+            ->line('All team data, including contacts, companies, tasks, opportunities, and notes, will be permanently removed after this date.')
+            ->line('You can cancel the deletion from your team settings at any time before that date.')
+            ->salutation('Thank you for using Relaticle.');
+    }
+}

--- a/app/Notifications/TeamMemberRemovedNotification.php
+++ b/app/Notifications/TeamMemberRemovedNotification.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Team;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+final class TeamMemberRemovedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly Team $team,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject("You've been removed from {$this->team->name}")
+            ->line("You have been removed from the {$this->team->name} team.")
+            ->line('You will no longer have access to this team\'s data.')
+            ->salutation('Thank you for using Relaticle.');
+    }
+}

--- a/app/Notifications/UserDeletionCancelledNotification.php
+++ b/app/Notifications/UserDeletionCancelledNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+final class UserDeletionCancelledNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly User $user,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your account deletion has been cancelled')
+            ->greeting("Welcome back, {$this->user->name}!")
+            ->line('Your account deletion has been cancelled. Your account and data are safe.')
+            ->line('No further action is needed.')
+            ->salutation('Thank you for staying with Relaticle.');
+    }
+}

--- a/app/Notifications/UserDeletionReminderNotification.php
+++ b/app/Notifications/UserDeletionReminderNotification.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
+
+final class UserDeletionReminderNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly User $user,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $days = (int) config('relaticle.deletion.reminder_days_before');
+
+        return (new MailMessage)
+            ->subject("Final reminder: your account will be deleted in {$days} ".Str::plural('day', $days))
+            ->line("Your account is scheduled for permanent deletion on {$this->user->scheduled_deletion_at->format('F j, Y')}.")
+            ->line('This is your final reminder. All data will be permanently removed after this date.')
+            ->line('To cancel, log in to your account before the deletion date.')
+            ->salutation('Thank you for using Relaticle.');
+    }
+}

--- a/app/Notifications/UserDeletionScheduledNotification.php
+++ b/app/Notifications/UserDeletionScheduledNotification.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+final class UserDeletionScheduledNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly User $user,
+    ) {}
+
+    /** @return list<string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Your account is scheduled for deletion')
+            ->greeting("Hello {$this->user->name},")
+            ->line("Your account is scheduled for permanent deletion on {$this->user->scheduled_deletion_at->format('F j, Y')}.")
+            ->line('All your data will be permanently removed after this date.')
+            ->line('If you changed your mind, simply log in anytime before that date to cancel the deletion.')
+            ->salutation('Thank you for using Relaticle.');
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -13,7 +13,9 @@ use App\Filament\Pages\EditProfile;
 use App\Filament\Pages\EditTeam;
 use App\Filament\Resources\CompanyResource;
 use App\Http\Middleware\ApplyTenantScopes;
+use App\Http\Middleware\CheckScheduledDeletion;
 use App\Listeners\SwitchTeam;
+use App\Livewire\App\Profile\ScheduledDeletionInterstitial;
 use App\Models\Team;
 use Asmit\ResizedColumn\ResizedColumnPlugin;
 use Exception;
@@ -44,6 +46,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Laravel\Jetstream\Features;
 use Laravel\Pennant\Feature;
@@ -140,6 +143,11 @@ final class AppPanelProvider extends PanelProvider
                 AccessTokens::class,
             ])
             ->spa()
+            ->routes(function (): void {
+                Route::get('/scheduled-deletion', ScheduledDeletionInterstitial::class)
+                    ->middleware('auth')
+                    ->name('scheduled-deletion');
+            })
             ->breadcrumbs(false)
             ->sidebarCollapsibleOnDesktop()
             ->navigationGroups([
@@ -162,6 +170,7 @@ final class AppPanelProvider extends PanelProvider
             ->authPasswordBroker('users')
             ->authMiddleware([
                 Authenticate::class,
+                CheckScheduledDeletion::class,
             ])
             ->tenantMiddleware(
                 [

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers\Filament;
 
+use App\Features\SocialAuth;
 use App\Filament\Pages\AccessTokens;
 use App\Filament\Pages\Auth\Login;
 use App\Filament\Pages\Auth\Register;
@@ -45,6 +46,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Laravel\Jetstream\Features;
+use Laravel\Pennant\Feature;
 use Relaticle\CustomFields\CustomFieldsPlugin;
 use Relaticle\ImportWizard\Filament\Pages\ImportHistory;
 
@@ -175,15 +177,21 @@ final class AppPanelProvider extends PanelProvider
             ->renderHook(
                 PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
                 fn (): string => Blade::render('@env(\'local\')<x-login-link email="manuk.minasyan1@gmail.com" redirect-url="'.url()->getAppUrl().'" />@endenv'),
-            )
-            ->renderHook(
-                PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
-                fn (): View|Factory => view('filament.auth.social_login_buttons')
-            )
-            ->renderHook(
-                PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE,
-                fn (): View|Factory => view('filament.auth.social_login_buttons')
-            )
+            );
+
+        if (Feature::active(SocialAuth::class)) {
+            $panel
+                ->renderHook(
+                    PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
+                    fn (): View|Factory => view('filament.auth.social_login_buttons')
+                )
+                ->renderHook(
+                    PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE,
+                    fn (): View|Factory => view('filament.auth.social_login_buttons')
+                );
+        }
+
+        $panel
             ->renderHook(
                 PanelsRenderHook::HEAD_END,
                 fn (): View|Factory => view('filament.app.analytics')

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -8,6 +8,7 @@ use App\ActivityLog\AppEventPalette;
 use App\ActivityLog\AppEventRenderer;
 use App\ActivityLog\MeetingEventPalette;
 use App\ActivityLog\MeetingEventRenderer;
+use App\Features\SocialAuth;
 use App\Filament\Pages\AccessTokens;
 use App\Filament\Pages\Auth\Login;
 use App\Filament\Pages\Auth\Register;
@@ -17,7 +18,9 @@ use App\Filament\Pages\EditTeam;
 use App\Filament\Pages\EmailPrivacySettingsPage;
 use App\Filament\Resources\CompanyResource;
 use App\Http\Middleware\ApplyTenantScopes;
+use App\Http\Middleware\CheckScheduledDeletion;
 use App\Listeners\SwitchTeam;
+use App\Livewire\App\Profile\ScheduledDeletionInterstitial;
 use App\Models\Team;
 use Asmit\ResizedColumn\ResizedColumnPlugin;
 use Exception;
@@ -49,8 +52,10 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Laravel\Jetstream\Features;
+use Laravel\Pennant\Feature;
 use Relaticle\ActivityLog\Filament\ActivityLogPlugin;
 use Relaticle\CustomFields\CustomFieldsPlugin;
 use Relaticle\ImportWizard\Filament\Pages\ImportHistory;
@@ -156,6 +161,11 @@ final class AppPanelProvider extends PanelProvider
             ->spa()
             ->sidebarWidth('67')
             ->maxContentWidth(Width::Full)
+            ->routes(function (): void {
+                Route::get('/scheduled-deletion', ScheduledDeletionInterstitial::class)
+                    ->middleware('auth')
+                    ->name('scheduled-deletion');
+            })
             ->breadcrumbs(false)
             ->sidebarCollapsibleOnDesktop()
             ->navigationGroups([
@@ -181,6 +191,7 @@ final class AppPanelProvider extends PanelProvider
             ->authPasswordBroker('users')
             ->authMiddleware([
                 Authenticate::class,
+                CheckScheduledDeletion::class,
             ])
             ->tenantMiddleware(
                 [
@@ -205,15 +216,21 @@ final class AppPanelProvider extends PanelProvider
             ->renderHook(
                 PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
                 fn (): string => Blade::render('@env(\'local\')<x-login-link email="manuk.minasyan1@gmail.com" redirect-url="'.url()->getAppUrl().'" />@endenv'),
-            )
-            ->renderHook(
-                PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
-                fn (): View|Factory => view('filament.auth.social_login_buttons')
-            )
-            ->renderHook(
-                PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE,
-                fn (): View|Factory => view('filament.auth.social_login_buttons')
-            )
+            );
+
+        if (Feature::active(SocialAuth::class)) {
+            $panel
+                ->renderHook(
+                    PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
+                    fn (): View|Factory => view('filament.auth.social_login_buttons')
+                )
+                ->renderHook(
+                    PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE,
+                    fn (): View|Factory => view('filament.auth.social_login_buttons')
+                );
+        }
+
+        $panel
             ->renderHook(
                 PanelsRenderHook::HEAD_END,
                 fn (): View|Factory => view('filament.app.analytics')

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -75,6 +75,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('import:cleanup')->hourly();
         $schedule->command('queue:prune-batches --hours=24')->daily();
         $schedule->command('invitations:cleanup')->daily();
+        $schedule->command('app:purge-scheduled-deletions')->daily()->withoutOverlapping()->onOneServer();
 
         if (config('app.health_checks_enabled')) {
             $schedule->command(RunHealthChecksCommand::class)->everyMinute();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -80,6 +80,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('queue:prune-batches --hours=24')->daily();
         $schedule->command('invitations:cleanup')->daily();
         $schedule->command('activitylog:clean')->daily();
+        $schedule->command('app:purge-scheduled-deletions')->daily()->withoutOverlapping()->onOneServer();
 
         // TODO::Separate it in different command class
         $schedule->call(function (): void {

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.0",
+        "nunomaduro/pao": "^0.1",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-browser": "^4.3",
         "pestphp/pest-plugin-laravel": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "rector/rector": "^2.0",
-        "spatie/boost-spatie-guidelines": "^1.1",
+        "spatie/guidelines-skills": "dev-main",
         "spatie/pest-plugin-route-testing": "^1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "laravel/horizon": "^5.29",
         "laravel/jetstream": "^5.2",
         "laravel/mcp": "^0.6.2",
+        "laravel/pennant": "^1.23",
         "laravel/sanctum": "^4.0",
         "laravel/socialite": "^5.16",
         "laravel/tinker": "^2.9",
@@ -73,12 +74,13 @@
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.0",
+        "nunomaduro/pao": "^0.1",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-browser": "^4.3",
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-type-coverage": "^4.0",
         "rector/rector": "^2.0",
-        "spatie/boost-spatie-guidelines": "^1.1",
+        "spatie/guidelines-skills": "dev-main",
         "spatie/pest-plugin-route-testing": "^1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "laravel/horizon": "^5.29",
         "laravel/jetstream": "^5.2",
         "laravel/mcp": "^0.6.2",
+        "laravel/pennant": "^1.23",
         "laravel/sanctum": "^4.0",
         "laravel/socialite": "^5.16",
         "laravel/tinker": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d312f070a43df846f90bc9a44cec0d6",
+    "content-hash": "53fe1dabb25a39997cca446fcedb736a",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -5634,23 +5634,23 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.9.1",
+            "version": "v8.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935"
+                "reference": "b0d8ab95b29c3189aeeb902d81215231df4c1b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/b0d8ab95b29c3189aeeb902d81215231df4c1b64",
+                "reference": "b0d8ab95b29c3189aeeb902d81215231df4c1b64",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "^2.18.4",
                 "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.4.4 || ^8.0.4"
+                "symfony/console": "^7.4.8 || ^8.0.4"
             },
             "conflict": {
                 "laravel/framework": "<11.48.0 || >=14.0.0",
@@ -5658,12 +5658,12 @@
             },
             "require-dev": {
                 "brianium/paratest": "^7.8.5",
-                "larastan/larastan": "^3.9.2",
-                "laravel/framework": "^11.48.0 || ^12.52.0",
-                "laravel/pint": "^1.27.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.9.0",
-                "pestphp/pest": "^3.8.5 || ^4.4.1 || ^5.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0.3 || ^9.0.0"
+                "larastan/larastan": "^3.9.3",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.2.0",
+                "laravel/pint": "^1.29.0",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.0.0",
+                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.0.0"
             },
             "type": "library",
             "extra": {
@@ -5726,7 +5726,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-02-17T17:33:08+00:00"
+            "time": "2026-04-06T19:25:53+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -10962,16 +10962,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.7",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
                 "shasum": ""
             },
             "require": {
@@ -11036,7 +11036,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.7"
+                "source": "https://github.com/symfony/console/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -11056,7 +11056,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T14:06:20+00:00"
+            "time": "2026-03-30T13:54:39+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -13502,16 +13502,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.6",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4"
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
-                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
                 "shasum": ""
             },
             "require": {
@@ -13568,7 +13568,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.6"
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -13588,7 +13588,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T10:14:57+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/translation",
@@ -16682,6 +16682,104 @@
             "time": "2025-08-01T08:46:24+00:00"
         },
         {
+            "name": "nunomaduro/pao",
+            "version": "v0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/pao.git",
+                "reference": "4c5db4a762b1a99a91d6249892b356a1f0681a33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/pao/zipball/4c5db4a762b1a99a91d6249892b356a1f0681a33",
+                "reference": "4c5db4a762b1a99a91d6249892b356a1f0681a33",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^8.3",
+                "shipfastlabs/agent-detector": "^1.1.0"
+            },
+            "conflict": {
+                "laravel/framework": "<12.0",
+                "nunomaduro/collision": "<8.9.2",
+                "pestphp/pest": "<4.4.3 || >=6.0",
+                "phpunit/phpunit": "<12.5.14 || >=13.0.0 <13.0.5 || >=14.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.20.0",
+                "laravel/pint": "^1.29.0",
+                "orchestra/testbench": "^10.11.0 || ^11.0.0",
+                "pestphp/pest": "^4.4.3 || ^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.3 || ^5.0.0",
+                "phpstan/phpstan": "^2.1.46",
+                "rector/rector": "^2.4.1",
+                "symfony/process": "^7.4.5 || ^8.1.0",
+                "symfony/var-dumper": "^7.4.6 || ^8.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pao\\Drivers\\Pest\\Plugin"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Pao\\Laravel\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pao\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Agent-optimized output for PHP testing tools",
+            "keywords": [
+                "Agent",
+                "PHPStan",
+                "json",
+                "paratest",
+                "pest",
+                "php",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/pao/issues",
+                "source": "https://github.com/nunomaduro/pao/tree/v0.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-08T15:22:27+00:00"
+        },
+        {
             "name": "nunomaduro/pokio",
             "version": "v0.1.2",
             "source": {
@@ -19025,6 +19123,73 @@
                 }
             ],
             "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
+            "name": "shipfastlabs/agent-detector",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/shipfastlabs/agent-detector.git",
+                "reference": "eefb18b61968a59a0428a4f75bee2e21596fe949"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/shipfastlabs/agent-detector/zipball/eefb18b61968a59a0428a4f75bee2e21596fe949",
+                "reference": "eefb18b61968a59a0428a4f75bee2e21596fe949",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.24.0",
+                "pestphp/pest": "^3.8.5|^4.1.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0|^4.0.2",
+                "phpstan/phpstan": "^2.1.26",
+                "rector/rector": "^2.1.7",
+                "symfony/var-dumper": "^7.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pushpak Chahjed",
+                    "email": "pushpak1300@gmail.com"
+                }
+            ],
+            "description": "Detect if code is running in an AI agent or automated development environment",
+            "keywords": [
+                "Agent",
+                "ai",
+                "automation",
+                "claude",
+                "cursor",
+                "detection",
+                "devin",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/shipfastlabs/agent-detector/issues",
+                "source": "https://github.com/shipfastlabs/agent-detector/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/pushpak1300",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-11T22:59:30+00:00"
         },
         {
             "name": "spatie/boost-spatie-guidelines",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b242fceef183fbd3be4dbddec3d9ed25",
+    "content-hash": "1c86c5e64cb30e2d65114a04f883cac7",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -16278,16 +16278,16 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v2.4.0",
+            "version": "v2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "a09bebcff238ed92fd123e460b27bd58bed22520"
+                "reference": "841d52905728cfac9f93c778a1758e740ce9a367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/a09bebcff238ed92fd123e460b27bd58bed22520",
-                "reference": "a09bebcff238ed92fd123e460b27bd58bed22520",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/841d52905728cfac9f93c778a1758e740ce9a367",
+                "reference": "841d52905728cfac9f93c778a1758e740ce9a367",
                 "shasum": ""
             },
             "require": {
@@ -16340,7 +16340,7 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-03-23T16:01:08+00:00"
+            "time": "2026-04-10T15:59:10+00:00"
         },
         {
             "name": "laravel/pail",
@@ -19268,34 +19268,35 @@
             "time": "2026-03-11T22:59:30+00:00"
         },
         {
-            "name": "spatie/boost-spatie-guidelines",
-            "version": "1.1.0",
+            "name": "spatie/guidelines-skills",
+            "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spatie/boost-spatie-guidelines.git",
-                "reference": "1d15ddcd4077f7f7230fa9550fad16b6d78d0493"
+                "url": "https://github.com/spatie/guidelines-skills.git",
+                "reference": "0fb11f5cd3607db70a7c7503b8f437c8adeeeba5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/boost-spatie-guidelines/zipball/1d15ddcd4077f7f7230fa9550fad16b6d78d0493",
-                "reference": "1d15ddcd4077f7f7230fa9550fad16b6d78d0493",
+                "url": "https://api.github.com/repos/spatie/guidelines-skills/zipball/0fb11f5cd3607db70a7c7503b8f437c8adeeeba5",
+                "reference": "0fb11f5cd3607db70a7c7503b8f437c8adeeeba5",
                 "shasum": ""
             },
             "require": {
                 "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
                     "providers": [
-                        "Spatie\\BoostSpatieGuidelines\\BoostSpatieGuidelinesServiceProvider"
+                        "Spatie\\Guidelines\\GuidelinesServiceProvider"
                     ]
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Spatie\\BoostSpatieGuidelines\\": "src"
+                    "Spatie\\Guidelines\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -19310,20 +19311,22 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Spatie's Laravel & PHP coding guidelines for Laravel Boost",
-            "homepage": "https://github.com/spatie/boost-spatie-guidelines",
+            "description": "Spatie's coding guidelines as AI skills for Laravel Boost and skills.sh",
+            "homepage": "https://github.com/spatie/guidelines-skills",
             "keywords": [
+                "ai",
                 "boost",
                 "coding-standards",
                 "guidelines",
                 "laravel",
+                "skills",
                 "spatie"
             ],
             "support": {
-                "issues": "https://github.com/spatie/boost-spatie-guidelines/issues",
-                "source": "https://github.com/spatie/boost-spatie-guidelines/tree/1.1.0"
+                "issues": "https://github.com/spatie/guidelines-skills/issues",
+                "source": "https://github.com/spatie/guidelines-skills/tree/main"
             },
-            "time": "2026-03-06T08:25:49+00:00"
+            "time": "2026-03-16T14:11:29+00:00"
         },
         {
             "name": "spatie/pest-plugin-route-testing",
@@ -19626,7 +19629,9 @@
     ],
     "aliases": [],
     "minimum-stability": "beta",
-    "stability-flags": {},
+    "stability-flags": {
+        "spatie/guidelines-skills": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f9fbebfe57781972cd9dba2f995da3b",
+    "content-hash": "8513bfe4cba6bee9ce9db99799758faa",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -2063,12 +2063,12 @@
             "version": "v7.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
+                "url": "https://github.com/googleapis/php-jwt.git",
                 "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
                 "reference": "28aa0694bcfdfa5e2959c394d5a1ee7a5083629e",
                 "shasum": ""
             },
@@ -3641,6 +3641,82 @@
                 "source": "https://github.com/laravel/mcp"
             },
             "time": "2026-03-19T12:37:13+00:00"
+        },
+        {
+            "name": "laravel/pennant",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pennant.git",
+                "reference": "d3d531d0ba640f9d0bd3580990fb205244e956ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pennant/zipball/d3d531d0ba640f9d0bd3580990fb205244e956ca",
+                "reference": "d3d531d0ba640f9d0bd3580990fb205244e956ca",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/container": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/finder": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "laravel/octane": "^1.4|^2.0",
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Feature": "Laravel\\Pennant\\Feature"
+                    },
+                    "providers": [
+                        "Laravel\\Pennant\\PennantServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Pennant\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "A simple, lightweight library for managing feature flags.",
+            "homepage": "https://github.com/laravel/pennant",
+            "keywords": [
+                "feature",
+                "flags",
+                "laravel",
+                "pennant"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pennant/issues",
+                "source": "https://github.com/laravel/pennant"
+            },
+            "time": "2026-03-19T02:27:39+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -5813,23 +5889,23 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.9.1",
+            "version": "v8.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935"
+                "reference": "b0d8ab95b29c3189aeeb902d81215231df4c1b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/b0d8ab95b29c3189aeeb902d81215231df4c1b64",
+                "reference": "b0d8ab95b29c3189aeeb902d81215231df4c1b64",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "^2.18.4",
                 "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.4.4 || ^8.0.4"
+                "symfony/console": "^7.4.8 || ^8.0.4"
             },
             "conflict": {
                 "laravel/framework": "<11.48.0 || >=14.0.0",
@@ -5837,12 +5913,12 @@
             },
             "require-dev": {
                 "brianium/paratest": "^7.8.5",
-                "larastan/larastan": "^3.9.2",
-                "laravel/framework": "^11.48.0 || ^12.52.0",
-                "laravel/pint": "^1.27.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.9.0",
-                "pestphp/pest": "^3.8.5 || ^4.4.1 || ^5.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0.3 || ^9.0.0"
+                "larastan/larastan": "^3.9.3",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.2.0",
+                "laravel/pint": "^1.29.0",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.0.0",
+                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.0.0"
             },
             "type": "library",
             "extra": {
@@ -5905,7 +5981,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-02-17T17:33:08+00:00"
+            "time": "2026-04-06T19:25:53+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -6658,16 +6734,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.50",
+            "version": "3.0.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
+                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
-                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
+                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
                 "shasum": ""
             },
             "require": {
@@ -6748,7 +6824,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
             },
             "funding": [
                 {
@@ -6764,7 +6840,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T02:57:58+00:00"
+            "time": "2026-04-10T01:33:53+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -16732,16 +16808,16 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v2.4.0",
+            "version": "v2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "a09bebcff238ed92fd123e460b27bd58bed22520"
+                "reference": "841d52905728cfac9f93c778a1758e740ce9a367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/a09bebcff238ed92fd123e460b27bd58bed22520",
-                "reference": "a09bebcff238ed92fd123e460b27bd58bed22520",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/841d52905728cfac9f93c778a1758e740ce9a367",
+                "reference": "841d52905728cfac9f93c778a1758e740ce9a367",
                 "shasum": ""
             },
             "require": {
@@ -16794,7 +16870,7 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-03-23T16:01:08+00:00"
+            "time": "2026-04-10T15:59:10+00:00"
         },
         {
             "name": "laravel/pail",
@@ -17210,6 +17286,104 @@
                 }
             ],
             "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nunomaduro/pao",
+            "version": "v0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/pao.git",
+                "reference": "4c5db4a762b1a99a91d6249892b356a1f0681a33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/pao/zipball/4c5db4a762b1a99a91d6249892b356a1f0681a33",
+                "reference": "4c5db4a762b1a99a91d6249892b356a1f0681a33",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^8.3",
+                "shipfastlabs/agent-detector": "^1.1.0"
+            },
+            "conflict": {
+                "laravel/framework": "<12.0",
+                "nunomaduro/collision": "<8.9.2",
+                "pestphp/pest": "<4.4.3 || >=6.0",
+                "phpunit/phpunit": "<12.5.14 || >=13.0.0 <13.0.5 || >=14.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.20.0",
+                "laravel/pint": "^1.29.0",
+                "orchestra/testbench": "^10.11.0 || ^11.0.0",
+                "pestphp/pest": "^4.4.3 || ^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.3 || ^5.0.0",
+                "phpstan/phpstan": "^2.1.46",
+                "rector/rector": "^2.4.1",
+                "symfony/process": "^7.4.5 || ^8.1.0",
+                "symfony/var-dumper": "^7.4.6 || ^8.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pao\\Drivers\\Pest\\Plugin"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Pao\\Laravel\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pao\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Agent-optimized output for PHP testing tools",
+            "keywords": [
+                "Agent",
+                "PHPStan",
+                "json",
+                "paratest",
+                "pest",
+                "php",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/pao/issues",
+                "source": "https://github.com/nunomaduro/pao/tree/v0.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-04-08T15:22:27+00:00"
         },
         {
             "name": "nunomaduro/pokio",
@@ -19557,34 +19731,102 @@
             "time": "2025-02-07T05:00:38+00:00"
         },
         {
-            "name": "spatie/boost-spatie-guidelines",
-            "version": "1.1.0",
+            "name": "shipfastlabs/agent-detector",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spatie/boost-spatie-guidelines.git",
-                "reference": "1d15ddcd4077f7f7230fa9550fad16b6d78d0493"
+                "url": "https://github.com/shipfastlabs/agent-detector.git",
+                "reference": "eefb18b61968a59a0428a4f75bee2e21596fe949"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/boost-spatie-guidelines/zipball/1d15ddcd4077f7f7230fa9550fad16b6d78d0493",
-                "reference": "1d15ddcd4077f7f7230fa9550fad16b6d78d0493",
+                "url": "https://api.github.com/repos/shipfastlabs/agent-detector/zipball/eefb18b61968a59a0428a4f75bee2e21596fe949",
+                "reference": "eefb18b61968a59a0428a4f75bee2e21596fe949",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.24.0",
+                "pestphp/pest": "^3.8.5|^4.1.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0|^4.0.2",
+                "phpstan/phpstan": "^2.1.26",
+                "rector/rector": "^2.1.7",
+                "symfony/var-dumper": "^7.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pushpak Chahjed",
+                    "email": "pushpak1300@gmail.com"
+                }
+            ],
+            "description": "Detect if code is running in an AI agent or automated development environment",
+            "keywords": [
+                "Agent",
+                "ai",
+                "automation",
+                "claude",
+                "cursor",
+                "detection",
+                "devin",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/shipfastlabs/agent-detector/issues",
+                "source": "https://github.com/shipfastlabs/agent-detector/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/pushpak1300",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-11T22:59:30+00:00"
+        },
+        {
+            "name": "spatie/guidelines-skills",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/guidelines-skills.git",
+                "reference": "0fb11f5cd3607db70a7c7503b8f437c8adeeeba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/guidelines-skills/zipball/0fb11f5cd3607db70a7c7503b8f437c8adeeeba5",
+                "reference": "0fb11f5cd3607db70a7c7503b8f437c8adeeeba5",
                 "shasum": ""
             },
             "require": {
                 "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "php": "^8.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
                     "providers": [
-                        "Spatie\\BoostSpatieGuidelines\\BoostSpatieGuidelinesServiceProvider"
+                        "Spatie\\Guidelines\\GuidelinesServiceProvider"
                     ]
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Spatie\\BoostSpatieGuidelines\\": "src"
+                    "Spatie\\Guidelines\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -19599,20 +19841,22 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Spatie's Laravel & PHP coding guidelines for Laravel Boost",
-            "homepage": "https://github.com/spatie/boost-spatie-guidelines",
+            "description": "Spatie's coding guidelines as AI skills for Laravel Boost and skills.sh",
+            "homepage": "https://github.com/spatie/guidelines-skills",
             "keywords": [
+                "ai",
                 "boost",
                 "coding-standards",
                 "guidelines",
                 "laravel",
+                "skills",
                 "spatie"
             ],
             "support": {
-                "issues": "https://github.com/spatie/boost-spatie-guidelines/issues",
-                "source": "https://github.com/spatie/boost-spatie-guidelines/tree/1.1.0"
+                "issues": "https://github.com/spatie/guidelines-skills/issues",
+                "source": "https://github.com/spatie/guidelines-skills/tree/main"
             },
-            "time": "2026-03-06T08:25:49+00:00"
+            "time": "2026-03-16T14:11:29+00:00"
         },
         {
             "name": "spatie/pest-plugin-route-testing",
@@ -19916,7 +20160,8 @@
     "aliases": [],
     "minimum-stability": "beta",
     "stability-flags": {
-        "relaticle/activity-log": 20
+        "relaticle/activity-log": 20,
+        "spatie/guidelines-skills": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -6479,16 +6479,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.50",
+            "version": "3.0.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
+                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
-                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
+                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
                 "shasum": ""
             },
             "require": {
@@ -6569,7 +6569,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
             },
             "funding": [
                 {
@@ -6585,7 +6585,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T02:57:58+00:00"
+            "time": "2026-04-10T01:33:53+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53fe1dabb25a39997cca446fcedb736a",
+    "content-hash": "b242fceef183fbd3be4dbddec3d9ed25",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -3462,6 +3462,82 @@
                 "source": "https://github.com/laravel/mcp"
             },
             "time": "2026-03-19T12:37:13+00:00"
+        },
+        {
+            "name": "laravel/pennant",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pennant.git",
+                "reference": "d3d531d0ba640f9d0bd3580990fb205244e956ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pennant/zipball/d3d531d0ba640f9d0bd3580990fb205244e956ca",
+                "reference": "d3d531d0ba640f9d0bd3580990fb205244e956ca",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/container": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/finder": "^6.0|^7.0|^8.0"
+            },
+            "require-dev": {
+                "laravel/octane": "^1.4|^2.0",
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Feature": "Laravel\\Pennant\\Feature"
+                    },
+                    "providers": [
+                        "Laravel\\Pennant\\PennantServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Pennant\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "A simple, lightweight library for managing feature flags.",
+            "homepage": "https://github.com/laravel/pennant",
+            "keywords": [
+                "feature",
+                "flags",
+                "laravel",
+                "pennant"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pennant/issues",
+                "source": "https://github.com/laravel/pennant"
+            },
+            "time": "2026-03-19T02:27:39+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/config/pennant.php
+++ b/config/pennant.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Pennant Store
+    |--------------------------------------------------------------------------
+    |
+    | Here you will specify the default store that Pennant should use when
+    | storing and resolving feature flag values. Pennant ships with the
+    | ability to store flag values in an in-memory array or database.
+    |
+    | Supported: "array", "database"
+    |
+    */
+
+    'default' => env('PENNANT_STORE', 'array'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pennant Stores
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure each of the stores that should be available to
+    | Pennant. These stores shall be used to store resolved feature flag
+    | values - you may configure as many as your application requires.
+    |
+    */
+
+    'stores' => [
+
+        'array' => [
+            'driver' => 'array',
+        ],
+
+        'database' => [
+            'driver' => 'database',
+            'connection' => null,
+            'table' => 'features',
+        ],
+
+    ],
+];

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -8,4 +8,26 @@ return [
         'email' => env('CONTACT_EMAIL', 'hello@relaticle.com'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Feature Flags
+    |--------------------------------------------------------------------------
+    |
+    | Toggle Relaticle features on or off. Useful for forks and custom
+    | deployments that want to disable specific functionality without
+    | modifying upstream code. All features are enabled by default.
+    |
+    */
+
+    'deletion' => [
+        'grace_period_days' => 30,
+        'reminder_days_before' => 5,
+    ],
+
+    'features' => [
+        'onboard_seed' => (bool) env('RELATICLE_FEATURE_ONBOARD_SEED', true),
+        'social_auth' => (bool) env('RELATICLE_FEATURE_SOCIAL_AUTH', true),
+        'documentation' => (bool) env('RELATICLE_FEATURE_DOCUMENTATION', true),
+    ],
+
 ];

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -8,4 +8,21 @@ return [
         'email' => env('CONTACT_EMAIL', 'hello@relaticle.com'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Feature Flags
+    |--------------------------------------------------------------------------
+    |
+    | Toggle Relaticle features on or off. Useful for forks and custom
+    | deployments that want to disable specific functionality without
+    | modifying upstream code. All features are enabled by default.
+    |
+    */
+
+    'features' => [
+        'onboard_seed' => (bool) env('RELATICLE_FEATURE_ONBOARD_SEED', true),
+        'social_auth' => (bool) env('RELATICLE_FEATURE_SOCIAL_AUTH', true),
+        'documentation' => (bool) env('RELATICLE_FEATURE_DOCUMENTATION', true),
+    ],
+
 ];

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -19,6 +19,11 @@ return [
     |
     */
 
+    'deletion' => [
+        'grace_period_days' => 30,
+        'reminder_days_before' => 5,
+    ],
+
     'features' => [
         'onboard_seed' => (bool) env('RELATICLE_FEATURE_ONBOARD_SEED', true),
         'social_auth' => (bool) env('RELATICLE_FEATURE_SOCIAL_AUTH', true),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -101,6 +101,13 @@ final class UserFactory extends Factory
         ]);
     }
 
+    public function scheduledForDeletion(int $daysFromNow = 30): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'scheduled_deletion_at' => now()->addDays($daysFromNow),
+        ]);
+    }
+
     public function configure(): Factory
     {
         return $this->sequence(fn (Sequence $sequence): array => [

--- a/database/migrations/2026_04_04_162500_add_scheduled_deletion_at_to_users_and_teams.php
+++ b/database/migrations/2026_04_04_162500_add_scheduled_deletion_at_to_users_and_teams.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->timestamp('scheduled_deletion_at')->nullable()->index()->after('remember_token');
+        });
+
+        Schema::table('teams', function (Blueprint $table): void {
+            $table->timestamp('scheduled_deletion_at')->nullable()->index()->after('personal_team');
+        });
+    }
+};

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -52,8 +52,8 @@ return [
         ],
         'delete_account' => [
             'title' => 'Delete Account',
-            'description' => 'Permanently delete your account.',
-            'notice' => 'Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.',
+            'description' => 'Schedule your account for deletion.',
+            'notice' => 'Deleting your account will schedule it for permanent removal after a 30-day grace period. You can cancel the deletion by logging back in at any time before that. After the grace period, all your data will be permanently deleted.',
         ],
     ],
 
@@ -74,8 +74,8 @@ return [
 
     'modals' => [
         'delete_account' => [
-            'notice' => 'Are you sure you want to delete your account? Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.',
-            'notice_no_password' => 'Are you sure you want to delete your account? Once your account is deleted, all of its resources and data will be permanently deleted.',
+            'notice' => 'This will schedule your account for deletion. You will have 30 days to cancel by logging back in. After that, all data will be permanently removed. Please enter your password to confirm.',
+            'notice_no_password' => 'This will schedule your account for deletion. You will have 30 days to cancel by logging back in. After that, all data will be permanently removed.',
         ],
         'log_out_other_browsers' => [
             'title' => 'Log Out Other Browser Sessions',

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -36,8 +36,9 @@ return [
         ],
         'delete_team' => [
             'title' => 'Delete Team',
-            'description' => 'Permanently delete this team.',
-            'notice' => 'Once a team is deleted, all of its resources and data will be permanently deleted. Before deleting this team, please download any data or information that you wish to retain.',
+            'description' => 'Schedule this team for deletion.',
+            'notice' => 'Deleting this team will schedule it for permanent removal after a 30-day grace period. You can cancel the deletion at any time before that. After the grace period, all resources and data will be permanently deleted.',
+            'scheduled_notice' => 'This team is scheduled for deletion on :date.',
         ],
     ],
 
@@ -52,6 +53,7 @@ return [
         'copy_invite_link' => 'Copy Link',
         'cancel_team_invitation' => 'Cancel',
         'delete_team' => 'Delete Team',
+        'cancel_deletion' => 'Cancel Deletion',
     ],
 
     'notifications' => [
@@ -83,6 +85,8 @@ return [
             'cannot_update_team_member' => 'You do not have permission to update this team member.',
             'cannot_leave_team' => 'You may not leave a team that you created.',
             'cannot_remove_team_member' => 'You do not have permission to remove this team member.',
+            'cannot_delete_team' => 'You do not have permission to delete this team.',
+            'cannot_cancel_team_deletion' => 'You do not have permission to cancel this team\'s deletion.',
         ],
     ],
 
@@ -95,7 +99,11 @@ return [
             'notice' => 'Are you sure you would like to leave this team?',
         ],
         'delete_team' => [
-            'notice' => 'Are you sure you want to delete this team? Once a team is deleted, all of its resources and data will be permanently deleted.',
+            'notice' => 'This will schedule the team for deletion. You will have 30 days to cancel before all data is permanently removed.',
+        ],
+        'cancel_deletion' => [
+            'heading' => 'Cancel team deletion?',
+            'notice' => 'The team and all its data will be preserved.',
         ],
     ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1140,6 +1140,64 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.8.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.1.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.8.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.1.0",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.1",
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
@@ -2156,9 +2214,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -2681,9 +2739,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.27.0",
@@ -2766,9 +2824,9 @@
             }
         },
         "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/packages/Documentation/resources/markdown/developer-guide.md
+++ b/packages/Documentation/resources/markdown/developer-guide.md
@@ -39,7 +39,7 @@ Visit `http://localhost:8000` to access the application.
 ```
 Team ─┬─ User (via Membership)
       ├─ Company ─┬─ People
-      │           └─ Opportunity ─── Contact (People)
+      │           └─ Opportunity ─── People
       ├─ Task (many-to-many with Company, People, Opportunity)
       └─ Note (many-to-many with Company, People, Opportunity)
 ```

--- a/packages/Documentation/resources/markdown/getting-started.md
+++ b/packages/Documentation/resources/markdown/getting-started.md
@@ -93,10 +93,14 @@ Every entity supports custom fields for tracking data specific to your business.
 3. Choose the entity type (Companies, People, etc.)
 4. Add, edit, or reorder fields
 
-**Field types available:**
-- Text, Number, Date, Email, URL
-- Select (dropdown), Multi-select
-- Boolean (yes/no)
+**22 field types available**, including:
+- Text, Textarea, Number, Date, Date & Time
+- Email, Phone, Link, Color Picker
+- Select, Multi-select, Radio, Checkbox, Checkbox List
+- Toggle, Toggle Buttons, Tags Input
+- Currency, Rich Editor, Markdown Editor
+- File Upload
+- Record (link to another entity)
 
 ---
 

--- a/packages/Documentation/resources/markdown/mcp-guide.md
+++ b/packages/Documentation/resources/markdown/mcp-guide.md
@@ -9,9 +9,11 @@ MCP (Model Context Protocol) lets AI assistants like Claude work directly with y
 With the Relaticle MCP server, your AI assistant can:
 
 - **List and search** companies, people, opportunities, tasks, and notes
+- **Get a single record** with full details and relationships
 - **Create new records** directly from a conversation
 - **Update existing records** -- rename a company, reassign a task
 - **Delete records** you no longer need
+- **Attach or detach** tasks and notes to companies, people, and opportunities
 - **Read entity schemas** to understand your custom fields
 - **Get a CRM overview** with record counts and recent activity
 
@@ -104,13 +106,20 @@ Add this to your VS Code settings (`.vscode/mcp.json`):
 
 ## Available Tools
 
-The server provides 30 tools across five CRM entities:
+The server provides 30 tools: one account tool plus full CRUD across five CRM entities, with link management for tasks and notes.
+
+### Account
+
+| Tool | Description |
+|------|-------------|
+| `whoami` | Get the authenticated user, current team, team members, and token abilities |
 
 ### Companies
 
 | Tool | Description |
 |------|-------------|
 | `list_companies` | List companies with optional search by name and pagination |
+| `get_company` | Get a single company by ID with full details and relationships |
 | `create_company` | Create a new company (requires `name`) |
 | `update_company` | Update a company by ID |
 | `delete_company` | Soft-delete a company by ID |
@@ -120,6 +129,7 @@ The server provides 30 tools across five CRM entities:
 | Tool | Description |
 |------|-------------|
 | `list_people` | List contacts with optional search, filter by company |
+| `get_people` | Get a single person by ID with full details and relationships |
 | `create_people` | Create a new contact (requires `name`, optional `company_id`) |
 | `update_people` | Update a contact by ID |
 | `delete_people` | Soft-delete a contact by ID |
@@ -129,6 +139,7 @@ The server provides 30 tools across five CRM entities:
 | Tool | Description |
 |------|-------------|
 | `list_opportunities` | List deals with optional search, filter by company |
+| `get_opportunity` | Get a single opportunity by ID with full details and relationships |
 | `create_opportunity` | Create a new deal (requires `name`, optional `company_id`, `contact_id`) |
 | `update_opportunity` | Update a deal by ID |
 | `delete_opportunity` | Soft-delete a deal by ID |
@@ -138,18 +149,24 @@ The server provides 30 tools across five CRM entities:
 | Tool | Description |
 |------|-------------|
 | `list_tasks` | List tasks with optional search by title |
+| `get_task` | Get a single task by ID with full details and relationships |
 | `create_task` | Create a new task (requires `title`) |
 | `update_task` | Update a task by ID |
 | `delete_task` | Soft-delete a task by ID |
+| `attach_task_to_entities` | Link a task to companies, people, opportunities, or assign users. Adds without removing existing links. |
+| `detach_task_from_entities` | Unlink a task from companies, people, opportunities, or unassign users |
 
 ### Notes
 
 | Tool | Description |
 |------|-------------|
 | `list_notes` | List notes with optional search by title |
+| `get_note` | Get a single note by ID with full details and relationships |
 | `create_note` | Create a new note (requires `title`) |
 | `update_note` | Update a note by ID |
 | `delete_note` | Soft-delete a note by ID |
+| `attach_note_to_entities` | Link a note to companies, people, or opportunities. Adds without removing existing links. |
+| `detach_note_from_entities` | Unlink a note from companies, people, or opportunities |
 
 All list tools support `search`, `per_page` (default 15), and `page` parameters. Create and update tools accept `custom_fields` as key-value pairs when your team has custom fields configured.
 

--- a/packages/Documentation/resources/markdown/self-hosting-guide.md
+++ b/packages/Documentation/resources/markdown/self-hosting-guide.md
@@ -115,6 +115,16 @@ These are pre-configured in `compose.yml` and generally don't need changing.
 | `SENTRY_LARAVEL_DSN` | Sentry DSN for error tracking. |
 | `FATHOM_ANALYTICS_SITE_ID` | Fathom Analytics site ID. |
 
+### Feature Flags
+
+Toggle features on or off. All are enabled by default. Useful for forks and custom deployments that want to disable specific functionality without modifying code.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RELATICLE_FEATURE_ONBOARD_SEED` | `true` | Seed demo data (sample companies, contacts, tasks) when a new team is created. Set to `false` to start with an empty workspace. |
+| `RELATICLE_FEATURE_SOCIAL_AUTH` | `true` | Enable Google and GitHub social login. Set to `false` to use only email/password authentication. |
+| `RELATICLE_FEATURE_DOCUMENTATION` | `true` | Enable the `/docs` documentation module. Set to `false` to remove documentation routes and navigation links. |
+
 ---
 
 ## Architecture

--- a/packages/Documentation/routes/web.php
+++ b/packages/Documentation/routes/web.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Relaticle\Documentation\Http\Controllers\DocumentationController;
 use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 
-Route::middleware(ProvideMarkdownResponse::class)->prefix('docs')->name('documentation.')->group(function (): void {
+Route::middleware([ProvideMarkdownResponse::class])->prefix('docs')->name('documentation.')->group(function (): void {
     Route::get('/', [DocumentationController::class, 'index'])->name('index');
     Route::get('/search', [DocumentationController::class, 'search'])->name('search');
     Route::get('/{type}', [DocumentationController::class, 'show'])->name('show');

--- a/packages/Documentation/src/DocumentationServiceProvider.php
+++ b/packages/Documentation/src/DocumentationServiceProvider.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Relaticle\Documentation;
 
+use App\Features\Documentation;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Pennant\Feature;
 use Relaticle\Documentation\Services\DocumentationService;
 
 final class DocumentationServiceProvider extends ServiceProvider
@@ -26,6 +28,10 @@ final class DocumentationServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        if (! Feature::active(Documentation::class)) {
+            return;
+        }
+
         $this->registerRoutes();
         $this->registerViews();
         $this->registerComponents();

--- a/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
@@ -44,7 +44,7 @@ final class TopTeamsTableWidget extends BaseWidget
                 TextColumn::make('owner.name')
                     ->label('Owner')
                     ->sortable()
-                    ->url(fn (Team $record): string => UserResource::getUrl('view', ['record' => $record->owner])),
+                    ->url(fn (Team $record): ?string => $record->owner ? UserResource::getUrl('view', ['record' => $record->owner]) : null),
 
                 TextColumn::make('members_count')
                     ->label('Members')

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -42,5 +42,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="PENNANT_STORE" value="array"/>
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,6 +32,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_DEBUG" value="false"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
@@ -42,5 +43,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="PENNANT_STORE" value="array"/>
     </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,6 +32,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_DEBUG" value="false"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/resources/views/components/layout/footer.blade.php
+++ b/resources/views/components/layout/footer.blade.php
@@ -48,12 +48,14 @@
                             Pricing
                         </a>
                     </li>
+                    @feature(App\Features\Documentation::class)
                     <li>
                         <a href="{{ route('documentation.index') }}"
                            class="text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 text-sm transition-colors">
                             Documentation
                         </a>
                     </li>
+                    @endfeature
                     <li>
                         <a href="{{ url('/#features') }}"
                            class="text-gray-500 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 text-sm transition-colors">

--- a/resources/views/components/layout/header.blade.php
+++ b/resources/views/components/layout/header.blade.php
@@ -20,10 +20,12 @@
                        class="px-4 py-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-[13px] font-medium transition-colors">
                         Pricing
                     </a>
+                    @feature(App\Features\Documentation::class)
                     <a href="{{ route('documentation.index') }}"
                        class="px-4 py-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-[13px] font-medium transition-colors">
                         Documentation
                     </a>
+                    @endfeature
                     <a href="{{ route('discord') }}" target="_blank"
                        class="px-4 py-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white text-[13px] font-medium transition-colors flex items-center gap-1.5">
                         <x-ri-discord-fill class="w-4 h-4"/>

--- a/resources/views/components/layout/mobile-menu.blade.php
+++ b/resources/views/components/layout/mobile-menu.blade.php
@@ -23,7 +23,6 @@
             @foreach([
                 ['url' => url('/#features'), 'label' => 'Features'],
                 ['url' => route('pricing'), 'label' => 'Pricing'],
-                ['url' => route('documentation.index'), 'label' => 'Docs'],
                 ['url' => route('contact'), 'label' => 'Contact'],
             ] as $link)
                 <a href="{{ $link['url'] }}" @click="mobileMenu = false"
@@ -31,6 +30,12 @@
                     {{ $link['label'] }}
                 </a>
             @endforeach
+            @feature(App\Features\Documentation::class)
+                <a href="{{ route('documentation.index') }}" @click="mobileMenu = false"
+                   class="block text-[2rem] font-semibold text-gray-950 dark:text-white hover:text-primary dark:hover:text-primary-400 transition-colors py-2">
+                    Docs
+                </a>
+            @endfeature
         </div>
     </nav>
 

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -23,10 +23,12 @@
                     </p>
 
                     <div class="mt-8 space-y-4">
+                        @feature(App\Features\Documentation::class)
                         <a href="{{ route('documentation.index') }}" class="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 transition-colors">
                             <x-ri-book-open-line class="w-4 h-4"/>
                             Documentation
                         </a>
+                        @endfeature
                         <a href="{{ route('discord') }}" target="_blank" class="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 transition-colors">
                             <x-ri-discord-fill class="w-4 h-4"/>
                             Join Discord community

--- a/resources/views/filament/auth/social_login_buttons.blade.php
+++ b/resources/views/filament/auth/social_login_buttons.blade.php
@@ -1,3 +1,4 @@
+@feature(App\Features\SocialAuth::class)
 <div class="space-y-3">
     <x-filament::button
         :href="route('auth.socialite.redirect', 'google')"
@@ -44,3 +45,4 @@
     </div>
 
 </div>
+@endfeature

--- a/resources/views/filament/pages/access-tokens.blade.php
+++ b/resources/views/filament/pages/access-tokens.blade.php
@@ -16,6 +16,7 @@
                 </div>
                 <x-heroicon-m-arrow-right class="w-4 h-4 flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition" />
             </a>
+            @feature(App\Features\Documentation::class)
             <a href="{{ route('documentation.show', ['type' => 'mcp']) }}" target="_blank" class="flex items-center gap-4 bg-white dark:bg-white/5 px-4 py-3 transition hover:bg-gray-50 dark:hover:bg-white/10 group">
                 <div class="flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 dark:bg-white/10 text-gray-500 dark:text-gray-400 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition">
                     <x-heroicon-o-cpu-chip class="w-5 h-5" />
@@ -26,6 +27,7 @@
                 </div>
                 <x-heroicon-m-arrow-right class="w-4 h-4 flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition" />
             </a>
+            @endfeature
         </div>
     </div>
 </x-filament-panels::page>

--- a/resources/views/home/partials/community.blade.php
+++ b/resources/views/home/partials/community.blade.php
@@ -12,11 +12,17 @@
         </div>
 
         <div class="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-3 mb-10">
-            @foreach([
-                ['url' => 'https://github.com/relaticle/relaticle', 'icon' => 'ri-github-fill', 'iconClass' => '', 'title' => 'GitHub', 'desc' => 'Star our repo, report issues, and contribute code. Completely open source and free to use.', 'cta' => 'View Repository', 'external' => true],
-                ['url' => route('discord'), 'icon' => 'ri-discord-fill', 'iconClass' => 'text-[#5865F2]', 'title' => 'Discord', 'desc' => 'Chat with developers, get help, and share ideas. Join our growing community of builders.', 'cta' => 'Join Discord', 'external' => true],
-                ['url' => route('documentation.index'), 'icon' => 'ri-book-open-line', 'iconClass' => 'text-primary dark:text-primary-400', 'title' => 'Documentation', 'desc' => 'Learn how to use Relaticle. Comprehensive guides for users and developers alike.', 'cta' => 'Read the Docs', 'external' => false],
-            ] as $card)
+            @php
+                $cards = [
+                    ['url' => 'https://github.com/relaticle/relaticle', 'icon' => 'ri-github-fill', 'iconClass' => '', 'title' => 'GitHub', 'desc' => 'Star our repo, report issues, and contribute code. Completely open source and free to use.', 'cta' => 'View Repository', 'external' => true],
+                    ['url' => route('discord'), 'icon' => 'ri-discord-fill', 'iconClass' => 'text-[#5865F2]', 'title' => 'Discord', 'desc' => 'Chat with developers, get help, and share ideas. Join our growing community of builders.', 'cta' => 'Join Discord', 'external' => true],
+                ];
+
+                if (\Laravel\Pennant\Feature::active(\App\Features\Documentation::class)) {
+                    $cards[] = ['url' => route('documentation.index'), 'icon' => 'ri-book-open-line', 'iconClass' => 'text-primary dark:text-primary-400', 'title' => 'Documentation', 'desc' => 'Learn how to use Relaticle. Comprehensive guides for users and developers alike.', 'cta' => 'Read the Docs', 'external' => false];
+                }
+            @endphp
+            @foreach($cards as $card)
                 <a href="{{ $card['url'] }}" @if($card['external']) target="_blank" rel="noopener noreferrer" @endif
                    class="group rounded-xl border border-gray-200/80 dark:border-white/[0.06] bg-white dark:bg-white/[0.02] p-6 transition-all duration-300 hover:border-gray-300 dark:hover:border-white/[0.10] hover:shadow-sm flex flex-col">
                     <div class="flex items-center justify-between mb-3">

--- a/resources/views/layouts/filament-standalone.blade.php
+++ b/resources/views/layouts/filament-standalone.blade.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>{{ config('app.name', 'Relaticle') }}</title>
+
+    <!-- Dark mode FOUC prevention -->
+    <script>
+        document.documentElement.classList.toggle(
+            'dark',
+            localStorage.getItem('theme') === 'dark' || ((!localStorage.getItem('theme') || localStorage.getItem('theme') === 'system') && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        );
+    </script>
+
+    @filamentStyles
+    @vite(['resources/css/filament/app/theme.css'])
+</head>
+<body class="font-sans antialiased">
+    {{ $slot }}
+
+    @livewireScripts
+    @filamentScripts
+</body>
+</html>

--- a/resources/views/livewire/app/profile/scheduled-deletion-interstitial.blade.php
+++ b/resources/views/livewire/app/profile/scheduled-deletion-interstitial.blade.php
@@ -1,0 +1,79 @@
+<div class="flex min-h-screen flex-col bg-gray-50 dark:bg-gray-950">
+    @php
+        $user = auth()->user();
+        $deletionDate = $user->scheduled_deletion_at;
+        $daysRemaining = (int) now()->diffInDays($deletionDate, absolute: false);
+        $teamCount = $user->ownedTeams()->count();
+    @endphp
+
+    {{-- Centered logo --}}
+    <div class="flex justify-center pt-10">
+        <x-brand.logo-lockup size="md" class="text-gray-900 dark:text-white" />
+    </div>
+
+    {{-- Card --}}
+    <div class="flex flex-1 items-start justify-center px-4 pt-8 pb-16">
+        <div class="w-full max-w-md">
+            <div class="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+
+                {{-- Icon --}}
+                <div class="mx-auto mb-5 flex size-12 items-center justify-center rounded-full bg-danger-50 dark:bg-danger-500/10">
+                    <x-filament::icon icon="ri-delete-bin-line" class="size-6 text-danger-600 dark:text-danger-400" />
+                </div>
+
+                {{-- Heading --}}
+                <h1 class="text-center text-lg font-semibold text-gray-950 dark:text-white">
+                    Your account is being deleted
+                </h1>
+
+                {{-- Countdown --}}
+                <div class="mx-auto mt-4 w-fit rounded-lg bg-danger-50 px-4 py-2 dark:bg-danger-500/10">
+                    <p class="text-center text-sm font-medium text-danger-700 dark:text-danger-300">
+                        @if ($daysRemaining > 0)
+                            {{ $daysRemaining }} {{ Str::plural('day', $daysRemaining) }} remaining
+                        @elseif ($daysRemaining === 0)
+                            Deletion is scheduled for today
+                        @else
+                            Deletion is overdue
+                        @endif
+                    </p>
+                </div>
+
+                {{-- Details --}}
+                <div class="mt-5 space-y-2 text-center text-sm text-gray-500 dark:text-gray-400">
+                    <p>
+                        Your account and all associated data will be permanently deleted on
+                        <strong class="text-gray-950 dark:text-white">{{ $deletionDate->format('F j, Y') }}</strong>.
+                    </p>
+                    <p>
+                        This includes {{ $teamCount }} {{ Str::plural('workspace', $teamCount) }}, contacts, companies, opportunities, and notes.
+                    </p>
+                </div>
+
+                {{-- Actions --}}
+                <div class="mt-6 space-y-3">
+                    {{ $this->cancelDeletionAction }}
+                    <div class="text-center">
+                        {{ $this->logoutAction }}
+                    </div>
+                </div>
+            </div>
+
+            {{-- Help text --}}
+            <p class="mt-4 text-center text-xs text-gray-400 dark:text-gray-500">
+                Changed your mind? Cancel the deletion above and your account will be fully restored.
+            </p>
+        </div>
+    </div>
+
+    {{-- Footer --}}
+    <div class="flex items-center justify-center gap-x-1 py-6 text-xs text-gray-400 dark:text-gray-500">
+        <span>&copy; {{ date('Y') }} Relaticle</span>
+        <span>&middot;</span>
+        <a href="{{ url('/privacy-policy') }}" class="hover:text-gray-600 dark:hover:text-gray-300">Privacy Policy</a>
+        <span>&middot;</span>
+        <a href="{{ url('/terms-of-service') }}" class="hover:text-gray-600 dark:hover:text-gray-300">Terms</a>
+    </div>
+
+    <x-filament-actions::modals />
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Features\SocialAuth;
 use App\Http\Controllers\AcceptTeamInvitationController;
 use App\Http\Controllers\Auth\CallbackController;
 use App\Http\Controllers\Auth\RedirectController;
@@ -12,6 +13,7 @@ use App\Http\Controllers\PrivacyPolicyController;
 use App\Http\Controllers\TermsOfServiceController;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Support\Facades\Route;
+use Laravel\Pennant\Feature;
 use Spatie\Honeypot\ProtectAgainstSpam;
 use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 
@@ -27,12 +29,14 @@ use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 */
 
 Route::middleware('guest')->group(function () {
-    Route::get('/auth/redirect/{provider}', RedirectController::class)
-        ->name('auth.socialite.redirect')
-        ->middleware('throttle:10,1');
-    Route::get('/auth/callback/{provider}', CallbackController::class)
-        ->name('auth.socialite.callback')
-        ->middleware('throttle:10,1');
+    if (Feature::active(SocialAuth::class)) {
+        Route::get('/auth/redirect/{provider}', RedirectController::class)
+            ->name('auth.socialite.redirect')
+            ->middleware('throttle:10,1');
+        Route::get('/auth/callback/{provider}', CallbackController::class)
+            ->name('auth.socialite.callback')
+            ->middleware('throttle:10,1');
+    }
 
     Route::get('/login', fn () => redirect()->to(url()->getAppUrl('login')))->name('login');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Features\SocialAuth;
 use App\Http\Controllers\AcceptTeamInvitationController;
 use App\Http\Controllers\Auth\CallbackController;
 use App\Http\Controllers\Auth\RedirectController;
@@ -11,6 +12,7 @@ use App\Http\Controllers\PrivacyPolicyController;
 use App\Http\Controllers\TermsOfServiceController;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Support\Facades\Route;
+use Laravel\Pennant\Feature;
 use Spatie\Honeypot\ProtectAgainstSpam;
 use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 
@@ -26,12 +28,14 @@ use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 */
 
 Route::middleware('guest')->group(function () {
-    Route::get('/auth/redirect/{provider}', RedirectController::class)
-        ->name('auth.socialite.redirect')
-        ->middleware('throttle:10,1');
-    Route::get('/auth/callback/{provider}', CallbackController::class)
-        ->name('auth.socialite.callback')
-        ->middleware('throttle:10,1');
+    if (Feature::active(SocialAuth::class)) {
+        Route::get('/auth/redirect/{provider}', RedirectController::class)
+            ->name('auth.socialite.redirect')
+            ->middleware('throttle:10,1');
+        Route::get('/auth/callback/{provider}', CallbackController::class)
+            ->name('auth.socialite.callback')
+            ->middleware('throttle:10,1');
+    }
 
     Route::get('/login', fn () => redirect()->to(url()->getAppUrl('login')))->name('login');
 

--- a/tests/Browser/SmokeBrowserTest.php
+++ b/tests/Browser/SmokeBrowserTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+beforeEach(function (): void {
+    $this->withVite();
+});
+
 it('public pages have no javascript errors', function (): void {
     $this->visit('/')
         ->assertNoJavaScriptErrors();

--- a/tests/Feature/Api/V1/ApiMiddlewareTest.php
+++ b/tests/Feature/Api/V1/ApiMiddlewareTest.php
@@ -85,7 +85,7 @@ describe('rate limiting', function (): void {
 
 describe('real-token middleware chain', function (): void {
     it('authenticates and scopes via real bearer token through full middleware stack', function (): void {
-        $companies = Company::factory()->for($this->team)->count(2)->create();
+        $companies = Company::factory()->recycle([$this->user, $this->team])->count(2)->create();
 
         $raw = Str::random(40);
         $token = $this->user->tokens()->create([

--- a/tests/Feature/Api/V1/ApiTeamScopingTest.php
+++ b/tests/Feature/Api/V1/ApiTeamScopingTest.php
@@ -20,7 +20,7 @@ beforeEach(function () {
 it('uses current team by default', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/companies');
 
@@ -38,7 +38,7 @@ it('can switch team via X-Team-Id header', function (): void {
 
     Sanctum::actingAs($this->user);
 
-    Company::factory()->for($this->team)->create();
+    Company::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/companies', ['X-Team-Id' => $otherTeam->id]);
 
@@ -85,7 +85,7 @@ describe('token-based team scoping', function (): void {
         $this->user->teams()->attach($otherTeam);
 
         $otherCompany = Company::withoutEvents(fn () => Company::factory()->create(['team_id' => $otherTeam->id]));
-        Company::factory()->for($this->team)->create();
+        Company::factory()->recycle([$this->user, $this->team])->create();
 
         $raw = Str::random(40);
         $token = $this->user->tokens()->create([
@@ -111,7 +111,7 @@ describe('token-based team scoping', function (): void {
         $this->user->teams()->attach($otherTeam);
 
         $otherCompany = Company::withoutEvents(fn () => Company::factory()->create(['team_id' => $otherTeam->id]));
-        Company::factory()->for($this->team)->create();
+        Company::factory()->recycle([$this->user, $this->team])->create();
 
         $raw = Str::random(40);
         $token = $this->user->tokens()->create([

--- a/tests/Feature/Api/V1/CompaniesApiTest.php
+++ b/tests/Feature/Api/V1/CompaniesApiTest.php
@@ -42,7 +42,7 @@ it('can list companies', function (): void {
     Sanctum::actingAs($this->user);
 
     $seeded = Company::query()->where('team_id', $this->team->id)->count();
-    Company::factory(3)->for($this->team)->create();
+    Company::factory(3)->recycle([$this->user, $this->team])->create();
 
     $this->getJson('/api/v1/companies')
         ->assertOk()
@@ -85,7 +85,7 @@ it('validates required fields on create', function (): void {
 it('can show a company', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create(['name' => 'Show Test']);
+    $company = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Show Test']);
 
     $this->getJson("/api/v1/companies/{$company->id}")
         ->assertOk()
@@ -109,7 +109,7 @@ it('can show a company', function (): void {
 it('can update a company', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     $this->putJson("/api/v1/companies/{$company->id}", ['name' => 'Updated Name'])
         ->assertOk()
@@ -130,7 +130,7 @@ it('can update a company', function (): void {
 it('can delete a company', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     $this->deleteJson("/api/v1/companies/{$company->id}")
         ->assertNoContent();
@@ -143,7 +143,7 @@ it('scopes companies to current team', function (): void {
 
     Sanctum::actingAs($this->user);
 
-    $ownCompany = Company::factory()->for($this->team)->create();
+    $ownCompany = Company::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/companies');
 
@@ -190,7 +190,7 @@ describe('includes', function (): void {
     it('can include relations on list endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory()->for($this->team)->create();
+        Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/companies?include=creator')
             ->assertOk()
@@ -204,7 +204,7 @@ describe('includes', function (): void {
     it('can include relations on show endpoint with full structure', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson("/api/v1/companies/{$company->id}?include=creator")
             ->assertOk()
@@ -229,7 +229,7 @@ describe('includes', function (): void {
     it('can include multiple relations', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson("/api/v1/companies/{$company->id}?include=creator,people")
             ->assertOk()
@@ -243,7 +243,7 @@ describe('includes', function (): void {
     it('does not include relations when not requested', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson("/api/v1/companies/{$company->id}")
             ->assertOk();
@@ -254,8 +254,8 @@ describe('includes', function (): void {
     it('can include relationship counts', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        People::factory(3)->for($this->team)->create(['company_id' => $company->id]);
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        People::factory(3)->recycle([$this->user, $this->team])->create(['company_id' => $company->id]);
 
         $response = $this->getJson('/api/v1/companies?include=peopleCount');
 
@@ -337,7 +337,7 @@ describe('custom fields', function (): void {
             'validation_rules' => [],
         ]);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->putJson("/api/v1/companies/{$company->id}", [
             'name' => 'Updated Name',
@@ -513,7 +513,7 @@ describe('custom fields', function (): void {
             ['name' => 'Customer', 'sort_order' => 2, 'tenant_id' => $this->team->id],
         ]);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->putJson("/api/v1/companies/{$company->id}", [
             'name' => 'Updated Name',
@@ -587,7 +587,7 @@ describe('custom fields', function (): void {
     });
 
     it('handles orphaned custom field values gracefully', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $customField = CustomField::create([
             'tenant_id' => $this->team->getKey(),
@@ -800,8 +800,8 @@ describe('filtering and sorting', function (): void {
     it('can filter companies by name', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory()->for($this->team)->create(['name' => 'Acme Corp']);
-        Company::factory()->for($this->team)->create(['name' => 'Beta Inc']);
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Acme Corp']);
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Beta Inc']);
 
         $response = $this->getJson('/api/v1/companies?filter[name]=Acme');
 
@@ -815,8 +815,8 @@ describe('filtering and sorting', function (): void {
     it('can sort companies by name ascending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory()->for($this->team)->create(['name' => 'Zulu Corp']);
-        Company::factory()->for($this->team)->create(['name' => 'Alpha Inc']);
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Zulu Corp']);
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Alpha Inc']);
 
         $response = $this->getJson('/api/v1/companies?sort=name');
 
@@ -831,8 +831,8 @@ describe('filtering and sorting', function (): void {
     it('can sort companies by name descending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory()->for($this->team)->create(['name' => 'Alpha Inc']);
-        Company::factory()->for($this->team)->create(['name' => 'Zulu Corp']);
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Alpha Inc']);
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Zulu Corp']);
 
         $response = $this->getJson('/api/v1/companies?sort=-name');
 
@@ -863,10 +863,10 @@ describe('soft deletes', function (): void {
     it('excludes soft-deleted companies from list', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create(['name' => 'Deleted Corp']);
+        $company = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Deleted Corp']);
         $company->delete();
 
-        $active = Company::factory()->for($this->team)->create(['name' => 'Active Corp']);
+        $active = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Active Corp']);
 
         $response = $this->getJson('/api/v1/companies');
 
@@ -878,7 +878,7 @@ describe('soft deletes', function (): void {
     it('cannot show a soft-deleted company', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
         $company->delete();
 
         $this->getJson("/api/v1/companies/{$company->id}")
@@ -888,7 +888,7 @@ describe('soft deletes', function (): void {
     it('cannot update a soft-deleted company', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
         $company->delete();
 
         $this->putJson("/api/v1/companies/{$company->id}", ['name' => 'Revived'])
@@ -900,7 +900,7 @@ describe('pagination', function (): void {
     it('paginates with per_page parameter', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory(5)->for($this->team)->create();
+        Company::factory(5)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/companies?per_page=2')
             ->assertOk()
@@ -910,7 +910,7 @@ describe('pagination', function (): void {
     it('returns second page of results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory(5)->for($this->team)->create();
+        Company::factory(5)->recycle([$this->user, $this->team])->create();
 
         $page1 = $this->getJson('/api/v1/companies?per_page=3&page=1');
         $page2 = $this->getJson('/api/v1/companies?per_page=3&page=2');
@@ -934,7 +934,7 @@ describe('pagination', function (): void {
     it('returns empty data array for page beyond results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory(2)->for($this->team)->create();
+        Company::factory(2)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/companies?page=999')
             ->assertOk()
@@ -976,7 +976,7 @@ describe('mass assignment protection', function (): void {
     it('ignores team_id in update request', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
 
         $this->putJson("/api/v1/companies/{$company->id}", [
@@ -1034,7 +1034,7 @@ describe('non-existent record', function (): void {
 it('can update a company via PATCH', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->patchJson("/api/v1/companies/{$company->id}", [
         'name' => 'Patched Name',
@@ -1057,9 +1057,7 @@ describe('cursor pagination', function (): void {
     it('returns cursor-paginated results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Company::factory()->count(5)->create([
-            'team_id' => $this->team->id,
-        ]);
+        Company::factory()->count(5)->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson('/api/v1/companies?cursor=true&per_page=2');
 

--- a/tests/Feature/Api/V1/NotesApiTest.php
+++ b/tests/Feature/Api/V1/NotesApiTest.php
@@ -39,7 +39,7 @@ it('can list notes', function (): void {
     Sanctum::actingAs($this->user);
 
     $seeded = Note::query()->where('team_id', $this->team->id)->count();
-    Note::factory(3)->for($this->team)->create();
+    Note::factory(3)->recycle([$this->user, $this->team])->create();
 
     $this->getJson('/api/v1/notes')
         ->assertOk()
@@ -84,7 +84,7 @@ it('validates required fields on create', function (): void {
 it('can show a note', function (): void {
     Sanctum::actingAs($this->user);
 
-    $note = Note::factory()->for($this->team)->create(['title' => 'Show Test']);
+    $note = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Show Test']);
 
     $this->getJson("/api/v1/notes/{$note->id}")
         ->assertOk()
@@ -108,7 +108,7 @@ it('can show a note', function (): void {
 it('can update a note', function (): void {
     Sanctum::actingAs($this->user);
 
-    $note = Note::factory()->for($this->team)->create();
+    $note = Note::factory()->recycle([$this->user, $this->team])->create();
 
     $this->putJson("/api/v1/notes/{$note->id}", ['title' => 'Updated Title'])
         ->assertOk()
@@ -129,7 +129,7 @@ it('can update a note', function (): void {
 it('can delete a note', function (): void {
     Sanctum::actingAs($this->user);
 
-    $note = Note::factory()->for($this->team)->create();
+    $note = Note::factory()->recycle([$this->user, $this->team])->create();
 
     $this->deleteJson("/api/v1/notes/{$note->id}")
         ->assertNoContent();
@@ -142,7 +142,7 @@ it('scopes notes to current team', function (): void {
 
     Sanctum::actingAs($this->user);
 
-    $ownNote = Note::factory()->for($this->team)->create();
+    $ownNote = Note::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/notes');
 
@@ -189,7 +189,7 @@ describe('includes', function (): void {
     it('can include creator on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $note = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson("/api/v1/notes/{$note->id}?include=creator")
             ->assertOk()
@@ -211,7 +211,7 @@ describe('includes', function (): void {
     it('can include creator on list endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        Note::factory()->for($this->team)->create();
+        Note::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/notes?include=creator')
             ->assertOk()
@@ -225,8 +225,8 @@ describe('includes', function (): void {
     it('can include companies on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $note = Note::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
         $note->companies()->attach($company);
 
         $this->getJson("/api/v1/notes/{$note->id}?include=companies")
@@ -241,8 +241,8 @@ describe('includes', function (): void {
     it('can include multiple relations', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $note = Note::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
         $note->companies()->attach($company);
 
         $this->getJson("/api/v1/notes/{$note->id}?include=creator,companies")
@@ -257,7 +257,7 @@ describe('includes', function (): void {
     it('does not include relations when not requested', function (): void {
         Sanctum::actingAs($this->user);
 
-        $note = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson("/api/v1/notes/{$note->id}")
             ->assertOk();
@@ -268,7 +268,7 @@ describe('includes', function (): void {
     it('can include relationship counts', function (): void {
         Sanctum::actingAs($this->user);
 
-        $note = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson('/api/v1/notes?include=companiesCount');
 
@@ -291,8 +291,8 @@ describe('filtering and sorting', function (): void {
     it('can filter notes by title', function (): void {
         Sanctum::actingAs($this->user);
 
-        Note::factory()->for($this->team)->create(['title' => 'Meeting summary']);
-        Note::factory()->for($this->team)->create(['title' => 'Code review']);
+        Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Meeting summary']);
+        Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Code review']);
 
         $response = $this->getJson('/api/v1/notes?filter[title]=Meeting');
 
@@ -306,8 +306,8 @@ describe('filtering and sorting', function (): void {
     it('can sort notes by title ascending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Note::factory()->for($this->team)->create(['title' => 'Zulu Note']);
-        Note::factory()->for($this->team)->create(['title' => 'Alpha Note']);
+        Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Zulu Note']);
+        Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Alpha Note']);
 
         $response = $this->getJson('/api/v1/notes?sort=title');
 
@@ -322,8 +322,8 @@ describe('filtering and sorting', function (): void {
     it('can sort notes by title descending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Note::factory()->for($this->team)->create(['title' => 'Alpha Note']);
-        Note::factory()->for($this->team)->create(['title' => 'Zulu Note']);
+        Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Alpha Note']);
+        Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Zulu Note']);
 
         $response = $this->getJson('/api/v1/notes?sort=-title');
 
@@ -354,7 +354,7 @@ describe('pagination', function (): void {
     it('paginates with per_page parameter', function (): void {
         Sanctum::actingAs($this->user);
 
-        Note::factory(5)->for($this->team)->create();
+        Note::factory(5)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/notes?per_page=2')
             ->assertOk()
@@ -364,7 +364,7 @@ describe('pagination', function (): void {
     it('returns second page of results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Note::factory(5)->for($this->team)->create();
+        Note::factory(5)->recycle([$this->user, $this->team])->create();
 
         $page1 = $this->getJson('/api/v1/notes?per_page=3&page=1');
         $page2 = $this->getJson('/api/v1/notes?per_page=3&page=2');
@@ -388,7 +388,7 @@ describe('pagination', function (): void {
     it('returns empty data array for page beyond results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Note::factory(2)->for($this->team)->create();
+        Note::factory(2)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/notes?page=999')
             ->assertOk()
@@ -430,7 +430,7 @@ describe('mass assignment protection', function (): void {
     it('ignores team_id in update request', function (): void {
         Sanctum::actingAs($this->user);
 
-        $note = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
 
         $this->putJson("/api/v1/notes/{$note->id}", [
@@ -480,8 +480,8 @@ describe('soft deletes', function (): void {
     it('excludes soft-deleted notes from list', function (): void {
         Sanctum::actingAs($this->user);
 
-        $note = Note::factory()->for($this->team)->create();
-        $deleted = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
+        $deleted = Note::factory()->recycle([$this->user, $this->team])->create();
         $deleted->delete();
 
         $ids = collect($this->getJson('/api/v1/notes')->json('data'))->pluck('id');
@@ -492,7 +492,7 @@ describe('soft deletes', function (): void {
     it('cannot show a soft-deleted note', function (): void {
         Sanctum::actingAs($this->user);
 
-        $note = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
         $note->delete();
 
         $this->getJson("/api/v1/notes/{$note->id}")
@@ -512,9 +512,9 @@ describe('non-existent record', function (): void {
 it('can create a note with relationship ids', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
-    $person = People::factory()->for($this->team)->create();
-    $opportunity = Opportunity::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
+    $person = People::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     $this->postJson('/api/v1/notes', [
         'title' => 'Linked note',

--- a/tests/Feature/Api/V1/OpportunitiesApiTest.php
+++ b/tests/Feature/Api/V1/OpportunitiesApiTest.php
@@ -40,7 +40,7 @@ it('can list opportunities', function (): void {
     Sanctum::actingAs($this->user);
 
     $seeded = Opportunity::query()->where('team_id', $this->team->id)->count();
-    Opportunity::factory(3)->for($this->team)->create();
+    Opportunity::factory(3)->recycle([$this->user, $this->team])->create();
 
     $this->getJson('/api/v1/opportunities')
         ->assertOk()
@@ -85,7 +85,7 @@ it('validates required fields on create', function (): void {
 it('can show an opportunity', function (): void {
     Sanctum::actingAs($this->user);
 
-    $opportunity = Opportunity::factory()->for($this->team)->create(['name' => 'Show Test']);
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Show Test']);
 
     $this->getJson("/api/v1/opportunities/{$opportunity->id}")
         ->assertOk()
@@ -109,7 +109,7 @@ it('can show an opportunity', function (): void {
 it('can update an opportunity', function (): void {
     Sanctum::actingAs($this->user);
 
-    $opportunity = Opportunity::factory()->for($this->team)->create();
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     $this->putJson("/api/v1/opportunities/{$opportunity->id}", ['name' => 'Updated Name'])
         ->assertOk()
@@ -130,7 +130,7 @@ it('can update an opportunity', function (): void {
 it('can delete an opportunity', function (): void {
     Sanctum::actingAs($this->user);
 
-    $opportunity = Opportunity::factory()->for($this->team)->create();
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     $this->deleteJson("/api/v1/opportunities/{$opportunity->id}")
         ->assertNoContent();
@@ -143,7 +143,7 @@ it('scopes opportunities to current team', function (): void {
 
     Sanctum::actingAs($this->user);
 
-    $ownOpportunity = Opportunity::factory()->for($this->team)->create();
+    $ownOpportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/opportunities');
 
@@ -222,7 +222,7 @@ describe('includes', function (): void {
     it('can include creator on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson("/api/v1/opportunities/{$opportunity->id}?include=creator")
             ->assertOk()
@@ -244,7 +244,7 @@ describe('includes', function (): void {
     it('can include creator on list endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        Opportunity::factory()->for($this->team)->create();
+        Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/opportunities?include=creator')
             ->assertOk()
@@ -258,8 +258,8 @@ describe('includes', function (): void {
     it('can include company on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $opportunity = Opportunity::factory()->for($this->team)->create(['company_id' => $company->id]);
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['company_id' => $company->id]);
 
         $this->getJson("/api/v1/opportunities/{$opportunity->id}?include=company")
             ->assertOk()
@@ -281,8 +281,8 @@ describe('includes', function (): void {
     it('can include contact on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
-        $opportunity = Opportunity::factory()->for($this->team)->create(['contact_id' => $person->id]);
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['contact_id' => $person->id]);
 
         $this->getJson("/api/v1/opportunities/{$opportunity->id}?include=contact")
             ->assertOk()
@@ -304,8 +304,8 @@ describe('includes', function (): void {
     it('can include multiple relations', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $opportunity = Opportunity::factory()->for($this->team)->create(['company_id' => $company->id]);
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['company_id' => $company->id]);
 
         $this->getJson("/api/v1/opportunities/{$opportunity->id}?include=creator,company")
             ->assertOk()
@@ -319,7 +319,7 @@ describe('includes', function (): void {
     it('does not include relations when not requested', function (): void {
         Sanctum::actingAs($this->user);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson("/api/v1/opportunities/{$opportunity->id}")
             ->assertOk();
@@ -330,7 +330,7 @@ describe('includes', function (): void {
     it('can include relationship counts', function (): void {
         Sanctum::actingAs($this->user);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson('/api/v1/opportunities?include=tasksCount');
 
@@ -353,8 +353,8 @@ describe('filtering and sorting', function (): void {
     it('can filter opportunities by name', function (): void {
         Sanctum::actingAs($this->user);
 
-        Opportunity::factory()->for($this->team)->create(['name' => 'Enterprise Deal']);
-        Opportunity::factory()->for($this->team)->create(['name' => 'Small Contract']);
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Enterprise Deal']);
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Small Contract']);
 
         $response = $this->getJson('/api/v1/opportunities?filter[name]=Enterprise');
 
@@ -368,9 +368,9 @@ describe('filtering and sorting', function (): void {
     it('can filter opportunities by company_id', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $matched = Opportunity::factory()->for($this->team)->create(['company_id' => $company->id]);
-        $unmatched = Opportunity::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $matched = Opportunity::factory()->recycle([$this->user, $this->team])->create(['company_id' => $company->id]);
+        $unmatched = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson("/api/v1/opportunities?filter[company_id]={$company->id}");
 
@@ -384,8 +384,8 @@ describe('filtering and sorting', function (): void {
     it('can sort opportunities by name ascending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Opportunity::factory()->for($this->team)->create(['name' => 'Zulu Deal']);
-        Opportunity::factory()->for($this->team)->create(['name' => 'Alpha Deal']);
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Zulu Deal']);
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Alpha Deal']);
 
         $response = $this->getJson('/api/v1/opportunities?sort=name');
 
@@ -400,8 +400,8 @@ describe('filtering and sorting', function (): void {
     it('can sort opportunities by name descending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Opportunity::factory()->for($this->team)->create(['name' => 'Alpha Deal']);
-        Opportunity::factory()->for($this->team)->create(['name' => 'Zulu Deal']);
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Alpha Deal']);
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Zulu Deal']);
 
         $response = $this->getJson('/api/v1/opportunities?sort=-name');
 
@@ -432,7 +432,7 @@ describe('pagination', function (): void {
     it('paginates with per_page parameter', function (): void {
         Sanctum::actingAs($this->user);
 
-        Opportunity::factory(5)->for($this->team)->create();
+        Opportunity::factory(5)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/opportunities?per_page=2')
             ->assertOk()
@@ -442,7 +442,7 @@ describe('pagination', function (): void {
     it('returns second page of results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Opportunity::factory(5)->for($this->team)->create();
+        Opportunity::factory(5)->recycle([$this->user, $this->team])->create();
 
         $page1 = $this->getJson('/api/v1/opportunities?per_page=3&page=1');
         $page2 = $this->getJson('/api/v1/opportunities?per_page=3&page=2');
@@ -466,7 +466,7 @@ describe('pagination', function (): void {
     it('returns empty data array for page beyond results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Opportunity::factory(2)->for($this->team)->create();
+        Opportunity::factory(2)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/opportunities?page=999')
             ->assertOk()
@@ -508,7 +508,7 @@ describe('mass assignment protection', function (): void {
     it('ignores team_id in update request', function (): void {
         Sanctum::actingAs($this->user);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
 
         $this->putJson("/api/v1/opportunities/{$opportunity->id}", [
@@ -578,7 +578,7 @@ describe('input validation', function (): void {
             'validation_rules' => [],
         ]);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         $this->putJson("/api/v1/opportunities/{$opportunity->id}", [
             'name' => $opportunity->name,
@@ -613,7 +613,7 @@ describe('input validation', function (): void {
             'validation_rules' => [],
         ]);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         $this->putJson("/api/v1/opportunities/{$opportunity->id}", [
             'name' => $opportunity->name,
@@ -628,8 +628,8 @@ describe('soft deletes', function (): void {
     it('excludes soft-deleted opportunities from list', function (): void {
         Sanctum::actingAs($this->user);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
-        $deleted = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
+        $deleted = Opportunity::factory()->recycle([$this->user, $this->team])->create();
         $deleted->delete();
 
         $ids = collect($this->getJson('/api/v1/opportunities')->json('data'))->pluck('id');
@@ -640,7 +640,7 @@ describe('soft deletes', function (): void {
     it('cannot show a soft-deleted opportunity', function (): void {
         Sanctum::actingAs($this->user);
 
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
         $opportunity->delete();
 
         $this->getJson("/api/v1/opportunities/{$opportunity->id}")
@@ -660,9 +660,9 @@ describe('non-existent record', function (): void {
 it('includes company_id and contact_id in attributes', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
-    $person = People::factory()->for($this->team)->create();
-    $opportunity = Opportunity::factory()->for($this->team)->create([
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
+    $person = People::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create([
         'company_id' => $company->id,
         'contact_id' => $person->id,
     ]);

--- a/tests/Feature/Api/V1/PeopleApiTest.php
+++ b/tests/Feature/Api/V1/PeopleApiTest.php
@@ -36,7 +36,7 @@ it('requires authentication', function (): void {
 it('can list people', function (): void {
     Sanctum::actingAs($this->user);
 
-    $people = People::factory(3)->for($this->team)->create();
+    $people = People::factory(3)->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/people');
 
@@ -84,7 +84,7 @@ it('validates required fields on create', function (): void {
 it('can show a person', function (): void {
     Sanctum::actingAs($this->user);
 
-    $person = People::factory()->for($this->team)->create(['name' => 'Show Test']);
+    $person = People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Show Test']);
 
     $this->getJson("/api/v1/people/{$person->id}")
         ->assertOk()
@@ -108,7 +108,7 @@ it('can show a person', function (): void {
 it('can update a person', function (): void {
     Sanctum::actingAs($this->user);
 
-    $person = People::factory()->for($this->team)->create();
+    $person = People::factory()->recycle([$this->user, $this->team])->create();
 
     $this->putJson("/api/v1/people/{$person->id}", ['name' => 'Updated Name'])
         ->assertOk()
@@ -129,7 +129,7 @@ it('can update a person', function (): void {
 it('can delete a person', function (): void {
     Sanctum::actingAs($this->user);
 
-    $person = People::factory()->for($this->team)->create();
+    $person = People::factory()->recycle([$this->user, $this->team])->create();
 
     $this->deleteJson("/api/v1/people/{$person->id}")
         ->assertNoContent();
@@ -142,7 +142,7 @@ it('scopes people to current team', function (): void {
 
     Sanctum::actingAs($this->user);
 
-    $ownPerson = People::factory()->for($this->team)->create();
+    $ownPerson = People::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/people');
 
@@ -200,7 +200,7 @@ describe('cross-tenant isolation', function (): void {
     it('rejects company_id from another team on update', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
         $otherCompany = Company::withoutEvents(fn () => Company::factory()->create([
             'team_id' => $otherTeam->id,
@@ -218,7 +218,7 @@ describe('includes', function (): void {
     it('can include creator on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson("/api/v1/people/{$person->id}?include=creator")
             ->assertOk()
@@ -240,7 +240,7 @@ describe('includes', function (): void {
     it('can include creator on list endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        People::factory()->for($this->team)->create();
+        People::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/people?include=creator')
             ->assertOk()
@@ -254,8 +254,8 @@ describe('includes', function (): void {
     it('can include company on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $person = People::factory()->for($this->team)->create(['company_id' => $company->id]);
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create(['company_id' => $company->id]);
 
         $this->getJson("/api/v1/people/{$person->id}?include=company")
             ->assertOk()
@@ -277,8 +277,8 @@ describe('includes', function (): void {
     it('can include multiple relations', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $person = People::factory()->for($this->team)->create(['company_id' => $company->id]);
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create(['company_id' => $company->id]);
 
         $this->getJson("/api/v1/people/{$person->id}?include=creator,company")
             ->assertOk()
@@ -292,7 +292,7 @@ describe('includes', function (): void {
     it('does not include relations when not requested', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson("/api/v1/people/{$person->id}")
             ->assertOk();
@@ -303,7 +303,7 @@ describe('includes', function (): void {
     it('can include relationship counts', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson('/api/v1/people?include=tasksCount');
 
@@ -326,8 +326,8 @@ describe('filtering and sorting', function (): void {
     it('can filter people by name', function (): void {
         Sanctum::actingAs($this->user);
 
-        People::factory()->for($this->team)->create(['name' => 'Alice Johnson']);
-        People::factory()->for($this->team)->create(['name' => 'Bob Smith']);
+        People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Alice Johnson']);
+        People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Bob Smith']);
 
         $response = $this->getJson('/api/v1/people?filter[name]=Alice');
 
@@ -341,9 +341,9 @@ describe('filtering and sorting', function (): void {
     it('can filter people by company_id', function (): void {
         Sanctum::actingAs($this->user);
 
-        $company = Company::factory()->for($this->team)->create();
-        $matched = People::factory()->for($this->team)->create(['company_id' => $company->id]);
-        $unmatched = People::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $matched = People::factory()->recycle([$this->user, $this->team])->create(['company_id' => $company->id]);
+        $unmatched = People::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson("/api/v1/people?filter[company_id]={$company->id}");
 
@@ -357,8 +357,8 @@ describe('filtering and sorting', function (): void {
     it('can sort people by name ascending', function (): void {
         Sanctum::actingAs($this->user);
 
-        People::factory()->for($this->team)->create(['name' => 'Zulu Person']);
-        People::factory()->for($this->team)->create(['name' => 'Alpha Person']);
+        People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Zulu Person']);
+        People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Alpha Person']);
 
         $response = $this->getJson('/api/v1/people?sort=name');
 
@@ -373,8 +373,8 @@ describe('filtering and sorting', function (): void {
     it('can sort people by name descending', function (): void {
         Sanctum::actingAs($this->user);
 
-        People::factory()->for($this->team)->create(['name' => 'Alpha Person']);
-        People::factory()->for($this->team)->create(['name' => 'Zulu Person']);
+        People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Alpha Person']);
+        People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Zulu Person']);
 
         $response = $this->getJson('/api/v1/people?sort=-name');
 
@@ -405,7 +405,7 @@ describe('pagination', function (): void {
     it('paginates with per_page parameter', function (): void {
         Sanctum::actingAs($this->user);
 
-        People::factory(5)->for($this->team)->create();
+        People::factory(5)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/people?per_page=2')
             ->assertOk()
@@ -415,7 +415,7 @@ describe('pagination', function (): void {
     it('returns second page of results', function (): void {
         Sanctum::actingAs($this->user);
 
-        People::factory(5)->for($this->team)->create();
+        People::factory(5)->recycle([$this->user, $this->team])->create();
 
         $page1 = $this->getJson('/api/v1/people?per_page=3&page=1');
         $page2 = $this->getJson('/api/v1/people?per_page=3&page=2');
@@ -439,7 +439,7 @@ describe('pagination', function (): void {
     it('returns empty data array for page beyond results', function (): void {
         Sanctum::actingAs($this->user);
 
-        People::factory(2)->for($this->team)->create();
+        People::factory(2)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/people?page=999')
             ->assertOk()
@@ -481,7 +481,7 @@ describe('mass assignment protection', function (): void {
     it('ignores team_id in update request', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
 
         $this->putJson("/api/v1/people/{$person->id}", [
@@ -542,8 +542,8 @@ describe('soft deletes', function (): void {
     it('excludes soft-deleted people from list', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
-        $deleted = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
+        $deleted = People::factory()->recycle([$this->user, $this->team])->create();
         $deleted->delete();
 
         $ids = collect($this->getJson('/api/v1/people')->json('data'))->pluck('id');
@@ -554,7 +554,7 @@ describe('soft deletes', function (): void {
     it('cannot show a soft-deleted person', function (): void {
         Sanctum::actingAs($this->user);
 
-        $person = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
         $person->delete();
 
         $this->getJson("/api/v1/people/{$person->id}")
@@ -574,8 +574,8 @@ describe('non-existent record', function (): void {
 it('includes company_id in attributes', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
-    $person = People::factory()->for($this->team)->create([
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
+    $person = People::factory()->recycle([$this->user, $this->team])->create([
         'company_id' => $company->id,
     ]);
 

--- a/tests/Feature/Api/V1/TasksApiTest.php
+++ b/tests/Feature/Api/V1/TasksApiTest.php
@@ -39,7 +39,7 @@ it('can list tasks', function (): void {
     Sanctum::actingAs($this->user);
 
     $seeded = Task::query()->where('team_id', $this->team->id)->count();
-    Task::factory(3)->for($this->team)->create();
+    Task::factory(3)->recycle([$this->user, $this->team])->create();
 
     $this->getJson('/api/v1/tasks')
         ->assertOk()
@@ -84,7 +84,7 @@ it('validates required fields on create', function (): void {
 it('can show a task', function (): void {
     Sanctum::actingAs($this->user);
 
-    $task = Task::factory()->for($this->team)->create(['title' => 'Show Test']);
+    $task = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Show Test']);
 
     $this->getJson("/api/v1/tasks/{$task->id}")
         ->assertOk()
@@ -108,7 +108,7 @@ it('can show a task', function (): void {
 it('can update a task', function (): void {
     Sanctum::actingAs($this->user);
 
-    $task = Task::factory()->for($this->team)->create();
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
 
     $this->putJson("/api/v1/tasks/{$task->id}", ['title' => 'Updated Title'])
         ->assertOk()
@@ -129,7 +129,7 @@ it('can update a task', function (): void {
 it('can delete a task', function (): void {
     Sanctum::actingAs($this->user);
 
-    $task = Task::factory()->for($this->team)->create();
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
 
     $this->deleteJson("/api/v1/tasks/{$task->id}")
         ->assertNoContent();
@@ -142,7 +142,7 @@ it('scopes tasks to current team', function (): void {
 
     Sanctum::actingAs($this->user);
 
-    $ownTask = Task::factory()->for($this->team)->create();
+    $ownTask = Task::factory()->recycle([$this->user, $this->team])->create();
 
     $response = $this->getJson('/api/v1/tasks');
 
@@ -156,9 +156,9 @@ it('scopes tasks to current team', function (): void {
 it('can create a task with relationship ids', function (): void {
     Sanctum::actingAs($this->user);
 
-    $company = Company::factory()->for($this->team)->create();
-    $person = People::factory()->for($this->team)->create();
-    $opportunity = Opportunity::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
+    $person = People::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     $this->postJson('/api/v1/tasks', [
         'title' => 'Linked task',
@@ -226,7 +226,7 @@ describe('includes', function (): void {
     it('can include creator on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson("/api/v1/tasks/{$task->id}?include=creator")
             ->assertOk()
@@ -248,7 +248,7 @@ describe('includes', function (): void {
     it('can include creator on list endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        Task::factory()->for($this->team)->create();
+        Task::factory()->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/tasks?include=creator')
             ->assertOk()
@@ -262,7 +262,7 @@ describe('includes', function (): void {
     it('can include assignees on show endpoint', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
         $task->assignees()->attach($this->user);
 
         $this->getJson("/api/v1/tasks/{$task->id}?include=assignees")
@@ -277,7 +277,7 @@ describe('includes', function (): void {
     it('can include multiple relations', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
         $task->assignees()->attach($this->user);
 
         $this->getJson("/api/v1/tasks/{$task->id}?include=creator,assignees")
@@ -292,7 +292,7 @@ describe('includes', function (): void {
     it('does not include relations when not requested', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson("/api/v1/tasks/{$task->id}")
             ->assertOk();
@@ -303,7 +303,7 @@ describe('includes', function (): void {
     it('can include relationship counts', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
 
         $response = $this->getJson('/api/v1/tasks?include=assigneesCount');
 
@@ -326,8 +326,8 @@ describe('filtering and sorting', function (): void {
     it('ignores assigned_to_me filter when value is false', function (): void {
         Sanctum::actingAs($this->user);
 
-        $unassignedTask = Task::factory()->for($this->team)->create(['title' => 'Unassigned']);
-        $assignedTask = Task::factory()->for($this->team)->create(['title' => 'Assigned']);
+        $unassignedTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Unassigned']);
+        $assignedTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Assigned']);
         $assignedTask->assignees()->attach($this->user);
 
         $this->getJson('/api/v1/tasks?filter[assigned_to_me]=false')
@@ -339,8 +339,8 @@ describe('filtering and sorting', function (): void {
     it('can filter tasks by title', function (): void {
         Sanctum::actingAs($this->user);
 
-        Task::factory()->for($this->team)->create(['title' => 'Fix login bug']);
-        Task::factory()->for($this->team)->create(['title' => 'Deploy to staging']);
+        Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Fix login bug']);
+        Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Deploy to staging']);
 
         $response = $this->getJson('/api/v1/tasks?filter[title]=login');
 
@@ -354,8 +354,8 @@ describe('filtering and sorting', function (): void {
     it('can sort tasks by title ascending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Task::factory()->for($this->team)->create(['title' => 'Zulu Task']);
-        Task::factory()->for($this->team)->create(['title' => 'Alpha Task']);
+        Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Zulu Task']);
+        Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Alpha Task']);
 
         $response = $this->getJson('/api/v1/tasks?sort=title');
 
@@ -370,8 +370,8 @@ describe('filtering and sorting', function (): void {
     it('can sort tasks by title descending', function (): void {
         Sanctum::actingAs($this->user);
 
-        Task::factory()->for($this->team)->create(['title' => 'Alpha Task']);
-        Task::factory()->for($this->team)->create(['title' => 'Zulu Task']);
+        Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Alpha Task']);
+        Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Zulu Task']);
 
         $response = $this->getJson('/api/v1/tasks?sort=-title');
 
@@ -402,7 +402,7 @@ describe('pagination', function (): void {
     it('paginates with per_page parameter', function (): void {
         Sanctum::actingAs($this->user);
 
-        Task::factory(5)->for($this->team)->create();
+        Task::factory(5)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/tasks?per_page=2')
             ->assertOk()
@@ -412,7 +412,7 @@ describe('pagination', function (): void {
     it('returns second page of results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Task::factory(5)->for($this->team)->create();
+        Task::factory(5)->recycle([$this->user, $this->team])->create();
 
         $page1 = $this->getJson('/api/v1/tasks?per_page=3&page=1');
         $page2 = $this->getJson('/api/v1/tasks?per_page=3&page=2');
@@ -436,7 +436,7 @@ describe('pagination', function (): void {
     it('returns empty data array for page beyond results', function (): void {
         Sanctum::actingAs($this->user);
 
-        Task::factory(2)->for($this->team)->create();
+        Task::factory(2)->recycle([$this->user, $this->team])->create();
 
         $this->getJson('/api/v1/tasks?page=999')
             ->assertOk()
@@ -478,7 +478,7 @@ describe('mass assignment protection', function (): void {
     it('ignores team_id in update request', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
 
         $this->putJson("/api/v1/tasks/{$task->id}", [
@@ -528,8 +528,8 @@ describe('soft deletes', function (): void {
     it('excludes soft-deleted tasks from list', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
-        $deleted = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
+        $deleted = Task::factory()->recycle([$this->user, $this->team])->create();
         $deleted->delete();
 
         $ids = collect($this->getJson('/api/v1/tasks')->json('data'))->pluck('id');
@@ -540,7 +540,7 @@ describe('soft deletes', function (): void {
     it('cannot show a soft-deleted task', function (): void {
         Sanctum::actingAs($this->user);
 
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
         $task->delete();
 
         $this->getJson("/api/v1/tasks/{$task->id}")

--- a/tests/Feature/Api/V1/TokenAbilitiesApiTest.php
+++ b/tests/Feature/Api/V1/TokenAbilitiesApiTest.php
@@ -25,7 +25,7 @@ describe('read-only token', function (): void {
     });
 
     it('can show a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->getJson("/api/v1/companies/{$company->id}")
@@ -39,7 +39,7 @@ describe('read-only token', function (): void {
     });
 
     it('cannot update a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->putJson("/api/v1/companies/{$company->id}", ['name' => 'Blocked'])
@@ -47,7 +47,7 @@ describe('read-only token', function (): void {
     });
 
     it('cannot delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->deleteJson("/api/v1/companies/{$company->id}")
@@ -73,7 +73,7 @@ describe('create-only token', function (): void {
     });
 
     it('cannot update a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->putJson("/api/v1/companies/{$company->id}", ['name' => 'Blocked'])
@@ -81,7 +81,7 @@ describe('create-only token', function (): void {
     });
 
     it('cannot delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->deleteJson("/api/v1/companies/{$company->id}")
@@ -107,7 +107,7 @@ describe('update-only token', function (): void {
     });
 
     it('can update a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->putJson("/api/v1/companies/{$company->id}", ['name' => 'Updated'])
@@ -115,7 +115,7 @@ describe('update-only token', function (): void {
     });
 
     it('cannot delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->deleteJson("/api/v1/companies/{$company->id}")
@@ -141,7 +141,7 @@ describe('delete-only token', function (): void {
     });
 
     it('can delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->deleteJson("/api/v1/companies/{$company->id}")
@@ -167,7 +167,7 @@ describe('wildcard token', function (): void {
     });
 
     it('can update a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->putJson("/api/v1/companies/{$company->id}", ['name' => 'Updated'])
@@ -175,7 +175,7 @@ describe('wildcard token', function (): void {
     });
 
     it('can delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($this->token)
             ->deleteJson("/api/v1/companies/{$company->id}")
@@ -195,7 +195,7 @@ describe('multi-ability token', function (): void {
             ->postJson('/api/v1/companies', ['name' => 'Multi Corp'])
             ->assertCreated();
 
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         $this->withToken($token)
             ->putJson("/api/v1/companies/{$company->id}", ['name' => 'Blocked'])

--- a/tests/Feature/Commands/PurgeScheduledDeletionsCommandTest.php
+++ b/tests/Feature/Commands/PurgeScheduledDeletionsCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\TeamDeletionReminderNotification;
+use App\Notifications\UserDeletionReminderNotification;
+use Illuminate\Support\Facades\Notification;
+
+test('expired users are permanently deleted', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion(-1)->create();
+    $userId = $user->id;
+
+    $this->artisan('app:purge-scheduled-deletions')
+        ->assertExitCode(0);
+
+    expect(User::query()->find($userId))->toBeNull();
+});
+
+test('non-expired users are not deleted', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion(15)->create();
+
+    $this->artisan('app:purge-scheduled-deletions')
+        ->assertExitCode(0);
+
+    expect($user->refresh())->not->toBeNull();
+});
+
+test('expired teams are permanently deleted', function () {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->currentTeam;
+    $team->update(['scheduled_deletion_at' => now()->subDay()]);
+    $teamId = $team->id;
+
+    $this->artisan('app:purge-scheduled-deletions')
+        ->assertExitCode(0);
+
+    expect(Team::query()->find($teamId))->toBeNull();
+});
+
+test('day 25 reminder is sent for users', function () {
+    Notification::fake();
+
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion(5)->create();
+
+    $this->travelTo(now());
+
+    $this->artisan('app:purge-scheduled-deletions')
+        ->assertExitCode(0);
+
+    Notification::assertSentTo($user, UserDeletionReminderNotification::class);
+});
+
+test('day 25 reminder is sent to team owner only', function () {
+    Notification::fake();
+
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+    $team->update(['scheduled_deletion_at' => now()->addDays(5)]);
+    $member = User::factory()->create();
+    $team->users()->attach($member, ['role' => 'editor']);
+
+    $this->artisan('app:purge-scheduled-deletions')
+        ->assertExitCode(0);
+
+    Notification::assertSentTo($owner, TeamDeletionReminderNotification::class);
+    Notification::assertNotSentTo($member, TeamDeletionReminderNotification::class);
+});

--- a/tests/Feature/FeatureFlagsTest.php
+++ b/tests/Feature/FeatureFlagsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\Documentation;
+use App\Features\OnboardSeed;
+use App\Features\SocialAuth;
+use App\Filament\Pages\CreateTeam;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
+use Illuminate\Foundation\Testing\CachedState;
+use Illuminate\Support\Facades\Http;
+use Laravel\Pennant\Feature;
+
+mutates(OnboardSeed::class, SocialAuth::class, Documentation::class);
+
+describe('OnboardSeed', function (): void {
+    it('seeds demo data when feature is active', function (): void {
+        Feature::define(OnboardSeed::class, true);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        livewire(CreateTeam::class)
+            ->fillForm([
+                'name' => 'Seed Enabled Team',
+            ])
+            ->call('register')
+            ->assertHasNoFormErrors();
+
+        $team = $user->fresh()->personalTeam();
+
+        expect(Company::where('team_id', $team->id)->count())->toBeGreaterThan(0);
+    });
+
+    it('skips demo data when feature is inactive', function (): void {
+        Feature::define(OnboardSeed::class, false);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        livewire(CreateTeam::class)
+            ->fillForm([
+                'name' => 'Seed Disabled Team',
+            ])
+            ->call('register')
+            ->assertHasNoFormErrors();
+
+        $team = $user->fresh()->personalTeam();
+
+        expect(Company::where('team_id', $team->id)->count())->toBe(0);
+    });
+});
+
+describe('SocialAuth', function (): void {
+    it('registers social auth routes when feature is active', function (): void {
+        $this->get(route('auth.socialite.redirect', 'google'))
+            ->assertRedirect();
+    });
+
+    it('does not register social auth routes when feature is inactive', function (): void {
+        putenv('RELATICLE_FEATURE_SOCIAL_AUTH=false');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
+        RouteServiceProvider::loadCachedRoutesUsing(null);
+        LoadConfiguration::alwaysUse(null);
+        $this->refreshApplication();
+
+        $this->get('/auth/redirect/google')
+            ->assertNotFound();
+
+        putenv('RELATICLE_FEATURE_SOCIAL_AUTH');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
+    });
+});
+
+describe('Documentation', function (): void {
+    beforeEach(function () {
+        Http::fake([
+            'api.github.com/*' => Http::response(['stargazers_count' => 0], 200),
+        ]);
+    });
+
+    it('serves documentation pages when feature is active', function (): void {
+        $this->get('/docs')
+            ->assertOk();
+    });
+
+    it('does not register documentation routes when feature is inactive', function (): void {
+        putenv('RELATICLE_FEATURE_DOCUMENTATION=false');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
+        RouteServiceProvider::loadCachedRoutesUsing(null);
+        LoadConfiguration::alwaysUse(null);
+        $this->refreshApplication();
+
+        $this->get('/docs')
+            ->assertNotFound();
+
+        putenv('RELATICLE_FEATURE_DOCUMENTATION');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
+    });
+});

--- a/tests/Feature/FeatureFlagsTest.php
+++ b/tests/Feature/FeatureFlagsTest.php
@@ -8,6 +8,10 @@ use App\Features\SocialAuth;
 use App\Filament\Pages\CreateTeam;
 use App\Models\Company;
 use App\Models\User;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
+use Illuminate\Foundation\Testing\CachedState;
+use Illuminate\Support\Facades\Http;
 use Laravel\Pennant\Feature;
 
 mutates(OnboardSeed::class, SocialAuth::class, Documentation::class);
@@ -60,16 +64,28 @@ describe('SocialAuth', function (): void {
 
     it('does not register social auth routes when feature is inactive', function (): void {
         putenv('RELATICLE_FEATURE_SOCIAL_AUTH=false');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
+        RouteServiceProvider::loadCachedRoutesUsing(null);
+        LoadConfiguration::alwaysUse(null);
         $this->refreshApplication();
 
         $this->get('/auth/redirect/google')
             ->assertNotFound();
 
         putenv('RELATICLE_FEATURE_SOCIAL_AUTH');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
     });
 });
 
 describe('Documentation', function (): void {
+    beforeEach(function () {
+        Http::fake([
+            'api.github.com/*' => Http::response(['stargazers_count' => 0], 200),
+        ]);
+    });
+
     it('serves documentation pages when feature is active', function (): void {
         $this->get('/docs')
             ->assertOk();
@@ -77,11 +93,17 @@ describe('Documentation', function (): void {
 
     it('does not register documentation routes when feature is inactive', function (): void {
         putenv('RELATICLE_FEATURE_DOCUMENTATION=false');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
+        RouteServiceProvider::loadCachedRoutesUsing(null);
+        LoadConfiguration::alwaysUse(null);
         $this->refreshApplication();
 
         $this->get('/docs')
             ->assertNotFound();
 
         putenv('RELATICLE_FEATURE_DOCUMENTATION');
+        CachedState::$cachedRoutes = null;
+        CachedState::$cachedConfig = null;
     });
 });

--- a/tests/Feature/FeatureFlagsTest.php
+++ b/tests/Feature/FeatureFlagsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\Documentation;
+use App\Features\OnboardSeed;
+use App\Features\SocialAuth;
+use App\Filament\Pages\CreateTeam;
+use App\Models\Company;
+use App\Models\User;
+use Laravel\Pennant\Feature;
+
+mutates(OnboardSeed::class, SocialAuth::class, Documentation::class);
+
+describe('OnboardSeed', function (): void {
+    it('seeds demo data when feature is active', function (): void {
+        Feature::define(OnboardSeed::class, true);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        livewire(CreateTeam::class)
+            ->fillForm([
+                'name' => 'Seed Enabled Team',
+            ])
+            ->call('register')
+            ->assertHasNoFormErrors();
+
+        $team = $user->fresh()->personalTeam();
+
+        expect(Company::where('team_id', $team->id)->count())->toBeGreaterThan(0);
+    });
+
+    it('skips demo data when feature is inactive', function (): void {
+        Feature::define(OnboardSeed::class, false);
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        livewire(CreateTeam::class)
+            ->fillForm([
+                'name' => 'Seed Disabled Team',
+            ])
+            ->call('register')
+            ->assertHasNoFormErrors();
+
+        $team = $user->fresh()->personalTeam();
+
+        expect(Company::where('team_id', $team->id)->count())->toBe(0);
+    });
+});
+
+describe('SocialAuth', function (): void {
+    it('registers social auth routes when feature is active', function (): void {
+        $this->get(route('auth.socialite.redirect', 'google'))
+            ->assertRedirect();
+    });
+
+    it('does not register social auth routes when feature is inactive', function (): void {
+        putenv('RELATICLE_FEATURE_SOCIAL_AUTH=false');
+        $this->refreshApplication();
+
+        $this->get('/auth/redirect/google')
+            ->assertNotFound();
+
+        putenv('RELATICLE_FEATURE_SOCIAL_AUTH');
+    });
+});
+
+describe('Documentation', function (): void {
+    it('serves documentation pages when feature is active', function (): void {
+        $this->get('/docs')
+            ->assertOk();
+    });
+
+    it('does not register documentation routes when feature is inactive', function (): void {
+        putenv('RELATICLE_FEATURE_DOCUMENTATION=false');
+        $this->refreshApplication();
+
+        $this->get('/docs')
+            ->assertNotFound();
+
+        putenv('RELATICLE_FEATURE_DOCUMENTATION');
+    });
+});

--- a/tests/Feature/Filament/App/Pages/OpportunitiesBoardTest.php
+++ b/tests/Feature/Filament/App/Pages/OpportunitiesBoardTest.php
@@ -41,10 +41,10 @@ it('displays opportunities in the correct board columns', function (): void {
     $prospecting = $this->stageField->options->firstWhere('name', 'Prospecting');
     $closedWon = $this->stageField->options->firstWhere('name', 'Closed Won');
 
-    $prospectingOpportunity = Opportunity::factory()->for($this->team)->create();
+    $prospectingOpportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
     $prospectingOpportunity->saveCustomFieldValue($this->stageField, $prospecting->getKey());
 
-    $closedWonOpportunity = Opportunity::factory()->for($this->team)->create();
+    $closedWonOpportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
     $closedWonOpportunity->saveCustomFieldValue($this->stageField, $closedWon->getKey());
 
     $board = getOpportunityBoard();
@@ -71,7 +71,7 @@ it('moves a card between columns via moveCard', function (): void {
     $prospecting = $this->stageField->options->firstWhere('name', 'Prospecting');
     $qualification = $this->stageField->options->firstWhere('name', 'Qualification');
 
-    $opportunity = Opportunity::factory()->for($this->team)->create();
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
     $opportunity->saveCustomFieldValue($this->stageField, $prospecting->getKey());
 
     livewire(OpportunitiesBoard::class)

--- a/tests/Feature/Filament/App/Pages/TasksBoardTest.php
+++ b/tests/Feature/Filament/App/Pages/TasksBoardTest.php
@@ -41,10 +41,10 @@ it('displays tasks in the correct board columns', function (): void {
     $todo = $this->statusField->options->firstWhere('name', 'To do');
     $done = $this->statusField->options->firstWhere('name', 'Done');
 
-    $todoTask = Task::factory()->for($this->team)->create();
+    $todoTask = Task::factory()->recycle([$this->user, $this->team])->create();
     $todoTask->saveCustomFieldValue($this->statusField, $todo->getKey());
 
-    $doneTask = Task::factory()->for($this->team)->create();
+    $doneTask = Task::factory()->recycle([$this->user, $this->team])->create();
     $doneTask->saveCustomFieldValue($this->statusField, $done->getKey());
 
     $board = getTaskBoard();
@@ -71,7 +71,7 @@ it('moves a card between columns via moveCard', function (): void {
     $todo = $this->statusField->options->firstWhere('name', 'To do');
     $inProgress = $this->statusField->options->firstWhere('name', 'In progress');
 
-    $task = Task::factory()->for($this->team)->create();
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
     $task->saveCustomFieldValue($this->statusField, $todo->getKey());
 
     livewire(TasksBoard::class)

--- a/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
@@ -26,7 +26,7 @@ it('can render the index page', function (): void {
 });
 
 it('can render the view page', function (): void {
-    $record = Company::factory()->for($this->team)->create();
+    $record = Company::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ViewCompany::class, ['record' => $record->getKey()])
         ->assertOk();
@@ -53,7 +53,7 @@ it('shows `:dataset` column', function (string $column): void {
 })->with(['name', 'accountOwner.name', 'creator.name', 'deleted_at', 'created_at', 'updated_at']);
 
 it('can sort `:dataset` column', function (string $column): void {
-    $records = Company::factory(3)->for($this->team)->create();
+    $records = Company::factory(3)->recycle([$this->user, $this->team])->create();
 
     $sortingKey = data_get($records->first(), $column) instanceof BackedEnum
         ? fn (Model $record) => data_get($record, $column)->value
@@ -67,7 +67,7 @@ it('can sort `:dataset` column', function (string $column): void {
 })->with(['name', 'accountOwner.name', 'creator.name', 'deleted_at', 'created_at', 'updated_at']);
 
 it('can search `:dataset` column', function (string $column): void {
-    $records = Company::factory(3)->for($this->team)->create();
+    $records = Company::factory(3)->recycle([$this->user, $this->team])->create();
     $search = data_get($records->first(), $column);
 
     $visibleRecords = $records->filter(fn (Model $record) => data_get($record, $column) === $search);
@@ -79,8 +79,8 @@ it('can search `:dataset` column', function (string $column): void {
 })->with(['name', 'accountOwner.name', 'creator.name']);
 
 it('cannot display trashed records by default', function (): void {
-    $records = Company::factory()->count(4)->for($this->team)->create();
-    $trashedRecords = Company::factory()->trashed()->count(6)->for($this->team)->create();
+    $records = Company::factory()->count(4)->recycle([$this->user, $this->team])->create();
+    $trashedRecords = Company::factory()->trashed()->count(6)->recycle([$this->user, $this->team])->create();
 
     livewire(ListCompanies::class)
         ->assertCanSeeTableRecords($records)
@@ -89,7 +89,7 @@ it('cannot display trashed records by default', function (): void {
 });
 
 it('can paginate records', function (): void {
-    $records = Company::factory(20)->for($this->team)->create();
+    $records = Company::factory(20)->recycle([$this->user, $this->team])->create();
 
     // Fetch records with the same sort order as the table (created_at DESC)
     $sortedRecords = Company::query()
@@ -104,7 +104,7 @@ it('can paginate records', function (): void {
 });
 
 it('can bulk delete records', function (): void {
-    $records = Company::factory(5)->for($this->team)->create();
+    $records = Company::factory(5)->recycle([$this->user, $this->team])->create();
 
     livewire(ListCompanies::class)
         ->assertCanSeeTableRecords($records)
@@ -132,7 +132,7 @@ it('can create a company', function (): void {
 });
 
 it('can edit a company', function (): void {
-    $record = Company::factory()->for($this->team)->create();
+    $record = Company::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ListCompanies::class)
         ->callAction(TestAction::make('edit')->table($record), data: [
@@ -144,7 +144,7 @@ it('can edit a company', function (): void {
 });
 
 it('can delete a company', function (): void {
-    $record = Company::factory()->for($this->team)->create();
+    $record = Company::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ListCompanies::class)
         ->callAction(TestAction::make('delete')->table($record));
@@ -179,7 +179,7 @@ it('sets creator_id and team_id via observer when creating a company', function 
 });
 
 it('authorizes team member to view and update own team company', function (): void {
-    $record = Company::factory()->for($this->team)->create();
+    $record = Company::factory()->recycle([$this->user, $this->team])->create();
 
     expect($this->user->can('view', $record))->toBeTrue()
         ->and($this->user->can('update', $record))->toBeTrue()

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -45,7 +45,7 @@ it('shows `:dataset` column', function (string $column): void {
 })->with(['title', 'companies.name', 'people.name', 'creator.name', 'deleted_at', 'created_at', 'updated_at']);
 
 it('can sort `:dataset` column', function (string $column): void {
-    $records = Note::factory(3)->for($this->team)->create();
+    $records = Note::factory(3)->recycle([$this->user, $this->team])->create();
 
     $sortingKey = data_get($records->first(), $column) instanceof BackedEnum
         ? fn (Model $record) => data_get($record, $column)->value
@@ -59,7 +59,7 @@ it('can sort `:dataset` column', function (string $column): void {
 })->with(['creator.name', 'deleted_at', 'created_at', 'updated_at']);
 
 it('can search `:dataset` column', function (string $column): void {
-    $records = Note::factory(3)->for($this->team)->create();
+    $records = Note::factory(3)->recycle([$this->user, $this->team])->create();
     $search = data_get($records->first(), $column);
 
     livewire(ManageNotes::class)
@@ -69,8 +69,8 @@ it('can search `:dataset` column', function (string $column): void {
 })->with(['title', 'creator.name']);
 
 it('cannot display trashed records by default', function (): void {
-    $records = Note::factory()->count(4)->for($this->team)->create();
-    $trashedRecords = Note::factory()->trashed()->count(6)->for($this->team)->create();
+    $records = Note::factory()->count(4)->recycle([$this->user, $this->team])->create();
+    $trashedRecords = Note::factory()->trashed()->count(6)->recycle([$this->user, $this->team])->create();
 
     livewire(ManageNotes::class)
         ->assertCanSeeTableRecords($records)
@@ -79,7 +79,7 @@ it('cannot display trashed records by default', function (): void {
 });
 
 it('can paginate records', function (): void {
-    $records = Note::factory(20)->for($this->team)->create();
+    $records = Note::factory(20)->recycle([$this->user, $this->team])->create();
 
     livewire(ManageNotes::class)
         ->assertCanSeeTableRecords($records->take(10), inOrder: true)
@@ -88,7 +88,7 @@ it('can paginate records', function (): void {
 });
 
 it('can bulk delete records', function (): void {
-    $records = Note::factory(5)->for($this->team)->create();
+    $records = Note::factory(5)->recycle([$this->user, $this->team])->create();
 
     livewire(ManageNotes::class)
         ->assertCanSeeTableRecords($records)
@@ -116,7 +116,7 @@ it('can create a note', function (): void {
 });
 
 it('can edit a note', function (): void {
-    $record = Note::factory()->for($this->team)->create();
+    $record = Note::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ManageNotes::class)
         ->callAction(TestAction::make('edit')->table($record), data: [
@@ -128,7 +128,7 @@ it('can edit a note', function (): void {
 });
 
 it('can delete a note', function (): void {
-    $record = Note::factory()->for($this->team)->create();
+    $record = Note::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ManageNotes::class)
         ->callAction(TestAction::make('delete')->table($record));
@@ -163,7 +163,7 @@ it('sets creator_id and team_id via observer when creating a note', function ():
 });
 
 it('authorizes team member to view and update own team note', function (): void {
-    $record = Note::factory()->for($this->team)->create();
+    $record = Note::factory()->recycle([$this->user, $this->team])->create();
 
     expect($this->user->can('view', $record))->toBeTrue()
         ->and($this->user->can('update', $record))->toBeTrue()

--- a/tests/Feature/Filament/App/Resources/OpportunityResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/OpportunityResourceTest.php
@@ -26,7 +26,7 @@ it('can render the index page', function (): void {
 });
 
 it('can render the view page', function (): void {
-    $record = Opportunity::factory()->for($this->team)->create();
+    $record = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ViewOpportunity::class, ['record' => $record->getKey()])
         ->assertOk();
@@ -53,7 +53,7 @@ it('shows `:dataset` column', function (string $column): void {
 })->with(['name', 'creator.name', 'deleted_at', 'created_at', 'updated_at']);
 
 it('can sort `:dataset` column', function (string $column): void {
-    $records = Opportunity::factory(3)->for($this->team)->create();
+    $records = Opportunity::factory(3)->recycle([$this->user, $this->team])->create();
 
     $sortingKey = data_get($records->first(), $column) instanceof BackedEnum
         ? fn (Model $record) => data_get($record, $column)->value
@@ -67,7 +67,7 @@ it('can sort `:dataset` column', function (string $column): void {
 })->with(['creator.name', 'deleted_at', 'created_at', 'updated_at']);
 
 it('can search `:dataset` column', function (string $column): void {
-    $records = Opportunity::factory(3)->for($this->team)->create();
+    $records = Opportunity::factory(3)->recycle([$this->user, $this->team])->create();
     $search = data_get($records->first(), $column);
 
     livewire(ListOpportunities::class)
@@ -77,8 +77,8 @@ it('can search `:dataset` column', function (string $column): void {
 })->with(['name', 'creator.name']);
 
 it('cannot display trashed records by default', function (): void {
-    $records = Opportunity::factory()->count(4)->for($this->team)->create();
-    $trashedRecords = Opportunity::factory()->trashed()->count(6)->for($this->team)->create();
+    $records = Opportunity::factory()->count(4)->recycle([$this->user, $this->team])->create();
+    $trashedRecords = Opportunity::factory()->trashed()->count(6)->recycle([$this->user, $this->team])->create();
 
     livewire(ListOpportunities::class)
         ->assertCanSeeTableRecords($records)
@@ -87,7 +87,7 @@ it('cannot display trashed records by default', function (): void {
 });
 
 it('can paginate records', function (): void {
-    $records = Opportunity::factory(20)->for($this->team)->create();
+    $records = Opportunity::factory(20)->recycle([$this->user, $this->team])->create();
 
     livewire(ListOpportunities::class)
         ->assertCanSeeTableRecords($records->take(10), inOrder: true)
@@ -96,7 +96,7 @@ it('can paginate records', function (): void {
 });
 
 it('can bulk delete records', function (): void {
-    $records = Opportunity::factory(5)->for($this->team)->create();
+    $records = Opportunity::factory(5)->recycle([$this->user, $this->team])->create();
 
     livewire(ListOpportunities::class)
         ->assertCanSeeTableRecords($records)
@@ -124,7 +124,7 @@ it('can create an opportunity', function (): void {
 });
 
 it('can edit an opportunity', function (): void {
-    $record = Opportunity::factory()->for($this->team)->create();
+    $record = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ListOpportunities::class)
         ->callAction(TestAction::make('edit')->table($record), data: [
@@ -136,7 +136,7 @@ it('can edit an opportunity', function (): void {
 });
 
 it('can delete an opportunity', function (): void {
-    $record = Opportunity::factory()->for($this->team)->create();
+    $record = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ListOpportunities::class)
         ->callAction(TestAction::make('delete')->table($record));
@@ -171,7 +171,7 @@ it('sets creator_id and team_id via observer when creating an opportunity', func
 });
 
 it('authorizes team member to view and update own team opportunity', function (): void {
-    $record = Opportunity::factory()->for($this->team)->create();
+    $record = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     expect($this->user->can('view', $record))->toBeTrue()
         ->and($this->user->can('update', $record))->toBeTrue()

--- a/tests/Feature/Filament/App/Resources/PeopleResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/PeopleResourceTest.php
@@ -26,7 +26,7 @@ it('can render the index page', function (): void {
 });
 
 it('can render the view page', function (): void {
-    $record = People::factory()->for($this->team)->create();
+    $record = People::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ViewPeople::class, ['record' => $record->getKey()])
         ->assertOk();
@@ -53,7 +53,7 @@ it('shows `:dataset` column', function (string $column): void {
 })->with(['name', 'company.name', 'creator.name', 'created_at', 'updated_at', 'deleted_at']);
 
 it('can sort `:dataset` column', function (string $column): void {
-    $records = People::factory(3)->for($this->team)->create();
+    $records = People::factory(3)->recycle([$this->user, $this->team])->create();
 
     $sortingKey = data_get($records->first(), $column) instanceof BackedEnum
         ? fn (Model $record) => data_get($record, $column)->value
@@ -67,7 +67,7 @@ it('can sort `:dataset` column', function (string $column): void {
 })->with(['company.name', 'creator.name', 'created_at', 'updated_at', 'deleted_at']);
 
 it('can search `:dataset` column', function (string $column): void {
-    $records = People::factory(3)->for($this->team)->create();
+    $records = People::factory(3)->recycle([$this->user, $this->team])->create();
     $search = data_get($records->first(), $column);
 
     livewire(ListPeople::class)
@@ -77,8 +77,8 @@ it('can search `:dataset` column', function (string $column): void {
 })->with(['name', 'company.name', 'creator.name']);
 
 it('cannot display trashed records by default', function (): void {
-    $records = People::factory()->count(4)->for($this->team)->create();
-    $trashedRecords = People::factory()->trashed()->count(6)->for($this->team)->create();
+    $records = People::factory()->count(4)->recycle([$this->user, $this->team])->create();
+    $trashedRecords = People::factory()->trashed()->count(6)->recycle([$this->user, $this->team])->create();
 
     livewire(ListPeople::class)
         ->assertCanSeeTableRecords($records)
@@ -87,7 +87,7 @@ it('cannot display trashed records by default', function (): void {
 });
 
 it('can paginate records', function (): void {
-    $records = People::factory(20)->for($this->team)->create();
+    $records = People::factory(20)->recycle([$this->user, $this->team])->create();
 
     livewire(ListPeople::class)
         ->assertCanSeeTableRecords($records->take(10), inOrder: true)
@@ -96,7 +96,7 @@ it('can paginate records', function (): void {
 });
 
 it('can bulk delete records', function (): void {
-    $records = People::factory(5)->for($this->team)->create();
+    $records = People::factory(5)->recycle([$this->user, $this->team])->create();
 
     livewire(ListPeople::class)
         ->assertCanSeeTableRecords($records)
@@ -124,7 +124,7 @@ it('can create a person', function (): void {
 });
 
 it('can edit a person', function (): void {
-    $record = People::factory()->for($this->team)->create();
+    $record = People::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ListPeople::class)
         ->callAction(TestAction::make('edit')->table($record), data: [
@@ -136,7 +136,7 @@ it('can edit a person', function (): void {
 });
 
 it('can delete a person', function (): void {
-    $record = People::factory()->for($this->team)->create();
+    $record = People::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ListPeople::class)
         ->callAction(TestAction::make('delete')->table($record));
@@ -171,7 +171,7 @@ it('sets creator_id and team_id via observer when creating a person', function (
 });
 
 it('authorizes team member to view and update own team person', function (): void {
-    $record = People::factory()->for($this->team)->create();
+    $record = People::factory()->recycle([$this->user, $this->team])->create();
 
     expect($this->user->can('view', $record))->toBeTrue()
         ->and($this->user->can('update', $record))->toBeTrue()

--- a/tests/Feature/Filament/App/Resources/TaskResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/TaskResourceTest.php
@@ -45,7 +45,7 @@ it('shows `:dataset` column', function (string $column): void {
 })->with(['title', 'assignees.name', 'creator.name', 'created_at', 'updated_at', 'deleted_at']);
 
 it('can sort `:dataset` column', function (string $column): void {
-    $records = Task::factory(3)->for($this->team)->create();
+    $records = Task::factory(3)->recycle([$this->user, $this->team])->create();
 
     $sortingKey = data_get($records->first(), $column) instanceof BackedEnum
         ? fn (Model $record) => data_get($record, $column)->value
@@ -59,7 +59,7 @@ it('can sort `:dataset` column', function (string $column): void {
 })->with(['creator.name', 'created_at', 'updated_at', 'deleted_at']);
 
 it('can search `:dataset` column', function (string $column): void {
-    $records = Task::factory(3)->for($this->team)->create();
+    $records = Task::factory(3)->recycle([$this->user, $this->team])->create();
     $search = data_get($records->first(), $column);
 
     livewire(ManageTasks::class)
@@ -69,8 +69,8 @@ it('can search `:dataset` column', function (string $column): void {
 })->with(['title', 'assignees.name', 'creator.name']);
 
 it('cannot display trashed records by default', function (): void {
-    $records = Task::factory()->count(4)->for($this->team)->create();
-    $trashedRecords = Task::factory()->trashed()->count(6)->for($this->team)->create();
+    $records = Task::factory()->count(4)->recycle([$this->user, $this->team])->create();
+    $trashedRecords = Task::factory()->trashed()->count(6)->recycle([$this->user, $this->team])->create();
 
     livewire(ManageTasks::class)
         ->assertCanSeeTableRecords($records)
@@ -79,7 +79,7 @@ it('cannot display trashed records by default', function (): void {
 });
 
 it('can paginate records', function (): void {
-    $records = Task::factory(20)->for($this->team)->create();
+    $records = Task::factory(20)->recycle([$this->user, $this->team])->create();
 
     livewire(ManageTasks::class)
         ->assertCanSeeTableRecords($records->take(10), inOrder: true)
@@ -88,7 +88,7 @@ it('can paginate records', function (): void {
 });
 
 it('can bulk delete records', function (): void {
-    $records = Task::factory(5)->for($this->team)->create();
+    $records = Task::factory(5)->recycle([$this->user, $this->team])->create();
 
     livewire(ManageTasks::class)
         ->assertCanSeeTableRecords($records)
@@ -116,7 +116,7 @@ it('can create a task', function (): void {
 });
 
 it('can edit a task', function (): void {
-    $record = Task::factory()->for($this->team)->create();
+    $record = Task::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ManageTasks::class)
         ->callAction(TestAction::make('edit')->table($record), data: [
@@ -128,7 +128,7 @@ it('can edit a task', function (): void {
 });
 
 it('can delete a task', function (): void {
-    $record = Task::factory()->for($this->team)->create();
+    $record = Task::factory()->recycle([$this->user, $this->team])->create();
 
     livewire(ManageTasks::class)
         ->callAction(TestAction::make('delete')->table($record));
@@ -163,7 +163,7 @@ it('sets creator_id and team_id via observer when creating a task', function ():
 });
 
 it('authorizes team member to view and update own team task', function (): void {
-    $record = Task::factory()->for($this->team)->create();
+    $record = Task::factory()->recycle([$this->user, $this->team])->create();
 
     expect($this->user->can('view', $record))->toBeTrue()
         ->and($this->user->can('update', $record))->toBeTrue()

--- a/tests/Feature/Mcp/CompanyToolsTest.php
+++ b/tests/Feature/Mcp/CompanyToolsTest.php
@@ -24,7 +24,7 @@ afterEach(function () {
 });
 
 it('can get a company by ID', function (): void {
-    $company = Company::factory()->for($this->team)->create(['name' => 'Acme Corp']);
+    $company = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Acme Corp']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(GetCompanyTool::class, ['id' => $company->id])
@@ -43,7 +43,7 @@ describe('team scoping', function () {
             'team_id' => Team::factory()->create()->id,
             'name' => 'Other Team Corp',
         ]));
-        $ownCompany = Company::factory()->for($this->team)->create(['name' => 'Own Team Corp']);
+        $ownCompany = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Own Team Corp']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListCompaniesTool::class)
@@ -90,10 +90,10 @@ describe('team scoping', function () {
     });
 
     it('excludes soft-deleted companies from list', function (): void {
-        $deleted = Company::factory()->for($this->team)->create(['name' => 'Deleted Corp']);
+        $deleted = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Deleted Corp']);
         $deleted->delete();
 
-        $active = Company::factory()->for($this->team)->create(['name' => 'Active Corp']);
+        $active = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Active Corp']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListCompaniesTool::class)
@@ -105,7 +105,7 @@ describe('team scoping', function () {
 
 describe('pagination', function () {
     it('can paginate companies via MCP tool', function (): void {
-        Company::factory(3)->for($this->team)->create();
+        Company::factory(3)->recycle([$this->user, $this->team])->create();
 
         $page1 = RelaticleServer::actingAs($this->user)
             ->tool(ListCompaniesTool::class, [
@@ -125,7 +125,7 @@ describe('pagination', function () {
     });
 
     it('includes pagination metadata in list responses', function (): void {
-        Company::factory(3)->for($this->team)->create();
+        Company::factory(3)->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListCompaniesTool::class, [
@@ -141,7 +141,7 @@ describe('pagination', function () {
 
 describe('custom fields serialization', function () {
     it('returns empty custom_fields as object not array', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(GetCompanyTool::class, ['id' => $company->id])

--- a/tests/Feature/Mcp/CrmSummaryResourceTest.php
+++ b/tests/Feature/Mcp/CrmSummaryResourceTest.php
@@ -17,9 +17,9 @@ beforeEach(function (): void {
 });
 
 it('returns CRM summary with record counts', function (): void {
-    Company::factory()->for($this->team)->count(3)->create();
-    People::factory()->for($this->team)->count(5)->create();
-    Opportunity::factory()->for($this->team)->count(2)->create();
+    Company::factory()->recycle([$this->user, $this->team])->count(3)->create();
+    People::factory()->recycle([$this->user, $this->team])->count(5)->create();
+    Opportunity::factory()->recycle([$this->user, $this->team])->count(2)->create();
 
     $response = RelaticleServer::actingAs($this->user)
         ->resource(CrmSummaryResource::class);
@@ -33,7 +33,7 @@ it('returns CRM summary with record counts', function (): void {
 });
 
 it('includes opportunity pipeline breakdown', function (): void {
-    $opp = Opportunity::factory()->for($this->team)->create();
+    $opp = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     $stageField = CustomField::query()
         ->withoutGlobalScopes()
@@ -55,7 +55,7 @@ it('includes opportunity pipeline breakdown', function (): void {
 });
 
 it('includes task overdue and due this week counts', function (): void {
-    Task::factory()->for($this->team)->create();
+    Task::factory()->recycle([$this->user, $this->team])->create();
 
     $response = RelaticleServer::actingAs($this->user)
         ->resource(CrmSummaryResource::class);

--- a/tests/Feature/Mcp/Filters/CustomFieldFilterTest.php
+++ b/tests/Feature/Mcp/Filters/CustomFieldFilterTest.php
@@ -24,8 +24,8 @@ afterEach(function (): void {
 });
 
 it('filters by custom field equality', function (): void {
-    $opportunity1 = Opportunity::factory()->for($this->team)->create(['name' => 'Deal A']);
-    $opportunity2 = Opportunity::factory()->for($this->team)->create(['name' => 'Deal B']);
+    $opportunity1 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Deal A']);
+    $opportunity2 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Deal B']);
 
     $stageField = CustomField::query()
         ->withoutGlobalScopes()
@@ -58,8 +58,8 @@ it('filters by custom field equality', function (): void {
 });
 
 it('filters by currency field with gte operator', function (): void {
-    $opportunity1 = Opportunity::factory()->for($this->team)->create(['name' => 'Big Deal']);
-    $opportunity2 = Opportunity::factory()->for($this->team)->create(['name' => 'Small Deal']);
+    $opportunity1 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Big Deal']);
+    $opportunity2 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Small Deal']);
 
     $amountField = CustomField::query()
         ->withoutGlobalScopes()
@@ -94,7 +94,7 @@ it('filters by currency field with gte operator', function (): void {
 it('silently ignores unknown field codes', function (): void {
     $countBefore = Opportunity::query()->count();
 
-    Opportunity::factory()->for($this->team)->create();
+    Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     $request = new Request([
         'filter' => [
@@ -134,7 +134,7 @@ it('rejects more than 10 filter conditions', function (): void {
 it('handles empty filter object as no-op', function (): void {
     $countBefore = Opportunity::query()->count();
 
-    Opportunity::factory()->for($this->team)->count(3)->create();
+    Opportunity::factory()->recycle([$this->user, $this->team])->count(3)->create();
 
     $request = new Request([
         'filter' => [

--- a/tests/Feature/Mcp/Filters/CustomFieldSortTest.php
+++ b/tests/Feature/Mcp/Filters/CustomFieldSortTest.php
@@ -23,8 +23,8 @@ afterEach(function (): void {
 });
 
 it('sorts opportunities by custom field value ascending', function (): void {
-    $opp1 = Opportunity::factory()->for($this->team)->create(['name' => 'A']);
-    $opp2 = Opportunity::factory()->for($this->team)->create(['name' => 'B']);
+    $opp1 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'A']);
+    $opp2 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'B']);
 
     $amountField = CustomField::query()
         ->withoutGlobalScopes()
@@ -57,8 +57,8 @@ it('sorts opportunities by custom field value ascending', function (): void {
 });
 
 it('sorts opportunities by custom field value descending', function (): void {
-    $opp1 = Opportunity::factory()->for($this->team)->create(['name' => 'A']);
-    $opp2 = Opportunity::factory()->for($this->team)->create(['name' => 'B']);
+    $opp1 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'A']);
+    $opp2 = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'B']);
 
     $amountField = CustomField::query()
         ->withoutGlobalScopes()

--- a/tests/Feature/Mcp/McpToolFeaturesTest.php
+++ b/tests/Feature/Mcp/McpToolFeaturesTest.php
@@ -40,10 +40,10 @@ beforeEach(function () {
 // ---------------------------------------------------------------------------
 describe('ListTasksTool assigned_to_me', function () {
     it('filters tasks assigned to the current user', function (): void {
-        $assignedTask = Task::factory()->for($this->team)->create(['title' => 'Assigned Task']);
+        $assignedTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Assigned Task']);
         $assignedTask->assignees()->attach($this->user);
 
-        $unassignedTask = Task::factory()->for($this->team)->create(['title' => 'Unassigned Task']);
+        $unassignedTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Unassigned Task']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListTasksTool::class, [
@@ -55,10 +55,10 @@ describe('ListTasksTool assigned_to_me', function () {
     });
 
     it('returns all tasks when assigned_to_me is not set', function (): void {
-        $assignedTask = Task::factory()->for($this->team)->create(['title' => 'Assigned Task']);
+        $assignedTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Assigned Task']);
         $assignedTask->assignees()->attach($this->user);
 
-        Task::factory()->for($this->team)->create(['title' => 'Unassigned Task']);
+        Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Unassigned Task']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListTasksTool::class)
@@ -73,13 +73,13 @@ describe('ListTasksTool assigned_to_me', function () {
 // ---------------------------------------------------------------------------
 describe('ListNotesTool notable filtering', function () {
     it('filters notes by notable_type company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
-        $person = People::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
 
-        $companyNote = Note::factory()->for($this->team)->create(['title' => 'Company Note']);
+        $companyNote = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Company Note']);
         $companyNote->companies()->attach($company);
 
-        $personNote = Note::factory()->for($this->team)->create(['title' => 'Person Note']);
+        $personNote = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Person Note']);
         $personNote->people()->attach($person);
 
         RelaticleServer::actingAs($this->user)
@@ -92,13 +92,13 @@ describe('ListNotesTool notable filtering', function () {
     });
 
     it('filters notes by notable_type people', function (): void {
-        $company = Company::factory()->for($this->team)->create();
-        $person = People::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
 
-        $companyNote = Note::factory()->for($this->team)->create(['title' => 'Company Note']);
+        $companyNote = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Company Note']);
         $companyNote->companies()->attach($company);
 
-        $personNote = Note::factory()->for($this->team)->create(['title' => 'Person Note']);
+        $personNote = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Person Note']);
         $personNote->people()->attach($person);
 
         RelaticleServer::actingAs($this->user)
@@ -111,13 +111,13 @@ describe('ListNotesTool notable filtering', function () {
     });
 
     it('filters notes by notable_id', function (): void {
-        $company1 = Company::factory()->for($this->team)->create();
-        $company2 = Company::factory()->for($this->team)->create();
+        $company1 = Company::factory()->recycle([$this->user, $this->team])->create();
+        $company2 = Company::factory()->recycle([$this->user, $this->team])->create();
 
-        $note1 = Note::factory()->for($this->team)->create(['title' => 'Note For Company 1']);
+        $note1 = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Note For Company 1']);
         $note1->companies()->attach($company1);
 
-        $note2 = Note::factory()->for($this->team)->create(['title' => 'Note For Company 2']);
+        $note2 = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Note For Company 2']);
         $note2->companies()->attach($company2);
 
         RelaticleServer::actingAs($this->user)
@@ -130,13 +130,13 @@ describe('ListNotesTool notable filtering', function () {
     });
 
     it('filters notes by notable_type and notable_id combined', function (): void {
-        $company = Company::factory()->for($this->team)->create();
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
-        $companyNote = Note::factory()->for($this->team)->create(['title' => 'Specific Company Note']);
+        $companyNote = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Specific Company Note']);
         $companyNote->companies()->attach($company);
 
-        $opportunityNote = Note::factory()->for($this->team)->create(['title' => 'Opportunity Note']);
+        $opportunityNote = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Opportunity Note']);
         $opportunityNote->opportunities()->attach($opportunity);
 
         RelaticleServer::actingAs($this->user)
@@ -387,7 +387,7 @@ describe('custom field update via MCP', function () {
     });
 
     it('updates company with custom fields', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdateCompanyTool::class, [
@@ -398,7 +398,7 @@ describe('custom field update via MCP', function () {
     });
 
     it('updates person with custom fields', function (): void {
-        $person = People::factory()->for($this->team)->create();
+        $person = People::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdatePeopleTool::class, [
@@ -409,7 +409,7 @@ describe('custom field update via MCP', function () {
     });
 
     it('updates opportunity with custom fields', function (): void {
-        $opportunity = Opportunity::factory()->for($this->team)->create();
+        $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdateOpportunityTool::class, [
@@ -420,7 +420,7 @@ describe('custom field update via MCP', function () {
     });
 
     it('updates task with custom fields', function (): void {
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdateTaskTool::class, [
@@ -431,7 +431,7 @@ describe('custom field update via MCP', function () {
     });
 
     it('updates note with custom fields', function (): void {
-        $note = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdateNoteTool::class, [
@@ -648,7 +648,7 @@ describe('unknown custom field key rejection', function () {
     });
 
     it('rejects unknown custom field key on update', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdateCompanyTool::class, [
@@ -754,7 +754,7 @@ describe('custom field validation rejection', function () {
 // ---------------------------------------------------------------------------
 describe('relationship includes filter sensitive fields', function () {
     it('does not leak sensitive user fields in GetCompanyTool creator include', function (): void {
-        $company = Company::factory()->for($this->team)->create([
+        $company = Company::factory()->recycle([$this->user, $this->team])->create([
             'creator_id' => $this->user->id,
         ]);
 
@@ -773,7 +773,7 @@ describe('relationship includes filter sensitive fields', function () {
     });
 
     it('does not leak sensitive fields in ListCompaniesTool with creator include', function (): void {
-        Company::factory()->for($this->team)->create([
+        Company::factory()->recycle([$this->user, $this->team])->create([
             'creator_id' => $this->user->id,
         ]);
 
@@ -791,8 +791,8 @@ describe('relationship includes filter sensitive fields', function () {
     });
 
     it('serializes related people through resource in GetCompanyTool', function (): void {
-        $company = Company::factory()->for($this->team)->create();
-        People::factory()->for($this->team)->create([
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
+        People::factory()->recycle([$this->user, $this->team])->create([
             'name' => 'Included Person',
             'company_id' => $company->id,
         ]);
@@ -815,7 +815,7 @@ describe('relationship includes filter sensitive fields', function () {
 // ---------------------------------------------------------------------------
 describe('detach tools reject cross-team entity IDs', function () {
     it('rejects company from another team when detaching from task', function (): void {
-        $task = Task::factory()->for($this->team)->create();
+        $task = Task::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
         $otherCompany = Company::withoutEvents(fn () => Company::factory()->create([
             'team_id' => $otherTeam->id,
@@ -830,7 +830,7 @@ describe('detach tools reject cross-team entity IDs', function () {
     });
 
     it('rejects company from another team when detaching from note', function (): void {
-        $note = Note::factory()->for($this->team)->create();
+        $note = Note::factory()->recycle([$this->user, $this->team])->create();
         $otherTeam = Team::factory()->create();
         $otherCompany = Company::withoutEvents(fn () => Company::factory()->create([
             'team_id' => $otherTeam->id,

--- a/tests/Feature/Mcp/NoteToolsTest.php
+++ b/tests/Feature/Mcp/NoteToolsTest.php
@@ -27,7 +27,7 @@ afterEach(function () {
 });
 
 it('can create a note linked to a company', function (): void {
-    $company = Company::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     RelaticleServer::actingAs($this->user)
         ->tool(CreateNoteTool::class, [
@@ -43,8 +43,8 @@ it('can create a note linked to a company', function (): void {
 });
 
 it('can update a note to link to an opportunity', function (): void {
-    $note = Note::factory()->for($this->team)->create();
-    $opportunity = Opportunity::factory()->for($this->team)->create();
+    $note = Note::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     RelaticleServer::actingAs($this->user)
         ->tool(UpdateNoteTool::class, [
@@ -57,8 +57,8 @@ it('can update a note to link to an opportunity', function (): void {
 });
 
 it('can detach all companies from a note via empty array', function (): void {
-    $note = Note::factory()->for($this->team)->create();
-    $company = Company::factory()->for($this->team)->create();
+    $note = Note::factory()->recycle([$this->user, $this->team])->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
     $note->companies()->attach($company);
 
     RelaticleServer::actingAs($this->user)
@@ -72,7 +72,7 @@ it('can detach all companies from a note via empty array', function (): void {
 });
 
 it('can get a note by ID', function (): void {
-    $note = Note::factory()->for($this->team)->create(['title' => 'Meeting Notes']);
+    $note = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Meeting Notes']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(GetNoteTool::class, ['id' => $note->id])
@@ -81,7 +81,7 @@ it('can get a note by ID', function (): void {
 });
 
 it('can update a note via MCP tool', function (): void {
-    $note = Note::factory()->for($this->team)->create(['title' => 'Old Note']);
+    $note = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Old Note']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(UpdateNoteTool::class, [
@@ -95,7 +95,7 @@ it('can update a note via MCP tool', function (): void {
 });
 
 it('can delete a note via MCP tool', function (): void {
-    $note = Note::factory()->for($this->team)->create(['title' => 'Delete Me']);
+    $note = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Delete Me']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(DeleteNoteTool::class, [
@@ -108,8 +108,8 @@ it('can delete a note via MCP tool', function (): void {
 });
 
 it('can attach a note to a company', function (): void {
-    $note = Note::factory()->for($this->team)->create();
-    $company = Company::factory()->for($this->team)->create();
+    $note = Note::factory()->recycle([$this->user, $this->team])->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     RelaticleServer::actingAs($this->user)
         ->tool(AttachNoteToEntitiesTool::class, [
@@ -122,8 +122,8 @@ it('can attach a note to a company', function (): void {
 });
 
 it('can detach a note from a company', function (): void {
-    $note = Note::factory()->for($this->team)->create();
-    $company = Company::factory()->for($this->team)->create();
+    $note = Note::factory()->recycle([$this->user, $this->team])->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
     $note->companies()->attach($company);
 
     RelaticleServer::actingAs($this->user)
@@ -137,9 +137,9 @@ it('can detach a note from a company', function (): void {
 });
 
 it('attach does not remove existing links', function (): void {
-    $note = Note::factory()->for($this->team)->create();
-    $company1 = Company::factory()->for($this->team)->create();
-    $company2 = Company::factory()->for($this->team)->create();
+    $note = Note::factory()->recycle([$this->user, $this->team])->create();
+    $company1 = Company::factory()->recycle([$this->user, $this->team])->create();
+    $company2 = Company::factory()->recycle([$this->user, $this->team])->create();
     $note->companies()->attach($company1);
 
     RelaticleServer::actingAs($this->user)
@@ -162,7 +162,7 @@ describe('team scoping', function () {
             'team_id' => Team::factory()->create()->id,
             'title' => 'Other Team Note',
         ]));
-        $ownNote = Note::factory()->for($this->team)->create(['title' => 'Own Team Note']);
+        $ownNote = Note::factory()->recycle([$this->user, $this->team])->create(['title' => 'Own Team Note']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListNotesTool::class)

--- a/tests/Feature/Mcp/OpportunityToolsTest.php
+++ b/tests/Feature/Mcp/OpportunityToolsTest.php
@@ -25,7 +25,7 @@ afterEach(function () {
 });
 
 it('can get an opportunity by ID', function (): void {
-    $opportunity = Opportunity::factory()->for($this->team)->create(['name' => 'Big Deal']);
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Big Deal']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(GetOpportunityTool::class, ['id' => $opportunity->id])
@@ -34,7 +34,7 @@ it('can get an opportunity by ID', function (): void {
 });
 
 it('can update an opportunity via MCP tool', function (): void {
-    $opportunity = Opportunity::factory()->for($this->team)->create(['name' => 'Old Deal']);
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Old Deal']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(UpdateOpportunityTool::class, [
@@ -48,7 +48,7 @@ it('can update an opportunity via MCP tool', function (): void {
 });
 
 it('can delete an opportunity via MCP tool', function (): void {
-    $opportunity = Opportunity::factory()->for($this->team)->create(['name' => 'Closing Deal']);
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Closing Deal']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(DeleteOpportunityTool::class, [
@@ -61,11 +61,11 @@ it('can delete an opportunity via MCP tool', function (): void {
 });
 
 it('can filter opportunities by contact_id', function (): void {
-    $person = People::factory()->for($this->team)->create();
-    $matchingOpp = Opportunity::factory()->for($this->team)->create([
+    $person = People::factory()->recycle([$this->user, $this->team])->create();
+    $matchingOpp = Opportunity::factory()->recycle([$this->user, $this->team])->create([
         'contact_id' => $person->id,
     ]);
-    $otherOpp = Opportunity::factory()->for($this->team)->create();
+    $otherOpp = Opportunity::factory()->recycle([$this->user, $this->team])->create();
 
     RelaticleServer::actingAs($this->user)
         ->tool(ListOpportunitiesTool::class, [
@@ -86,7 +86,7 @@ describe('team scoping', function () {
             'team_id' => Team::factory()->create()->id,
             'name' => 'Other Team Deal',
         ]));
-        $ownOpportunity = Opportunity::factory()->for($this->team)->create(['name' => 'Own Team Deal']);
+        $ownOpportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Own Team Deal']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListOpportunitiesTool::class)

--- a/tests/Feature/Mcp/PeopleToolsTest.php
+++ b/tests/Feature/Mcp/PeopleToolsTest.php
@@ -24,7 +24,7 @@ afterEach(function () {
 });
 
 it('can get a person by ID', function (): void {
-    $person = People::factory()->for($this->team)->create(['name' => 'Jane Doe']);
+    $person = People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Jane Doe']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(GetPeopleTool::class, ['id' => $person->id])
@@ -33,7 +33,7 @@ it('can get a person by ID', function (): void {
 });
 
 it('can update a person via MCP tool', function (): void {
-    $person = People::factory()->for($this->team)->create(['name' => 'Old Name']);
+    $person = People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Old Name']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(UpdatePeopleTool::class, [
@@ -47,7 +47,7 @@ it('can update a person via MCP tool', function (): void {
 });
 
 it('can delete a person via MCP tool', function (): void {
-    $person = People::factory()->for($this->team)->create(['name' => 'Jane Doe']);
+    $person = People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Jane Doe']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(DeletePeopleTool::class, [
@@ -68,7 +68,7 @@ describe('team scoping', function () {
         $otherPerson = People::withoutEvents(fn () => People::factory()->for(Team::factory())->create([
             'name' => 'Other Team Person',
         ]));
-        $ownPerson = People::factory()->for($this->team)->create(['name' => 'Own Team Person']);
+        $ownPerson = People::factory()->recycle([$this->user, $this->team])->create(['name' => 'Own Team Person']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListPeopleTool::class)

--- a/tests/Feature/Mcp/RelaticleServerTest.php
+++ b/tests/Feature/Mcp/RelaticleServerTest.php
@@ -28,7 +28,7 @@ beforeEach(function () {
 });
 
 it('can list companies via MCP tool', function (): void {
-    Company::factory(3)->for($this->team)->create();
+    Company::factory(3)->recycle([$this->user, $this->team])->create();
 
     $response = RelaticleServer::actingAs($this->user)
         ->tool(ListCompaniesTool::class);
@@ -52,7 +52,7 @@ it('can create a company via MCP tool', function (): void {
 });
 
 it('can update a company via MCP tool', function (): void {
-    $company = Company::factory()->for($this->team)->create(['name' => 'Old Name']);
+    $company = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Old Name']);
 
     $response = RelaticleServer::actingAs($this->user)
         ->tool(UpdateCompanyTool::class, [
@@ -67,7 +67,7 @@ it('can update a company via MCP tool', function (): void {
 });
 
 it('can delete a company via MCP tool', function (): void {
-    $company = Company::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     $response = RelaticleServer::actingAs($this->user)
         ->tool(DeleteCompanyTool::class, [
@@ -168,7 +168,7 @@ it('validates company_id exists when creating a person via MCP', function (): vo
 });
 
 it('validates company_id exists when updating a person via MCP', function (): void {
-    $person = People::factory()->for($this->team)->create();
+    $person = People::factory()->recycle([$this->user, $this->team])->create();
 
     $response = RelaticleServer::actingAs($this->user)
         ->tool(UpdatePeopleTool::class, [
@@ -191,8 +191,8 @@ it('validates company_id and contact_id exist when creating opportunity via MCP'
 });
 
 it('can filter companies by name via MCP search param', function (): void {
-    Company::factory()->for($this->team)->create(['name' => 'Acme Corp']);
-    Company::factory()->for($this->team)->create(['name' => 'Beta Inc']);
+    Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Acme Corp']);
+    Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Beta Inc']);
 
     $response = RelaticleServer::actingAs($this->user)
         ->tool(ListCompaniesTool::class, [

--- a/tests/Feature/Mcp/TaskToolsTest.php
+++ b/tests/Feature/Mcp/TaskToolsTest.php
@@ -25,7 +25,7 @@ afterEach(function () {
 });
 
 it('can create a task with assignees and company', function (): void {
-    $company = Company::factory()->for($this->team)->create();
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
     RelaticleServer::actingAs($this->user)
         ->tool(CreateTaskTool::class, [
@@ -43,7 +43,7 @@ it('can create a task with assignees and company', function (): void {
 });
 
 it('can update task assignees', function (): void {
-    $task = Task::factory()->for($this->team)->create();
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
     $member = User::factory()->create();
     $this->team->users()->attach($member);
 
@@ -59,7 +59,7 @@ it('can update task assignees', function (): void {
 });
 
 it('can get a task by ID', function (): void {
-    $task = Task::factory()->for($this->team)->create(['title' => 'Follow Up Call']);
+    $task = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Follow Up Call']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(GetTaskTool::class, ['id' => $task->id])
@@ -68,7 +68,7 @@ it('can get a task by ID', function (): void {
 });
 
 it('can update a task via MCP tool', function (): void {
-    $task = Task::factory()->for($this->team)->create(['title' => 'Old Task']);
+    $task = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Old Task']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(UpdateTaskTool::class, [
@@ -82,7 +82,7 @@ it('can update a task via MCP tool', function (): void {
 });
 
 it('can delete a task via MCP tool', function (): void {
-    $task = Task::factory()->for($this->team)->create(['title' => 'Delete Me']);
+    $task = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Delete Me']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(DeleteTaskTool::class, [
@@ -95,7 +95,7 @@ it('can delete a task via MCP tool', function (): void {
 });
 
 it('can attach assignees to a task', function (): void {
-    $task = Task::factory()->for($this->team)->create();
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
 
     RelaticleServer::actingAs($this->user)
         ->tool(AttachTaskToEntitiesTool::class, [
@@ -108,10 +108,10 @@ it('can attach assignees to a task', function (): void {
 });
 
 it('can filter tasks by company_id', function (): void {
-    $company = Company::factory()->for($this->team)->create();
-    $linkedTask = Task::factory()->for($this->team)->create(['title' => 'Linked Task']);
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
+    $linkedTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Linked Task']);
     $linkedTask->companies()->attach($company);
-    $unlinkedTask = Task::factory()->for($this->team)->create(['title' => 'Unlinked Task']);
+    $unlinkedTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Unlinked Task']);
 
     RelaticleServer::actingAs($this->user)
         ->tool(ListTasksTool::class, [
@@ -132,7 +132,7 @@ describe('team scoping', function () {
             'team_id' => Team::factory()->create()->id,
             'title' => 'Other Team Task',
         ]));
-        $ownTask = Task::factory()->for($this->team)->create(['title' => 'Own Team Task']);
+        $ownTask = Task::factory()->recycle([$this->user, $this->team])->create(['title' => 'Own Team Task']);
 
         RelaticleServer::actingAs($this->user)
             ->tool(ListTasksTool::class)

--- a/tests/Feature/Mcp/TokenAbilitiesMcpTest.php
+++ b/tests/Feature/Mcp/TokenAbilitiesMcpTest.php
@@ -34,7 +34,7 @@ describe('read-only token', function (): void {
     })->throws(MissingAbilityException::class);
 
     it('cannot update a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdateCompanyTool::class, [
@@ -44,7 +44,7 @@ describe('read-only token', function (): void {
     })->throws(MissingAbilityException::class);
 
     it('cannot delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(DeleteCompanyTool::class, [
@@ -71,7 +71,7 @@ describe('create-only token', function (): void {
     });
 
     it('cannot delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(DeleteCompanyTool::class, [
@@ -99,7 +99,7 @@ describe('wildcard token', function (): void {
     });
 
     it('can update a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(UpdateCompanyTool::class, [
@@ -110,7 +110,7 @@ describe('wildcard token', function (): void {
     });
 
     it('can delete a company', function (): void {
-        $company = Company::factory()->for($this->team)->create();
+        $company = Company::factory()->recycle([$this->user, $this->team])->create();
 
         RelaticleServer::actingAs($this->user)
             ->tool(DeleteCompanyTool::class, [

--- a/tests/Feature/Middleware/CheckScheduledDeletionTest.php
+++ b/tests/Feature/Middleware/CheckScheduledDeletionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\CheckScheduledDeletion;
+use App\Livewire\App\Profile\ScheduledDeletionInterstitial;
+use App\Models\User;
+use Filament\Facades\Filament;
+
+mutates(CheckScheduledDeletion::class, ScheduledDeletionInterstitial::class);
+
+test('user with scheduled deletion is redirected to interstitial from panel', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $this->actingAs($user)
+        ->get('/app')
+        ->assertRedirect(route('filament.app.scheduled-deletion'));
+});
+
+test('user without scheduled deletion is not redirected to interstitial', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $response = $this->actingAs($user)->get('/app');
+
+    expect($response->headers->get('Location'))->not->toBe(route('filament.app.scheduled-deletion'));
+});
+
+test('interstitial component renders for user with scheduled deletion', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $this->actingAs($user);
+
+    livewire(ScheduledDeletionInterstitial::class)
+        ->assertSuccessful()
+        ->assertSee('Your account is being deleted');
+});
+
+test('interstitial redirects non-scheduled user to home', function () {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $this->actingAs($user);
+    Filament::setTenant($user->personalTeam());
+
+    livewire(ScheduledDeletionInterstitial::class)
+        ->assertRedirect(Filament::getHomeUrl());
+});
+
+test('user can cancel deletion from interstitial', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $this->actingAs($user);
+    Filament::setTenant($user->personalTeam());
+
+    livewire(ScheduledDeletionInterstitial::class)
+        ->call('cancelDeletion')
+        ->assertRedirect(Filament::getHomeUrl());
+
+    expect($user->refresh()->scheduled_deletion_at)->toBeNull();
+});
+
+test('interstitial route lives under panel path in path mode', function () {
+    $panelPath = config('app.app_panel_path', 'app');
+    $url = route('filament.app.scheduled-deletion');
+
+    if (config('app.app_panel_domain')) {
+        expect(parse_url($url, PHP_URL_HOST))->toBe(config('app.app_panel_domain'));
+    } else {
+        expect(parse_url($url, PHP_URL_PATH))->toBe("/{$panelPath}/scheduled-deletion");
+    }
+});
+
+test('middleware redirect targets same host as interstitial route', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $response = $this->actingAs($user)->get('/app');
+
+    $redirectUrl = $response->headers->get('Location');
+    $interstitialUrl = route('filament.app.scheduled-deletion');
+
+    expect(parse_url($redirectUrl, PHP_URL_HOST))
+        ->toBe(parse_url($interstitialUrl, PHP_URL_HOST));
+});
+
+test('user can logout from interstitial', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $this->actingAs($user);
+
+    livewire(ScheduledDeletionInterstitial::class)
+        ->call('logout')
+        ->assertRedirect(Filament::getLoginUrl());
+});

--- a/tests/Feature/Profile/DeleteAccountTest.php
+++ b/tests/Feature/Profile/DeleteAccountTest.php
@@ -4,52 +4,62 @@ declare(strict_types=1);
 
 use App\Livewire\App\Profile\DeleteAccount;
 use App\Models\User;
+use App\Notifications\UserDeletionScheduledNotification;
+use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
 mutates(DeleteAccount::class, User::class);
 
-test('social user can delete account without password', function () {
-    $this->actingAs($user = User::factory()->withTeam()->socialOnly()->create());
+test('user can schedule account deletion with correct password', function () {
+    Notification::fake();
 
-    Livewire::test(DeleteAccount::class)
-        ->call('deleteAccount')
-        ->assertRedirect();
-
-    expect($user->fresh())->toBeNull();
-});
-
-test('password user can delete account with correct password', function () {
-    $this->actingAs($user = User::factory()->withTeam()->create());
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
     Livewire::test(DeleteAccount::class)
         ->call('deleteAccount', 'password')
         ->assertRedirect();
 
-    expect($user->fresh())->toBeNull();
+    expect($user->refresh()->scheduled_deletion_at)->not->toBeNull();
+
+    Notification::assertSentTo($user, UserDeletionScheduledNotification::class);
 });
 
-test('password user cannot delete account with wrong password', function () {
-    $this->actingAs($user = User::factory()->withTeam()->create());
+test('social user can schedule account deletion without password', function () {
+    Notification::fake();
+
+    $this->actingAs($user = User::factory()->withPersonalTeam()->socialOnly()->create());
+
+    Livewire::test(DeleteAccount::class)
+        ->call('deleteAccount')
+        ->assertRedirect();
+
+    expect($user->refresh()->scheduled_deletion_at)->not->toBeNull();
+});
+
+test('user cannot schedule deletion with wrong password', function () {
+    $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
     Livewire::test(DeleteAccount::class)
         ->call('deleteAccount', 'wrong-password')
         ->assertHasErrors(['password']);
 
-    expect($user->fresh())->not->toBeNull();
+    expect($user->refresh()->scheduled_deletion_at)->toBeNull();
 });
 
-test('password user cannot delete account without password', function () {
+test('user cannot schedule deletion when owning team with members', function () {
+    Notification::fake();
+
     $this->actingAs($user = User::factory()->withTeam()->create());
+    $team = $user->currentTeam;
+    $team->users()->attach(User::factory()->create(), ['role' => 'editor']);
 
     Livewire::test(DeleteAccount::class)
-        ->call('deleteAccount')
-        ->assertHasErrors(['password']);
-
-    expect($user->fresh())->not->toBeNull();
+        ->call('deleteAccount', 'password')
+        ->assertHasErrors(['team']);
 });
 
 test('delete account component renders correctly', function () {
-    $this->actingAs(User::factory()->withTeam()->create());
+    $this->actingAs(User::factory()->withPersonalTeam()->create());
 
     Livewire::test(DeleteAccount::class)
         ->assertSuccessful()

--- a/tests/Feature/Profile/ScheduleUserDeletionTest.php
+++ b/tests/Feature/Profile/ScheduleUserDeletionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Jetstream\CancelUserDeletion;
+use App\Actions\Jetstream\ScheduleUserDeletion;
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\UserDeletionCancelledNotification;
+use App\Notifications\UserDeletionScheduledNotification;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Validation\ValidationException;
+
+mutates(ScheduleUserDeletion::class, CancelUserDeletion::class);
+
+test('user can schedule account deletion', function () {
+    Notification::fake();
+
+    $user = User::factory()->withPersonalTeam()->create();
+
+    resolve(ScheduleUserDeletion::class)->schedule($user);
+
+    expect($user->refresh()->scheduled_deletion_at)->not->toBeNull()
+        ->and($user->scheduled_deletion_at->isSameDay(now()->addDays(config('relaticle.deletion.grace_period_days'))))->toBeTrue();
+
+    Notification::assertSentTo($user, UserDeletionScheduledNotification::class);
+});
+
+test('personal team is scheduled for deletion alongside user', function () {
+    Notification::fake();
+
+    $user = User::factory()->withPersonalTeam()->create();
+    $personalTeam = $user->personalTeam();
+
+    resolve(ScheduleUserDeletion::class)->schedule($user);
+
+    expect($personalTeam->refresh()->scheduled_deletion_at)->not->toBeNull();
+});
+
+test('user retains team memberships during grace period', function () {
+    Notification::fake();
+
+    $user = User::factory()->withPersonalTeam()->create();
+    $otherTeam = Team::factory()->create();
+    $otherTeam->users()->attach($user, ['role' => 'editor']);
+
+    expect($user->teams)->toHaveCount(1);
+
+    resolve(ScheduleUserDeletion::class)->schedule($user);
+
+    expect($user->refresh()->teams)->toHaveCount(1);
+});
+
+test('user cannot schedule deletion when owning team with other members', function () {
+    Notification::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $team = $user->currentTeam;
+    $team->users()->attach(User::factory()->create(), ['role' => 'editor']);
+
+    expect(fn () => resolve(ScheduleUserDeletion::class)->schedule($user))
+        ->toThrow(ValidationException::class);
+
+    expect($user->refresh()->scheduled_deletion_at)->toBeNull();
+});
+
+test('user can cancel scheduled deletion', function () {
+    Notification::fake();
+
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+    $personalTeam = $user->personalTeam();
+    $personalTeam->update(['scheduled_deletion_at' => $user->scheduled_deletion_at]);
+
+    resolve(CancelUserDeletion::class)->cancel($user);
+
+    expect($user->refresh()->scheduled_deletion_at)->toBeNull()
+        ->and($personalTeam->refresh()->scheduled_deletion_at)->toBeNull();
+
+    Notification::assertSentTo($user, UserDeletionCancelledNotification::class);
+});

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -9,6 +9,12 @@ use Illuminate\Support\Facades\Http;
 
 mutates(HomeController::class, TermsOfServiceController::class, PrivacyPolicyController::class);
 
+beforeEach(function () {
+    Http::fake([
+        'api.github.com/*' => Http::response(['stargazers_count' => 42], 200),
+    ]);
+});
+
 describe('Home page', function () {
     it('returns a successful response', function () {
         $response = $this->get('/');
@@ -18,16 +24,10 @@ describe('Home page', function () {
     });
 
     it('displays the GitHub stars count', function () {
-        Http::fake([
-            'api.github.com/repos/Relaticle/relaticle' => Http::response([
-                'stargazers_count' => 125,
-            ], 200),
-        ]);
-
         $response = $this->get('/');
 
         $response->assertStatus(200);
-        $response->assertSee('125');
+        $response->assertSee('42');
     });
 });
 

--- a/tests/Feature/Teams/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Teams/AcceptTeamInvitationTest.php
@@ -104,3 +104,22 @@ test('accepting invitation deletes the invitation record', function () {
 
     expect(TeamInvitation::count())->toBe(0);
 });
+
+test('user with scheduled deletion cannot accept invitation', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $team = Team::factory()->create();
+    $invitation = $team->teamInvitations()->create([
+        'email' => $user->email,
+        'role' => 'editor',
+        'expires_at' => now()->addDays(7),
+    ]);
+
+    $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
+
+    $this->actingAs($user)
+        ->get($acceptUrl)
+        ->assertForbidden();
+
+    expect($team->fresh()->hasUser($user))->toBeFalse();
+});

--- a/tests/Feature/Teams/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Teams/AcceptTeamInvitationTest.php
@@ -9,58 +9,54 @@ use Illuminate\Support\Facades\URL;
 
 mutates(TeamInvitation::class);
 
-test('valid invitation can be accepted', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->team = Team::factory()->create();
+});
 
+test('valid invitation can be accepted', function () {
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
         'role' => 'editor',
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get($acceptUrl)
         ->assertRedirect(config('fortify.home'));
 
-    expect($team->fresh()->hasUser($user))->toBeTrue();
+    expect($this->team->fresh()->hasUser($this->user))->toBeTrue();
     expect(TeamInvitation::find($invitation->id))->toBeNull();
-    expect($user->fresh()->current_team_id)->toBe($team->id);
+    expect($this->user->fresh()->current_team_id)->toBe($this->team->id);
 });
 
 test('expired invitation shows friendly expired page', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->expired()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get($acceptUrl)
         ->assertOk()
         ->assertViewIs('teams.invitation-expired');
 
-    expect($team->fresh()->hasUser($user))->toBeFalse();
+    expect($this->team->fresh()->hasUser($this->user))->toBeFalse();
 });
 
 test('null expires_at is treated as expired', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->withoutExpiry()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get($acceptUrl)
         ->assertOk()
         ->assertViewIs('teams.invitation-expired');
@@ -69,10 +65,9 @@ test('null expires_at is treated as expired', function () {
 test('invitation with wrong email is rejected', function () {
     $invitedUser = User::factory()->withPersonalTeam()->create(['email' => 'invited@example.com']);
     $wrongUser = User::factory()->withPersonalTeam()->create(['email' => 'wrong@example.com']);
-    $team = Team::factory()->create();
 
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
+        'team_id' => $this->team->id,
         'email' => 'invited@example.com',
     ]);
 
@@ -82,36 +77,30 @@ test('invitation with wrong email is rejected', function () {
         ->get($acceptUrl)
         ->assertForbidden();
 
-    expect($team->fresh()->hasUser($wrongUser))->toBeFalse();
+    expect($this->team->fresh()->hasUser($wrongUser))->toBeFalse();
 });
 
 test('invitation with invalid signature is rejected', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
     ]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get("/team-invitations/{$invitation->id}?signature=invalid")
         ->assertForbidden();
 });
 
 test('accepting invitation deletes the invitation record', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
         'role' => 'admin',
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)->get($acceptUrl);
+    $this->actingAs($this->user)->get($acceptUrl);
 
     expect(TeamInvitation::count())->toBe(0);
 });

--- a/tests/Feature/Teams/AcceptTeamInvitationTest.php
+++ b/tests/Feature/Teams/AcceptTeamInvitationTest.php
@@ -9,58 +9,54 @@ use Illuminate\Support\Facades\URL;
 
 mutates(TeamInvitation::class);
 
-test('valid invitation can be accepted', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->team = Team::factory()->create();
+});
 
+test('valid invitation can be accepted', function () {
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
         'role' => 'editor',
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get($acceptUrl)
         ->assertRedirect(config('fortify.home'));
 
-    expect($team->fresh()->hasUser($user))->toBeTrue();
+    expect($this->team->fresh()->hasUser($this->user))->toBeTrue();
     expect(TeamInvitation::find($invitation->id))->toBeNull();
-    expect($user->fresh()->current_team_id)->toBe($team->id);
+    expect($this->user->fresh()->current_team_id)->toBe($this->team->id);
 });
 
 test('expired invitation shows friendly expired page', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->expired()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get($acceptUrl)
         ->assertOk()
         ->assertViewIs('teams.invitation-expired');
 
-    expect($team->fresh()->hasUser($user))->toBeFalse();
+    expect($this->team->fresh()->hasUser($this->user))->toBeFalse();
 });
 
 test('null expires_at is treated as expired', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->withoutExpiry()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get($acceptUrl)
         ->assertOk()
         ->assertViewIs('teams.invitation-expired');
@@ -69,10 +65,9 @@ test('null expires_at is treated as expired', function () {
 test('invitation with wrong email is rejected', function () {
     $invitedUser = User::factory()->withPersonalTeam()->create(['email' => 'invited@example.com']);
     $wrongUser = User::factory()->withPersonalTeam()->create(['email' => 'wrong@example.com']);
-    $team = Team::factory()->create();
 
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
+        'team_id' => $this->team->id,
         'email' => 'invited@example.com',
     ]);
 
@@ -82,36 +77,49 @@ test('invitation with wrong email is rejected', function () {
         ->get($acceptUrl)
         ->assertForbidden();
 
-    expect($team->fresh()->hasUser($wrongUser))->toBeFalse();
+    expect($this->team->fresh()->hasUser($wrongUser))->toBeFalse();
 });
 
 test('invitation with invalid signature is rejected', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
     ]);
 
-    $this->actingAs($user)
+    $this->actingAs($this->user)
         ->get("/team-invitations/{$invitation->id}?signature=invalid")
         ->assertForbidden();
 });
 
 test('accepting invitation deletes the invitation record', function () {
-    $user = User::factory()->withPersonalTeam()->create();
-    $team = Team::factory()->create();
-
     $invitation = TeamInvitation::factory()->create([
-        'team_id' => $team->id,
-        'email' => $user->email,
+        'team_id' => $this->team->id,
+        'email' => $this->user->email,
         'role' => 'admin',
     ]);
 
     $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
 
-    $this->actingAs($user)->get($acceptUrl);
+    $this->actingAs($this->user)->get($acceptUrl);
 
     expect(TeamInvitation::count())->toBe(0);
+});
+
+test('user with scheduled deletion cannot accept invitation', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $team = Team::factory()->create();
+    $invitation = $team->teamInvitations()->create([
+        'email' => $user->email,
+        'role' => 'editor',
+        'expires_at' => now()->addDays(7),
+    ]);
+
+    $acceptUrl = URL::signedRoute('team-invitations.accept', ['invitation' => $invitation]);
+
+    $this->actingAs($user)
+        ->get($acceptUrl)
+        ->assertForbidden();
+
+    expect($team->fresh()->hasUser($user))->toBeFalse();
 });

--- a/tests/Feature/Teams/DeleteTeamTest.php
+++ b/tests/Feature/Teams/DeleteTeamTest.php
@@ -2,37 +2,42 @@
 
 declare(strict_types=1);
 
-use App\Models\Team;
+use App\Livewire\App\Teams\DeleteTeam;
 use App\Models\User;
-use Laravel\Jetstream\Http\Livewire\DeleteTeamForm;
+use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
-mutates(Team::class);
+mutates(DeleteTeam::class);
 
-test('teams can be deleted', function () {
+test('team owner can schedule team deletion', function () {
+    Notification::fake();
+
     $this->actingAs($user = User::factory()->withTeam()->create());
+    $team = $user->currentTeam;
 
-    $user->ownedTeams()->save($team = Team::factory()->make([
-        'personal_team' => false,
-    ]));
+    Livewire::test(DeleteTeam::class, ['team' => $team])
+        ->call('deleteTeam', $team);
 
-    $team->users()->attach(
-        $otherUser = User::factory()->create(), ['role' => 'test-role']
-    );
-
-    Livewire::test(DeleteTeamForm::class, ['team' => $team->fresh()])
-        ->call('deleteTeam');
-
-    expect($team->fresh())->toBeNull();
-    expect($otherUser->fresh()->teams)->toHaveCount(0);
+    expect($team->refresh()->scheduled_deletion_at)->not->toBeNull();
 });
 
-test('personal teams cant be deleted', function () {
+test('team owner can cancel scheduled team deletion', function () {
+    Notification::fake();
+
+    $this->actingAs($user = User::factory()->withTeam()->create());
+    $team = $user->currentTeam;
+    $team->update(['scheduled_deletion_at' => now()->addDays(30)]);
+
+    Livewire::test(DeleteTeam::class, ['team' => $team])
+        ->call('cancelTeamDeletion', $team);
+
+    expect($team->refresh()->scheduled_deletion_at)->toBeNull();
+});
+
+test('personal teams cant be scheduled for deletion', function () {
     $this->actingAs($user = User::factory()->withPersonalTeam()->create());
 
-    Livewire::test(DeleteTeamForm::class, ['team' => $user->personalTeam()])
-        ->call('deleteTeam')
+    Livewire::test(DeleteTeam::class, ['team' => $user->personalTeam()])
+        ->call('deleteTeam', $user->personalTeam())
         ->assertHasErrors(['team']);
-
-    expect($user->personalTeam()->fresh())->not->toBeNull();
 });

--- a/tests/Feature/Teams/RemoveTeamMemberTest.php
+++ b/tests/Feature/Teams/RemoveTeamMemberTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use App\Notifications\TeamMemberRemovedNotification;
+use Illuminate\Support\Facades\Notification;
 use Laravel\Jetstream\Http\Livewire\TeamMemberManager;
 use Livewire\Livewire;
 
@@ -20,6 +22,22 @@ test('team members can be removed from teams', function () {
         ->call('removeTeamMember');
 
     expect($user->currentTeam->fresh()->users)->toHaveCount(0);
+});
+
+test('removed team member receives notification', function () {
+    Notification::fake();
+
+    $this->actingAs($user = User::factory()->withTeam()->create());
+
+    $user->currentTeam->users()->attach(
+        $otherUser = User::factory()->create(), ['role' => 'admin']
+    );
+
+    Livewire::test(TeamMemberManager::class, ['team' => $user->currentTeam])
+        ->set('teamMemberIdBeingRemoved', $otherUser->id)
+        ->call('removeTeamMember');
+
+    Notification::assertSentTo($otherUser, TeamMemberRemovedNotification::class);
 });
 
 test('only team owner can remove team members', function () {

--- a/tests/Feature/Teams/ScheduleTeamDeletionTest.php
+++ b/tests/Feature/Teams/ScheduleTeamDeletionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Jetstream\CancelTeamDeletion;
+use App\Actions\Jetstream\ScheduleTeamDeletion;
+use App\Models\User;
+use App\Notifications\TeamDeletionCancelledNotification;
+use App\Notifications\TeamDeletionScheduledNotification;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Validation\ValidationException;
+
+mutates(ScheduleTeamDeletion::class, CancelTeamDeletion::class);
+
+test('team owner can schedule team deletion', function () {
+    Notification::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $team = $user->currentTeam;
+
+    resolve(ScheduleTeamDeletion::class)->schedule($user, $team);
+
+    expect($team->refresh()->scheduled_deletion_at)->not->toBeNull()
+        ->and($team->scheduled_deletion_at->isSameDay(now()->addDays(config('relaticle.deletion.grace_period_days'))))->toBeTrue();
+});
+
+test('team owner is notified when team is scheduled for deletion', function () {
+    Notification::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $team = $user->currentTeam;
+    $member = User::factory()->create();
+    $team->users()->attach($member, ['role' => 'editor']);
+
+    resolve(ScheduleTeamDeletion::class)->schedule($user, $team);
+
+    Notification::assertSentTo($user, TeamDeletionScheduledNotification::class);
+    Notification::assertNotSentTo($member, TeamDeletionScheduledNotification::class);
+});
+
+test('pending invitations are cancelled when team deletion is scheduled', function () {
+    Notification::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $team = $user->currentTeam;
+    $team->teamInvitations()->create([
+        'email' => 'invited@example.com',
+        'role' => 'editor',
+        'expires_at' => now()->addDays(7),
+    ]);
+
+    expect($team->teamInvitations)->toHaveCount(1);
+
+    resolve(ScheduleTeamDeletion::class)->schedule($user, $team);
+
+    expect($team->refresh()->teamInvitations)->toHaveCount(0);
+});
+
+test('personal team cannot be directly scheduled for deletion', function () {
+    Notification::fake();
+
+    $user = User::factory()->withPersonalTeam()->create();
+    $personalTeam = $user->personalTeam();
+
+    expect(fn () => resolve(ScheduleTeamDeletion::class)->schedule($user, $personalTeam))
+        ->toThrow(ValidationException::class);
+});
+
+test('non-owner cannot schedule team deletion', function () {
+    Notification::fake();
+
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+    $member = User::factory()->create();
+    $team->users()->attach($member, ['role' => 'editor']);
+
+    expect(fn () => resolve(ScheduleTeamDeletion::class)->schedule($member, $team))
+        ->toThrow(AuthorizationException::class);
+});
+
+test('team owner can cancel team deletion', function () {
+    Notification::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $team = $user->currentTeam;
+    $team->forceFill(['scheduled_deletion_at' => now()->addDays(30)])->save();
+    $member = User::factory()->create();
+    $team->users()->attach($member, ['role' => 'editor']);
+
+    resolve(CancelTeamDeletion::class)->cancel($user, $team);
+
+    expect($team->refresh()->scheduled_deletion_at)->toBeNull();
+
+    Notification::assertSentTo($user, TeamDeletionCancelledNotification::class);
+    Notification::assertNotSentTo($member, TeamDeletionCancelledNotification::class);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
  * Conventions: see CLAUDE.md -> Testing section
  */
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
 use Pest\Browser\Playwright\Playwright;
 use Tests\TestCase;
 
 pest()->extend(TestCase::class)
-    ->use(RefreshDatabase::class)
+    ->use(LazilyRefreshDatabase::class)
     ->in('Feature', 'Smoke', 'Browser');
 
 if (class_exists(Playwright::class)) {

--- a/tests/Smoke/RouteTest.php
+++ b/tests/Smoke/RouteTest.php
@@ -48,6 +48,7 @@ routeTesting('smoke: all GET routes return non-500 response')
         'discord',
         'user/confirm-password',
         'up',
+        'scheduled-deletion',
         'docs/api*',
         'api/*',
     ])

--- a/tests/Smoke/RouteTest.php
+++ b/tests/Smoke/RouteTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert;
 
@@ -21,6 +22,10 @@ TestResponse::macro('assertNotServerError', function (): TestResponse {
 
 routeTesting('smoke: all GET routes return non-500 response')
     ->setUp(function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response(['stargazers_count' => 0], 200),
+        ]);
+
         $user = User::factory()->withTeam()->create();
 
         $this->actingAs($user);

--- a/tests/Smoke/RouteTest.php
+++ b/tests/Smoke/RouteTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Testing\TestResponse;
 use PHPUnit\Framework\Assert;
 
@@ -21,6 +22,10 @@ TestResponse::macro('assertNotServerError', function (): TestResponse {
 
 routeTesting('smoke: all GET routes return non-500 response')
     ->setUp(function (): void {
+        Http::fake([
+            'api.github.com/*' => Http::response(['stargazers_count' => 0], 200),
+        ]);
+
         $user = User::factory()->withTeam()->create();
 
         $this->actingAs($user);
@@ -43,6 +48,7 @@ routeTesting('smoke: all GET routes return non-500 response')
         'discord',
         'user/confirm-password',
         'up',
+        'scheduled-deletion',
         'docs/api*',
         'api/*',
     ])

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,8 +5,24 @@ declare(strict_types=1);
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Foundation\Testing\WithCachedConfig;
+use Illuminate\Foundation\Testing\WithCachedRoutes;
+use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use WithCachedConfig;
+    use WithCachedRoutes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::preventStrayRequests();
+        Sleep::fake(syncWithCarbon: true);
+        Exceptions::fake();
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary

Merges the latest `origin/main` into `feat/email-calendar-integration` to bring the branch up to date and resolve conflicts before shipping further email/calendar work.

## Conflicts resolved

- **CLAUDE.md** — kept both sides (added main's new `deployments` and `herd` rule sections alongside the existing email-integration guidance).
- **app/Models/Team.php** — kept both `default_email_sharing_tier` (branch) and `scheduled_deletion_at` (main) in the `@property` docblock and `casts()` array.
- **app/Models/User.php** — same pattern; both casts retained.
- **app/Providers/Filament/AppPanelProvider.php** — preserved branch-side ActivityLog imports (`AppEventPalette`, `AppEventRenderer`, `MeetingEventPalette`, `MeetingEventRenderer`, `ActivityLogPlugin`) alongside main's `SocialAuth` feature + `Laravel\Pennant\Feature` imports. Combined the `spa()` chain to include `sidebarWidth('67')` / `maxContentWidth(Width::Full)` (branch) and the `/scheduled-deletion` route (main).
- **bootstrap/app.php** — kept the `activitylog:clean` daily schedule and the email incremental-sync + outbox-dispatch callbacks together with main's `app:purge-scheduled-deletions` command.
- **composer.lock** — merged `stability-flags` for both `relaticle/activity-log` and `spatie/guidelines-skills`, then ran `composer update --lock` to regenerate the content hash.

## Verification

- `vendor/bin/pint --dirty --format agent` — pass
- `vendor/bin/phpstan analyse` on the touched files — pass
- `php -l` syntax check on each resolved PHP file — pass
- `composer validate` — lock file consistent with `composer.json`

## Test plan

- [ ] CI green on `fix-email-conflict`
- [ ] Verify Filament app panel boots (ActivityLog plugin + scheduled-deletion route)
- [ ] Confirm scheduled commands (`activitylog:clean`, `email:incremental-sync`, `email:dispatch-outbox`, `app:purge-scheduled-deletions`) are all registered (`php artisan schedule:list`)