### PR TITLE
fix: surface team-ownership block when deleting account

### DIFF
--- a/app/Livewire/App/Profile/DeleteAccount.php
+++ b/app/Livewire/App/Profile/DeleteAccount.php
@@ -9,6 +9,7 @@ use App\Livewire\BaseLivewireComponent;
 use Filament\Actions\Action;
 use Filament\Forms;
 use Filament\Infolists\Components\TextEntry;
+use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
@@ -50,7 +51,7 @@ final class DeleteAccount extends BaseLivewireComponent
                                         ->required()
                                         ->currentPassword(),
                                 ] : [])
-                                ->action(fn (array $data): Redirector|RedirectResponse => $this->deleteAccount($data['password'] ?? null)),
+                                ->action(fn (array $data): Redirector|RedirectResponse|null => $this->deleteAccount($data['password'] ?? null)),
                         ]),
                     ]),
             ]);
@@ -61,7 +62,7 @@ final class DeleteAccount extends BaseLivewireComponent
      *
      * @throws ValidationException
      */
-    public function deleteAccount(?string $password = null): Redirector|RedirectResponse
+    public function deleteAccount(?string $password = null): Redirector|RedirectResponse|null
     {
         $user = $this->authUser();
 
@@ -71,7 +72,18 @@ final class DeleteAccount extends BaseLivewireComponent
             ]);
         }
 
-        resolve(ScheduleUserDeletion::class)->schedule($user);
+        try {
+            resolve(ScheduleUserDeletion::class)->schedule($user);
+        } catch (ValidationException $e) {
+            Notification::make()
+                ->danger()
+                ->title(__('profile.notifications.delete_account_blocked.title'))
+                ->body($e->validator->errors()->first())
+                ->persistent()
+                ->send();
+
+            return null;
+        }
 
         filament()->auth()->logout();
 

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -70,6 +70,9 @@ return [
         'logged_out_other_sessions' => [
             'success' => 'All other browser sessions have been logged out successfully.',
         ],
+        'delete_account_blocked' => [
+            'title' => 'Account deletion blocked',
+        ],
     ],
 
     'modals' => [

--- a/tests/Feature/Profile/DeleteAccountTest.php
+++ b/tests/Feature/Profile/DeleteAccountTest.php
@@ -55,7 +55,11 @@ test('user cannot schedule deletion when owning team with members', function () 
 
     Livewire::test(DeleteAccount::class)
         ->call('deleteAccount', 'password')
-        ->assertHasErrors(['team']);
+        ->assertHasNoErrors()
+        ->assertNotified(__('profile.notifications.delete_account_blocked.title'));
+
+    expect($user->refresh()->scheduled_deletion_at)->toBeNull();
+    Notification::assertNothingSentTo($user);
 });
 
 test('delete account component renders correctly', function () {


### PR DESCRIPTION
## Summary

The "Delete Account" modal silently fails for any user who owns a non-personal team that has at least one other member. They click the confirm button and nothing happens — no error, no feedback, modal closes.

## Root cause

`ScheduleUserDeletion::ensureUserCanBeDeleted()` blocks deletion by throwing `ValidationException::withMessages(['team' => [...]])` when the user owns a non-personal team with members.

The Filament action modal in `DeleteAccount` only declares a `password` form field. There is no field bound to `team`, so when Livewire receives the exception it adds the error to the bag with no UI element to render against — silent failure.

This matches the bug exactly: only the account that owns a team-with-members fails; every other account passes through cleanly.

## Fix

Catch the `ValidationException` in `DeleteAccount::deleteAccount()` and surface the message as a persistent danger Filament `Notification` so the user actually sees why deletion was blocked. Return `null` so the modal closes with the notification visible.

## Test plan

- [x] `php artisan test --compact --filter=DeleteAccountTest` (5/5 pass)
- [x] `php artisan test --compact --filter='DeleteAccountTest|ScheduleUserDeletion|ScheduleTeamDeletion|DeleteTeam|CheckScheduledDeletion|PurgeScheduledDeletions'` (32/32 pass)
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `vendor/bin/rector --dry-run`
- [x] `vendor/bin/phpstan analyse` (0 errors)
- [x] Type coverage 100%
- [ ] Manual verify in prod: log in as the affected account, click Delete Account, confirm — danger notification now appears explaining which team needs ownership transferred