### PR TITLE
fix: raise livewire payload max nesting depth for filament rich editor

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |---------------------------------------------------------------------------
+    | Payload Guards
+    |---------------------------------------------------------------------------
+    |
+    | Filament's RichEditor entangles a TipTap document JSON with $wire. Form
+    | data lives under mountedActions.0.data.<schema>.<field> (5+ segments)
+    | and TipTap nests bulletList → listItem → paragraph → mark → text. The
+    | default depth of 10 throws MaxNestingDepthExceededException for normal
+    | rich-text edits inside Filament action modals. Raising the limit keeps
+    | DoS protection while accommodating realistic editor content.
+    |
+    | The full payload array is repeated here because Laravel's
+    | mergeConfigFrom uses a shallow array_merge — omitting any sibling key
+    | drops the package default to null and disables that guard.
+    */
+
+    'payload' => [
+        'max_size' => 1024 * 1024,
+        'max_nesting_depth' => 30,
+        'max_calls' => 50,
+        'max_components' => 20,
+    ],
+];

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -182,3 +182,17 @@ it('denies non-team-member from viewing another team note', function (): void {
         ->and($this->user->can('update', $record))->toBeFalse()
         ->and($this->user->can('delete', $record))->toBeFalse();
 });
+
+it('accepts deeply nested rich-editor JSON in custom field action data', function (): void {
+    // The Filament RichEditor JS-side state is the TipTap document JSON,
+    // entangled to $wire.mountedActions.0.data.custom_fields.<field>. As the user
+    // edits nested lists/blockquotes, Livewire diffs the document and pushes
+    // partial updates with deeply nested dot paths. The default Livewire 4
+    // payload.max_nesting_depth = 10 is insufficient: the prefix
+    // (mountedActions.0.data.custom_fields.<field>) already consumes 5 levels,
+    // leaving only 5 for TipTap content — easily exceeded.
+    $deepPath = 'mountedActions.0.data.custom_fields.body.content.1.content.1.content.2.content.0.content';
+
+    livewire(ManageNotes::class)
+        ->set($deepPath, [['type' => 'text', 'text' => 'hello']]);
+})->throwsNoExceptions();


### PR DESCRIPTION
Filament's RichEditor entangles a TipTap document JSON with $wire. Form data inside an action modal lives under mountedActions.0.data.<schema>.<field> (5+ segments) and TipTap content nests bulletList → listItem → paragraph → marks → text. Livewire 4's default payload.max_nesting_depth of 10 throws MaxNestingDepthExceededException for routine rich-text edits — particularly when the field comes from the custom-fields package, which adds the `custom_fields.<code>` prefix.

Override the full payload guard block (Laravel's mergeConfigFrom is shallow so sibling keys must be repeated) with depth raised to 30. DoS protection remains active; size/calls/components keep their package defaults.

Adds a regression test that drives a 14-segment property path through ManageNotes — previously threw, now passes.