### PR TITLE
fix(chat): coerce empty tool_use input to JSON object for Anthropic

### DIFF
--- a/app/Ai/AiManager.php
+++ b/app/Ai/AiManager.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ai;
+
+use App\Ai\Anthropic\AnthropicGateway;
+use Illuminate\Contracts\Events\Dispatcher;
+use Laravel\Ai\AiManager as BaseAiManager;
+use Laravel\Ai\Providers\AnthropicProvider;
+
+final class AiManager extends BaseAiManager
+{
+    /**
+     * Use our patched gateway so tool_use blocks with empty arguments
+     * serialise as JSON objects rather than arrays.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function createAnthropicDriver(array $config): AnthropicProvider
+    {
+        return new AnthropicProvider(
+            new AnthropicGateway($this->app->make(Dispatcher::class)),
+            $config,
+            $this->app->make(Dispatcher::class),
+        );
+    }
+}

--- a/app/Ai/Anthropic/AnthropicGateway.php
+++ b/app/Ai/Anthropic/AnthropicGateway.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ai\Anthropic;
+
+use Laravel\Ai\Gateway\Anthropic\AnthropicGateway as BaseAnthropicGateway;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\Message;
+
+final class AnthropicGateway extends BaseAnthropicGateway
+{
+    /**
+     * Anthropic's Messages API rejects `tool_use.input` when it is a JSON array.
+     * Empty tool arguments round-tripped through PHP arrays serialise as `[]`
+     * instead of `{}`, which trips a 400. Coerce empty arguments to an object
+     * before the request body is built.
+     *
+     * Upstream bug: empty `ToolCall::$arguments` (typed `array`) cannot
+     * preserve the original JSON object semantic across persistence.
+     *
+     * @param  array<int, array<string, mixed>>  $mapped
+     */
+    protected function mapAssistantMessage(AssistantMessage|Message $message, array &$mapped): void
+    {
+        parent::mapAssistantMessage($message, $mapped);
+
+        $lastIndex = array_key_last($mapped);
+
+        if ($lastIndex === null || ($mapped[$lastIndex]['role'] ?? null) !== 'assistant') {
+            return;
+        }
+
+        $mapped[$lastIndex]['content'] = array_map(
+            static function (array $block): array {
+                if (($block['type'] ?? null) === 'tool_use') {
+                    $input = $block['input'] ?? [];
+                    $block['input'] = is_array($input) && $input === [] ? (object) [] : $input;
+                }
+
+                return $block;
+            },
+            $mapped[$lastIndex]['content'],
+        );
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -28,6 +28,7 @@ use Filament\Facades\Filament;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Http\FormRequest;
@@ -39,6 +40,7 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\View;
 use Knuckles\Scribe\Scribe;
+use Laravel\Ai\AiManager;
 use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamMemberAdded;
 use Laravel\Sanctum\Sanctum;
@@ -54,6 +56,8 @@ final class AppServiceProvider extends ServiceProvider
     {
         $this->app->bind(\Filament\Auth\Http\Responses\Contracts\LoginResponse::class, LoginResponse::class);
         $this->app->bind(\Filament\Actions\Exports\Models\Export::class, Export::class);
+
+        $this->app->scoped(AiManager::class, fn (Application $app): \App\Ai\AiManager => new \App\Ai\AiManager($app));
     }
 
     /**

--- a/tests/Feature/AI/AnthropicGatewayEmptyToolInputTest.php
+++ b/tests/Feature/AI/AnthropicGatewayEmptyToolInputTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\AiManager;
+use App\Ai\Anthropic\AnthropicGateway as PatchedAnthropicGateway;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\AiManager as BaseAiManager;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\ToolResultMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+
+mutates(PatchedAnthropicGateway::class);
+mutates(AiManager::class);
+
+it('binds our patched manager so the Anthropic driver uses our gateway', function (): void {
+    $manager = app(BaseAiManager::class);
+
+    expect($manager)->toBeInstanceOf(AiManager::class);
+
+    $provider = $manager->textProvider('anthropic');
+
+    $reflection = new ReflectionClass($provider);
+    $property = $reflection->getParentClass()->getProperty('gateway');
+    $property->setAccessible(true);
+
+    expect($property->getValue($provider))->toBeInstanceOf(PatchedAnthropicGateway::class);
+});
+
+it('encodes empty tool_use input as JSON object, not array', function (): void {
+    $gateway = new PatchedAnthropicGateway(new Dispatcher);
+
+    $messages = [
+        new UserMessage('summary please'),
+        new AssistantMessage('ok', collect([
+            new ToolCall(
+                id: 'toolu_test_id',
+                name: 'GetCrmSummaryTool',
+                arguments: [],
+                resultId: 'toolu_test_id',
+            ),
+        ])),
+        new ToolResultMessage(collect([
+            new ToolResult(
+                id: 'toolu_test_id',
+                name: 'GetCrmSummaryTool',
+                arguments: [],
+                result: '{"counts":{}}',
+                resultId: 'toolu_test_id',
+            ),
+        ])),
+        new UserMessage('thanks'),
+    ];
+
+    $reflection = new ReflectionMethod($gateway, 'mapMessages');
+    $reflection->setAccessible(true);
+
+    /** @var array<int, array{role: string, content: array<int, array<string, mixed>>}> $mapped */
+    $mapped = $reflection->invoke($gateway, $messages);
+
+    $assistantMessage = collect($mapped)
+        ->firstOrFail(fn (array $m): bool => $m['role'] === 'assistant');
+
+    $toolUseBlock = collect($assistantMessage['content'])
+        ->firstOrFail(fn (array $b): bool => ($b['type'] ?? '') === 'tool_use');
+
+    expect($toolUseBlock['input'])->toBeInstanceOf(stdClass::class);
+    expect(json_encode($toolUseBlock['input']))->toBe('{}');
+});
+
+it('preserves non-empty tool_use input as a dictionary', function (): void {
+    $gateway = new PatchedAnthropicGateway(new Dispatcher);
+
+    $messages = [
+        new UserMessage('list tasks'),
+        new AssistantMessage('ok', collect([
+            new ToolCall(
+                id: 'toolu_test_id',
+                name: 'ListTasksTool',
+                arguments: ['search' => 'todo', 'page' => 2],
+                resultId: 'toolu_test_id',
+            ),
+        ])),
+        new ToolResultMessage(collect([
+            new ToolResult(
+                id: 'toolu_test_id',
+                name: 'ListTasksTool',
+                arguments: ['search' => 'todo', 'page' => 2],
+                result: '[]',
+                resultId: 'toolu_test_id',
+            ),
+        ])),
+    ];
+
+    $reflection = new ReflectionMethod($gateway, 'mapMessages');
+    $reflection->setAccessible(true);
+
+    /** @var array<int, array{role: string, content: array<int, array<string, mixed>>}> $mapped */
+    $mapped = $reflection->invoke($gateway, $messages);
+
+    $toolUseBlock = collect($mapped)
+        ->firstOrFail(fn (array $m): bool => $m['role'] === 'assistant')['content'];
+
+    $toolUse = collect($toolUseBlock)
+        ->firstOrFail(fn (array $b): bool => ($b['type'] ?? '') === 'tool_use');
+
+    expect(json_encode($toolUse['input']))->toBe('{"search":"todo","page":2}');
+});
+
+it('produces a request body Anthropic accepts as valid JSON dict for empty arguments', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'api.anthropic.com/*' => Http::response("event: message_start\ndata: {}\n\n", 200, [
+            'Content-Type' => 'text/event-stream',
+        ]),
+    ]);
+
+    $gateway = new PatchedAnthropicGateway(new Dispatcher);
+
+    $reflection = new ReflectionMethod($gateway, 'mapMessages');
+    $reflection->setAccessible(true);
+
+    $mapped = $reflection->invoke($gateway, [
+        new AssistantMessage('', collect([
+            new ToolCall('toolu_x', 'GetCrmSummaryTool', [], 'toolu_x'),
+        ])),
+    ]);
+
+    $payload = ['model' => 'claude-haiku-4-5', 'messages' => $mapped, 'max_tokens' => 64];
+    $json = json_encode($payload);
+
+    expect($json)->toContain('"input":{}');
+    expect($json)->not->toContain('"input":[]');
+});


### PR DESCRIPTION
## Summary

Chat conversations that invoke a parameterless tool (e.g. `GetCrmSummaryTool`) become permanently broken on the next turn — Anthropic returns:

```
HTTP 400 invalid_request_error
messages.N.content.M.tool_use.input: Input should be a valid dictionary
```

## Root cause

`laravel/ai` v0.4.5 erases the JSON-object semantic of empty tool arguments across persistence:

1. `HandlesTextStreaming.php:275` — `json_decode($call['arguments'] ?: '{}', true)` returns PHP `[]` for the JSON `{}` (because of `assoc=true`)
2. `ToolCall::$arguments` is typed `array` — the DTO can't hold `stdClass`
3. `DatabaseConversationStore::storeAssistantMessage` writes `[]` to the `tool_calls` JSONB column
4. On reload, `MapsMessages.php:89` passes the array straight into the request body — `json_encode([])` → `"input":[]`
5. Anthropic 400s because `tool_use.input` must be a JSON object

I traced PHP type through every stage; all five lose object semantic. Detailed write-up in the discussion that produced this PR.

## Fix

Local override of `AnthropicGateway::mapAssistantMessage` casts empty `tool_use.input` to `stdClass` before the request is built. A custom `AiManager` wires the patched gateway into the Anthropic driver. Both are bound in `AppServiceProvider`.

The override is intentionally minimal — three changed lines of behavior. No vendor edits, no `composer-patches`. Drops cleanly when `laravel/ai` ships an upstream fix (worth filing).

## What changed

- `app/Ai/Anthropic/AnthropicGateway.php` — extends vendor gateway, overrides `mapAssistantMessage`
- `app/Ai/AiManager.php` — extends vendor manager, overrides `createAnthropicDriver`
- `app/Providers/AppServiceProvider.php` — rebinds `Laravel\Ai\AiManager` to our subclass

## Test plan

TDD red→green. Four tests in `tests/Feature/AI/AnthropicGatewayEmptyToolInputTest.php`:

- [x] Empty `ToolCall::$arguments` produces `tool_use.input` as `stdClass` and JSON-serialises to `{}`
- [x] Non-empty arguments survive untouched as a dictionary
- [x] End-to-end mapped payload `json_encode`s to a body containing `"input":{}` and not `"input":[]`
- [x] Container resolves `Laravel\Ai\AiManager` to our patched manager and the Anthropic provider holds our patched gateway

```
$ php artisan test --compact tests/Feature/Ai tests/Feature/Chat
{"result":"passed","tests":123,"passed":123,"assertions":269}
```

Pre-merge gauntlet: `pint --dirty`, `rector`, `phpstan analyse`, `pest --type-coverage --min=100` all clean.

## Existing broken conversations

Any row in `agent_conversation_messages` where `tool_calls` contains `"arguments": []` was sending broken bodies. The fix is at request-build time so it repairs the in-flight payload regardless of the persisted state — no DB migration required.

## Upstream

Worth filing a PR against `laravel/ai`. The minimal upstream change is one line at `MapsMessages.php:89`:

```diff
- 'input' => $toolCall->arguments,
+ 'input' => (object) ($toolCall->arguments ?: []),
```

Once that lands, this override can be deleted.