### PR TITLE
chore(migrations): drop down() methods from email/calendar migrations

### DIFF
--- a/database/migrations/2026_03_21_050414_create_email_accounts_table.php
+++ b/database/migrations/2026_03_21_050414_create_email_accounts_table.php
@@ -47,9 +47,4 @@ return new class extends Migration
             $table->index(['team_id', 'status']);
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('connected_accounts');
-    }
 };

--- a/database/migrations/2026_03_21_050430_create_emails_table.php
+++ b/database/migrations/2026_03_21_050430_create_emails_table.php
@@ -65,9 +65,4 @@ return new class extends Migration
             $table->index(['user_id', 'status'], 'idx_emails_user_status');
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('emails');
-    }
 };

--- a/database/migrations/2026_03_21_050442_create_email_participants_table.php
+++ b/database/migrations/2026_03_21_050442_create_email_participants_table.php
@@ -38,9 +38,4 @@ return new class extends Migration
             $table->index('contact_id');
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_participants');
-    }
 };

--- a/database/migrations/2026_03_21_050455_create_email_bodies_table.php
+++ b/database/migrations/2026_03_21_050455_create_email_bodies_table.php
@@ -20,9 +20,4 @@ return new class extends Migration
             $table->unique('email_id');
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_bodies');
-    }
 };

--- a/database/migrations/2026_03_21_050506_create_email_attachments_table.php
+++ b/database/migrations/2026_03_21_050506_create_email_attachments_table.php
@@ -22,9 +22,4 @@ return new class extends Migration
             $table->timestamps();
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_attachments');
-    }
 };

--- a/database/migrations/2026_03_21_050520_create_email_shares_table.php
+++ b/database/migrations/2026_03_21_050520_create_email_shares_table.php
@@ -22,9 +22,4 @@ return new class extends Migration
             $table->unique(['email_id', 'shared_with'], 'email_shares_email_user_unique');
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_shares');
-    }
 };

--- a/database/migrations/2026_03_21_050535_create_email_blocklists_table.php
+++ b/database/migrations/2026_03_21_050535_create_email_blocklists_table.php
@@ -21,9 +21,4 @@ return new class extends Migration
             $table->index(['user_id', 'type', 'value']);
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_blocklists');
-    }
 };

--- a/database/migrations/2026_03_21_050549_create_protected_recipients_table.php
+++ b/database/migrations/2026_03_21_050549_create_protected_recipients_table.php
@@ -19,9 +19,4 @@ return new class extends Migration
             $table->timestamps();
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('protected_recipients');
-    }
 };

--- a/database/migrations/2026_03_21_054333_create_emailables.php
+++ b/database/migrations/2026_03_21_054333_create_emailables.php
@@ -20,9 +20,4 @@ return new class extends Migration
             $table->index('email_id');
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('emailables');
-    }
 };

--- a/database/migrations/2026_03_21_054840_create_email_threads_table.php
+++ b/database/migrations/2026_03_21_054840_create_email_threads_table.php
@@ -28,9 +28,4 @@ return new class extends Migration
             $table->index(['team_id', 'last_email_at']);
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_threads');
-    }
 };

--- a/database/migrations/2026_03_21_054856_create_connected_account_syncs_table.php
+++ b/database/migrations/2026_03_21_054856_create_connected_account_syncs_table.php
@@ -28,9 +28,4 @@ return new class extends Migration
             $table->index(['connected_account_id', 'started_at']);
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('connected_account_syncs');
-    }
 };

--- a/database/migrations/2026_03_21_054912_create_email_access_requests_table.php
+++ b/database/migrations/2026_03_21_054912_create_email_access_requests_table.php
@@ -35,9 +35,4 @@ return new class extends Migration
             $table->index('email_id');
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_access_requests');
-    }
 };

--- a/database/migrations/2026_03_21_054922_create_public_email_domains_table.php
+++ b/database/migrations/2026_03_21_054922_create_public_email_domains_table.php
@@ -19,9 +19,4 @@ return new class extends Migration
             $table->unique(['team_id', 'domain']);
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('public_email_domains');
-    }
 };

--- a/database/migrations/2026_03_21_054937_create_email_templates_table.php
+++ b/database/migrations/2026_03_21_054937_create_email_templates_table.php
@@ -25,9 +25,4 @@ return new class extends Migration
             $table->softDeletes();
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_templates');
-    }
 };

--- a/database/migrations/2026_03_21_054952_create_email_signatures_table.php
+++ b/database/migrations/2026_03_21_054952_create_email_signatures_table.php
@@ -24,9 +24,4 @@ return new class extends Migration
             $table->timestamps();
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_signatures');
-    }
 };

--- a/database/migrations/2026_03_21_055334_add_default_email_sharing_tier_to_teams.php
+++ b/database/migrations/2026_03_21_055334_add_default_email_sharing_tier_to_teams.php
@@ -16,11 +16,4 @@ return new class extends Migration
                 ->after('personal_team');
         });
     }
-
-    public function down(): void
-    {
-        Schema::table('teams', function (Blueprint $table): void {
-            $table->dropColumn('default_email_sharing_tier');
-        });
-    }
 };

--- a/database/migrations/2026_03_21_055435_add_email_intelligence_to_people_and_companies.php
+++ b/database/migrations/2026_03_21_055435_add_email_intelligence_to_people_and_companies.php
@@ -21,20 +21,4 @@ return new class extends Migration
             });
         }
     }
-
-    public function down(): void
-    {
-        foreach (['people', 'companies'] as $tbl) {
-            Schema::table($tbl, function (Blueprint $table): void {
-                $table->dropColumn([
-                    'last_email_at',
-                    'last_interaction_at',
-                    'email_count',
-                    'inbound_email_count',
-                    'outbound_email_count',
-                    'avg_response_time_hours',
-                ]);
-            });
-        }
-    }
 };

--- a/database/migrations/2026_03_21_055500_create_email_labels_table.php
+++ b/database/migrations/2026_03_21_055500_create_email_labels_table.php
@@ -20,9 +20,4 @@ return new class extends Migration
             $table->index(['email_id', 'label']);
         });
     }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('email_labels');
-    }
 };

--- a/database/migrations/2026_03_25_000001_add_default_email_sharing_tier_to_users_table.php
+++ b/database/migrations/2026_03_25_000001_add_default_email_sharing_tier_to_users_table.php
@@ -16,11 +16,4 @@ return new class extends Migration
                 ->after('profile_photo_path');
         });
     }
-
-    public function down(): void
-    {
-        Schema::table('users', function (Blueprint $table): void {
-            $table->dropColumn('default_email_sharing_tier');
-        });
-    }
 };

--- a/database/migrations/2026_03_29_045319_add_email_metrics_to_opportunities_table.php
+++ b/database/migrations/2026_03_29_045319_add_email_metrics_to_opportunities_table.php
@@ -21,18 +21,4 @@ return new class extends Migration
             $table->integer('outbound_email_count')->default(0);
         });
     }
-
-    /**
-     * Reverse the migrations.
-     */
-    public function down(): void
-    {
-        Schema::table('opportunities', function (Blueprint $table): void {
-            $table->dropColumn('last_email_at');
-            $table->dropColumn('last_interaction_at');
-            $table->dropColumn('email_count');
-            $table->dropColumn('inbound_email_count');
-            $table->dropColumn('outbound_email_count');
-        });
-    }
 };


### PR DESCRIPTION
## Summary
- Strip `down()` blocks from 20 email/calendar feature migrations to comply with the project rule in `CLAUDE.md`: *"Migrations must only have `up()` methods — do not write `down()` methods."*
- Brings these migrations in line with the convention already followed by the `2026_04_20_*` migrations.

## Files touched
All 18 `2026_03_21_*` email migrations, plus `2026_03_25_000001_add_default_email_sharing_tier_to_users_table.php` and `2026_03_29_045319_add_email_metrics_to_opportunities_table.php`.

`2026_03_21_050429_create_email_batches_table.php` already complied — left alone.

## Test plan
- [x] `php -l` on every modified migration — no syntax errors
- [x] `vendor/bin/pint --dirty --format agent` — pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)