### PR TITLE
chore(deps): pin socialiteproviders/microsoft-azure to ^5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ryangjchandler/laravel-cloudflare-turnstile": "^3.0",
         "scalar/laravel": "^0.2.0",
         "sentry/sentry-laravel": "^4.13",
-        "socialiteproviders/microsoft-azure": "*",
+        "socialiteproviders/microsoft-azure": "^5.2",
         "spatie/cpu-load-health-check": "^1.0",
         "spatie/eloquent-sortable": "^4.4",
         "spatie/laravel-data": "^4.15",


### PR DESCRIPTION
## Summary
- Replace wildcard `"*"` constraint on `socialiteproviders/microsoft-azure` with `^5.2` in `composer.json`.

## Why
Wildcard constraints have no upper bound. Any future major release would silently land on `composer update`, risking breaking changes in OAuth flow without review. Pinning to `^5.2` keeps minor/patch updates flowing while requiring an explicit bump for majors.

`composer.lock` already resolves to `5.2.0`, which satisfies `^5.2` — no lock changes needed.

## Test plan
- [ ] `composer validate`
- [ ] CI green
- [ ] Verify Azure social login still works in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)