### PR TITLE
fix(email): scope email sharing actions to current team

### DIFF
--- a/app/Filament/Pages/EmailInboxPage.php
+++ b/app/Filament/Pages/EmailInboxPage.php
@@ -113,7 +113,7 @@ final class EmailInboxPage extends Page
 
         $query = Email::query()
             ->with(['from', 'labels'])
-            ->where('team_id', $user->current_team_id)
+            ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user));
 
         if ($this->folder === EmailFolder::Sent) {
@@ -142,7 +142,7 @@ final class EmailInboxPage extends Page
         /** @var Email|null */
         return Email::query()
             ->with(['body', 'participants', 'labels', 'attachments', 'from'])
-            ->where('team_id', $this->authUser()->current_team_id)
+            ->forTeam($this->authUser()->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($this->authUser()))
             ->whereKey($this->selectedEmailId)
             ->first();
@@ -154,7 +154,7 @@ final class EmailInboxPage extends Page
         $user = $this->authUser();
 
         return Email::query()
-            ->where('team_id', $user->current_team_id)
+            ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user))
             ->where('direction', EmailDirection::INBOUND)
             ->whereNull('read_at')
@@ -374,9 +374,9 @@ final class EmailInboxPage extends Page
                     ]),
             ])
             ->fillForm(function (array $arguments): array {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'share');
 
-                if ($email === null) {
+                if (! $email instanceof Email) {
                     return [];
                 }
 
@@ -392,11 +392,9 @@ final class EmailInboxPage extends Page
                 ];
             })
             ->action(function (array $data, array $arguments, EmailSharingService $sharingService): void {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'share');
 
-                if ($email === null) {
-                    return;
-                }
+                abort_if(! $email instanceof Email, 403);
 
                 $sharer = $this->authUser();
 
@@ -404,8 +402,13 @@ final class EmailInboxPage extends Page
                 $email->shares()->where('shared_by', $sharer->getKey())->delete();
 
                 foreach ($data['shares'] ?? [] as $share) {
-                    /** @var User $sharedWithUser */
-                    $sharedWithUser = User::query()->findOrFail($share['shared_with']);
+                    $sharedWithUser = User::query()
+                        ->inTeam($sharer->current_team_id)
+                        ->whereKey($share['shared_with'])
+                        ->first();
+
+                    abort_if($sharedWithUser === null, 403);
+
                     $sharingService->shareEmail(
                         $email,
                         $sharer,
@@ -421,6 +424,30 @@ final class EmailInboxPage extends Page
             });
     }
 
+    private function resolveTeamEmail(?string $emailId, string $ability): ?Email
+    {
+        if ($emailId === null) {
+            return null;
+        }
+
+        $user = $this->authUser();
+
+        $email = Email::query()
+            ->forTeam($user->current_team_id)
+            ->whereKey($emailId)
+            ->first();
+
+        if ($email === null) {
+            return null;
+        }
+
+        if (! $user->can($ability, $email)) {
+            return null;
+        }
+
+        return $email;
+    }
+
     protected function summarizeThreadAction(): Action
     {
         return Action::make('summarizeThread')
@@ -432,9 +459,9 @@ final class EmailInboxPage extends Page
             ->modalSubmitAction(false)
             ->modalCancelActionLabel('Close')
             ->modalContent(function (array $arguments): View {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'viewBody');
 
-                if ($email === null) {
+                if (! $email instanceof Email) {
                     return view('filament.actions.ai-summary', ['summary' => null]);
                 }
 
@@ -457,11 +484,9 @@ final class EmailInboxPage extends Page
                     ->required(),
             ])
             ->action(function (array $data, array $arguments): void {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'requestAccess');
 
-                if ($email === null) {
-                    return;
-                }
+                abort_if(! $email instanceof Email, 403);
 
                 $requester = $this->authUser();
 

--- a/app/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/app/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -106,10 +106,17 @@ abstract class BaseEmailsRelationManager extends RelationManager
                         $sharingService->setTierForAllOnRecord($record, $owner, $data['privacy_tier']);
 
                         foreach ($data['shares'] ?? [] as $share) {
+                            $sharedWithUser = User::query()
+                                ->inTeam($owner->current_team_id)
+                                ->whereKey((string) $share['shared_with'])
+                                ->first();
+
+                            abort_if($sharedWithUser === null, 403);
+
                             $sharingService->shareAllOnRecord(
                                 $record,
                                 $owner,
-                                User::query()->findOrFail((string) $share['shared_with']),
+                                $sharedWithUser,
                                 $share['tier'],
                             );
                         }
@@ -248,15 +255,24 @@ abstract class BaseEmailsRelationManager extends RelationManager
                         ->action(function (Email $record, array $data, EmailSharingService $sharingService): void {
                             $sharer = $this->authUser();
 
+                            abort_unless($sharer->can('share', $record), 403);
+
                             $sharingService->setEmailTier($record, $data['privacy_tier']);
 
                             $record->shares()->where('shared_by', $sharer->getKey())->delete();
 
                             foreach ($data['shares'] ?? [] as $share) {
+                                $sharedWithUser = User::query()
+                                    ->inTeam($sharer->current_team_id)
+                                    ->whereKey((string) $share['shared_with'])
+                                    ->first();
+
+                                abort_if($sharedWithUser === null, 403);
+
                                 $sharingService->shareEmail(
                                     $record,
                                     $sharer,
-                                    User::query()->findOrFail((string) $share['shared_with']),
+                                    $sharedWithUser,
                                     $share['tier'],
                                 );
                             }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -137,6 +137,16 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
      * @return Builder<User>
      */
     #[Scope]
+    protected function inTeam(Builder $query, string $teamId): Builder
+    {
+        return $query->where('current_team_id', $teamId);
+    }
+
+    /**
+     * @param  Builder<User>  $query
+     * @return Builder<User>
+     */
+    #[Scope]
     protected function expiredDeletion(Builder $query): Builder
     {
         return $query->whereNotNull('scheduled_deletion_at')

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -11,6 +11,8 @@ use App\Models\People;
 use App\Models\User;
 use Database\Factories\EmailFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -115,6 +117,16 @@ final class Email extends Model
         'attempts' => 'integer',
         'priority' => EmailPriority::class,
     ];
+
+    /**
+     * @param  Builder<Email>  $query
+     * @return Builder<Email>
+     */
+    #[Scope]
+    protected function forTeam(Builder $query, string $teamId): Builder
+    {
+        return $query->where('team_id', $teamId);
+    }
 
     // Relations
 


### PR DESCRIPTION
## Summary

`manageSharing`, `summarizeThread`, and `requestAccess` actions on `EmailInboxPage` resolved the target email via `Email::query()->whereKey($arguments['emailId'])->first()` with no `team_id`, ownership, or policy check. `Email` has no global tenant scope, so any authenticated user could mutate another tenant's email by supplying its ULID:

- Flip `privacy_tier` on a foreign email
- Wipe its existing shares
- Grant arbitrary users (looked up via `User::findOrFail(...)`, also unscoped) access via `EmailSharingService::shareEmail`

The same unscoped `User::findOrFail($share['shared_with'])` pattern existed in `BaseEmailsRelationManager` (`manageSharing`, `shareAllOnRecord`).

## Changes

- Add `#[Scope] inTeam(Builder, string)` on `App\Models\User`
- Add `#[Scope] forTeam(Builder, string)` on `Relaticle\EmailIntegration\Models\Email`
- Introduce `EmailInboxPage::resolveTeamEmail(?string $emailId, string $ability)` helper that filters by `team_id` and runs `$user->can($ability, $email)` against `EmailPolicy`
- Use the helper in `manageSharing` (`share`), `summarizeThread` (`viewBody`), and `requestAccess` (`requestAccess`); `abort(403)` on miss in mutating actions
- Scope `shared_with` user lookups to `$sharer->current_team_id` via `inTeam(...)` in `EmailInboxPage::manageSharing` and both `BaseEmailsRelationManager` actions; `abort(403)` if the user is not in the sharer's team
- Explicit `abort_unless($sharer->can('share', $record), 403)` gate in `BaseEmailsRelationManager::manageSharing` as defense in depth
- Refactor existing `where('team_id', ...)` Email queries on the page to `forTeam(...)`

## Test plan

- [ ] `vendor/bin/pint --dirty --format agent`
- [ ] `vendor/bin/rector --dry-run`
- [ ] `vendor/bin/phpstan analyse`
- [ ] `php artisan test --compact --filter=Sharing`
- [ ] Manually verify: invoking `manageSharing`, `summarizeThread`, `requestAccess` with a foreign-tenant `emailId` returns 403
- [ ] Manually verify: submitting `shared_with` for a user outside the sharer's team returns 403
- [ ] Manually verify: legitimate same-team sharing still saves and notifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)