### PR TITLE
fix(email): correct config key typo in InitialEmailSyncJob

### DIFF
--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -43,7 +43,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $daysBack = Config::integer('email-integratdion.sync.initial_days', 90);
+        $daysBack = Config::integer('email-integration.sync.initial_days', 90);
 
         $service = GmailService::forAccount($account);
 


### PR DESCRIPTION
## Summary

- Fix typo in config key used by `InitialEmailSyncJob`: `email-integratdion.sync.initial_days` → `email-integration.sync.initial_days`.
- Without this fix, `Config::integer(...)` never resolved the key, so the configured value (and any `EMAIL_SYNC_INITIAL_DAYS` env override) was silently ignored and the 90-day fallback was always used during initial Gmail sync.

## Why

The misspelled namespace `email-integratdion` does not match the actual config file (`packages/EmailIntegration/config/email-integration.php`), so deployments could not customize the initial sync window. Single-character fix restores the intended behavior.

## Test plan

- [x] Verified config key resolves to `packages/EmailIntegration/config/email-integration.php` (`initial_days` → `EMAIL_SYNC_INITIAL_DAYS` env, default 90).
- [x] `vendor/bin/pint --dirty --format agent` passes.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)