### PR TITLE
chore(deps): pin relaticle/activity-log to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "laravel/tinker": "^2.9",
         "livewire/livewire": "^4.0",
         "prism-php/prism": "^0.98.5",
-        "relaticle/activity-log": "1.x-dev",
+        "relaticle/activity-log": "^1.0",
         "relaticle/custom-fields": "^3.0",
         "relaticle/flowforge": "^4.0",
         "ryangjchandler/laravel-cloudflare-turnstile": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8513bfe4cba6bee9ce9db99799758faa",
+    "content-hash": "ec2a88bdff9ec8c55f2c21bfa05e2162",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -7970,16 +7970,16 @@
         },
         {
             "name": "relaticle/activity-log",
-            "version": "1.x-dev",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/relaticle/activity-log.git",
-                "reference": "f8839ef86308a2a31006dbbdeacece41b075cfa8"
+                "reference": "2ae439b1df363302f263ed16bce5606773d4c11f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/relaticle/activity-log/zipball/f8839ef86308a2a31006dbbdeacece41b075cfa8",
-                "reference": "f8839ef86308a2a31006dbbdeacece41b075cfa8",
+                "url": "https://api.github.com/repos/relaticle/activity-log/zipball/2ae439b1df363302f263ed16bce5606773d4c11f",
+                "reference": "2ae439b1df363302f263ed16bce5606773d4c11f",
                 "shasum": ""
             },
             "require": {
@@ -7998,7 +7998,6 @@
                 "pestphp/pest-plugin-laravel": "^4.0",
                 "pestphp/pest-plugin-livewire": "^4.0"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -8019,9 +8018,9 @@
             "description": "Reusable Filament plugin that renders a unified activity-log timeline for any Eloquent model",
             "support": {
                 "issues": "https://github.com/relaticle/activity-log/issues",
-                "source": "https://github.com/relaticle/activity-log/tree/1.x"
+                "source": "https://github.com/relaticle/activity-log/tree/v1.0.0"
             },
-            "time": "2026-04-21T15:23:52+00:00"
+            "time": "2026-04-26T14:15:07+00:00"
         },
         {
             "name": "relaticle/custom-fields",
@@ -20160,7 +20159,6 @@
     "aliases": [],
     "minimum-stability": "beta",
     "stability-flags": {
-        "relaticle/activity-log": 20,
         "spatie/guidelines-skills": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
## Summary
- Tagged `v1.0.0` on [relaticle/activity-log](https://github.com/relaticle/activity-log/releases/tag/v1.0.0) at `2ae439b1` (current `1.x` HEAD).
- Replaced the `1.x-dev` constraint in `composer.json` with `^1.0` so we depend on a stable tagged release instead of a moving dev branch.
- Refreshed `composer.lock` to resolve `relaticle/activity-log` at `v1.0.0`.

## Why
`1.x-dev` combined with `minimum-stability: beta` meant any push to the package's `1.x` branch could change behavior on the next `composer update`. Pinning to `^1.0` removes that drift while still allowing future 1.x patch/minor upgrades.

## Test plan
- [ ] CI green on this branch
- [ ] `composer show relaticle/activity-log` reports `v1.0.0`
- [ ] App boots and activity-log plugin behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)