### PR TITLE
fix(email): add team_id to email_signatures for tenant scoping

### DIFF
--- a/database/factories/EmailSignatureFactory.php
+++ b/database/factories/EmailSignatureFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
-use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\EmailSignature;
@@ -20,7 +19,12 @@ final class EmailSignatureFactory extends Factory
     {
         return [
             'connected_account_id' => ConnectedAccount::factory(),
-            'user_id' => User::factory(),
+            'team_id' => fn (array $attributes): string => ConnectedAccount::query()
+                ->whereKey($attributes['connected_account_id'])
+                ->value('team_id'),
+            'user_id' => fn (array $attributes): string => ConnectedAccount::query()
+                ->whereKey($attributes['connected_account_id'])
+                ->value('user_id'),
             'name' => $this->faker->words(2, true),
             'content_html' => '<p>'.$this->faker->sentence().'</p>',
             'is_default' => false,

--- a/database/migrations/2026_03_21_054952_create_email_signatures_table.php
+++ b/database/migrations/2026_03_21_054952_create_email_signatures_table.php
@@ -12,6 +12,7 @@ return new class extends Migration
     {
         Schema::create('email_signatures', function (Blueprint $table): void {
             $table->ulid('id')->primary();
+            $table->teams();
             $table->foreignUlid('connected_account_id')
                 ->constrained('connected_accounts')
                 ->cascadeOnDelete();
@@ -22,6 +23,8 @@ return new class extends Migration
             $table->boolean('is_default')->default(false);
 
             $table->timestamps();
+
+            $table->index(['team_id', 'connected_account_id']);
         });
     }
 

--- a/packages/EmailIntegration/src/Actions/CreateSignatureAction.php
+++ b/packages/EmailIntegration/src/Actions/CreateSignatureAction.php
@@ -21,6 +21,7 @@ final readonly class CreateSignatureAction
         }
 
         return EmailSignature::query()->create([
+            'team_id' => $account->team_id,
             'connected_account_id' => $account->getKey(),
             'user_id' => $account->user_id,
             'name' => $data['name'],

--- a/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
@@ -12,7 +12,6 @@ use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Support\Enums\Size;
-use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Relaticle\EmailIntegration\Actions\CreateSignatureAction;
 use Relaticle\EmailIntegration\Actions\UpdateSignatureAction;
@@ -54,10 +53,8 @@ final class EmailSignaturesPage extends Page
     private function loadSignatures(): Collection
     {
         return EmailSignature::query()
-            ->whereHas('connectedAccount', fn (Builder $accountQuery) => $accountQuery
-                ->where('user_id', auth()->id())
-                ->where('team_id', filament()->getTenant()?->getKey())
-            )
+            ->where('team_id', filament()->getTenant()?->getKey())
+            ->where('user_id', auth()->id())
             ->with('connectedAccount')
             ->get();
     }
@@ -175,7 +172,8 @@ final class EmailSignaturesPage extends Page
             ->requiresConfirmation()
             ->action(function (array $arguments): void {
                 $deleted = EmailSignature::query()->where('id', $arguments['signature_id'])
-                    ->whereHas('connectedAccount', fn (Builder $accountQuery) => $accountQuery->where('user_id', auth()->id()))
+                    ->where('team_id', filament()->getTenant()?->getKey())
+                    ->where('user_id', auth()->id())
                     ->delete();
 
                 $this->signatures = $this->loadSignatures();

--- a/packages/EmailIntegration/src/Models/EmailSignature.php
+++ b/packages/EmailIntegration/src/Models/EmailSignature.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Models;
 
+use App\Models\Concerns\HasTeam;
 use App\Models\User;
 use Database\Factories\EmailSignatureFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -16,7 +17,7 @@ final class EmailSignature extends Model
     /**
      * @use HasFactory<EmailSignatureFactory>
      */
-    use HasFactory, HasUlids;
+    use HasFactory, HasTeam, HasUlids;
 
     protected static function newFactory(): EmailSignatureFactory
     {
@@ -24,6 +25,7 @@ final class EmailSignature extends Model
     }
 
     protected $fillable = [
+        'team_id',
         'connected_account_id',
         'user_id',
         'name',

--- a/tests/Feature/EmailIntegration/EmailSignatureManagementTest.php
+++ b/tests/Feature/EmailIntegration/EmailSignatureManagementTest.php
@@ -42,6 +42,7 @@ it('creates a signature record', function (): void {
 
 it('sets new signature as default and unsets the previous default', function (): void {
     $existingDefault = EmailSignature::create([
+        'team_id' => $this->team->id,
         'connected_account_id' => $this->account->getKey(),
         'user_id' => $this->user->id,
         'name' => 'Old Default',
@@ -78,6 +79,7 @@ it('allows multiple non-default signatures', function (): void {
 
 it('updates signature name', function (): void {
     $signature = EmailSignature::create([
+        'team_id' => $this->team->id,
         'connected_account_id' => $this->account->getKey(),
         'user_id' => $this->user->id,
         'name' => 'Original Name',
@@ -92,6 +94,7 @@ it('updates signature name', function (): void {
 
 it('setting is_default clears other defaults for the same account', function (): void {
     $sigA = EmailSignature::create([
+        'team_id' => $this->team->id,
         'connected_account_id' => $this->account->getKey(),
         'user_id' => $this->user->id,
         'name' => 'Sig A',
@@ -100,6 +103,7 @@ it('setting is_default clears other defaults for the same account', function ():
     ]);
 
     $sigB = EmailSignature::create([
+        'team_id' => $this->team->id,
         'connected_account_id' => $this->account->getKey(),
         'user_id' => $this->user->id,
         'name' => 'Sig B',


### PR DESCRIPTION
## Summary

- Adds `team_id` column, FK, and `(team_id, connected_account_id)` index to `email_signatures`. It was the only email table in this PR series missing it.
- Adds `HasTeam` trait to `EmailSignature`, includes `team_id` in `$fillable`, and writes it from `$account->team_id` in `CreateSignatureAction`.
- Scopes `EmailSignaturesPage` queries directly by `team_id` + `user_id` instead of joining through `connected_accounts` via `whereHas`.
- Factory derives `team_id` and `user_id` from the resolved `connected_account_id` so generated signatures stay tenant-coherent.

## Why

Without `team_id` on `email_signatures`, multi-tenant queries had to traverse `connected_accounts` to scope correctly. That blocks straightforward tenant filters/policies/eager-loads and is inconsistent with every other email table in this feature branch.

## Test plan

- [x] `php artisan migrate:fresh --env=testing` succeeds; new column, FK to `teams`, and composite index appear in `db:table email_signatures`.
- [x] `tests/Feature/EmailIntegration/EmailSignatureManagementTest.php` (5 tests) pass.
- [x] `tests/Feature/EmailIntegration/EmailSignaturesPageTest.php` (10 tests) pass.
- [x] All 150 `tests/Feature/EmailIntegration` tests pass.
- [x] `vendor/bin/pint --dirty --format agent` clean.
- [x] `vendor/bin/rector --dry-run` clean.
- [x] `vendor/bin/phpstan analyse` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)