### PR TITLE
Require actor on Approve/Deny email access request actions

### DIFF
--- a/app/Filament/Pages/BaseRecordEmailsPage.php
+++ b/app/Filament/Pages/BaseRecordEmailsPage.php
@@ -361,7 +361,7 @@ abstract class BaseRecordEmailsPage extends Page
                     return;
                 }
 
-                resolve(ApproveEmailAccessRequestAction::class)->execute($accessRequest);
+                resolve(ApproveEmailAccessRequestAction::class)->execute($accessRequest, $this->authUser());
 
                 unset($this->selectedEmail);
 
@@ -394,7 +394,7 @@ abstract class BaseRecordEmailsPage extends Page
                     return;
                 }
 
-                resolve(DenyEmailAccessRequestAction::class)->execute($accessRequest);
+                resolve(DenyEmailAccessRequestAction::class)->execute($accessRequest, $this->authUser());
 
                 unset($this->selectedEmail);
 

--- a/app/Filament/Pages/EmailAccessRequestsPage.php
+++ b/app/Filament/Pages/EmailAccessRequestsPage.php
@@ -225,7 +225,7 @@ final class EmailAccessRequestsPage extends Page
                     return;
                 }
 
-                resolve(ApproveEmailAccessRequestAction::class)->execute($accessRequest);
+                resolve(ApproveEmailAccessRequestAction::class)->execute($accessRequest, $this->authUser());
 
                 $this->selectedRequestId = null;
                 unset($this->selectedRequest, $this->requests, $this->pendingIncomingCount);
@@ -263,7 +263,7 @@ final class EmailAccessRequestsPage extends Page
                     return;
                 }
 
-                resolve(DenyEmailAccessRequestAction::class)->execute($accessRequest);
+                resolve(DenyEmailAccessRequestAction::class)->execute($accessRequest, $this->authUser());
 
                 $this->selectedRequestId = null;
                 unset($this->selectedRequest, $this->requests, $this->pendingIncomingCount);

--- a/app/Filament/Pages/EmailInboxPage.php
+++ b/app/Filament/Pages/EmailInboxPage.php
@@ -519,7 +519,7 @@ final class EmailInboxPage extends Page
                     return;
                 }
 
-                resolve(ApproveEmailAccessRequestAction::class)->execute($accessRequest);
+                resolve(ApproveEmailAccessRequestAction::class)->execute($accessRequest, $this->authUser());
 
                 unset($this->selectedEmail);
 
@@ -552,7 +552,7 @@ final class EmailInboxPage extends Page
                     return;
                 }
 
-                resolve(DenyEmailAccessRequestAction::class)->execute($accessRequest);
+                resolve(DenyEmailAccessRequestAction::class)->execute($accessRequest, $this->authUser());
 
                 unset($this->selectedEmail);
 

--- a/packages/EmailIntegration/src/Actions/ApproveEmailAccessRequestAction.php
+++ b/packages/EmailIntegration/src/Actions/ApproveEmailAccessRequestAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use App\Models\User;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
@@ -14,8 +15,10 @@ final readonly class ApproveEmailAccessRequestAction
 {
     public function __construct(private EmailSharingService $sharingService) {}
 
-    public function execute(EmailAccessRequest $accessRequest): void
+    public function execute(EmailAccessRequest $accessRequest, User $actor): void
     {
+        abort_unless($accessRequest->owner_id === $actor->getKey(), 403);
+
         if ($accessRequest->status !== EmailAccessRequestStatus::PENDING) {
             return;
         }

--- a/packages/EmailIntegration/src/Actions/DenyEmailAccessRequestAction.php
+++ b/packages/EmailIntegration/src/Actions/DenyEmailAccessRequestAction.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use App\Models\User;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Notifications\EmailAccessRespondedNotification;
 
 final readonly class DenyEmailAccessRequestAction
 {
-    public function execute(EmailAccessRequest $accessRequest): void
+    public function execute(EmailAccessRequest $accessRequest, User $actor): void
     {
+        abort_unless($accessRequest->owner_id === $actor->getKey(), 403);
+
         if ($accessRequest->status !== EmailAccessRequestStatus::PENDING) {
             return;
         }

--- a/tests/Feature/EmailIntegration/EmailAccessRequestTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccessRequestTest.php
@@ -15,6 +15,7 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Notifications\EmailAccessRespondedNotification;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 mutates(ApproveEmailAccessRequestAction::class, CancelEmailAccessRequestAction::class, DenyEmailAccessRequestAction::class);
 
@@ -49,7 +50,7 @@ describe('ApproveEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(ApproveEmailAccessRequestAction::class)->execute($request);
+        app(ApproveEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         $this->assertDatabaseHas('email_shares', [
             'email_id' => $this->email->getKey(),
@@ -67,7 +68,7 @@ describe('ApproveEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(ApproveEmailAccessRequestAction::class)->execute($request);
+        app(ApproveEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::APPROVED);
     });
@@ -81,7 +82,7 @@ describe('ApproveEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(ApproveEmailAccessRequestAction::class)->execute($request);
+        app(ApproveEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         Notification::assertSentTo($this->requester, EmailAccessRespondedNotification::class);
     });
@@ -95,7 +96,7 @@ describe('ApproveEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(ApproveEmailAccessRequestAction::class)->execute($request);
+        app(ApproveEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         Notification::assertNothingSent();
         expect(EmailShare::where('email_id', $this->email->getKey())->count())->toBe(0);
@@ -110,9 +111,28 @@ describe('ApproveEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(ApproveEmailAccessRequestAction::class)->execute($request);
+        app(ApproveEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         Notification::assertNothingSent();
+        expect(EmailShare::where('email_id', $this->email->getKey())->count())->toBe(0);
+    });
+
+    it('aborts with 403 when actor is not the owner', function (): void {
+        $request = EmailAccessRequest::factory()->forTier(EmailPrivacyTier::FULL)->create([
+            'requester_id' => $this->requester->id,
+            'owner_id' => $this->owner->id,
+            'email_id' => $this->email->getKey(),
+        ]);
+
+        $intruder = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        Notification::fake();
+
+        expect(fn () => app(ApproveEmailAccessRequestAction::class)->execute($request, $intruder))
+            ->toThrow(HttpException::class);
+
+        Notification::assertNothingSent();
+        expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::PENDING);
         expect(EmailShare::where('email_id', $this->email->getKey())->count())->toBe(0);
     });
 });
@@ -127,7 +147,7 @@ describe('DenyEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(DenyEmailAccessRequestAction::class)->execute($request);
+        app(DenyEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::DENIED);
     });
@@ -141,7 +161,7 @@ describe('DenyEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(DenyEmailAccessRequestAction::class)->execute($request);
+        app(DenyEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         Notification::assertSentTo($this->requester, EmailAccessRespondedNotification::class);
     });
@@ -155,7 +175,7 @@ describe('DenyEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(DenyEmailAccessRequestAction::class)->execute($request);
+        app(DenyEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         expect(EmailShare::where('email_id', $this->email->getKey())->count())->toBe(0);
     });
@@ -169,7 +189,7 @@ describe('DenyEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(DenyEmailAccessRequestAction::class)->execute($request);
+        app(DenyEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         Notification::assertNothingSent();
         expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::APPROVED);
@@ -184,9 +204,27 @@ describe('DenyEmailAccessRequestAction', function (): void {
 
         Notification::fake();
 
-        app(DenyEmailAccessRequestAction::class)->execute($request);
+        app(DenyEmailAccessRequestAction::class)->execute($request, $this->owner);
 
         Notification::assertNothingSent();
+    });
+
+    it('aborts with 403 when actor is not the owner', function (): void {
+        $request = EmailAccessRequest::factory()->forTier(EmailPrivacyTier::FULL)->create([
+            'requester_id' => $this->requester->id,
+            'owner_id' => $this->owner->id,
+            'email_id' => $this->email->getKey(),
+        ]);
+
+        $intruder = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        Notification::fake();
+
+        expect(fn () => app(DenyEmailAccessRequestAction::class)->execute($request, $intruder))
+            ->toThrow(HttpException::class);
+
+        Notification::assertNothingSent();
+        expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::PENDING);
     });
 });
 


### PR DESCRIPTION
## Summary

- `ApproveEmailAccessRequestAction::execute()` and `DenyEmailAccessRequestAction::execute()` now accept a `User $actor` argument and call `abort_unless($accessRequest->owner_id === $actor->getKey(), 403)` before mutating state. Defense-in-depth so authorization is enforced inside the action, not only at the calling Filament page.
- Filament call sites (`EmailAccessRequestsPage`, `EmailInboxPage`, `BaseRecordEmailsPage`) pass `$this->authUser()` to both actions.
- Tests updated to pass the actor; new owner-mismatch cases assert that a non-owner caller raises an `HttpException` (403) and that no state changes (status stays `PENDING`, no `EmailShare` row, no notification).

## Why

Approve/deny grants are security-critical primitives. Owner gating previously lived only in the Filament pages; an action invoked from any other entry point would have skipped the owner check. Pushing the assertion into the action makes the primitive safe by construction.

## Test plan
- [x] `vendor/bin/pest tests/Feature/EmailIntegration/EmailAccessRequestTest.php --compact` — 15 tests pass
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `vendor/bin/rector --dry-run`
- [x] `vendor/bin/phpstan analyse`
- [x] `pest --type-coverage --min=99.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)