### PR TITLE
fix: deployable compose.yml + trust private-network proxies

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -39,6 +39,17 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->trustProxies(at: [
+            '127.0.0.0/8',
+            '10.0.0.0/8',
+            '172.16.0.0/12',
+            '192.168.0.0/16',
+            '169.254.0.0/16',
+            '::1/128',
+            'fc00::/7',
+            'fe80::/10',
+        ]);
+
         $middleware->prepend(SubdomainRootResponse::class);
 
         $middleware->prependToPriorityList(

--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,5 @@
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
     image: ghcr.io/relaticle/relaticle:latest
     restart: unless-stopped
     ports:
@@ -57,10 +53,6 @@ services:
       start_period: 60s
 
   horizon:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
     image: ghcr.io/relaticle/relaticle:latest
     restart: unless-stopped
     command: ["php", "/var/www/html/artisan", "horizon"]
@@ -97,10 +89,6 @@ services:
       start_period: 10s
 
   scheduler:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
     image: ghcr.io/relaticle/relaticle:latest
     restart: unless-stopped
     command: ["php", "/var/www/html/artisan", "schedule:work"]

--- a/packages/Documentation/resources/markdown/self-hosting-guide.md
+++ b/packages/Documentation/resources/markdown/self-hosting-guide.md
@@ -220,7 +220,7 @@ labels:
   - "traefik.http.services.relaticle.loadbalancer.server.port=8080"
 ```
 
-**Note**: When using a reverse proxy, set `APP_URL` to your public HTTPS URL (e.g., `https://crm.example.com`). The `TRUSTED_PROXIES` environment variable defaults to `*` in Docker, so forwarded headers are handled automatically.
+**Note**: When using a reverse proxy, set `APP_URL` to your public HTTPS URL (e.g., `https://crm.example.com`). The app trusts `X-Forwarded-*` headers from RFC1918 private networks, loopback, and IPv6 ULA/link-local — covering Coolify/Dokploy/Traefik on a Docker network and reverse proxies on the host. Headers from public IPs are rejected, preventing spoofing.
 
 ---
 

--- a/tests/Feature/Middleware/TrustProxiesTest.php
+++ b/tests/Feature/Middleware/TrustProxiesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function (): void {
+    Route::get('/_trust-proxy-probe', fn (Request $request): array => [
+        'isSecure' => $request->isSecure(),
+        'scheme' => $request->getScheme(),
+        'host' => $request->getHost(),
+        'clientIp' => $request->getClientIp(),
+    ]);
+});
+
+it('honours forwarded headers from a private network proxy so HTTPS is detected behind Traefik', function (): void {
+    $this->call(
+        method: 'GET',
+        uri: '/_trust-proxy-probe',
+        server: [
+            'REMOTE_ADDR' => '172.18.0.2',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'HTTP_X_FORWARDED_HOST' => 'crm.example.com',
+            'HTTP_X_FORWARDED_FOR' => '203.0.113.5',
+        ],
+    )->assertOk()->assertJson([
+        'isSecure' => true,
+        'scheme' => 'https',
+        'host' => 'crm.example.com',
+        'clientIp' => '203.0.113.5',
+    ]);
+});
+
+it('refuses to honour forwarded headers from a public IP so attackers cannot spoof X-Forwarded-* directly against the FPM port', function (): void {
+    $this->call(
+        method: 'GET',
+        uri: '/_trust-proxy-probe',
+        server: [
+            'REMOTE_ADDR' => '203.0.113.99',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'HTTP_X_FORWARDED_HOST' => 'evil.example.com',
+            'HTTP_X_FORWARDED_FOR' => '10.0.0.1',
+        ],
+    )->assertOk()->assertJson([
+        'isSecure' => false,
+        'scheme' => 'http',
+        'clientIp' => '203.0.113.99',
+    ]);
+});
+
+it('honours forwarded headers from loopback so reverse proxies on the host work', function (): void {
+    $this->call(
+        method: 'GET',
+        uri: '/_trust-proxy-probe',
+        server: [
+            'REMOTE_ADDR' => '127.0.0.1',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+        ],
+    )->assertOk()->assertJson([
+        'isSecure' => true,
+    ]);
+});

--- a/tests/Feature/Middleware/TrustProxiesTest.php
+++ b/tests/Feature/Middleware/TrustProxiesTest.php
@@ -35,7 +35,7 @@ it('honours forwarded headers from a private network proxy so HTTPS is detected 
 it('refuses to honour forwarded headers from a public IP so attackers cannot spoof X-Forwarded-* directly against the FPM port', function (): void {
     $this->call(
         method: 'GET',
-        uri: '/_trust-proxy-probe',
+        uri: 'http://crm.example.com/_trust-proxy-probe',
         server: [
             'REMOTE_ADDR' => '203.0.113.99',
             'HTTP_X_FORWARDED_PROTO' => 'https',
@@ -45,6 +45,7 @@ it('refuses to honour forwarded headers from a public IP so attackers cannot spo
     )->assertOk()->assertJson([
         'isSecure' => false,
         'scheme' => 'http',
+        'host' => 'crm.example.com',
         'clientIp' => '203.0.113.99',
     ]);
 });
@@ -60,4 +61,43 @@ it('honours forwarded headers from loopback so reverse proxies on the host work'
     )->assertOk()->assertJson([
         'isSecure' => true,
     ]);
+});
+
+it('emits https asset URLs when the proxy forwards X-Forwarded-Proto: https — the actual mechanism behind the unstyled-CSS bug', function (): void {
+    Route::get('/_vite-asset-probe', fn (): array => [
+        'asset' => asset('build/app.css'),
+        'scheme' => request()->getScheme(),
+    ]);
+
+    $response = $this->call(
+        method: 'GET',
+        uri: '/_vite-asset-probe',
+        server: [
+            'REMOTE_ADDR' => '172.18.0.2',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+            'HTTP_X_FORWARDED_HOST' => 'crm.example.com',
+        ],
+    )->assertOk();
+
+    expect($response->json('scheme'))->toBe('https');
+    expect($response->json('asset'))->toStartWith('https://');
+});
+
+it('emits http asset URLs when forwarded headers come from an untrusted public IP — confirming this would cause the unstyled-CSS bug if trust were misconfigured', function (): void {
+    Route::get('/_vite-asset-probe', fn (): array => [
+        'asset' => asset('build/app.css'),
+        'scheme' => request()->getScheme(),
+    ]);
+
+    $response = $this->call(
+        method: 'GET',
+        uri: '/_vite-asset-probe',
+        server: [
+            'REMOTE_ADDR' => '203.0.113.99',
+            'HTTP_X_FORWARDED_PROTO' => 'https',
+        ],
+    )->assertOk();
+
+    expect($response->json('scheme'))->toBe('http');
+    expect($response->json('asset'))->toStartWith('http://');
 });


### PR DESCRIPTION
## Summary

Closes #250.

Two related fixes for self-hosted deploys (Coolify, Dokploy, anyone curl-ing the compose.yml standalone):

- **`compose.yml`** — removed the `build:` blocks from `app`, `horizon`, and `scheduler`. They referenced a Dockerfile that isn't in the build context when the file is pulled by itself, which is exactly the failure reported in the issue (`failed to read dockerfile: open Dockerfile: no such file or directory`). Pre-built multi-arch images already publish to `ghcr.io/relaticle/relaticle` via `.github/workflows/docker-publish.yml`, so the `image:` directive is sufficient.
- **`bootstrap/app.php`** — registered `$middleware->trustProxies(at: [...])` with RFC1918 + loopback + IPv6 ULA/link-local CIDRs. Without this, Laravel's default behavior is to ignore `X-Forwarded-Proto` from any proxy, which causes `request()->isSecure()` to return false behind Coolify's Traefik. The visible symptom is the unstyled login page the reporter shared in the issue comment — Vite emits `http://` asset URLs on an HTTPS page and the browser blocks them as mixed content.

## Why these CIDRs

The list trusts proxies on private networks only:

```
127.0.0.0/8           IPv4 loopback
10.0.0.0/8            RFC1918
172.16.0.0/12         RFC1918 (Docker default bridge range)
192.168.0.0/16        RFC1918
169.254.0.0/16        link-local
::1/128               IPv6 loopback
fc00::/7              IPv6 ULA
fe80::/10             IPv6 link-local
```

Covers Coolify/Dokploy/Traefik on a Docker network, host-local nginx/Caddy, and direct-loopback proxies. Public-internet IPs are rejected — if the FPM port is ever reachable directly (which the standalone `compose.yml` allows via `ports: ${APP_PORT:-80}:8080`), an attacker still can't spoof `X-Forwarded-*` headers.

This is the canonical Laravel 12 idiom — matches the example in https://laravel.com/docs/12.x/requests#configuring-trusted-proxies. No new config file, no env plumbing, no service provider mutation.

## Test plan

- [x] `tests/Feature/Middleware/TrustProxiesTest.php` covers three regression cases:
  - private-network proxy → forwarded headers honored, `isSecure() === true`
  - public-IP caller → forwarded headers rejected (security regression test)
  - loopback proxy → forwarded headers honored
- [x] `vendor/bin/pint --dirty --format agent` — passed
- [x] `vendor/bin/phpstan analyse bootstrap/app.php` — 0 errors
- [x] `vendor/bin/rector --dry-run` — clean
- [x] `composer test:type-coverage` — 100.0%
- [x] `php artisan test --compact tests/Feature/Middleware/ tests/Feature/Auth/` — 31 passed
- [x] `docker compose -f compose.yml config --quiet` — valid
- [ ] Verify on a real Coolify deploy: paste compose.yml, set `APP_KEY` / `DB_PASSWORD` / `APP_URL=https://...`, deploy, confirm login page renders styled