### PR TITLE
fix(emailables): add unique link index

### DIFF
--- a/database/migrations/2026_03_21_054333_create_emailables.php
+++ b/database/migrations/2026_03_21_054333_create_emailables.php
@@ -18,11 +18,7 @@ return new class extends Migration
 
             $table->timestamps();
             $table->index('email_id');
+            $table->unique(['email_id', 'emailable_type', 'emailable_id'], 'emailables_unique_link');
         });
-    }
-
-    public function down(): void
-    {
-        Schema::dropIfExists('emailables');
     }
 };


### PR DESCRIPTION
## Summary

- Add unique index on `(email_id, emailable_type, emailable_id)` to the `emailables` pivot, named `emailables_unique_link`. Mirrors sister `meetingables` table from `2026_04_20_000004_create_meetingables_table.php`.
- Drop `down()` from the migration per project rule (Postgres-only, `up()`-only migrations).

## Why

`LinkEmailAction` uses `syncWithoutDetaching` for auto-linking emails to People/Companies/Opportunities. Without a unique constraint, concurrent runs (e.g. retry of `LinkEmailJob`, or two participants resolving to the same record) can race between the SELECT and INSERT and create duplicate pivot rows. Duplicate links inflate `email_count`, `inbound_email_count`, and `outbound_email_count` on linked records via `LinkEmailAction::updateCompanyMetrics()` etc.

The sister `meetingables` table already has this constraint — `emailables` should match.

## Test plan

- [ ] `php artisan migrate:fresh --env=testing` succeeds (verified locally)
- [ ] EmailIntegration test suite green
- [ ] Duplicate insert into `emailables` with same `(email_id, emailable_type, emailable_id)` is rejected by Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)