### PR TITLE
feat(queue): isolate email sync/classify on dedicated emails-sync queue

### DIFF
--- a/app/Jobs/ClassifyEmailJob.php
+++ b/app/Jobs/ClassifyEmailJob.php
@@ -27,7 +27,10 @@ final class ClassifyEmailJob implements ShouldQueue
         'Other',
     ];
 
-    public function __construct(public readonly string $emailId) {}
+    public function __construct(public readonly string $emailId)
+    {
+        $this->onQueue('emails-sync');
+    }
 
     public function handle(): void
     {

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -88,6 +88,7 @@ return [
     'waits' => [
         'redis:default' => 60,
         'redis:imports' => 120,
+        'redis:emails-sync' => 300,
     ],
 
     /*
@@ -264,6 +265,20 @@ return [
             'timeout' => 120,
             'nice' => 5,
         ],
+        'supervisor-emails-sync' => [
+            'connection' => 'redis',
+            'queue' => ['emails-sync'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            'maxProcesses' => 10,
+            'minProcesses' => 2,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 256,
+            'tries' => 3,
+            'timeout' => 300,
+            'nice' => 5,
+        ],
     ],
 
     'environments' => [
@@ -345,6 +360,20 @@ return [
                 'timeout' => 120,
                 'nice' => 5,
             ],
+            'supervisor-emails-sync' => [
+                'connection' => 'redis',
+                'queue' => ['emails-sync'],
+                'balance' => 'auto',
+                'autoScalingStrategy' => 'time',
+                'maxProcesses' => 20,
+                'minProcesses' => 3,
+                'balanceMaxShift' => 5,
+                'balanceCooldown' => 2,
+                'memory' => 256,
+                'tries' => 3,
+                'timeout' => 300,
+                'nice' => 5,
+            ],
         ],
 
         'local' => [
@@ -358,6 +387,9 @@ return [
                 'maxProcesses' => 3,
             ],
             'supervisor-imports' => [
+                'maxProcesses' => 5,
+            ],
+            'supervisor-emails-sync' => [
                 'maxProcesses' => 5,
             ],
         ],

--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -26,7 +26,9 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
-    ) {}
+    ) {
+        $this->onQueue('emails-sync');
+    }
 
     public function handle(CalendarServiceFactoryInterface $serviceFactory): void
     {

--- a/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
@@ -28,7 +28,9 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
-    ) {}
+    ) {
+        $this->onQueue('emails-sync');
+    }
 
     public function handle(): void
     {

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -25,7 +25,9 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
-    ) {}
+    ) {
+        $this->onQueue('emails-sync');
+    }
 
     public function handle(CalendarServiceFactoryInterface $serviceFactory): void
     {

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -29,7 +29,9 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
-    ) {}
+    ) {
+        $this->onQueue('emails-sync');
+    }
 
     /**
      * @throws \Throwable

--- a/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
@@ -30,7 +30,9 @@ final class StoreEmailJob implements ShouldBeUnique, ShouldQueue
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
         public readonly string $messageId,
-    ) {}
+    ) {
+        $this->onQueue('emails-sync');
+    }
 
     /**
      * Unique key prevents duplicate jobs for the same account + message from

--- a/packages/EmailIntegration/src/Jobs/StoreMeetingJob.php
+++ b/packages/EmailIntegration/src/Jobs/StoreMeetingJob.php
@@ -25,7 +25,9 @@ final class StoreMeetingJob implements ShouldQueue
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
         public readonly string $serializedEvent,
-    ) {}
+    ) {
+        $this->onQueue('emails-sync');
+    }
 
     public function handle(
         StoreMeetingAction $store,

--- a/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
+++ b/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\ClassifyEmailJob;
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
+use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
+use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
+use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
+use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
+use Relaticle\EmailIntegration\Jobs\StoreMeetingJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+mutates(
+    ClassifyEmailJob::class,
+    IncrementalEmailSyncJob::class,
+    InitialEmailSyncJob::class,
+    StoreEmailJob::class,
+    IncrementalCalendarSyncJob::class,
+    InitialCalendarSyncJob::class,
+    StoreMeetingJob::class,
+);
+
+it('routes inbound email sync and classify jobs to emails-sync queue', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    expect((new IncrementalEmailSyncJob($account))->queue)->toBe('emails-sync')
+        ->and((new InitialEmailSyncJob($account))->queue)->toBe('emails-sync')
+        ->and((new StoreEmailJob($account, 'msg-1'))->queue)->toBe('emails-sync')
+        ->and((new IncrementalCalendarSyncJob($account))->queue)->toBe('emails-sync')
+        ->and((new InitialCalendarSyncJob($account))->queue)->toBe('emails-sync')
+        ->and((new StoreMeetingJob($account, 'serialized'))->queue)->toBe('emails-sync')
+        ->and((new ClassifyEmailJob('email-id'))->queue)->toBe('emails-sync');
+});


### PR DESCRIPTION
## Summary
- Adds `supervisor-emails-sync` Horizon block (defaults, production, local) listening to a new `emails-sync` queue.
- Routes the seven inbound sync/classify jobs onto `emails-sync` via `$this->onQueue(...)` in their constructors: `IncrementalEmailSyncJob`, `InitialEmailSyncJob`, `StoreEmailJob`, `IncrementalCalendarSyncJob`, `InitialCalendarSyncJob`, `StoreMeetingJob`, `ClassifyEmailJob`.
- Adds `tests/Feature/EmailIntegration/SyncQueueRoutingTest.php` asserting every job lands on `emails-sync`.

## Why
`supervisor-emails-priority` and `supervisor-emails-bulk` already isolate outbound `SendEmailJob`. The recurring per-account scheduler (`everyFiveMinutes`) was still dispatching sync, store, and classify jobs onto `default`, where they could starve the default supervisor as the active-account count grew. Giving sync its own queue + supervisor removes the contention without touching the outbound path.

## Test plan
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `vendor/bin/rector --dry-run`
- [x] `vendor/bin/phpstan analyse` (0 errors)
- [x] `composer test:type-coverage` (100%)
- [x] `php artisan test tests/Feature/EmailIntegration/SyncQueueRoutingTest.php` (1/1)
- [x] `php artisan test tests/Feature/CalendarIntegration` (43/43)
- [ ] Verify Horizon dashboard shows `supervisor-emails-sync` block after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)