### PR TITLE
fix(email): respect team/user privacy tier default on send

### DIFF
--- a/app/Filament/Concerns/HasEmailComposeActions.php
+++ b/app/Filament/Concerns/HasEmailComposeActions.php
@@ -35,6 +35,7 @@ use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
+use Relaticle\EmailIntegration\Services\PrivacyService;
 use RuntimeException;
 
 trait HasEmailComposeActions
@@ -82,6 +83,7 @@ trait HasEmailComposeActions
                     'connected_account_id' => $account->getKey(),
                     'signature_id' => $signature?->getKey(),
                     'body_html' => $signature !== null ? '<p></p><hr>'.$signature->content_html : '',
+                    'privacy_tier' => $this->defaultPrivacyTier()->value,
                 ];
             })
             ->schema($this->composeFormSchema())
@@ -151,6 +153,7 @@ trait HasEmailComposeActions
                     'quoted_body_html' => $email->body->body_html ?? '',
                     'mode' => $mode,
                     'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
+                    'privacy_tier' => $this->defaultPrivacyTier()->value,
                 ];
             })
             ->schema($this->replyFormSchema())
@@ -300,6 +303,17 @@ trait HasEmailComposeActions
                     'blockquote', 'h2', 'h3', 'undo', 'redo',
                 ]),
 
+            Section::make('Privacy')
+                ->collapsed()
+                ->schema([
+                    Select::make('privacy_tier')
+                        ->label('Who can see this email?')
+                        ->helperText('Defaults to your team or personal sharing setting.')
+                        ->options(EmailPrivacyTier::class)
+                        ->default(fn (): string => $this->defaultPrivacyTier()->value)
+                        ->required(),
+                ]),
+
             Section::make('Schedule')
                 ->collapsed()
                 ->schema([
@@ -406,6 +420,17 @@ trait HasEmailComposeActions
             Hidden::make('mode'),
             Hidden::make('in_reply_to_email_id'),
 
+            Section::make('Privacy')
+                ->collapsed()
+                ->schema([
+                    Select::make('privacy_tier')
+                        ->label('Who can see this email?')
+                        ->helperText('Defaults to your team or personal sharing setting.')
+                        ->options(EmailPrivacyTier::class)
+                        ->default(fn (): string => $this->defaultPrivacyTier()->value)
+                        ->required(),
+                ]),
+
             Placeholder::make('quoted_body_preview')
                 ->hiddenLabel()
                 ->content(function (Get $get): HtmlString {
@@ -468,11 +493,29 @@ trait HasEmailComposeActions
             'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['bcc'] ?? []),
             'in_reply_to_email_id' => $data['in_reply_to_email_id'] ?? null,
             'creation_source' => $source,
-            'privacy_tier' => EmailPrivacyTier::FULL,
+            'privacy_tier' => $this->resolvePrivacyTier($data['privacy_tier'] ?? null),
             'batch_id' => null,
             'scheduled_for' => $scheduledFor,
             'priority' => EmailPriority::PRIORITY,
         ];
+    }
+
+    private function defaultPrivacyTier(): EmailPrivacyTier
+    {
+        return resolve(PrivacyService::class)->defaultTierForUser($this->getAuthenticatedUser());
+    }
+
+    private function resolvePrivacyTier(mixed $value): EmailPrivacyTier
+    {
+        if ($value instanceof EmailPrivacyTier) {
+            return $value;
+        }
+
+        if (is_string($value) && $value !== '') {
+            return EmailPrivacyTier::from($value);
+        }
+
+        return $this->defaultPrivacyTier();
     }
 
     private function hasActiveConnectedAccount(): bool

--- a/app/Filament/Pages/EmailInboxPage.php
+++ b/app/Filament/Pages/EmailInboxPage.php
@@ -48,6 +48,7 @@ use Relaticle\EmailIntegration\Notifications\EmailAccessRequestedNotification;
 use Relaticle\EmailIntegration\Services\EmailSharingService;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\EmailThreadSummaryService;
+use Relaticle\EmailIntegration\Services\PrivacyService;
 
 final class EmailInboxPage extends Page
 {
@@ -241,6 +242,7 @@ final class EmailInboxPage extends Page
                     'connected_account_id' => $account->getKey(),
                     'signature_id' => $signature?->getKey(),
                     'body_html' => $signature !== null ? '<p></p><hr>'.$signature->content_html : '',
+                    'privacy_tier' => $this->defaultPrivacyTier()->value,
                 ];
             })
             ->schema($this->composeFormSchema())
@@ -305,6 +307,7 @@ final class EmailInboxPage extends Page
                     'quoted_body_html' => $email->body?->body_html,
                     'mode' => $mode,
                     'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
+                    'privacy_tier' => $this->defaultPrivacyTier()->value,
                 ];
             })
             ->schema($this->replyFormSchema())
@@ -654,6 +657,17 @@ final class EmailInboxPage extends Page
                     'blockquote', 'h2', 'h3', 'undo', 'redo',
                 ]),
 
+            Section::make('Privacy')
+                ->collapsed()
+                ->schema([
+                    Select::make('privacy_tier')
+                        ->label('Who can see this email?')
+                        ->helperText('Defaults to your team or personal sharing setting.')
+                        ->options(EmailPrivacyTier::class)
+                        ->default(fn (): string => $this->defaultPrivacyTier()->value)
+                        ->required(),
+                ]),
+
             Section::make('Signature')
                 ->collapsed()
                 ->schema([
@@ -749,6 +763,17 @@ final class EmailInboxPage extends Page
             Hidden::make('mode'),
             Hidden::make('in_reply_to_email_id'),
 
+            Section::make('Privacy')
+                ->collapsed()
+                ->schema([
+                    Select::make('privacy_tier')
+                        ->label('Who can see this email?')
+                        ->helperText('Defaults to your team or personal sharing setting.')
+                        ->options(EmailPrivacyTier::class)
+                        ->default(fn (): string => $this->defaultPrivacyTier()->value)
+                        ->required(),
+                ]),
+
             Placeholder::make('quoted_body_preview')
                 ->hiddenLabel()
                 ->content(function (Get $get): HtmlString {
@@ -803,9 +828,27 @@ final class EmailInboxPage extends Page
             'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['bcc'] ?? []),
             'in_reply_to_email_id' => $data['in_reply_to_email_id'] ?? null,
             'creation_source' => $source,
-            'privacy_tier' => EmailPrivacyTier::FULL,
+            'privacy_tier' => $this->resolvePrivacyTier($data['privacy_tier'] ?? null),
             'batch_id' => null,
         ];
+    }
+
+    private function defaultPrivacyTier(): EmailPrivacyTier
+    {
+        return resolve(PrivacyService::class)->defaultTierForUser($this->authUser());
+    }
+
+    private function resolvePrivacyTier(mixed $value): EmailPrivacyTier
+    {
+        if ($value instanceof EmailPrivacyTier) {
+            return $value;
+        }
+
+        if (is_string($value) && $value !== '') {
+            return EmailPrivacyTier::from($value);
+        }
+
+        return $this->defaultPrivacyTier();
     }
 
     #[Computed]


### PR DESCRIPTION
## Summary

- Outbound compose, reply, and forward flows hardcoded `EmailPrivacyTier::FULL` in `buildSendData()`, bypassing `PrivacyService::defaultTierForUser()` and silently contradicting the team/user sharing setting (asymmetric with the inbound sync path, which honors the default via `EmailObserver::creating()`).
- Resolve the default through `PrivacyService` in `app/Filament/Concerns/HasEmailComposeActions.php` and `app/Filament/Pages/EmailInboxPage.php`, falling back to it when no override is provided.
- Surface a required `Select::make('privacy_tier')` inside a collapsed **Privacy** section on both the compose and reply schemas so the sender can override per email while the team/user default remains the seeded value.

## Test plan

- [x] `vendor/bin/pint --dirty --format agent`
- [x] `vendor/bin/rector --dry-run`
- [x] `php artisan test --compact tests/Feature/EmailIntegration/` (150/150 passing)
- [ ] Manual: as a team member with `users.default_email_sharing_tier = METADATA_ONLY`, compose + send an email and verify `emails.privacy_tier = metadata_only` (previously stamped `full`).
- [ ] Manual: open the Privacy section in the compose modal, override to `subject`, send, and confirm the override persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)