### PR TITLE
fix(email): harden attachment download against MIME sniffing

### DIFF
--- a/app/Http/Controllers/EmailAttachmentController.php
+++ b/app/Http/Controllers/EmailAttachmentController.php
@@ -45,14 +45,21 @@ final readonly class EmailAttachmentController
             ->downloadAttachment($email->provider_message_id, $attachment->provider_attachment_id);
 
         $filename = $attachment->filename ?? 'attachment';
-        $mimeType = $attachment->mime_type ?? 'application/octet-stream';
 
+        // Force a generic binary content-type and tell browsers not to MIME-sniff.
+        // Sender-controlled mime types (image/svg+xml, text/html) combined with
+        // browser sniffing could otherwise lead to scripts executing in the app
+        // origin if the disposition header were ever weakened.
         return response()->streamDownload(
             function () use ($binary): void {
                 echo $binary;
             },
             $filename,
-            ['Content-Type' => $mimeType],
+            [
+                'Content-Type' => 'application/octet-stream',
+                'X-Content-Type-Options' => 'nosniff',
+                'Content-Security-Policy' => "default-src 'none'; sandbox",
+            ],
         );
     }
 }

--- a/tests/Feature/EmailIntegration/EmailAttachmentDownloadTest.php
+++ b/tests/Feature/EmailIntegration/EmailAttachmentDownloadTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\EmailAttachmentController;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
+
+mutates(EmailAttachmentController::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->team = $this->user->currentTeam;
+    $this->actingAs($this->user);
+    Filament::setTenant($this->team);
+
+    $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+});
+
+function makeAttachmentForUser(User $owner, Team $team, ConnectedAccount $account, array $emailOverrides = [], array $attachmentOverrides = []): EmailAttachment
+{
+    $email = Email::factory()->create(array_merge([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+        'connected_account_id' => $account->id,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'provider_message_id' => 'msg-test',
+    ], $emailOverrides));
+
+    return EmailAttachment::factory()->create(array_merge([
+        'email_id' => $email->id,
+        'provider_attachment_id' => 'attach-test',
+        'mime_type' => 'text/html',
+        'filename' => 'evil.html',
+    ], $attachmentOverrides));
+}
+
+it('requires authentication', function (): void {
+    $attachment = makeAttachmentForUser($this->user, $this->team, $this->account);
+
+    auth()->logout();
+
+    $this->get(route('email-attachments.download', ['attachment' => $attachment->id]))
+        ->assertRedirect(route('login'));
+});
+
+it('aborts 403 when user belongs to a different team than the email', function (): void {
+    $otherUser = User::factory()->withTeam()->create();
+    $otherTeam = $otherUser->currentTeam;
+    $otherAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $otherTeam->id,
+        'user_id' => $otherUser->id,
+    ]));
+
+    $attachment = makeAttachmentForUser($otherUser, $otherTeam, $otherAccount);
+
+    $this->get(route('email-attachments.download', ['attachment' => $attachment->id]))
+        ->assertForbidden();
+});
+
+it('aborts 403 when viewer has no body access (private privacy tier)', function (): void {
+    $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($owner, ['role' => 'editor']);
+
+    $email = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $owner->id,
+        'connected_account_id' => $this->account->id,
+        'privacy_tier' => EmailPrivacyTier::PRIVATE,
+        'provider_message_id' => 'msg-private',
+    ]);
+    $attachment = EmailAttachment::factory()->create([
+        'email_id' => $email->id,
+        'provider_attachment_id' => 'attach-x',
+    ]);
+
+    $this->get(route('email-attachments.download', ['attachment' => $attachment->id]))
+        ->assertForbidden();
+});
+
+it('aborts 404 when provider_attachment_id is missing', function (): void {
+    $attachment = makeAttachmentForUser($this->user, $this->team, $this->account, attachmentOverrides: [
+        'provider_attachment_id' => null,
+    ]);
+
+    $this->get(route('email-attachments.download', ['attachment' => $attachment->id]))
+        ->assertNotFound();
+});
+
+it('aborts 404 when the connected account is missing', function (): void {
+    $attachment = makeAttachmentForUser($this->user, $this->team, $this->account);
+    $this->account->delete();
+
+    $this->get(route('email-attachments.download', ['attachment' => $attachment->id]))
+        ->assertNotFound();
+});


### PR DESCRIPTION
## Summary

Addresses PR #237 review warning **#14** (`EmailAttachmentController` — provider-supplied `Content-Type`, no `nosniff`).

The attachment download endpoint was streaming attachments back with the sender-controlled MIME type (`$attachment->mime_type`, populated from Gmail) and no `X-Content-Type-Options: nosniff` header. A sender could craft an `image/svg+xml` (with embedded `<script>`) or `text/html` attachment; combined with browser MIME-sniffing edge cases, this is a defense-in-depth gap that could lead to script execution at the app origin → session theft.

## Changes

`app/Http/Controllers/EmailAttachmentController.php`:

- Force `Content-Type: application/octet-stream` — drops sender control of MIME type.
- Add `X-Content-Type-Options: nosniff` — disables MIME sniffing.
- Add `Content-Security-Policy: default-src 'none'; sandbox` — defense-in-depth; even if a body is rendered, no scripts/network/forms execute.
- Laravel's `streamDownload()` already sets `Content-Disposition: attachment`, so the inline-render vector remains closed.

`tests/Feature/EmailIntegration/EmailAttachmentDownloadTest.php` (new):

- Auth required → redirects to login.
- Cross-team viewer → 403.
- `PRIVATE` privacy tier → 403 (`viewBody` policy).
- Missing `provider_attachment_id` → 404.
- Missing `connectedAccount` → 404.

## Why

`Content-Disposition: attachment` blocks most inline rendering, but:

- SVG with embedded `<script>` opened from disk still executes.
- Without `nosniff`, browsers may sniff `application/octet-stream` bodies that look like HTML and render them.
- Any future code path that switched to `inline` would suddenly be a direct stored-XSS vector at the app origin.

This change closes those gaps while staying compatible with the existing Filament UI and the `viewBody` policy.

## Test plan

- [x] `vendor/bin/pint --dirty --format agent` — pass
- [x] `vendor/bin/rector --dry-run` (changed files) — pass
- [x] `vendor/bin/phpstan analyse app/Http/Controllers/EmailAttachmentController.php` — 0 errors
- [ ] `php -d memory_limit=2G vendor/bin/pest --type-coverage --min=100` — 100%
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailAttachmentDownloadTest.php` — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)