### PR TITLE
fix(email-accounts): scope ConnectedAccount lookups to current user + team

### DIFF
--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Pages;
 
+use App\Models\Team;
+use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -12,6 +14,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Grid;
 use Filament\Support\Enums\Size;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
@@ -48,9 +51,7 @@ final class EmailAccountsPage extends Page
      */
     private function getAccounts(): Collection
     {
-        return ConnectedAccount::query()->where('user_id', auth()->id())
-            ->where('team_id', filament()->getTenant()?->getKey())
-            ->get();
+        return $this->ownedAccountsQuery()->get();
     }
 
     public function connectGmailAction(): Action
@@ -81,7 +82,7 @@ final class EmailAccountsPage extends Page
             ->color('warning')
             ->size(Size::Small)
             ->url(fn (array $arguments): string => route('email-accounts.redirect', [
-                'provider' => ConnectedAccount::query()->find((string) $arguments['account_id'])?->provider->value,
+                'provider' => $this->findAccount($arguments)?->provider->value,
             ]), true);
     }
 
@@ -93,7 +94,7 @@ final class EmailAccountsPage extends Page
             ->color('gray')
             ->size(Size::Small)
             ->fillForm(function (array $arguments): array {
-                $account = ConnectedAccount::query()->findOrFail((string) $arguments['account_id']);
+                $account = $this->findOwnedAccountOrFail($arguments);
 
                 return [
                     'sync_inbox' => $account->sync_inbox,
@@ -139,16 +140,14 @@ final class EmailAccountsPage extends Page
                     ]),
             ])
             ->action(function (array $arguments, array $data): void {
-                ConnectedAccount::query()->where('id', $arguments['account_id'])
-                    ->where('user_id', auth()->id())
-                    ->update([
-                        'sync_inbox' => $data['sync_inbox'],
-                        'sync_sent' => $data['sync_sent'],
-                        'contact_creation_mode' => $data['contact_creation_mode'],
-                        'auto_create_companies' => $data['auto_create_companies'],
-                        'hourly_send_limit' => filled($data['hourly_send_limit'] ?? null) ? (int) $data['hourly_send_limit'] : null,
-                        'daily_send_limit' => filled($data['daily_send_limit'] ?? null) ? (int) $data['daily_send_limit'] : null,
-                    ]);
+                $this->findOwnedAccountOrFail($arguments)->update([
+                    'sync_inbox' => $data['sync_inbox'],
+                    'sync_sent' => $data['sync_sent'],
+                    'contact_creation_mode' => $data['contact_creation_mode'],
+                    'auto_create_companies' => $data['auto_create_companies'],
+                    'hourly_send_limit' => filled($data['hourly_send_limit'] ?? null) ? (int) $data['hourly_send_limit'] : null,
+                    'daily_send_limit' => filled($data['daily_send_limit'] ?? null) ? (int) $data['daily_send_limit'] : null,
+                ]);
             })
             ->modalHeading('Account Settings')
             ->modalSubmitActionLabel('Save');
@@ -168,7 +167,7 @@ final class EmailAccountsPage extends Page
                 ? 'This will stop syncing calendar events for this account.'
                 : 'You will be redirected to Google to grant calendar access.')
             ->action(function (array $arguments): void {
-                $account = ConnectedAccount::query()->findOrFail((string) $arguments['account_id']);
+                $account = $this->findOwnedAccountOrFail($arguments);
 
                 if ($account->hasCalendar()) {
                     $account->disableCalendar();
@@ -191,7 +190,7 @@ final class EmailAccountsPage extends Page
             ->size(Size::Small)
             ->visible(fn (array $arguments): bool => (bool) $this->findAccount($arguments)?->hasCalendar())
             ->action(function (array $arguments): void {
-                $account = ConnectedAccount::query()->findOrFail((string) $arguments['account_id']);
+                $account = $this->findOwnedAccountOrFail($arguments);
 
                 dispatch(new IncrementalCalendarSyncJob($account));
 
@@ -207,7 +206,27 @@ final class EmailAccountsPage extends Page
     private function findAccount(array $arguments): ?ConnectedAccount
     {
         /** @var ConnectedAccount|null */
-        return ConnectedAccount::query()->find((string) $arguments['account_id']);
+        return $this->ownedAccountsQuery()->find((string) $arguments['account_id']);
+    }
+
+    /** @param array<string, mixed> $arguments */
+    private function findOwnedAccountOrFail(array $arguments): ConnectedAccount
+    {
+        /** @var ConnectedAccount */
+        return $this->ownedAccountsQuery()->findOrFail((string) $arguments['account_id']);
+    }
+
+    /**
+     * @return Builder<ConnectedAccount>
+     */
+    private function ownedAccountsQuery(): Builder
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        /** @var Team $team */
+        $team = filament()->getTenant();
+
+        return ConnectedAccount::query()->ownedBy($user, $team);
     }
 
     public function disconnectAction(): Action
@@ -219,9 +238,7 @@ final class EmailAccountsPage extends Page
             ->size(Size::Small)
             ->requiresConfirmation()
             ->action(function (array $arguments): void {
-                ConnectedAccount::query()->where('id', $arguments['account_id'])
-                    ->where('user_id', auth()->id())
-                    ->delete();
+                $this->findOwnedAccountOrFail($arguments)->delete();
             });
     }
 

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Models;
 
 use App\Models\Concerns\HasTeam;
+use App\Models\Team;
 use App\Models\User;
 use Database\Factories\ConnectedAccountFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -92,6 +95,22 @@ final class ConnectedAccount extends Model
         'daily_send_limit' => 'integer',
         'hourly_send_limit' => 'integer',
     ];
+
+    // Scopes
+
+    /**
+     * Scope to accounts owned by the given user within the given team.
+     *
+     * @param  Builder<ConnectedAccount>  $query
+     * @return Builder<ConnectedAccount>
+     */
+    #[Scope]
+    protected function ownedBy(Builder $query, User $user, Team $team): Builder
+    {
+        return $query
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $team->getKey());
+    }
 
     // Relations
 

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -46,13 +47,14 @@ it('does not update another user\'s account via editSettings', function (): void
         'sync_inbox' => true,
     ]));
 
-    livewire(EmailAccountsPage::class)
+    expect(fn () => livewire(EmailAccountsPage::class)
         ->callAction('editSettings', data: [
             'sync_inbox' => false,
             'sync_sent' => false,
             'contact_creation_mode' => ContactCreationMode::None->value,
             'auto_create_companies' => false,
-        ], arguments: ['account_id' => $otherAccount->id]);
+        ], arguments: ['account_id' => $otherAccount->id]))
+        ->toThrow(ModelNotFoundException::class);
 
     expect($otherAccount->fresh()->sync_inbox)->toBeTrue();
 });
@@ -73,8 +75,9 @@ it('does not delete another user\'s account on disconnect', function (): void {
         'user_id' => $otherUser->id,
     ]));
 
-    livewire(EmailAccountsPage::class)
-        ->callAction('disconnect', arguments: ['account_id' => $otherAccount->id]);
+    expect(fn () => livewire(EmailAccountsPage::class)
+        ->callAction('disconnect', arguments: ['account_id' => $otherAccount->id]))
+        ->toThrow(ModelNotFoundException::class);
 
     $this->assertNotSoftDeleted(ConnectedAccount::class, [
         'id' => $otherAccount->id,


### PR DESCRIPTION
## Summary

Closes PR #237 review **warning 13** (cross-tenant authorization gap on `EmailAccountsPage`).

`editSettingsAction->fillForm`, `syncCalendarAction->action`, and `syncCalendarNowAction->action` looked up `ConnectedAccount` via bare `ConnectedAccount::query()->findOrFail((string) $arguments['account_id'])`. The `account_id` flows from a Livewire client payload, so any authenticated user with a foreign account ULID could:

- read another tenant's account settings (sync flags, send limits, contact-creation mode)
- toggle off another tenant's Gmail calendar sync (`disableCalendar()`)
- dispatch `IncrementalCalendarSyncJob` against an account they do not own

Only the `editSettings->action` write path was correctly scoped.

## Changes

- **`ConnectedAccount`** — added `#[Scope] ownedBy(User $user, Team $team)` Laravel 12 attributed scope as single source of truth for "this user's accounts within this team."
- **`EmailAccountsPage`** — replaced every raw `ConnectedAccount::query()` lookup with `ownedAccountsQuery()` / `findOwnedAccountOrFail()` helpers backed by the new scope. Covered call sites:
  - `findAccount()` (label/visibility/color/confirmation closures)
  - `reAuthAction` URL provider lookup
  - `editSettingsAction` — both `fillForm` read and `action` update
  - `syncCalendarAction` action body
  - `syncCalendarNowAction` action body
  - `disconnectAction` action body
  - `getAccounts()` page mount listing
- **`EmailAccountsPageTest`** — cross-tenant tests now assert `ModelNotFoundException` is thrown (loud failure surfaces the scope mismatch instead of relying on silent no-op).

## Test plan

- [x] `vendor/bin/pint --dirty --format agent` — pass
- [x] `vendor/bin/rector --dry-run` on changed files — clean
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailAccountsPageTest.php tests/Feature/CalendarIntegration/EmailAccountsCalendarToggleTest.php` — 7/7 pass
- [ ] Manual: confirm legitimate user can still edit/sync/disconnect their own account
- [ ] Manual: confirm crafted Livewire payload with foreign `account_id` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)