### PR TITLE
fix(email): allow undo while SENDING when Gmail not yet called

### DIFF
--- a/packages/EmailIntegration/src/Actions/CancelQueuedEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/CancelQueuedEmailAction.php
@@ -17,7 +17,13 @@ final readonly class CancelQueuedEmailAction
             /** @var Email $lockedEmail */
             $lockedEmail = Email::query()->lockForUpdate()->findOrFail($email->getKey());
 
-            if ($lockedEmail->status !== EmailStatus::QUEUED) {
+            $isCancellable = match (true) {
+                $lockedEmail->status === EmailStatus::QUEUED => true,
+                $lockedEmail->status === EmailStatus::SENDING && $lockedEmail->provider_message_id === null => true,
+                default => false,
+            };
+
+            if (! $isCancellable) {
                 throw new RuntimeException("Email cannot be cancelled — status is {$lockedEmail->status->value}.");
             }
 

--- a/tests/Feature/EmailIntegration/UndoSendFlowTest.php
+++ b/tests/Feature/EmailIntegration/UndoSendFlowTest.php
@@ -44,11 +44,37 @@ it('cancels a single send within the 30s undo window', function (): void {
     expect($email->refresh()->status)->toBe(EmailStatus::CANCELLED);
 });
 
-it('rejects an undo after the dispatcher has picked up the email', function (): void {
+it('allows undo while SENDING when Gmail has not been called yet', function (): void {
     $email = ConnectedAccount::withoutEvents(fn (): Email => Email::factory()->create([
         'status' => EmailStatus::SENDING,
+        'provider_message_id' => null,
+    ]));
+
+    resolve(CancelQueuedEmailAction::class)->execute($email);
+
+    expect($email->refresh()->status)->toBe(EmailStatus::CANCELLED);
+});
+
+it('rejects undo once Gmail has accepted the message', function (): void {
+    $email = ConnectedAccount::withoutEvents(fn (): Email => Email::factory()->create([
+        'status' => EmailStatus::SENDING,
+        'provider_message_id' => 'gmail-msg-id-123',
     ]));
 
     expect(fn () => resolve(CancelQueuedEmailAction::class)->execute($email))
         ->toThrow(RuntimeException::class);
 });
+
+it('rejects undo on terminal statuses', function (EmailStatus $status): void {
+    $email = ConnectedAccount::withoutEvents(fn (): Email => Email::factory()->create([
+        'status' => $status,
+        'provider_message_id' => $status === EmailStatus::SENT ? 'gmail-msg-id-xyz' : null,
+    ]));
+
+    expect(fn () => resolve(CancelQueuedEmailAction::class)->execute($email))
+        ->toThrow(RuntimeException::class);
+})->with([
+    EmailStatus::SENT,
+    EmailStatus::CANCELLED,
+    EmailStatus::FAILED,
+]);


### PR DESCRIPTION
## Summary

Fixes warning #16 from the PR #237 review.

`CancelQueuedEmailAction` only accepted `status === QUEUED`. The dispatcher (`email:dispatch-outbox`, runs every minute) flips `QUEUED -> SENDING` *before* `SendEmailJob` actually calls Gmail. If the user clicks Undo in that gap (between dispatcher claim and worker pickup), cancel rejected with "Too late" even though the message was still cancellable.

## Change

`CancelQueuedEmailAction::execute()` now allows cancel when:
- `status === QUEUED`, **or**
- `status === SENDING && provider_message_id === null` (Gmail not called yet)

`SendEmailJob::handle()` already returns early on `CANCELLED` inside its `lockForUpdate` block, so the two locks serialize correctly: whichever writes first wins. If cancel writes `CANCELLED` first, the worker sees it and skips Gmail. If the worker writes `provider_message_id` first, subsequent cancel requests are rejected.

## Why not also add a dispatcher safety margin (the second option in the review)?

Considered and skipped. Adding `now()->subSeconds(N)` to the dispatcher's `scheduled_for` filter would only shrink the race window, not eliminate it (worker pickup latency is the real variable). It would also delay every exact-time scheduled send by N seconds for no benefit. Option #1 alone closes the race correctly via DB row locks.

## Test plan

- [x] `it('allows undo while SENDING when Gmail has not been called yet')` — new test
- [x] `it('rejects undo once Gmail has accepted the message')` — new test, asserts provider_message_id guard
- [x] `it('rejects undo on terminal statuses')` — new dataset test (SENT, CANCELLED, FAILED)
- [x] Existing `cancels a single send within the 30s undo window` still passes
- [x] All 15 tests in `UndoSendFlowTest.php` + `EmailOutboxPageTest.php` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)