### PR TITLE
fix: point rest api button to scribe docs route

### DIFF
--- a/resources/views/filament/pages/access-tokens.blade.php
+++ b/resources/views/filament/pages/access-tokens.blade.php
@@ -6,7 +6,7 @@
             {{ __('access-tokens.integrations.heading') }}
         </p>
         <div class="divide-y divide-gray-200 dark:divide-white/10 rounded-xl border border-gray-200 dark:border-white/10 overflow-hidden">
-            <a href="{{ config('scribe.docs_url') }}" target="_blank" class="flex items-center gap-4 bg-white dark:bg-white/5 px-4 py-3 transition hover:bg-gray-50 dark:hover:bg-white/10 group">
+            <a href="{{ route('scribe') }}" target="_blank" class="flex items-center gap-4 bg-white dark:bg-white/5 px-4 py-3 transition hover:bg-gray-50 dark:hover:bg-white/10 group">
                 <div class="flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-lg bg-gray-100 dark:bg-white/10 text-gray-500 dark:text-gray-400 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition">
                     <x-heroicon-o-code-bracket class="w-5 h-5" />
                 </div>

--- a/tests/Feature/AccessTokens/AccessTokensPageTest.php
+++ b/tests/Feature/AccessTokens/AccessTokensPageTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\AccessTokens;
+use App\Models\User;
+use Laravel\Jetstream\Features;
+
+test('rest api integration link points to scribe docs', function (): void {
+    $this->actingAs(User::factory()->withTeam()->create());
+
+    livewire(AccessTokens::class)
+        ->assertSee(route('scribe'), escape: false)
+        ->assertDontSee('href=""', escape: false);
+})->skip(fn (): bool => ! Features::hasApiFeatures(), 'API support is not enabled.');


### PR DESCRIPTION
## Summary

Fixes #264.

The **REST API** button on the access tokens page (`/app/access-tokens`) navigated back to the same page instead of opening the API documentation.

## Root cause

The blade view called `config('scribe.docs_url')`, but in `config/scribe.php` the key is nested under `laravel`:

```php
'laravel' => [
    'docs_url' => '/docs/api',
],
```

The correct key is `scribe.laravel.docs_url`. The shallow lookup returned `null`, rendering `href=""`, which the browser resolves to the current URL (`/app/access-tokens`).

## Fix

Replaced the broken config call with `route('scribe')` — Scribe's named route for `/docs/api`. Cleaner than fixing the config key path and avoids hardcoding a URL.

## Test plan

- [x] New test `tests/Feature/AccessTokens/AccessTokensPageTest.php` renders the page and asserts the button contains `route('scribe')` and no empty `href=""`
- [x] Full `tests/Feature/AccessTokens/` suite passes (13/13)
- [x] Pint, PHPStan, type coverage (100.0%) clean