### PR TITLE
fix: handle array state for multi-assignee avatars on tasks board

### DIFF
--- a/app/Filament/Pages/TasksBoard.php
+++ b/app/Filament/Pages/TasksBoard.php
@@ -113,7 +113,7 @@ final class TasksBoard extends BoardPage
                                 ->alignLeft()
                                 ->imageHeight(20)
                                 ->circular()
-                                ->visible(fn (?string $state): bool => filled($state))
+                                ->visible(fn (mixed $state): bool => filled($state))
                                 ->stacked(),
                         ])->align('center'),
                     ]);

--- a/tests/Feature/Filament/App/Pages/TasksBoardTest.php
+++ b/tests/Feature/Filament/App/Pages/TasksBoardTest.php
@@ -67,6 +67,19 @@ it('does not show tasks from other teams', function (): void {
     expect($allRecordIds)->not->toContain($otherTask->id);
 });
 
+it('renders the board when a task has multiple assignees', function (): void {
+    $todo = $this->statusField->options->firstWhere('name', 'To do');
+
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
+    $task->saveCustomFieldValue($this->statusField, $todo->getKey());
+
+    $secondMember = User::factory()->create();
+    $this->team->users()->attach($secondMember);
+    $task->assignees()->attach([$this->user->id, $secondMember->id]);
+
+    livewire(TasksBoard::class)->assertOk();
+});
+
 it('moves a card between columns via moveCard', function (): void {
     $todo = $this->statusField->options->firstWhere('name', 'To do');
     $inProgress = $this->statusField->options->firstWhere('name', 'In progress');


### PR DESCRIPTION
## Summary

Fixes a 500 error on the Task Board when any visible task has more than one assignee.

The `ImageEntry::make('assignees.profile_photo_url')` `visible()` closure type-hinted `?string`, but for the `BelongsToMany` `assignees` relation Filament resolves `assignees.profile_photo_url` to an array of URLs as soon as a task has 2+ assignees — triggering `TypeError: Argument #1 ($state) must be of type ?string, array given` and 500-ing the whole board view.

Fix: widen the closure parameter to `mixed`. `filled()` already handles `null`, empty string, and empty array correctly.

Closes #267

## Changes

- `app/Filament/Pages/TasksBoard.php` — change `?string $state` to `mixed $state` on the assignees `ImageEntry` `visible()` closure.
- `tests/Feature/Filament/App/Pages/TasksBoardTest.php` — add a regression test that creates a task with two assignees and asserts the board renders.

## Test plan

- [x] Regression test fails on `main` with the exact `TypeError` at line 116, passes after the fix
- [x] All existing TasksBoard tests still pass (5/5)
- [x] `vendor/bin/pint --dirty` clean
- [x] `vendor/bin/rector --dry-run` clean for modified files
- [x] `vendor/bin/phpstan` introduces no new errors
- [x] Type coverage stays at 100%