### PR TITLE
fix: assign role when creating sysadmin via make:filament-user

### DIFF
--- a/app/Console/Commands/MakeFilamentUserCommand.php
+++ b/app/Console/Commands/MakeFilamentUserCommand.php
@@ -9,9 +9,23 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
 final class MakeFilamentUserCommand extends MakeUserCommand
 {
+    #[\Override]
+    protected function getUserData(): array
+    {
+        $data = parent::getUserData();
+
+        if (is_a(self::getUserModel(), SystemAdministrator::class, allow_string: true)) {
+            $data['role'] = SystemAdministratorRole::SuperAdministrator;
+        }
+
+        return $data;
+    }
+
     #[\Override]
     protected function createUser(): Model&Authenticatable
     {

--- a/packages/Documentation/resources/markdown/self-hosting-guide.md
+++ b/packages/Documentation/resources/markdown/self-hosting-guide.md
@@ -162,7 +162,7 @@ After starting the containers, create your first admin user:
 docker compose exec app php artisan make:filament-user
 ```
 
-You will be prompted to pick a panel (`app` or `sysadmin`), then a name, email, and password. Once created, access the CRM panel at `{APP_URL}/app`.
+When prompted to pick a panel, choose `app`, then enter a name, email, and password. Once created, access the CRM panel at `{APP_URL}/app`. (To create the instance-wide system administrator instead, see the next section.)
 
 **Note**: By default the CRM panel is available at the `/app` path. To use subdomain routing instead (e.g., `app.example.com`), set the `APP_PANEL_DOMAIN` environment variable.
 

--- a/packages/Documentation/resources/markdown/self-hosting-guide.md
+++ b/packages/Documentation/resources/markdown/self-hosting-guide.md
@@ -162,9 +162,17 @@ After starting the containers, create your first admin user:
 docker compose exec app php artisan make:filament-user
 ```
 
-You will be prompted for a name, email, and password. Once created, access the CRM panel at `{APP_URL}/app`.
+You will be prompted to pick a panel (`app` or `sysadmin`), then a name, email, and password. Once created, access the CRM panel at `{APP_URL}/app`.
 
 **Note**: By default the CRM panel is available at the `/app` path. To use subdomain routing instead (e.g., `app.example.com`), set the `APP_PANEL_DOMAIN` environment variable.
+
+### System Administrator Account
+
+The `sysadmin` panel at `{APP_URL}/sysadmin` is a separate, instance-wide admin surface for managing every team and user on your installation. To create a system administrator, you can either pick `sysadmin` from the `make:filament-user` panel prompt, or use the dedicated command:
+
+```bash
+docker compose exec app php artisan sysadmin:create
+```
 
 ---
 

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -138,6 +138,7 @@ arch('main app must not depend on SystemAdmin module')
         'App\Providers\AppServiceProvider',
         'App\Console\Commands\InstallCommand',
         'App\Console\Commands\CreateSystemAdminCommand',
+        'App\Console\Commands\MakeFilamentUserCommand',
     ]);
 
 arch('SystemAdmin module must not depend on main app namespace')

--- a/tests/Feature/Commands/MakeFilamentUserCommandTest.php
+++ b/tests/Feature/Commands/MakeFilamentUserCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Console\Commands\MakeFilamentUserCommand;
 use App\Models\User;
 use Illuminate\Auth\Events\Verified;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;

--- a/tests/Feature/Commands/MakeFilamentUserCommandTest.php
+++ b/tests/Feature/Commands/MakeFilamentUserCommandTest.php
@@ -6,6 +6,8 @@ use App\Console\Commands\MakeFilamentUserCommand;
 use App\Models\User;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Event;
+use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
 mutates(MakeFilamentUserCommand::class);
 
@@ -33,4 +35,19 @@ it('marks the user verified and dispatches the Verified event so downstream list
         ->and($user->hasVerifiedEmail())->toBeTrue();
 
     Event::assertDispatched(Verified::class, fn (Verified $event): bool => $event->user->is($user));
+});
+
+it('creates a system administrator with the SuperAdministrator role when targeting the sysadmin panel', function (): void {
+    $this->artisan('make:filament-user', [
+        '--name' => 'SysAdmin',
+        '--email' => 'sysadmin@example.com',
+        '--password' => 'password123',
+        '--panel' => 'sysadmin',
+    ])->assertSuccessful();
+
+    $admin = SystemAdministrator::query()->where('email', 'sysadmin@example.com')->first();
+
+    expect($admin)->not->toBeNull()
+        ->and($admin->role)->toBe(SystemAdministratorRole::SuperAdministrator)
+        ->and($admin->hasVerifiedEmail())->toBeTrue();
 });


### PR DESCRIPTION
## Summary

Filament's `make:filament-user` command does not populate the `role` column when creating a user, but `system_administrators.role` is `NOT NULL`. Picking the `sysadmin` panel from the prompt always crashed with `SQLSTATE[23502]`.

This PR overrides `getUserData()` in our local `MakeFilamentUserCommand` to inject `SystemAdministratorRole::SuperAdministrator` when the resolved user model is `SystemAdministrator`. The `app` panel path is unchanged.

The self-hosting guide is updated to mention the new behaviour and to surface the dedicated `php artisan sysadmin:create` command (which already existed and provides a richer interactive UX).

Closes #273.

## Why this shape

- `make:filament-user` is the documented entry point and Filament's panel prompt openly offers `sysadmin` — picking it should just work.
- The override uses Filament's intended extension hook (`getUserData()`), keeping the change tiny and aligned with the existing `createUser()` override that already lives in the same file.
- Today `SystemAdministratorRole` has only `SuperAdministrator`, so the default is unambiguous. If a second role is added later, this should be promoted to an interactive prompt.

## Test plan

- [x] New Pest test: `make:filament-user --panel=sysadmin` creates a row with `role=super_administrator` and verified email.
- [x] Existing `app` panel test still passes (verification + `Verified` event dispatch).
- [x] Manually ran all three flows against PostgreSQL: `make:filament-user --panel=sysadmin`, `sysadmin:create`, and `make:filament-user --panel=app` — all create rows correctly.
- [x] `vendor/bin/pint --dirty`, `vendor/bin/rector --dry-run`, `vendor/bin/phpstan analyse`, type coverage at 100%, `php artisan test --filter=MakeFilamentUserCommand` (3/3 pass).