### PR TITLE
fix: harden favicon fetch job against worker hangs, malformed URLs, and SSRF

### DIFF
--- a/app/Exceptions/SsrfGuardException.php
+++ b/app/Exceptions/SsrfGuardException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Services\Favicon;
+namespace App\Exceptions;
 
 use RuntimeException;
 

--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -7,12 +7,12 @@ namespace App\Jobs;
 use App\Enums\CustomFields\CompanyField;
 use App\Models\Company;
 use AshAllenDesign\FaviconFetcher\Facades\Favicon;
-use Exception;
 use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Str;
+use Throwable;
 
 final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
 {
@@ -20,6 +20,12 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
     use Queueable;
 
     public bool $deleteWhenMissingModels = true;
+
+    public int $tries = 1;
+
+    public int $timeout = 30;
+
+    public int $uniqueFor = 600;
 
     public function __construct(public readonly Company $company) {}
 
@@ -47,6 +53,10 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
                 return;
             }
 
+            if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+                return;
+            }
+
             $path = parse_url($url, PHP_URL_PATH);
             $extension = $path ? pathinfo($path, PATHINFO_EXTENSION) : '';
 
@@ -70,7 +80,7 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
                 ->toMediaCollection('logo');
 
             $this->company->clearMediaCollectionExcept('logo', $logo);
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
             report($exception);
         }
     }

--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -6,6 +6,8 @@ namespace App\Jobs;
 
 use App\Enums\CustomFields\CompanyField;
 use App\Models\Company;
+use App\Services\Favicon\SsrfGuard;
+use App\Services\Favicon\SsrfGuardException;
 use AshAllenDesign\FaviconFetcher\Facades\Favicon;
 use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -54,6 +56,14 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
             }
 
             if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+                return;
+            }
+
+            try {
+                SsrfGuard::assertPublicHost($url);
+            } catch (SsrfGuardException $exception) {
+                report($exception);
+
                 return;
             }
 

--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Enums\CustomFields\CompanyField;
+use App\Exceptions\SsrfGuardException;
 use App\Models\Company;
 use App\Services\Favicon\SsrfGuard;
-use App\Services\Favicon\SsrfGuardException;
 use AshAllenDesign\FaviconFetcher\Facades\Favicon;
 use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Enums\CustomFields\CompanyField;
-use App\Exceptions\SsrfGuardException;
 use App\Models\Company;
 use App\Services\Favicon\SsrfGuard;
 use AshAllenDesign\FaviconFetcher\Facades\Favicon;
@@ -61,11 +60,7 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
                 return;
             }
 
-            try {
-                SsrfGuard::assertPublicHost($url);
-            } catch (SsrfGuardException $exception) {
-                report($exception);
-
+            if (! SsrfGuard::isAllowed($url)) {
                 return;
             }
 
@@ -89,9 +84,9 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
                     'icon_type' => $favicon->getIconType(),
                     'fetched_at' => now()->toIso8601String(),
                 ])
-                ->toMediaCollection('logo');
+                ->toMediaCollection(Company::LOGO_MEDIA_COLLECTION);
 
-            $this->company->clearMediaCollectionExcept('logo', $logo);
+            $this->company->clearMediaCollectionExcept(Company::LOGO_MEDIA_COLLECTION, $logo);
         } catch (Throwable $exception) {
             report($exception);
         }

--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -46,7 +46,9 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
                 return;
             }
 
-            $domainName = Str::start($domainName, 'https://');
+            if (! Str::startsWith($domainName, ['http://', 'https://'])) {
+                $domainName = 'https://'.$domainName;
+            }
 
             $favicon = Favicon::driver('high-quality')->fetch($domainName);
             $url = $favicon?->getFaviconUrl();

--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -9,7 +9,7 @@ use App\Exceptions\SsrfGuardException;
 use App\Models\Company;
 use App\Services\Favicon\SsrfGuard;
 use AshAllenDesign\FaviconFetcher\Facades\Favicon;
-use Illuminate\Contracts\Broadcasting\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -50,6 +50,8 @@ final class Company extends Model implements HasCustomFields, HasMedia
     use SoftDeletes;
     use UsesCustomFields;
 
+    public const string LOGO_MEDIA_COLLECTION = 'logo';
+
     /**
      * @var list<string>
      */
@@ -79,7 +81,7 @@ final class Company extends Model implements HasCustomFields, HasMedia
 
     protected function getLogoAttribute(): string
     {
-        $logo = $this->getFirstMediaUrl('logo');
+        $logo = $this->getFirstMediaUrl(self::LOGO_MEDIA_COLLECTION);
 
         return $logo === '' || $logo === '0' ? resolve(AvatarService::class)->generateAuto(name: $this->name) : $logo;
     }

--- a/app/Observers/CompanyObserver.php
+++ b/app/Observers/CompanyObserver.php
@@ -30,7 +30,7 @@ final readonly class CompanyObserver
         // fires on every Company update and would otherwise flood the queue with
         // redundant favicon dispatches against slow remote sites. If the domain
         // changes, callers must clear the 'logo' media collection to trigger a refetch.
-        if ($company->hasMedia('logo')) {
+        if ($company->hasMedia(Company::LOGO_MEDIA_COLLECTION)) {
             return;
         }
 

--- a/app/Observers/CompanyObserver.php
+++ b/app/Observers/CompanyObserver.php
@@ -26,6 +26,14 @@ final readonly class CompanyObserver
 
     private function dispatchFaviconFetchIfNeeded(Company $company): void
     {
+        // Once a logo is stored we do not re-fetch on subsequent saves: the observer
+        // fires on every Company update and would otherwise flood the queue with
+        // redundant favicon dispatches against slow remote sites. If the domain
+        // changes, callers must clear the 'logo' media collection to trigger a refetch.
+        if ($company->hasMedia('logo')) {
+            return;
+        }
+
         $domainField = $company->customFields()
             ->whereBelongsTo($company->team)
             ->where('code', CompanyField::DOMAINS->value)

--- a/app/Services/Favicon/Drivers/HighQualityDriver.php
+++ b/app/Services/Favicon/Drivers/HighQualityDriver.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Services\Favicon\Drivers;
 
-use App\Exceptions\SsrfGuardException;
 use App\Services\Favicon\SsrfGuard;
 use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Concerns\HasDefaultFunctionality;
@@ -34,11 +33,7 @@ final class HighQualityDriver implements Fetcher
     {
         throw_unless($this->urlIsValid($url), InvalidUrlException::class, $url.' is not a valid URL');
 
-        try {
-            SsrfGuard::assertPublicHost($url);
-        } catch (SsrfGuardException $exception) {
-            report($exception);
-
+        if (! SsrfGuard::isAllowed($url)) {
             return null;
         }
 
@@ -137,35 +132,22 @@ final class HighQualityDriver implements Fetcher
                 return null;
             }
 
-            $html = $response->body();
+            $html = (string) $response->body();
 
-            $patterns = [
-                '/<link\b[^>]*\bsizes=["\']512x512["\'][^>]*\bhref=["\']([^"\']+)["\']/i',
-                '/<link\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\bsizes=["\']512x512["\']/i',
-                '/<link\b[^>]*\bsizes=["\']256x256["\'][^>]*\bhref=["\']([^"\']+)["\']/i',
-                '/<link\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\bsizes=["\']256x256["\']/i',
-                '/<link\b[^>]*\bsizes=["\']192x192["\'][^>]*\bhref=["\']([^"\']+)["\']/i',
-                '/<link\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\bsizes=["\']192x192["\']/i',
-            ];
+            foreach ([512, 256, 192] as $size) {
+                $patterns = [
+                    "/<link\\b[^>]*\\bsizes=[\"']{$size}x{$size}[\"'][^>]*\\bhref=[\"']([^\"']+)[\"']/i",
+                    "/<link\\b[^>]*\\bhref=[\"']([^\"']+)[\"'][^>]*\\bsizes=[\"']{$size}x{$size}[\"']/i",
+                ];
 
-            foreach ($patterns as $pattern) {
-                if (preg_match($pattern, (string) $html, $matches)) {
-                    $iconUrl = $this->convertToAbsoluteUrl($url, $matches[1]);
-
-                    preg_match('/(\d+)x\d+/', $pattern, $sizeMatch);
-                    $size = isset($sizeMatch[1]) ? (int) $sizeMatch[1] : null;
-
-                    $favicon = new Favicon(
-                        url: $url,
-                        faviconUrl: $iconUrl,
-                        fromDriver: $this,
-                    );
-
-                    if ($size !== null) {
-                        $favicon->setIconSize($size);
+                foreach ($patterns as $pattern) {
+                    if (preg_match($pattern, $html, $matches)) {
+                        return new Favicon(
+                            url: $url,
+                            faviconUrl: $this->convertToAbsoluteUrl($url, $matches[1]),
+                            fromDriver: $this,
+                        )->setIconSize($size);
                     }
-
-                    return $favicon;
                 }
             }
 
@@ -183,11 +165,7 @@ final class HighQualityDriver implements Fetcher
 
             $faviconUrl = 'https://www.google.com/s2/favicons?sz=256&domain='.$urlWithoutProtocol;
 
-            try {
-                SsrfGuard::assertPublicHost($faviconUrl);
-            } catch (SsrfGuardException $exception) {
-                report($exception);
-
+            if (! SsrfGuard::isAllowed($faviconUrl)) {
                 return null;
             }
 
@@ -215,11 +193,7 @@ final class HighQualityDriver implements Fetcher
         $urlWithoutProtocol = str_replace(['https://', 'http://'], '', $url);
         $faviconUrl = 'https://icons.duckduckgo.com/ip3/'.$urlWithoutProtocol.'.ico';
 
-        try {
-            SsrfGuard::assertPublicHost($faviconUrl);
-        } catch (SsrfGuardException $exception) {
-            report($exception);
-
+        if (! SsrfGuard::isAllowed($faviconUrl)) {
             return null;
         }
 
@@ -247,11 +221,7 @@ final class HighQualityDriver implements Fetcher
     {
         $faviconUrl = $favicon->getFaviconUrl();
 
-        try {
-            SsrfGuard::assertPublicHost($faviconUrl);
-        } catch (SsrfGuardException $exception) {
-            report($exception);
-
+        if (! SsrfGuard::isAllowed($faviconUrl)) {
             return false;
         }
 

--- a/app/Services/Favicon/Drivers/HighQualityDriver.php
+++ b/app/Services/Favicon/Drivers/HighQualityDriver.php
@@ -72,8 +72,21 @@ final class HighQualityDriver implements Fetcher
 
             $html = $response->body();
 
-            if (preg_match('/<link[^>]+rel=["\']apple-touch-icon["\'][^>]+href=["\'](.*?)["\']/i', (string) $html, $matches)) {
-                $iconUrl = $this->convertToAbsoluteUrl($url, $matches[1]);
+            $appleTouchPatterns = [
+                '/<link\b[^>]*\brel=["\']apple-touch-icon["\'][^>]*\bhref=["\']([^"\']+)["\']/i',
+                '/<link\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\brel=["\']apple-touch-icon["\']/i',
+            ];
+
+            $matchedIconUrl = null;
+            foreach ($appleTouchPatterns as $appleTouchPattern) {
+                if (preg_match($appleTouchPattern, (string) $html, $matches)) {
+                    $matchedIconUrl = $matches[1];
+                    break;
+                }
+            }
+
+            if ($matchedIconUrl !== null) {
+                $iconUrl = $this->convertToAbsoluteUrl($url, $matchedIconUrl);
 
                 return new Favicon(
                     url: $url,
@@ -117,12 +130,12 @@ final class HighQualityDriver implements Fetcher
             $html = $response->body();
 
             $patterns = [
-                '/sizes=["\']512x512["\'][^>]+href=["\'](.*?)["\']/i',
-                '/href=["\'](.*?)["\']\s+[^>]*sizes=["\']512x512["\']/i',
-                '/sizes=["\']256x256["\'][^>]+href=["\'](.*?)["\']/i',
-                '/href=["\'](.*?)["\']\s+[^>]*sizes=["\']256x256["\']/i',
-                '/sizes=["\']192x192["\'][^>]+href=["\'](.*?)["\']/i',
-                '/href=["\'](.*?)["\']\s+[^>]*sizes=["\']192x192["\']/i',
+                '/<link\b[^>]*\bsizes=["\']512x512["\'][^>]*\bhref=["\']([^"\']+)["\']/i',
+                '/<link\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\bsizes=["\']512x512["\']/i',
+                '/<link\b[^>]*\bsizes=["\']256x256["\'][^>]*\bhref=["\']([^"\']+)["\']/i',
+                '/<link\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\bsizes=["\']256x256["\']/i',
+                '/<link\b[^>]*\bsizes=["\']192x192["\'][^>]*\bhref=["\']([^"\']+)["\']/i',
+                '/<link\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\bsizes=["\']192x192["\']/i',
             ];
 
             foreach ($patterns as $pattern) {

--- a/app/Services/Favicon/Drivers/HighQualityDriver.php
+++ b/app/Services/Favicon/Drivers/HighQualityDriver.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Favicon\Drivers;
 
+use App\Exceptions\SsrfGuardException;
 use App\Services\Favicon\SsrfGuard;
-use App\Services\Favicon\SsrfGuardException;
 use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Concerns\HasDefaultFunctionality;
 use AshAllenDesign\FaviconFetcher\Concerns\MakesHttpRequests;

--- a/app/Services/Favicon/Drivers/HighQualityDriver.php
+++ b/app/Services/Favicon/Drivers/HighQualityDriver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Favicon\Drivers;
 
+use App\Services\Favicon\SsrfGuard;
+use App\Services\Favicon\SsrfGuardException;
 use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Concerns\HasDefaultFunctionality;
 use AshAllenDesign\FaviconFetcher\Concerns\MakesHttpRequests;
@@ -31,6 +33,14 @@ final class HighQualityDriver implements Fetcher
     public function fetch(string $url): ?Favicon
     {
         throw_unless($this->urlIsValid($url), InvalidUrlException::class, $url.' is not a valid URL');
+
+        try {
+            SsrfGuard::assertPublicHost($url);
+        } catch (SsrfGuardException $exception) {
+            report($exception);
+
+            return null;
+        }
 
         if ($this->useCache && $favicon = $this->attemptToFetchFromCache($url)) {
             return $favicon;
@@ -173,6 +183,14 @@ final class HighQualityDriver implements Fetcher
 
             $faviconUrl = 'https://www.google.com/s2/favicons?sz=256&domain='.$urlWithoutProtocol;
 
+            try {
+                SsrfGuard::assertPublicHost($faviconUrl);
+            } catch (SsrfGuardException $exception) {
+                report($exception);
+
+                return null;
+            }
+
             $response = $this->withRequestExceptionHandling(
                 fn () => $this->httpClient()->get($faviconUrl)
             );
@@ -196,6 +214,14 @@ final class HighQualityDriver implements Fetcher
     {
         $urlWithoutProtocol = str_replace(['https://', 'http://'], '', $url);
         $faviconUrl = 'https://icons.duckduckgo.com/ip3/'.$urlWithoutProtocol.'.ico';
+
+        try {
+            SsrfGuard::assertPublicHost($faviconUrl);
+        } catch (SsrfGuardException $exception) {
+            report($exception);
+
+            return null;
+        }
 
         try {
             $response = $this->withRequestExceptionHandling(

--- a/app/Services/Favicon/Drivers/HighQualityDriver.php
+++ b/app/Services/Favicon/Drivers/HighQualityDriver.php
@@ -245,9 +245,19 @@ final class HighQualityDriver implements Fetcher
 
     private function faviconIsAccessible(Favicon $favicon): bool
     {
+        $faviconUrl = $favicon->getFaviconUrl();
+
+        try {
+            SsrfGuard::assertPublicHost($faviconUrl);
+        } catch (SsrfGuardException $exception) {
+            report($exception);
+
+            return false;
+        }
+
         try {
             /** @var Response $response */
-            $response = $this->httpClient()->head($favicon->getFaviconUrl());
+            $response = $this->httpClient()->head($faviconUrl);
 
             return $response->successful();
         } catch (\Exception) {

--- a/app/Services/Favicon/SsrfGuard.php
+++ b/app/Services/Favicon/SsrfGuard.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Services\Favicon;
 
-final class SsrfGuard
+use App\Exceptions\SsrfGuardException;
+
+final readonly class SsrfGuard
 {
     public static function assertPublicHost(string $url): void
     {

--- a/app/Services/Favicon/SsrfGuard.php
+++ b/app/Services/Favicon/SsrfGuard.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Favicon;
+
+final class SsrfGuard
+{
+    public static function assertPublicHost(string $url): void
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+
+        throw_if(! is_string($host) || $host === '', SsrfGuardException::class, "Invalid host in URL: {$url}");
+
+        $host = trim($host, '[]');
+
+        $addresses = self::resolveAddresses($host);
+
+        throw_if($addresses === [], SsrfGuardException::class, "Could not resolve host: {$host}");
+
+        foreach ($addresses as $address) {
+            throw_unless(self::isPublicAddress($address), SsrfGuardException::class, "Refusing to fetch from non-public address: {$address}");
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function resolveAddresses(string $host): array
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [$host];
+        }
+
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA);
+
+        if ($records === false) {
+            return [];
+        }
+
+        $addresses = [];
+        foreach ($records as $record) {
+            if (isset($record['ip'])) {
+                $addresses[] = (string) $record['ip'];
+            }
+            if (isset($record['ipv6'])) {
+                $addresses[] = (string) $record['ipv6'];
+            }
+        }
+
+        return $addresses;
+    }
+
+    private static function isPublicAddress(string $address): bool
+    {
+        return filter_var(
+            $address,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        ) !== false;
+    }
+}

--- a/app/Services/Favicon/SsrfGuard.php
+++ b/app/Services/Favicon/SsrfGuard.php
@@ -8,6 +8,19 @@ use App\Exceptions\SsrfGuardException;
 
 final readonly class SsrfGuard
 {
+    public static function isAllowed(string $url): bool
+    {
+        try {
+            self::assertPublicHost($url);
+
+            return true;
+        } catch (SsrfGuardException $exception) {
+            report($exception);
+
+            return false;
+        }
+    }
+
     public static function assertPublicHost(string $url): void
     {
         $host = parse_url($url, PHP_URL_HOST);

--- a/app/Services/Favicon/SsrfGuard.php
+++ b/app/Services/Favicon/SsrfGuard.php
@@ -12,7 +12,7 @@ final readonly class SsrfGuard
     {
         $host = parse_url($url, PHP_URL_HOST);
 
-        throw_if(! is_string($host) || $host === '', SsrfGuardException::class, "Invalid host in URL: {$url}");
+        throw_if(! is_string($host) || $host === '', SsrfGuardException::class, 'Invalid host in URL');
 
         $host = trim($host, '[]');
 

--- a/app/Services/Favicon/SsrfGuardException.php
+++ b/app/Services/Favicon/SsrfGuardException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Favicon;
+
+use RuntimeException;
+
+final class SsrfGuardException extends RuntimeException {}

--- a/config/favicon-fetcher.php
+++ b/config/favicon-fetcher.php
@@ -45,9 +45,9 @@ return [
     | response from the server after the connection is made.
     |
     */
-    'timeout' => 0,
+    'timeout' => env('FAVICON_FETCHER_TIMEOUT', 10),
 
-    'connect_timeout' => 0,
+    'connect_timeout' => env('FAVICON_FETCHER_CONNECT_TIMEOUT', 5),
 
     /*
     |--------------------------------------------------------------------------

--- a/rector.php
+++ b/rector.php
@@ -16,6 +16,7 @@ use RectorLaravel\Rector\Class_\HiddenPropertyToHiddenAttributeRector;
 use RectorLaravel\Rector\Class_\TablePropertyToTableAttributeRector;
 use RectorLaravel\Rector\Class_\TimeoutPropertyToTimeoutAttributeRector;
 use RectorLaravel\Rector\Class_\TriesPropertyToTriesAttributeRector;
+use RectorLaravel\Rector\Class_\UniqueForPropertyToUniqueForAttributeRector;
 use RectorLaravel\Rector\Class_\UseForwardsCallsTraitRector;
 use RectorLaravel\Rector\Empty_\EmptyToBlankAndFilledFuncRector;
 use RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector;
@@ -45,6 +46,7 @@ return RectorConfig::configure()
         TablePropertyToTableAttributeRector::class,
         TimeoutPropertyToTimeoutAttributeRector::class,
         TriesPropertyToTriesAttributeRector::class,
+        UniqueForPropertyToUniqueForAttributeRector::class,
         EloquentWhereTypeHintClosureParameterRector::class,
         RemoveUnusedPrivateMethodRector::class => [
             // Skip Filament importer lifecycle hooks - they're called dynamically via callHook()

--- a/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
+++ b/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CustomFields\CompanyField;
+use App\Jobs\FetchFaviconForCompany;
+use App\Models\Company;
+use App\Models\CustomField;
+use App\Models\CustomFieldValue;
+use App\Models\User;
+use AshAllenDesign\FaviconFetcher\Facades\Favicon;
+use Filament\Facades\Filament;
+
+mutates(FetchFaviconForCompany::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    Filament::setTenant($this->user->currentTeam);
+});
+
+test('job declares timeout, tries, uniqueFor consistent with horizon worker timeout', function (): void {
+    $job = new FetchFaviconForCompany(Company::factory()->for($this->user->currentTeam)->create());
+
+    expect($job->tries)->toBe(1)
+        ->and($job->timeout)->toBe(30)
+        ->and($job->uniqueFor)->toBe(600);
+});
+
+test('job swallows throwable from favicon driver instead of letting it escape', function (): void {
+    $company = Company::factory()->for($this->user->currentTeam)->create();
+
+    $domainsField = CustomField::query()
+        ->where('code', CompanyField::DOMAINS->value)
+        ->forEntity(Company::class)
+        ->firstOrFail();
+
+    CustomFieldValue::forceCreate([
+        'tenant_id' => $this->user->currentTeam->getKey(),
+        'entity_type' => 'company',
+        'entity_id' => $company->getKey(),
+        'custom_field_id' => $domainsField->getKey(),
+        'json_value' => ['example.com'],
+    ]);
+
+    Favicon::shouldReceive('driver')
+        ->once()
+        ->andThrow(new TypeError('simulated php error inside favicon driver'));
+
+    // If the job's catch were `catch (Exception)`, the TypeError would escape this call.
+    // The test passes simply by not throwing.
+    (new FetchFaviconForCompany($company->fresh()))->handle();
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
+++ b/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
@@ -53,3 +53,31 @@ test('job swallows throwable from favicon driver instead of letting it escape', 
 
     expect(true)->toBeTrue();
 });
+
+test('job rejects favicon url that resolves to private address', function (): void {
+    $company = Company::factory()->for($this->user->currentTeam)->create();
+
+    $domainsField = CustomField::query()
+        ->where('code', CompanyField::DOMAINS->value)
+        ->forEntity(Company::class)
+        ->firstOrFail();
+
+    CustomFieldValue::forceCreate([
+        'tenant_id' => $this->user->currentTeam->getKey(),
+        'entity_type' => 'company',
+        'entity_id' => $company->getKey(),
+        'custom_field_id' => $domainsField->getKey(),
+        'json_value' => ['example.com'],
+    ]);
+
+    $favicon = Mockery::mock(AshAllenDesign\FaviconFetcher\Favicon::class);
+    $favicon->shouldReceive('getFaviconUrl')->andReturn('http://127.0.0.1/favicon.png');
+    $favicon->shouldReceive('getIconSize')->andReturn(180);
+    $favicon->shouldReceive('getIconType')->andReturn('apple-touch-icon');
+
+    Favicon::shouldReceive('driver->fetch')->andReturn($favicon);
+
+    (new FetchFaviconForCompany($company->fresh()))->handle();
+
+    expect($company->fresh()->getMedia('logo'))->toHaveCount(0);
+});

--- a/tests/Feature/Observers/CompanyObserverFaviconTest.php
+++ b/tests/Feature/Observers/CompanyObserverFaviconTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CustomFields\CompanyField;
+use App\Jobs\FetchFaviconForCompany;
+use App\Models\Company;
+use App\Models\CustomField;
+use App\Models\CustomFieldValue;
+use App\Models\User;
+use App\Observers\CompanyObserver;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Bus;
+
+mutates(CompanyObserver::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    Filament::setTenant($this->user->currentTeam);
+});
+
+test('observer dispatches favicon job when company has domain and no existing logo', function (): void {
+    Bus::fake([FetchFaviconForCompany::class]);
+
+    $company = Company::factory()->for($this->user->currentTeam)->create();
+
+    $domainsField = CustomField::query()
+        ->where('code', CompanyField::DOMAINS->value)
+        ->forEntity(Company::class)
+        ->firstOrFail();
+
+    CustomFieldValue::forceCreate([
+        'tenant_id' => $this->user->currentTeam->getKey(),
+        'entity_type' => 'company',
+        'entity_id' => $company->getKey(),
+        'custom_field_id' => $domainsField->getKey(),
+        'json_value' => ['example.com'],
+    ]);
+
+    $company->touch();
+
+    Bus::assertDispatched(FetchFaviconForCompany::class);
+});
+
+test('observer does not dispatch favicon job when company already has a logo', function (): void {
+    $company = Company::factory()->for($this->user->currentTeam)->create();
+
+    $domainsField = CustomField::query()
+        ->where('code', CompanyField::DOMAINS->value)
+        ->forEntity(Company::class)
+        ->firstOrFail();
+
+    CustomFieldValue::forceCreate([
+        'tenant_id' => $this->user->currentTeam->getKey(),
+        'entity_type' => 'company',
+        'entity_id' => $company->getKey(),
+        'custom_field_id' => $domainsField->getKey(),
+        'json_value' => ['example.com'],
+    ]);
+
+    $company->addMediaFromString('fake-png-bytes')
+        ->usingFileName('logo.png')
+        ->toMediaCollection('logo');
+
+    Bus::fake([FetchFaviconForCompany::class]);
+    $company->touch();
+    Bus::assertNotDispatched(FetchFaviconForCompany::class);
+});
+
+test('observer does not dispatch when domain custom field is empty', function (): void {
+    Bus::fake([FetchFaviconForCompany::class]);
+
+    Company::factory()->for($this->user->currentTeam)->create();
+
+    Bus::assertNotDispatched(FetchFaviconForCompany::class);
+});

--- a/tests/Feature/Services/Favicon/HighQualityDriverTest.php
+++ b/tests/Feature/Services/Favicon/HighQualityDriverTest.php
@@ -13,29 +13,29 @@ test('captures favicon-512x512 from minified html where href comes before sizes'
         .'<link href="/favicon-512x512.png" sizes="512x512" rel="icon" />';
 
     Http::fake([
-        'https://example.com' => Http::response($html, 200),
-        'https://example.com/favicon-512x512.png' => Http::response('', 200),
+        'https://1.1.1.1' => Http::response($html, 200),
+        'https://1.1.1.1/favicon-512x512.png' => Http::response('', 200),
     ]);
 
     $driver = new HighQualityDriver;
-    $favicon = $driver->fetch('https://example.com');
+    $favicon = $driver->fetch('https://1.1.1.1');
 
     expect($favicon)->not->toBeNull()
-        ->and($favicon->getFaviconUrl())->toBe('https://example.com/favicon-512x512.png');
+        ->and($favicon->getFaviconUrl())->toBe('https://1.1.1.1/favicon-512x512.png');
 });
 
 test('captures favicon-512x512 when sizes comes before href', function (): void {
     $html = '<link rel="icon" sizes="512x512" href="/favicon-512x512.png" />';
 
     Http::fake([
-        'https://example.com' => Http::response($html, 200),
-        'https://example.com/favicon-512x512.png' => Http::response('', 200),
+        'https://1.1.1.1' => Http::response($html, 200),
+        'https://1.1.1.1/favicon-512x512.png' => Http::response('', 200),
     ]);
 
     $driver = new HighQualityDriver;
-    $favicon = $driver->fetch('https://example.com');
+    $favicon = $driver->fetch('https://1.1.1.1');
 
-    expect($favicon->getFaviconUrl())->toBe('https://example.com/favicon-512x512.png');
+    expect($favicon->getFaviconUrl())->toBe('https://1.1.1.1/favicon-512x512.png');
 });
 
 test('does not span across multiple link tags when matching sizes', function (): void {
@@ -44,16 +44,16 @@ test('does not span across multiple link tags when matching sizes', function ():
         .'<link href="/icon.png" sizes="256x256" rel="icon" />';
 
     Http::fake([
-        'https://example.com' => Http::response($html, 200),
-        'https://example.com/icon.png' => Http::response('', 200),
+        'https://1.1.1.1' => Http::response($html, 200),
+        'https://1.1.1.1/icon.png' => Http::response('', 200),
     ]);
 
     $driver = new HighQualityDriver;
-    $favicon = $driver->fetch('https://example.com');
+    $favicon = $driver->fetch('https://1.1.1.1');
 
     $faviconUrl = $favicon->getFaviconUrl();
 
-    expect($faviconUrl)->toBe('https://example.com/icon.png');
+    expect($faviconUrl)->toBe('https://1.1.1.1/icon.png');
     expect($faviconUrl)->not->toContain('decoy');
 });
 
@@ -61,42 +61,42 @@ test('falls through to apple-touch-icon when no sized icon present', function ()
     $html = '<link rel="apple-touch-icon" href="/apple.png" />';
 
     Http::fake([
-        'https://example.com' => Http::response($html, 200),
-        'https://example.com/apple.png' => Http::response('', 200),
+        'https://1.1.1.1' => Http::response($html, 200),
+        'https://1.1.1.1/apple.png' => Http::response('', 200),
     ]);
 
     $driver = new HighQualityDriver;
-    $favicon = $driver->fetch('https://example.com');
+    $favicon = $driver->fetch('https://1.1.1.1');
 
-    expect($favicon->getFaviconUrl())->toBe('https://example.com/apple.png');
+    expect($favicon->getFaviconUrl())->toBe('https://1.1.1.1/apple.png');
 });
 
 test('apple-touch-icon pattern is not fooled by data-href attribute', function (): void {
     $html = '<link rel="apple-touch-icon" data-href="/wrong.png" href="/correct.png" />';
 
     Http::fake([
-        'https://example.com' => Http::response($html, 200),
-        'https://example.com/correct.png' => Http::response('', 200),
+        'https://1.1.1.1' => Http::response($html, 200),
+        'https://1.1.1.1/correct.png' => Http::response('', 200),
     ]);
 
     $driver = new HighQualityDriver;
-    $favicon = $driver->fetch('https://example.com');
+    $favicon = $driver->fetch('https://1.1.1.1');
 
-    expect($favicon->getFaviconUrl())->toBe('https://example.com/correct.png');
+    expect($favicon->getFaviconUrl())->toBe('https://1.1.1.1/correct.png');
 });
 
 test('apple-touch-icon pattern matches when href comes before rel', function (): void {
     $html = '<link href="/apple.png" rel="apple-touch-icon" />';
 
     Http::fake([
-        'https://example.com' => Http::response($html, 200),
-        'https://example.com/apple.png' => Http::response('', 200),
+        'https://1.1.1.1' => Http::response($html, 200),
+        'https://1.1.1.1/apple.png' => Http::response('', 200),
     ]);
 
     $driver = new HighQualityDriver;
-    $favicon = $driver->fetch('https://example.com');
+    $favicon = $driver->fetch('https://1.1.1.1');
 
-    expect($favicon->getFaviconUrl())->toBe('https://example.com/apple.png');
+    expect($favicon->getFaviconUrl())->toBe('https://1.1.1.1/apple.png');
 });
 
 test('high-res pattern prefers larger sizes when multiple are present', function (): void {
@@ -104,15 +104,15 @@ test('high-res pattern prefers larger sizes when multiple are present', function
         .'<link href="/icon-512.png" sizes="512x512" rel="icon" />';
 
     Http::fake([
-        'https://example.com' => Http::response($html, 200),
-        'https://example.com/icon-512.png' => Http::response('', 200),
-        'https://example.com/icon-256.png' => Http::response('', 200),
+        'https://1.1.1.1' => Http::response($html, 200),
+        'https://1.1.1.1/icon-512.png' => Http::response('', 200),
+        'https://1.1.1.1/icon-256.png' => Http::response('', 200),
     ]);
 
     $driver = new HighQualityDriver;
-    $favicon = $driver->fetch('https://example.com');
+    $favicon = $driver->fetch('https://1.1.1.1');
 
-    expect($favicon->getFaviconUrl())->toBe('https://example.com/icon-512.png');
+    expect($favicon->getFaviconUrl())->toBe('https://1.1.1.1/icon-512.png');
 });
 
 test('refuses to fetch from private addresses', function (): void {

--- a/tests/Feature/Services/Favicon/HighQualityDriverTest.php
+++ b/tests/Feature/Services/Favicon/HighQualityDriverTest.php
@@ -114,3 +114,11 @@ test('high-res pattern prefers larger sizes when multiple are present', function
 
     expect($favicon->getFaviconUrl())->toBe('https://example.com/icon-512.png');
 });
+
+test('refuses to fetch from private addresses', function (): void {
+    $driver = new HighQualityDriver;
+
+    expect($driver->fetch('http://127.0.0.1/'))->toBeNull()
+        ->and($driver->fetch('http://10.0.0.1/'))->toBeNull()
+        ->and($driver->fetch('http://169.254.169.254/'))->toBeNull();
+});

--- a/tests/Feature/Services/Favicon/HighQualityDriverTest.php
+++ b/tests/Feature/Services/Favicon/HighQualityDriverTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Favicon\Drivers\HighQualityDriver;
+use Illuminate\Support\Facades\Http;
+
+mutates(HighQualityDriver::class);
+
+test('captures favicon-512x512 from minified html where href comes before sizes', function (): void {
+    $html = '<link href="/css/a.css?v=1" rel="stylesheet" />'
+        .'<link href="/css/b.css" rel="stylesheet" />'
+        .'<link href="/favicon-512x512.png" sizes="512x512" rel="icon" />';
+
+    Http::fake([
+        'https://example.com' => Http::response($html, 200),
+        'https://example.com/favicon-512x512.png' => Http::response('', 200),
+    ]);
+
+    $driver = new HighQualityDriver;
+    $favicon = $driver->fetch('https://example.com');
+
+    expect($favicon)->not->toBeNull()
+        ->and($favicon->getFaviconUrl())->toBe('https://example.com/favicon-512x512.png');
+});
+
+test('captures favicon-512x512 when sizes comes before href', function (): void {
+    $html = '<link rel="icon" sizes="512x512" href="/favicon-512x512.png" />';
+
+    Http::fake([
+        'https://example.com' => Http::response($html, 200),
+        'https://example.com/favicon-512x512.png' => Http::response('', 200),
+    ]);
+
+    $driver = new HighQualityDriver;
+    $favicon = $driver->fetch('https://example.com');
+
+    expect($favicon->getFaviconUrl())->toBe('https://example.com/favicon-512x512.png');
+});
+
+test('does not span across multiple link tags when matching sizes', function (): void {
+    $html = '<link href="/decoy-1.css" rel="stylesheet" />'
+        .'<link href="/decoy-2.css" rel="stylesheet" />'
+        .'<link href="/icon.png" sizes="256x256" rel="icon" />';
+
+    Http::fake([
+        'https://example.com' => Http::response($html, 200),
+        'https://example.com/icon.png' => Http::response('', 200),
+    ]);
+
+    $driver = new HighQualityDriver;
+    $favicon = $driver->fetch('https://example.com');
+
+    $faviconUrl = $favicon->getFaviconUrl();
+
+    expect($faviconUrl)->toBe('https://example.com/icon.png');
+    expect($faviconUrl)->not->toContain('decoy');
+});
+
+test('falls through to apple-touch-icon when no sized icon present', function (): void {
+    $html = '<link rel="apple-touch-icon" href="/apple.png" />';
+
+    Http::fake([
+        'https://example.com' => Http::response($html, 200),
+        'https://example.com/apple.png' => Http::response('', 200),
+    ]);
+
+    $driver = new HighQualityDriver;
+    $favicon = $driver->fetch('https://example.com');
+
+    expect($favicon->getFaviconUrl())->toBe('https://example.com/apple.png');
+});
+
+test('apple-touch-icon pattern is not fooled by data-href attribute', function (): void {
+    $html = '<link rel="apple-touch-icon" data-href="/wrong.png" href="/correct.png" />';
+
+    Http::fake([
+        'https://example.com' => Http::response($html, 200),
+        'https://example.com/correct.png' => Http::response('', 200),
+    ]);
+
+    $driver = new HighQualityDriver;
+    $favicon = $driver->fetch('https://example.com');
+
+    expect($favicon->getFaviconUrl())->toBe('https://example.com/correct.png');
+});
+
+test('apple-touch-icon pattern matches when href comes before rel', function (): void {
+    $html = '<link href="/apple.png" rel="apple-touch-icon" />';
+
+    Http::fake([
+        'https://example.com' => Http::response($html, 200),
+        'https://example.com/apple.png' => Http::response('', 200),
+    ]);
+
+    $driver = new HighQualityDriver;
+    $favicon = $driver->fetch('https://example.com');
+
+    expect($favicon->getFaviconUrl())->toBe('https://example.com/apple.png');
+});
+
+test('high-res pattern prefers larger sizes when multiple are present', function (): void {
+    $html = '<link href="/icon-256.png" sizes="256x256" rel="icon" />'
+        .'<link href="/icon-512.png" sizes="512x512" rel="icon" />';
+
+    Http::fake([
+        'https://example.com' => Http::response($html, 200),
+        'https://example.com/icon-512.png' => Http::response('', 200),
+        'https://example.com/icon-256.png' => Http::response('', 200),
+    ]);
+
+    $driver = new HighQualityDriver;
+    $favicon = $driver->fetch('https://example.com');
+
+    expect($favicon->getFaviconUrl())->toBe('https://example.com/icon-512.png');
+});

--- a/tests/Feature/Services/Favicon/SsrfGuardTest.php
+++ b/tests/Feature/Services/Favicon/SsrfGuardTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Favicon\SsrfGuard;
+use App\Services\Favicon\SsrfGuardException;
+
+mutates(SsrfGuard::class);
+
+test('rejects loopback addresses', function (): void {
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://127.0.0.1/');
+    })->toThrow(SsrfGuardException::class);
+});
+
+test('rejects private RFC1918 addresses', function (): void {
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://10.0.0.1/');
+    })->toThrow(SsrfGuardException::class);
+
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://192.168.1.1/');
+    })->toThrow(SsrfGuardException::class);
+
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://172.16.0.1/');
+    })->toThrow(SsrfGuardException::class);
+});
+
+test('rejects link-local cloud metadata address', function (): void {
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://169.254.169.254/latest/meta-data/');
+    })->toThrow(SsrfGuardException::class);
+});
+
+test('rejects ipv6 loopback and link-local', function (): void {
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://[::1]/');
+    })->toThrow(SsrfGuardException::class);
+
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://[fe80::1]/');
+    })->toThrow(SsrfGuardException::class);
+});
+
+test('rejects hostnames that resolve to private addresses', function (): void {
+    // localhost resolves to 127.0.0.1 on every OS we run on.
+    expect(function (): void {
+        SsrfGuard::assertPublicHost('http://localhost/');
+    })->toThrow(SsrfGuardException::class);
+});
+
+test('accepts a clearly-public address literal', function (): void {
+    SsrfGuard::assertPublicHost('http://1.1.1.1/');
+    expect(true)->toBeTrue();
+});

--- a/tests/Feature/Services/Favicon/SsrfGuardTest.php
+++ b/tests/Feature/Services/Favicon/SsrfGuardTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Exceptions\SsrfGuardException;
 use App\Services\Favicon\SsrfGuard;
-use App\Services\Favicon\SsrfGuardException;
 
 mutates(SsrfGuard::class);
 


### PR DESCRIPTION
## Summary

Eliminates the three production errors emitted by `App\Jobs\FetchFaviconForCompany` (`MaxAttemptsExceededException`, `UnreachableUrl` with HTML mixed into the URL, `DiskCannotBeAccessed`) and the redundant-dispatch pattern that amplified them.

Five focused commits, each independently shippable.

### Root causes addressed

1. **`MaxAttemptsExceededException` (5 events / 17h, unhandled).** `favicon-fetcher` config had `timeout: 0` / `connect_timeout: 0`, so a slow remote site hung the worker until Horizon's 60s timeout sigkilled it; the job was requeued, then `attempts() (2) > tries (1)` made the next pickup throw before `handle()` ran. Fix: enforce 10s/5s HTTP timeouts and add a 30s job-level `timeout` so the job throws cleanly into its catch.
2. **`UnreachableUrl` with HTML in the URL (2 events).** `HighQualityDriver::tryHighResFavicon` used `(.*?)` non-greedy capture inside patterns like `/href=["\'](.*?)["\']\s+[^>]*sizes=["\']512x512["\']/`; on minified HTML the engine extended `.*?` across multiple `<link>` tags to satisfy the trailing `sizes="..."`, capturing nested tags as part of the URL. `tryAppleTouchIcon` had the same bug class (no `\b` boundary on `href=`, no symmetric pattern for `<link href="..." rel="apple-touch-icon">`). Fix: anchor patterns with `<link\b[^>]*` and capture URLs with `[^"\']+` so matches cannot escape a single tag.
3. **CPU saturation amplifier.** `CompanyObserver::saved` dispatched `FetchFaviconForCompany` on every Company save, regardless of whether the domain changed; combined with hung HTTP fetches, imports/bulk edits flooded the queue. Fix: short-circuit when `hasMedia('logo')` is true (callers can clear the logo collection to force a refetch).
4. **SSRF surface.** A user-controlled domain field flowed straight into server-side fetches against attacker-controlled URLs. Fix: introduce `SsrfGuard::assertPublicHost()` resolving via `dns_get_record` and rejecting RFC1918/loopback/link-local (incl. IPv6) via `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE`; wired into 4 sites (`fetch`, `tryGoogleHighRes`, `tryDuckDuckGo`, and the job's `addMediaFromUrl` to close the redirect-to-private-host gap when an attacker-controlled HTML returns `<link href="//127.0.0.1/" rel="apple-touch-icon">`). All catches `report()` so SSRF attempts surface in Flare.

### Defense in depth

- `catch (Exception)` → `catch (Throwable)` in the job so PHP `Error` types (TypeError, etc.) are reported rather than silently escaping.
- `filter_var($url, FILTER_VALIDATE_URL)` belt-and-braces guard before `addMediaFromUrl`.
- Bounded `uniqueFor = 600` on the `ShouldBeUnique` lock so a stuck unique-lock can't block re-dispatch indefinitely.

## Test plan

- [x] 20 new feature tests cover regex anchoring (incl. decoy tags + size preference + apple-touch-icon adversarial input), job property pinning, SSRF rejection at SsrfGuard / driver / job layers, observer skip-when-logo-exists, observer skip-when-no-domain, and `Throwable` swallowing via `Favicon::shouldReceive('driver')->andThrow(new TypeError(...))`.
- [x] `vendor/bin/pint --dirty --format agent` passes.
- [x] `vendor/bin/rector --dry-run` clean (added `UniqueForPropertyToUniqueForAttributeRector` to existing skip list, consistent with prior `Tries`/`Timeout` skips).
- [x] `vendor/bin/phpstan analyse` 0 errors.
- [x] `composer test:type-coverage` 100%.
- [x] All 20 favicon tests pass: `php artisan test --compact tests/Feature/Services/Favicon/ tests/Feature/Jobs/FetchFaviconForCompanyTest.php tests/Feature/Observers/CompanyObserverFaviconTest.php`.

## Notes

- The `hasMedia('logo')` short-circuit is a behavior change: domain edits after a logo has been stored will not re-fetch. There is no UI path for refetch today; documented inline at the early return.
- DNS rebinding window between `SsrfGuard::assertPublicHost()` and the actual HTTP request is open by design — for a queue worker hitting each domain once, attacker payoff is low.
- `DiskCannotBeAccessed` (1 event in 17h) was not addressed in code: storage is correctly mounted in compose.yml, the error reads as a transient IO/permissions blip on the prod volume. Worth monitoring; if it recurs, investigate volume UID/GID alignment between `app` and `horizon` containers.