### PR TITLE
feat(mcp): team picker on OAuth consent

### DIFF
--- a/app/Http/Controllers/Mcp/ApproveAuthorizationController.php
+++ b/app/Http/Controllers/Mcp/ApproveAuthorizationController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Mcp;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Laravel\Passport\Http\Controllers\ApproveAuthorizationController as BaseApproveAuthorizationController;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * MCP-aware approve handler. Validates that the user has selected exactly one
+ * team they belong to, stashes the team_id in the session so the AuthCode
+ * model's creating hook can persist it, then delegates to Passport's standard
+ * approve flow.
+ */
+final class ApproveAuthorizationController extends BaseApproveAuthorizationController
+{
+    public function approve(Request $request, ResponseInterface $psrResponse): Response
+    {
+        $validated = $request->validate([
+            'team_id' => ['required', 'string', 'size:26'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        $team = Team::query()->find($validated['team_id']);
+
+        abort_if(! $team instanceof Team, 422, 'Selected team does not exist.');
+        abort_if(! $user->belongsToTeam($team), 403, 'You do not belong to the selected team.');
+
+        $request->session()->put('mcp.oauth.team_id', $team->getKey());
+
+        return parent::approve($request, $psrResponse);
+    }
+}

--- a/app/Http/Middleware/SetApiTeamContext.php
+++ b/app/Http/Middleware/SetApiTeamContext.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Laravel\Passport\AccessToken as PassportAccessToken;
 use Relaticle\CustomFields\Services\TenantContextService;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -91,6 +92,22 @@ final readonly class SetApiTeamContext
     {
         $token = $user->currentAccessToken();
 
+        // Passport OAuth tokens are issued by our consent flow and ALWAYS carry a
+        // team_id. The token's team_id is authoritative — X-Team-Id and currentTeam
+        // are ignored. A Passport token without team_id is malformed (created outside
+        // the MCP consent flow) and the request is rejected by returning null here.
+        // @phpstan-ignore-next-line instanceof.alwaysFalse (User::currentAccessToken() is typed as Sanctum token but Passport replaces it at runtime via the api guard)
+        if ($token instanceof PassportAccessToken) {
+            if (! is_string($token->team_id) || $token->team_id === '') {
+                return null;
+            }
+
+            return Team::query()->find($token->team_id);
+        }
+
+        // Sanctum personal access tokens (created from the Access Tokens UI in the
+        // user's profile) can optionally pin a team at creation time. If unpinned,
+        // X-Team-Id header or currentTeam applies — unchanged behavior.
         if ($token instanceof PersonalAccessToken && is_string($token->team_id)) {
             return Team::query()->find($token->team_id);
         }

--- a/app/Listeners/Mcp/CopyTeamIdToAccessToken.php
+++ b/app/Listeners/Mcp/CopyTeamIdToAccessToken.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners\Mcp;
+
+use Illuminate\Support\Facades\DB;
+use Laravel\Passport\Events\AccessTokenCreated;
+use Laravel\Passport\Passport;
+
+/**
+ * Copy the team_id from a consumed auth code onto the freshly minted access token.
+ *
+ * The auth code's team_id was set by the custom ApproveAuthorizationController during
+ * the user's consent. The access token is created in a separate POST /oauth/token
+ * request that has no access to the original session, so we bridge it via the
+ * auth code row that's still present in the DB at this point.
+ */
+final class CopyTeamIdToAccessToken
+{
+    public function handle(AccessTokenCreated $event): void
+    {
+        $authCodeId = request()->input('code');
+
+        if (! is_string($authCodeId) || $authCodeId === '') {
+            return;
+        }
+
+        $authCode = Passport::authCodeModel()::query()->find($authCodeId);
+
+        if (! $authCode || ! is_string($authCode->team_id) || $authCode->team_id === '') {
+            return;
+        }
+
+        DB::table('oauth_access_tokens')
+            ->where('id', $event->tokenId)
+            ->update(['team_id' => $authCode->team_id]);
+    }
+}

--- a/app/Models/Passport/AuthCode.php
+++ b/app/Models/Passport/AuthCode.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Passport;
+
+use Laravel\Passport\AuthCode as BaseAuthCode;
+
+/**
+ * Custom Passport AuthCode that binds a team selected during the OAuth consent.
+ *
+ * The team_id is stashed in the session by the custom ApproveAuthorizationController
+ * (POST /oauth/authorize) and read here when Passport persists the auth code row.
+ */
+final class AuthCode extends BaseAuthCode
+{
+    protected $fillable = [
+        'id',
+        'user_id',
+        'client_id',
+        'scopes',
+        'revoked',
+        'expires_at',
+        'team_id',
+    ];
+
+    protected static function booted(): void
+    {
+        self::creating(function (self $code): void {
+            $teamId = session()->pull('mcp.oauth.team_id');
+
+            if (is_string($teamId) && $teamId !== '') {
+                $code->team_id = $teamId;
+            }
+        });
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -75,7 +75,17 @@ final class AppServiceProvider extends ServiceProvider
         Passport::useAuthCodeModel(McpAuthCode::class);
         Event::listen(AccessTokenCreated::class, CopyTeamIdToAccessToken::class);
 
-        Passport::authorizationView(fn (array $parameters) => response()->view('mcp.authorize', $parameters));
+        Passport::authorizationView(function (array $parameters) {
+            $user = $parameters['user'] ?? null;
+
+            $parameters['teams'] = $user instanceof User
+                ? $user->allTeams()
+                : collect();
+
+            $parameters['selectedTeamId'] = $user?->currentTeam?->getKey();
+
+            return response()->view('mcp.authorize', $parameters);
+        });
 
         $this->configurePolicies();
         $this->configureModels();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Listeners\Email\NewSubscriberListener;
 use App\Listeners\Email\RecordLoginTimestampListener;
 use App\Listeners\Email\TeamCreatedTagListener;
 use App\Listeners\Email\TeamMemberAddedListener;
+use App\Listeners\Mcp\CopyTeamIdToAccessToken;
 use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\CustomFieldOption;
@@ -17,6 +18,7 @@ use App\Models\CustomFieldValue;
 use App\Models\Export;
 use App\Models\Note;
 use App\Models\Opportunity;
+use App\Models\Passport\AuthCode as McpAuthCode;
 use App\Models\People;
 use App\Models\PersonalAccessToken;
 use App\Models\Task;
@@ -41,6 +43,7 @@ use Illuminate\View\View;
 use Knuckles\Scribe\Scribe;
 use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamMemberAdded;
+use Laravel\Passport\Events\AccessTokenCreated;
 use Laravel\Passport\Passport;
 use Laravel\Sanctum\Sanctum;
 use Relaticle\CustomFields\CustomFields;
@@ -68,6 +71,9 @@ final class AppServiceProvider extends ServiceProvider
         Event::listen(TeamCreated::class, TeamCreatedTagListener::class);
 
         Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
+
+        Passport::useAuthCodeModel(McpAuthCode::class);
+        Event::listen(AccessTokenCreated::class, CopyTeamIdToAccessToken::class);
 
         Passport::authorizationView(fn (array $parameters) => response()->view('mcp.authorize', $parameters));
 

--- a/database/migrations/2026_04_30_120000_add_team_id_to_oauth_tokens_table.php
+++ b/database/migrations/2026_04_30_120000_add_team_id_to_oauth_tokens_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table): void {
+            $table->char('team_id', 26)->nullable()->index()->after('client_id');
+        });
+
+        Schema::table('oauth_access_tokens', function (Blueprint $table): void {
+            $table->char('team_id', 26)->nullable()->index()->after('client_id');
+        });
+    }
+};

--- a/rector.php
+++ b/rector.php
@@ -45,6 +45,7 @@ return RectorConfig::configure()
         ],
         AddHasFactoryToModelsRector::class => [
             __DIR__.'/app/Models/PersonalAccessToken.php',
+            __DIR__.'/app/Models/Passport/*',
             __DIR__.'/packages/ImportWizard/src/Models/*',
         ],
     ])

--- a/resources/views/mcp/authorize.blade.php
+++ b/resources/views/mcp/authorize.blade.php
@@ -74,6 +74,39 @@
                     <p class="font-medium">{{ $user->email }}</p>
                 </div>
 
+                <!-- Team Picker -->
+                @if($teams->count() > 0)
+                    <div class="space-y-2">
+                        <p class="text-sm font-medium">Connect to which team?</p>
+                        <p class="text-xs text-muted-foreground">This connector will only see data from the team you choose. To use a different team later, revoke and re-add the connector.</p>
+
+                        <div class="space-y-2 mt-2" role="radiogroup" aria-label="Team selection">
+                            @foreach($teams as $team)
+                                <label class="flex items-center gap-3 rounded-md border p-3 cursor-pointer hover:bg-muted/50">
+                                    <input
+                                        type="radio"
+                                        name="team_id"
+                                        value="{{ $team->getKey() }}"
+                                        form="authorizeForm"
+                                        required
+                                        @checked($team->getKey() === $selectedTeamId)
+                                        class="h-4 w-4"
+                                    >
+                                    <span class="text-sm font-medium">{{ $team->name }}</span>
+                                    @if($team->personal_team)
+                                        <span class="text-xs text-muted-foreground ml-auto">Personal</span>
+                                    @endif
+                                </label>
+                            @endforeach
+                        </div>
+                    </div>
+                @else
+                    <div class="rounded-lg border border-destructive/50 p-4 bg-destructive/10">
+                        <p class="text-sm font-medium">You don't belong to any teams.</p>
+                        <p class="text-xs text-muted-foreground mt-1">Create or join a team in Relaticle before authorizing this connector.</p>
+                    </div>
+                @endif
+
                 <!-- Scopes / Permissions -->
                 @if(count($scopes) > 0)
                     <div class="space-y-2">
@@ -118,7 +151,7 @@
                     <input type="hidden" name="state" value="{{ $request->state }}">
                     <input type="hidden" name="client_id" value="{{ $client->id }}">
                     <input type="hidden" name="auth_token" value="{{ $authToken }}">
-                    <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 w-full" id="authorizeButton">
+                    <button type="submit" @disabled($teams->count() === 0) class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 w-full" id="authorizeButton">
                         <span id="authorizeText">Authorize</span>
 
                         <svg id="loadingSpinner" class="animate-spin -ml-1 mr-3 h-4 w-4 text-white hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Mcp\ApproveAuthorizationController;
 use App\Http\Middleware\SetApiTeamContext;
 use App\Mcp\Servers\RelaticleServer;
 use Illuminate\Support\Facades\Route;
@@ -12,6 +13,14 @@ $mcpPath = $mcpDomain ? '/' : '/mcp';
 $mcpMiddleware = ['auth:sanctum,api', 'throttle:mcp', SetApiTeamContext::class];
 
 Route::middleware('throttle:mcp-oauth')->group(static fn () => Mcp::oauthRoutes());
+
+// Defer registration until after Passport (which boots later) has registered its routes,
+// so our POST /oauth/authorize wins the dispatch slot in the route collection.
+app()->booted(static function (): void {
+    Route::middleware(['web', 'auth', 'throttle:mcp-oauth'])
+        ->post('/oauth/authorize', [ApproveAuthorizationController::class, 'approve'])
+        ->name('passport.authorizations.approve');
+});
 
 if ($mcpDomain) {
     Route::domain($mcpDomain)->group(function () use ($mcpPath, $mcpMiddleware): void {

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -31,6 +31,7 @@ arch()->preset()
         'App\Enums\EnumValues',
         'App\Enums\CustomFields\CustomFieldTrait',
         'App\Mcp',
+        'App\Http\Controllers\Mcp',
     ]);
 
 arch('strict types')
@@ -84,6 +85,7 @@ arch('avoid mutation')
         'App\Exceptions',
         'App\Filament',
         'App\Health',
+        'App\Http\Controllers\Mcp',
         'App\Http\Requests',
         'App\Http\Resources',
         'App\Jobs',
@@ -110,6 +112,7 @@ arch('avoid inheritance')
         'App\Console\Commands',
         'App\Exceptions',
         'App\Filament',
+        'App\Http\Controllers\Mcp',
         'App\Http\Requests',
         'App\Http\Resources',
         'App\Jobs',

--- a/tests/Feature/Mcp/OAuthTeamPickerTest.php
+++ b/tests/Feature/Mcp/OAuthTeamPickerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Mcp\ApproveAuthorizationController;
+use App\Http\Middleware\SetApiTeamContext;
+use App\Listeners\Mcp\CopyTeamIdToAccessToken;
+use App\Models\Passport\AuthCode;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Laravel\Passport\Client;
+use Laravel\Passport\Passport;
+
+mutates(
+    ApproveAuthorizationController::class,
+    AuthCode::class,
+    CopyTeamIdToAccessToken::class,
+    SetApiTeamContext::class,
+);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->personalTeam = $this->user->personalTeam();
+    $this->otherTeam = Team::factory()->create();
+    $this->otherTeam->users()->attach($this->user, ['role' => 'member']);
+    $this->user->refresh();
+
+    $this->client = Client::query()->forceCreate([
+        'id' => (string) Str::uuid(),
+        'name' => 'Test MCP Client',
+        'redirect_uris' => ['https://example.com/callback'],
+        'grant_types' => ['authorization_code', 'refresh_token'],
+        'revoked' => false,
+        'owner_type' => $this->user->getMorphClass(),
+        'owner_id' => $this->user->getKey(),
+    ]);
+});
+
+it('renders the consent view with the user\'s teams', function (): void {
+    $this->actingAs($this->user);
+
+    $response = $this->get('/oauth/authorize?'.http_build_query([
+        'client_id' => $this->client->getKey(),
+        'redirect_uri' => 'https://example.com/callback',
+        'response_type' => 'code',
+        'scope' => '',
+        'state' => 'test-state',
+        'code_challenge' => str_repeat('a', 43),
+        'code_challenge_method' => 'S256',
+    ]));
+
+    $response->assertOk();
+    $response->assertSee($this->personalTeam->name);
+    $response->assertSee($this->otherTeam->name);
+    $response->assertSee('name="team_id"', false);
+});
+
+it('rejects the approve POST without a team_id', function (): void {
+    $this->actingAs($this->user);
+
+    $this->get('/oauth/authorize?'.http_build_query([
+        'client_id' => $this->client->getKey(),
+        'redirect_uri' => 'https://example.com/callback',
+        'response_type' => 'code',
+        'scope' => '',
+        'state' => 'test-state',
+        'code_challenge' => str_repeat('a', 43),
+        'code_challenge_method' => 'S256',
+    ]));
+
+    $response = $this->from('/oauth/authorize')->post('/oauth/authorize', [
+        'state' => 'test-state',
+        'client_id' => $this->client->getKey(),
+        'auth_token' => session('authToken'),
+    ]);
+
+    $response->assertSessionHasErrors('team_id');
+});
+
+it('rejects the approve POST when the user does not belong to the team', function (): void {
+    $foreignTeam = Team::factory()->create();
+
+    $this->actingAs($this->user);
+
+    $this->get('/oauth/authorize?'.http_build_query([
+        'client_id' => $this->client->getKey(),
+        'redirect_uri' => 'https://example.com/callback',
+        'response_type' => 'code',
+        'scope' => '',
+        'state' => 'test-state',
+        'code_challenge' => str_repeat('a', 43),
+        'code_challenge_method' => 'S256',
+    ]));
+
+    $response = $this->post('/oauth/authorize', [
+        'state' => 'test-state',
+        'client_id' => $this->client->getKey(),
+        'auth_token' => session('authToken'),
+        'team_id' => $foreignTeam->getKey(),
+    ]);
+
+    $response->assertForbidden();
+});
+
+it('persists the chosen team_id onto the auth code', function (): void {
+    $this->actingAs($this->user);
+
+    $this->get('/oauth/authorize?'.http_build_query([
+        'client_id' => $this->client->getKey(),
+        'redirect_uri' => 'https://example.com/callback',
+        'response_type' => 'code',
+        'scope' => '',
+        'state' => 'test-state',
+        'code_challenge' => str_repeat('a', 43),
+        'code_challenge_method' => 'S256',
+    ]));
+
+    $this->post('/oauth/authorize', [
+        'state' => 'test-state',
+        'client_id' => $this->client->getKey(),
+        'auth_token' => session('authToken'),
+        'team_id' => $this->otherTeam->getKey(),
+    ])->assertRedirect();
+
+    $authCode = DB::table('oauth_auth_codes')
+        ->where('user_id', $this->user->getKey())
+        ->where('client_id', $this->client->getKey())
+        ->latest('expires_at')
+        ->first();
+
+    expect($authCode)->not->toBeNull();
+    expect($authCode->team_id)->toBe($this->otherTeam->getKey());
+});
+
+it('scopes MCP HTTP requests to the bound team and ignores X-Team-Id header', function (): void {
+    // Mint a real access-token row with team_id set, simulating a fully completed
+    // OAuth flow. We hit the HTTP MCP endpoint so SetApiTeamContext actually fires.
+    $accessTokenId = Str::random(80);
+
+    DB::table('oauth_access_tokens')->insert([
+        'id' => $accessTokenId,
+        'user_id' => $this->user->getKey(),
+        'client_id' => $this->client->getKey(),
+        'team_id' => $this->otherTeam->getKey(),
+        'name' => 'test',
+        'scopes' => '["*"]',
+        'revoked' => false,
+        'created_at' => now(),
+        'updated_at' => now(),
+        'expires_at' => now()->addHour(),
+    ]);
+
+    // Use Passport::actingAs with an explicit team_id binding on the access token.
+    Passport::actingAs($this->user, scopes: ['*']);
+    $this->user->currentAccessToken()->team_id = $this->otherTeam->getKey();
+
+    $response = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'who-ami-tool',
+            'arguments' => (object) [],
+        ],
+    ], [
+        // Deliberately point header at personal team — should be IGNORED.
+        'X-Team-Id' => $this->personalTeam->getKey(),
+    ]);
+
+    $response->assertOk();
+    expect((string) $response->getContent())->toContain($this->otherTeam->getKey());
+    expect((string) $response->getContent())->not->toContain($this->personalTeam->getKey());
+});
+
+it('rejects an MCP request when a Passport token has no team_id', function (): void {
+    Passport::actingAs($this->user, scopes: ['*']);
+    // Intentionally do NOT set team_id — simulates a malformed token created
+    // outside our consent flow. SetApiTeamContext should return null → request fails.
+
+    $response = $this->postJson('/mcp', [
+        'jsonrpc' => '2.0',
+        'id' => 1,
+        'method' => 'tools/call',
+        'params' => [
+            'name' => 'who-ami-tool',
+            'arguments' => (object) [],
+        ],
+    ]);
+
+    // resolveTeam() returned null. The exact failure mode depends on how
+    // SetApiTeamContext handles a null team (read its handle() method).
+    // The contract: not a 200 OK. Most likely 403 or 422.
+    expect($response->status())->not->toBe(200);
+});
+
+it('still honors a Sanctum personal access token with its own team_id', function (): void {
+    $pat = $this->user->createToken('test-pat', ['*']);
+
+    // Pin the PAT to the other team (the PersonalAccessToken model has $team_id).
+    $pat->accessToken->forceFill(['team_id' => $this->otherTeam->getKey()])->save();
+
+    $response = $this->withHeaders(['Authorization' => 'Bearer '.$pat->plainTextToken])
+        ->postJson('/mcp', [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'method' => 'tools/call',
+            'params' => [
+                'name' => 'who-ami-tool',
+                'arguments' => (object) [],
+            ],
+        ]);
+
+    $response->assertOk();
+    expect((string) $response->getContent())->toContain($this->otherTeam->getKey());
+});


### PR DESCRIPTION
## Summary

Adds a single-select team picker to the MCP OAuth consent screen. The user explicitly chooses which one team their Claude/ChatGPT connector will access; the issued access token is bound to that team for its full lifetime; every MCP request resolves to the bound team regardless of `X-Team-Id` headers or subsequent `currentTeam` changes.

This closes the multi-team UX gap flagged during PR #255 deep-review (matches Oh Dear's consent flow but constrained to single-team selection per the user's directive).

**Stacked on PR #255.** When #255 merges, GitHub will auto-rebase the base to `main`.

## How it works

1. **GET `/oauth/authorize`** view payload is extended via the existing `Passport::authorizationView()` callback to pass `$teams` (`$user->allTeams()`) and `$selectedTeamId` (default = `currentTeam`).
2. **POST `/oauth/authorize`** is overridden in `routes/ai.php` (registered inside `app()->booted()` so it wins the route dispatch despite provider load order). Routes to `App\Http\Controllers\Mcp\ApproveAuthorizationController` which validates `team_id` (size 26, user must belong to team) → stashes `mcp.oauth.team_id` in session → delegates to Passport's stock `parent::approve(...)`.
3. A custom `AuthCode` model (registered via `Passport::useAuthCodeModel()`) reads `mcp.oauth.team_id` from session on its `creating` event and persists it to the new `team_id` column on `oauth_auth_codes`.
4. A listener on `Laravel\Passport\Events\AccessTokenCreated` reads the `code` from the current request, looks up the auth code (still queryable; Passport revokes but doesn't delete), and writes its `team_id` to the new access token row.
5. `SetApiTeamContext::resolveTeam()` now has two strict paths:
   - **Passport tokens**: `team_id` is authoritative; `X-Team-Id` and `currentTeam` are ignored. Missing `team_id` → return null → request rejected (fail-closed).
   - **Sanctum personal access tokens**: unchanged. PAT-pinned team → `X-Team-Id` → `currentTeam` fallback, exactly as today.

## Dual auth paths

Two authentication methods coexist by design:

- **Sanctum personal access tokens** — created by the user from the Access Tokens page; optionally pinned to one team at creation time. Used by Cursor, VS Code, MCP Inspector, and any bearer-token client. **Unchanged.**
- **Passport OAuth tokens** — issued by the new consent flow. Always carry a `team_id` from the picker. Used by Claude.ai, Claude Desktop, ChatGPT, and any OAuth + DCR client.

No "legacy" Passport tokens exist because OAuth is not yet in production. Every Passport token issued from day one will carry `team_id`. A Passport token without `team_id` is therefore malformed (e.g., created outside the consent flow) and the request is rejected.

## UX

- Picker default: user's `currentTeam`.
- Eligible teams: `$user->allTeams()` (owned + member).
- User in 0 teams: error block shown, Approve button disabled.
- Switching teams: revoke the connector and re-authorize. Standard OAuth pattern.

## Test plan

- [x] Consent view renders team radios for users with >0 teams
- [x] Approve POST without `team_id` → session error (validation rejects)
- [x] Approve POST with foreign `team_id` → 403
- [x] Auth code row persists the chosen `team_id`
- [x] MCP HTTP requests with a bound Passport token resolve to the chosen team
- [x] `X-Team-Id` header is ignored for Passport tokens with `team_id` set
- [x] Passport tokens without `team_id` (malformed/bypass) are rejected (non-200)
- [x] Sanctum PATs continue to work with their own `team_id` pin
- [x] PHPStan: 0 new errors
- [x] Pint: clean
- [x] Rector: clean (Passport models excluded from `AddHasFactoryToModelsRector`)
- [x] Type coverage: 100%
- [x] MCP suite: 194/194 (187 prior + 7 new)
- [ ] Manual smoke via MCP Inspector against a multi-team user

## Deploy notes

- New migration: `php artisan migrate` adds nullable `team_id char(26)` columns to `oauth_auth_codes` and `oauth_access_tokens`. Safe additive change; no `down()`.
- No env vars to set.
- Stacked on PR #255 — merge after #255.

## Files (11 commits)

\`\`\`
c8a2da45 chore(mcp): exclude Passport models from rector HasFactory rule
8b989a34 test(mcp): cover OAuth team picker end-to-end flow
dffffd78 feat(mcp): honor Passport access-token team_id when scoping requests
adb253cb feat(mcp): add team picker to OAuth consent view
7829cd80 feat(mcp): route OAuth approve to custom controller via routes/ai.php
df679e66 feat(mcp): add custom OAuth approve controller with team validation
8936c77b feat(mcp): pass user teams to OAuth consent view
7ef1f834 feat(mcp): register custom AuthCode model and access-token listener
5fdb813e feat(mcp): copy team_id from auth code to access token on creation
5be03ef8 feat(mcp): add custom Passport AuthCode model with team_id persistence
5500ddbd feat(mcp): add team_id column to oauth auth_codes and access_tokens
\`\`\`