### PR TITLE
chore: track polyscope workspace setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ api.json
 /storage/app/scribe
 /tests/Feature/Scribe
 .context
-/bin/setup-preview.sh
 .gstack/
 test-results.xml
 

--- a/bin/setup-workspace.sh
+++ b/bin/setup-workspace.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Bootstrap a Polyscope workspace: refresh dependencies and point .env at
+# the workspace's own hostname.
+#
+# Polyscope creates each workspace as a copy-on-write clone of the base repo
+# (vendor/, node_modules/, and .env are copied). The database stays shared
+# across workspaces. We rewrite APP_URL and SESSION_DOMAIN so absolute URLs
+# and session cookies match `<workspace>.test`.
+#
+# Mac-only: uses BSD sed (`sed -i ''`). Polyscope itself is macOS-only.
+
+set -euo pipefail
+
+WORKSPACE="$(basename "$PWD")"
+WORKSPACE_HOST="${WORKSPACE}.test"
+
+if [[ ! -f .env ]]; then
+    echo "✗ .env not found in $(pwd)" >&2
+    exit 1
+fi
+
+echo "→ Refreshing PHP dependencies"
+composer install --no-interaction --prefer-dist
+
+echo "→ Refreshing JS dependencies"
+npm ci
+
+echo "→ Pointing .env at ${WORKSPACE_HOST}"
+sed -i '' "s|^APP_URL=.*|APP_URL=https://${WORKSPACE_HOST}|" .env
+sed -i '' "s|^SESSION_DOMAIN=.*|SESSION_DOMAIN=.${WORKSPACE_HOST}|" .env
+
+echo "→ Building frontend assets"
+npm run build
+
+echo "✓ Workspace ready: https://${WORKSPACE_HOST}"

--- a/polyscope.json
+++ b/polyscope.json
@@ -3,7 +3,7 @@
         "setup": [
             "herd link",
             "herd secure",
-            "bin/setup-preview.sh"
+            "bin/setup-workspace.sh"
         ],
         "archive": [
             "herd unsecure",


### PR DESCRIPTION
## Summary
- Move `bin/setup-preview.sh` out of `.gitignore` and rename to `bin/setup-workspace.sh` so every Polyscope user shares the same workspace bootstrap.
- Rewrite `APP_URL` (in addition to `SESSION_DOMAIN`) to `<workspace>.test` so absolute URLs, signed routes, and mail links match the workspace hostname.
- Add a guard for a missing `.env`, switch to `set -euo pipefail`, and keep the script Mac-only (BSD sed) since Polyscope is macOS-only.

## Test plan
- [ ] Create a fresh Polyscope workspace and confirm `setup` runs cleanly
- [ ] Verify `.env` ends up with `APP_URL=https://<workspace>.test` and `SESSION_DOMAIN=.<workspace>.test`
- [ ] Confirm `https://<workspace>.test` loads and you can sign in (session cookie scoped correctly)