### PR TITLE
fix(email): scope email_shares by team_id + protected_recipients index

### DIFF
--- a/database/factories/EmailShareFactory.php
+++ b/database/factories/EmailShareFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
@@ -21,6 +22,7 @@ final class EmailShareFactory extends Factory
     {
         return [
             'email_id' => Email::factory(),
+            'team_id' => fn (array $attributes): mixed => Email::query()->whereKey($attributes['email_id'])->value('team_id') ?? Team::factory(),
             'shared_by' => User::factory(),
             'shared_with' => User::factory(),
             'tier' => EmailPrivacyTier::FULL->value,

--- a/database/migrations/2026_03_21_050520_create_email_shares_table.php
+++ b/database/migrations/2026_03_21_050520_create_email_shares_table.php
@@ -12,12 +12,14 @@ return new class extends Migration
     {
         Schema::create('email_shares', function (Blueprint $table): void {
             $table->ulid('id')->primary();
+            $table->foreignUlid('team_id')->constrained()->cascadeOnDelete();
             $table->foreignUlid('email_id')->constrained('emails')->cascadeOnDelete();
             $table->foreignUlid('shared_by')->constrained('users')->cascadeOnDelete();
             $table->foreignUlid('shared_with')->constrained('users')->cascadeOnDelete();
             $table->string('tier', 30);                      // metadata_only | subject | full
             $table->timestamps();
 
+            $table->index(['team_id', 'shared_with']);
             $table->index(['shared_with', 'email_id']);
             $table->unique(['email_id', 'shared_with'], 'email_shares_email_user_unique');
         });

--- a/database/migrations/2026_03_21_050549_create_protected_recipients_table.php
+++ b/database/migrations/2026_03_21_050549_create_protected_recipients_table.php
@@ -17,6 +17,8 @@ return new class extends Migration
             $table->string('value');
             $table->foreignUlid('created_by')->constrained('users')->cascadeOnDelete();
             $table->timestamps();
+
+            $table->index(['team_id', 'type', 'value']);
         });
     }
 };

--- a/packages/EmailIntegration/src/Models/EmailShare.php
+++ b/packages/EmailIntegration/src/Models/EmailShare.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Models;
 
+use App\Models\Team;
 use App\Models\User;
 use Database\Factories\EmailShareFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -24,11 +25,20 @@ final class EmailShare extends Model
     }
 
     protected $fillable = [
+        'team_id',
         'email_id',
         'shared_by',
         'shared_with',
         'tier',
     ];
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
 
     /**
      * @return BelongsTo<Email, $this>

--- a/packages/EmailIntegration/src/Services/EmailSharingService.php
+++ b/packages/EmailIntegration/src/Services/EmailSharingService.php
@@ -23,6 +23,7 @@ final readonly class EmailSharingService
             'email_id' => $email->getKey(),
             'shared_with' => $sharedWith->getKey(),
         ], [
+            'team_id' => $email->team_id,
             'shared_by' => $sharedBy->getKey(),
             'tier' => $tier->value,
         ]);


### PR DESCRIPTION
## Summary
Addresses deep-review **Info #29** on PR #237.

- `email_shares`: add `team_id` foreign key with cascade-on-delete + `(team_id, shared_with)` index for cheap per-tenant scoping. Cross-team queries no longer need to join through `emails`.
- `protected_recipients`: add a `(team_id, type, value)` composite index. The column already existed; only the index was missing.
- `EmailShare` model: `team_id` added to `$fillable` and a `team()` BelongsTo relation.
- `EmailShareFactory`: defaults `team_id` from the referenced email so factory-created shares stay tenant-consistent; falls back to `Team::factory()` when no email lookup is possible.
- `EmailSharingService::shareEmail`: writes `team_id` from `$email->team_id` on `updateOrCreate`.

## Why
Reviewer flagged that `email_shares` had no `team_id` at all and `protected_recipients` had the column but no index, forcing app-layer joins for tenant scoping. Adding the column + index gives the privacy/sharing layer cheap, indexed cross-team filters without ambient-state assumptions.

## Test plan
- [ ] `vendor/bin/pint --dirty --format agent` — passes
- [ ] `vendor/bin/rector --dry-run` — clean
- [ ] `vendor/bin/phpstan analyse` — 0 errors
- [ ] `composer test:type-coverage` — 100%
- [ ] `php artisan test --compact tests/Feature/EmailIntegration/` — green (could not run in workspace; Postgres test instance on `127.0.0.1:5433` not reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)