### PR TITLE
fix(email): handle OAuth callback exceptions with friendly notification

### DIFF
--- a/packages/EmailIntegration/src/Controllers/CallbackController.php
+++ b/packages/EmailIntegration/src/Controllers/CallbackController.php
@@ -8,13 +8,16 @@ use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\InvalidStateException;
 use Laravel\Socialite\Two\User as TwoUser;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use RuntimeException;
+use Throwable;
 
 final readonly class CallbackController
 {
@@ -25,7 +28,17 @@ final readonly class CallbackController
 
         $driver = Socialite::driver($this->resolveDriver($provider));
 
-        $socialUser = $driver->user();
+        try {
+            $socialUser = $driver->user();
+        } catch (InvalidStateException) {
+            Log::warning('OAuth callback state mismatch.', ['provider' => $provider, 'user_id' => $user->getKey()]);
+
+            return $this->redirectWithError($user, 'Your sign-in session expired. Please reconnect the account.');
+        } catch (Throwable $e) {
+            Log::error('OAuth callback failed.', ['provider' => $provider, 'user_id' => $user->getKey(), 'exception' => $e]);
+
+            return $this->redirectWithError($user, 'We could not connect that account. Please try again.');
+        }
 
         throw_unless($socialUser instanceof TwoUser, RuntimeException::class, "Socialite driver [{$provider}] returned an unexpected user type.");
 
@@ -72,5 +85,12 @@ final readonly class CallbackController
             'azure' => 'azure',
             default => $provider,
         };
+    }
+
+    private function redirectWithError(User $user, string $message): RedirectResponse
+    {
+        return redirect(EmailAccountsPage::getUrl([
+            'tenant' => $user->currentTeam->slug,
+        ]))->with('error', $message);
     }
 }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -40,6 +40,7 @@ final class EmailAccountsPage extends Page
     public function mount(): void
     {
         $this->sendSuccessNotification();
+        $this->sendErrorNotification();
         $this->connectedAccounts = $this->getAccounts();
     }
 
@@ -231,6 +232,16 @@ final class EmailAccountsPage extends Page
             Notification::make()
                 ->title(Session::get('success'))
                 ->success()
+                ->send();
+        }
+    }
+
+    public function sendErrorNotification(): void
+    {
+        if (Session::has('error')) {
+            Notification::make()
+                ->title(Session::get('error'))
+                ->danger()
                 ->send();
         }
     }

--- a/tests/Feature/EmailIntegration/EmailCallbackControllerTest.php
+++ b/tests/Feature/EmailIntegration/EmailCallbackControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\InvalidStateException;
+use Relaticle\EmailIntegration\Controllers\CallbackController;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
+
+mutates(CallbackController::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    Filament::setTenant($this->user->currentTeam);
+});
+
+it('redirects with a flashed error when Socialite throws InvalidStateException', function (): void {
+    Socialite::shouldReceive('driver')->andReturnSelf();
+    Socialite::shouldReceive('user')->andThrow(new InvalidStateException);
+
+    $response = $this->get(route('email-accounts.callback', ['provider' => 'gmail']));
+
+    $response->assertRedirect(EmailAccountsPage::getUrl([
+        'tenant' => $this->user->currentTeam->slug,
+    ], panel: 'app'));
+    $response->assertSessionHas('error', 'Your sign-in session expired. Please reconnect the account.');
+});
+
+it('redirects with a generic error when Socialite throws any other exception', function (): void {
+    Socialite::shouldReceive('driver')->andReturnSelf();
+    Socialite::shouldReceive('user')->andThrow(new RuntimeException('boom'));
+
+    $response = $this->get(route('email-accounts.callback', ['provider' => 'gmail']));
+
+    $response->assertRedirect();
+    $response->assertSessionHas('error', 'We could not connect that account. Please try again.');
+});


### PR DESCRIPTION
## Summary

Addresses **deep review info #30** from PR #237:
> `packages/EmailIntegration/src/Controllers/CallbackController.php:23-66` — Socialite's default state validation is in place. No try/catch around `$driver->user()` — `InvalidStateException` shows a stack trace if `APP_DEBUG=true`. Wrap in try/catch and redirect with a friendly notification.

## Changes

- `CallbackController` — wrap `$driver->user()` in try/catch.
  - `InvalidStateException` → redirect with "Your sign-in session expired. Please reconnect the account." (warning-logged).
  - any other `Throwable` → redirect with "We could not connect that account. Please try again." (error-logged with exception).
  - Both log `provider` + `user_id` for support.
- `EmailAccountsPage::mount()` — call new `sendErrorNotification()` so flashed `error` shows as a Filament danger notification (mirrors existing `sendSuccessNotification()`).
- `tests/Feature/EmailIntegration/EmailCallbackControllerTest.php` — two cases covering `InvalidStateException` and generic exception branches.

## Verification

- `vendor/bin/pint --dirty --format agent` → pass
- `vendor/bin/phpstan analyse` → 0 errors
- `vendor/bin/rector --dry-run` → clean
- `composer test:type-coverage` → 100.0%
- Tests not executed in this env (local Postgres on port 5433 unavailable); CI will run them.

## Test plan

- [ ] CI green
- [ ] Manually trigger a callback with a mismatched state (or expired auth session) and verify the friendly notification appears on `EmailAccountsPage` instead of a stack trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)