### PR TITLE
fix(import): custom-field re-import skip + tags-input option list (#282)

### DIFF
--- a/app/Actions/CustomFields/EnsureTagOptionsExist.php
+++ b/app/Actions/CustomFields/EnsureTagOptionsExist.php
@@ -6,6 +6,7 @@ namespace App\Actions\CustomFields;
 
 use App\Enums\CustomFieldType;
 use App\Models\CustomField;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Collection;
 
 /**
@@ -14,7 +15,7 @@ use Illuminate\Support\Collection;
  * Gated strictly to the `tags-input` field type — email/phone are also arbitrary
  * multi-choice fields but must NOT grow an option list.
  */
-final class EnsureTagOptionsExist
+final readonly class EnsureTagOptionsExist
 {
     public function handle(CustomField $field, mixed $values): void
     {
@@ -52,11 +53,16 @@ final class EnsureTagOptionsExist
                 continue;
             }
 
-            $field->options()->create([
-                $tenantKey => $field->{$tenantKey},
-                'name' => $value,
-                'sort_order' => ++$sortOrder,
-            ]);
+            try {
+                $field->options()->create([
+                    $tenantKey => $field->{$tenantKey},
+                    'name' => $value,
+                    'sort_order' => ++$sortOrder,
+                ]);
+            } catch (UniqueConstraintViolationException) {
+                // A concurrent import/edit created this option first — the option
+                // now exists, so treat it as a no-op rather than failing the row.
+            }
 
             $existing[$key] = true;
         }

--- a/app/Actions/CustomFields/EnsureTagOptionsExist.php
+++ b/app/Actions/CustomFields/EnsureTagOptionsExist.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\CustomFields;
+
+use App\Enums\CustomFieldType;
+use App\Models\CustomField;
+use BackedEnum;
+use Illuminate\Support\Collection;
+
+/**
+ * Promote newly-seen tags-input values into the field's CustomFieldOption list.
+ *
+ * Gated strictly to the `tags-input` field type — email/phone are also arbitrary
+ * multi-choice fields but must NOT grow an option list.
+ */
+final class EnsureTagOptionsExist
+{
+    public function handle(CustomField $field, mixed $values): void
+    {
+        if ($this->fieldType($field) !== CustomFieldType::TAGS_INPUT->value) {
+            return;
+        }
+
+        $candidates = collect($values instanceof Collection ? $values->all() : (array) $values)
+            ->filter(fn (mixed $value): bool => is_string($value) && trim($value) !== '')
+            ->map(fn (string $value): string => trim($value))
+            ->unique()
+            ->values();
+
+        if ($candidates->isEmpty()) {
+            return;
+        }
+
+        $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+
+        $existing = $field->options()
+            ->withoutGlobalScopes()
+            ->pluck('name')
+            ->map(fn (?string $name): string => mb_strtolower(trim((string) $name)))
+            ->flip();
+
+        $sortOrder = (int) $field->options()
+            ->withoutGlobalScopes()
+            ->max('sort_order');
+
+        foreach ($candidates as $value) {
+            $key = mb_strtolower($value);
+
+            if ($existing->has($key)) {
+                continue;
+            }
+
+            $field->options()->create([
+                $tenantKey => $field->{$tenantKey},
+                'name' => $value,
+                'sort_order' => ++$sortOrder,
+            ]);
+
+            $existing->put($key, true);
+        }
+    }
+
+    private function fieldType(CustomField $field): string
+    {
+        return $field->type instanceof BackedEnum ? $field->type->value : (string) $field->type;
+    }
+}

--- a/app/Actions/CustomFields/EnsureTagOptionsExist.php
+++ b/app/Actions/CustomFields/EnsureTagOptionsExist.php
@@ -4,28 +4,28 @@ declare(strict_types=1);
 
 namespace App\Actions\CustomFields;
 
-use App\Enums\CustomFieldType;
 use App\Models\CustomField;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Collection;
 
 /**
- * Promote newly-seen tags-input values into the field's CustomFieldOption list.
+ * Promote newly-seen values into a field's user-managed option list.
  *
- * Gated strictly to the `tags-input` field type — email/phone are also arbitrary
- * multi-choice fields but must NOT grow an option list.
+ * Gated to field types that accept arbitrary values AND own an option list
+ * (tags-input). Email/phone/link also accept arbitrary values but own no
+ * option list, so they are excluded — see CustomField::promotesValuesToOptions().
  */
 final readonly class EnsureTagOptionsExist
 {
     public function handle(CustomField $field, mixed $values): void
     {
-        if ($field->type !== CustomFieldType::TAGS_INPUT->value) {
+        if (! $field->promotesValuesToOptions()) {
             return;
         }
 
         $candidates = collect($values instanceof Collection ? $values->all() : (array) $values)
-            ->filter(fn (mixed $value): bool => is_string($value) && trim($value) !== '')
-            ->map(fn (string $value): string => trim($value))
+            ->map(fn (mixed $value): string => is_string($value) ? trim($value) : '')
+            ->filter(fn (string $value): bool => $value !== '')
             ->unique()
             ->values();
 
@@ -35,16 +35,15 @@ final readonly class EnsureTagOptionsExist
 
         $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
 
+        $options = $field->options()->withoutGlobalScopes()->get(['name', 'sort_order']);
+
         /** @var array<string, true> $existing */
-        $existing = $field->options()
-            ->withoutGlobalScopes()
+        $existing = $options
             ->pluck('name')
             ->mapWithKeys(fn (?string $name): array => [mb_strtolower(trim((string) $name)) => true])
             ->all();
 
-        $sortOrder = (int) $field->options()
-            ->withoutGlobalScopes()
-            ->max('sort_order');
+        $sortOrder = (int) $options->max('sort_order');
 
         foreach ($candidates as $value) {
             $key = mb_strtolower($value);

--- a/app/Actions/CustomFields/EnsureTagOptionsExist.php
+++ b/app/Actions/CustomFields/EnsureTagOptionsExist.php
@@ -6,7 +6,6 @@ namespace App\Actions\CustomFields;
 
 use App\Enums\CustomFieldType;
 use App\Models\CustomField;
-use BackedEnum;
 use Illuminate\Support\Collection;
 
 /**
@@ -19,7 +18,7 @@ final class EnsureTagOptionsExist
 {
     public function handle(CustomField $field, mixed $values): void
     {
-        if ($this->fieldType($field) !== CustomFieldType::TAGS_INPUT->value) {
+        if ($field->type !== CustomFieldType::TAGS_INPUT->value) {
             return;
         }
 
@@ -35,11 +34,12 @@ final class EnsureTagOptionsExist
 
         $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
 
+        /** @var array<string, true> $existing */
         $existing = $field->options()
             ->withoutGlobalScopes()
             ->pluck('name')
-            ->map(fn (?string $name): string => mb_strtolower(trim((string) $name)))
-            ->flip();
+            ->mapWithKeys(fn (?string $name): array => [mb_strtolower(trim((string) $name)) => true])
+            ->all();
 
         $sortOrder = (int) $field->options()
             ->withoutGlobalScopes()
@@ -48,7 +48,7 @@ final class EnsureTagOptionsExist
         foreach ($candidates as $value) {
             $key = mb_strtolower($value);
 
-            if ($existing->has($key)) {
+            if (isset($existing[$key])) {
                 continue;
             }
 
@@ -58,12 +58,7 @@ final class EnsureTagOptionsExist
                 'sort_order' => ++$sortOrder,
             ]);
 
-            $existing->put($key, true);
+            $existing[$key] = true;
         }
-    }
-
-    private function fieldType(CustomField $field): string
-    {
-        return $field->type instanceof BackedEnum ? $field->type->value : (string) $field->type;
     }
 }

--- a/app/Models/CustomField.php
+++ b/app/Models/CustomField.php
@@ -23,6 +23,16 @@ final class CustomField extends BaseCustomField
 {
     use HasUlids;
 
+    /**
+     * Whether saving an arbitrary value to this field should promote that value
+     * into the field's user-managed option list. True for tags-input; false for
+     * email/phone/link, which also accept arbitrary values but own no option list.
+     */
+    public function promotesValuesToOptions(): bool
+    {
+        return $this->typeData->acceptsArbitraryValues && ! $this->typeData->withoutUserOptions;
+    }
+
     /** @return CustomFieldFactory */
     protected static function newFactory(): Factory
     {

--- a/app/Models/CustomFieldValue.php
+++ b/app/Models/CustomFieldValue.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Observers\CustomFieldValueObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Relaticle\CustomFields\Models\CustomFieldValue as BaseCustomFieldValue;
 use Relaticle\CustomFields\Models\Scopes\TenantScope;
 
+#[ObservedBy(CustomFieldValueObserver::class)]
 #[ScopedBy([TenantScope::class])]
 final class CustomFieldValue extends BaseCustomFieldValue
 {

--- a/app/Observers/CustomFieldValueObserver.php
+++ b/app/Observers/CustomFieldValueObserver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Actions\CustomFields\EnsureTagOptionsExist;
+use App\Models\CustomFieldValue;
+
+final readonly class CustomFieldValueObserver
+{
+    public function __construct(
+        private EnsureTagOptionsExist $ensureTagOptionsExist,
+    ) {}
+
+    public function saved(CustomFieldValue $value): void
+    {
+        $field = $value->customField;
+
+        if ($field === null) {
+            return;
+        }
+
+        $this->ensureTagOptionsExist->handle($field, $value->json_value);
+    }
+}

--- a/app/Observers/CustomFieldValueObserver.php
+++ b/app/Observers/CustomFieldValueObserver.php
@@ -15,6 +15,13 @@ final readonly class CustomFieldValueObserver
 
     public function saved(CustomFieldValue $value): void
     {
+        // Only multi-value fields (tags-input et al.) store an array in json_value;
+        // scalar-typed fields leave it blank. Short-circuit before loading the
+        // customField relation so ordinary custom-field saves incur no extra query.
+        if (blank($value->json_value)) {
+            return;
+        }
+
         $field = $value->customField;
 
         // @phpstan-ignore identical.alwaysFalse (the customField relation can resolve to null for an orphaned value row)

--- a/app/Observers/CustomFieldValueObserver.php
+++ b/app/Observers/CustomFieldValueObserver.php
@@ -17,6 +17,7 @@ final readonly class CustomFieldValueObserver
     {
         $field = $value->customField;
 
+        // @phpstan-ignore identical.alwaysFalse (the customField relation can resolve to null for an orphaned value row)
         if ($field === null) {
             return;
         }

--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -6,7 +6,6 @@ namespace Relaticle\ImportWizard\Jobs;
 
 use App\Actions\CustomFields\EnsureTagOptionsExist;
 use App\Enums\CreationSource;
-use App\Enums\CustomFieldType;
 use App\Models\CustomField;
 use App\Models\User;
 use Carbon\Carbon;
@@ -357,7 +356,7 @@ final class ExecuteImportJob implements ShouldQueue
                 $safeValue = $this->mergeWithExistingMultiChoiceValues($record, $cf, $safeValue, $tenantKey);
             }
 
-            if ($cf->type === CustomFieldType::TAGS_INPUT->value && is_array($safeValue)) {
+            if ($cf->promotesValuesToOptions() && is_array($safeValue)) {
                 $this->accumulateTagOptions($cf, $safeValue);
             }
 

--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\ImportWizard\Jobs;
 
+use App\Actions\CustomFields\EnsureTagOptionsExist;
 use App\Enums\CreationSource;
 use App\Models\CustomField;
 use App\Models\User;
@@ -349,6 +350,10 @@ final class ExecuteImportJob implements ShouldQueue
 
             if (! $isCreate && $cf->typeData->dataType === FieldDataType::MULTI_CHOICE && is_array($safeValue)) {
                 $safeValue = $this->mergeWithExistingMultiChoiceValues($record, $cf, $safeValue, $tenantKey);
+            }
+
+            if (is_array($safeValue)) {
+                app(EnsureTagOptionsExist::class)->handle($cf, $safeValue);
             }
 
             $row = [

--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -357,9 +357,7 @@ final class ExecuteImportJob implements ShouldQueue
                 $safeValue = $this->mergeWithExistingMultiChoiceValues($record, $cf, $safeValue, $tenantKey);
             }
 
-            $cfType = $cf->type instanceof \BackedEnum ? $cf->type->value : (string) $cf->type;
-
-            if ($cfType === CustomFieldType::TAGS_INPUT->value && is_array($safeValue)) {
+            if ($cf->type === CustomFieldType::TAGS_INPUT->value && is_array($safeValue)) {
                 $this->accumulateTagOptions($cf, $safeValue);
             }
 

--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -481,7 +481,7 @@ final class ExecuteImportJob implements ShouldQueue
     private function flushTagOptions(): void
     {
         foreach ($this->pendingTagOptions as $pending) {
-            app(EnsureTagOptionsExist::class)->handle($pending['field'], $pending['values']);
+            resolve(EnsureTagOptionsExist::class)->handle($pending['field'], $pending['values']);
         }
 
         $this->pendingTagOptions = [];

--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -6,6 +6,7 @@ namespace Relaticle\ImportWizard\Jobs;
 
 use App\Actions\CustomFields\EnsureTagOptionsExist;
 use App\Enums\CreationSource;
+use App\Enums\CustomFieldType;
 use App\Models\CustomField;
 use App\Models\User;
 use Carbon\Carbon;
@@ -79,6 +80,9 @@ final class ExecuteImportJob implements ShouldQueue
     /** @var list<array<string, mixed>> */
     private array $pendingCustomFieldValues = [];
 
+    /** @var array<string, array{field: CustomField, values: array<int, string>}> */
+    private array $pendingTagOptions = [];
+
     public function __construct(
         private readonly string $importId,
         private readonly string $teamId,
@@ -138,6 +142,7 @@ final class ExecuteImportJob implements ShouldQueue
                         $this->flushProcessedRows($store);
                     }
                     $this->flushCustomFieldValues();
+                    $this->flushTagOptions();
                     $this->flushFailedRows($import);
                     $this->persistResults($import, $results);
                 });
@@ -352,8 +357,10 @@ final class ExecuteImportJob implements ShouldQueue
                 $safeValue = $this->mergeWithExistingMultiChoiceValues($record, $cf, $safeValue, $tenantKey);
             }
 
-            if (is_array($safeValue)) {
-                app(EnsureTagOptionsExist::class)->handle($cf, $safeValue);
+            $cfType = $cf->type instanceof \BackedEnum ? $cf->type->value : (string) $cf->type;
+
+            if ($cfType === CustomFieldType::TAGS_INPUT->value && is_array($safeValue)) {
+                $this->accumulateTagOptions($cf, $safeValue);
             }
 
             $row = [
@@ -453,6 +460,31 @@ final class ExecuteImportJob implements ShouldQueue
         }
 
         $this->pendingCustomFieldValues = [];
+    }
+
+    /** @param array<int, mixed> $values */
+    private function accumulateTagOptions(CustomField $cf, array $values): void
+    {
+        $code = $cf->code;
+
+        if (! isset($this->pendingTagOptions[$code])) {
+            $this->pendingTagOptions[$code] = ['field' => $cf, 'values' => []];
+        }
+
+        foreach ($values as $value) {
+            if (is_string($value) && trim($value) !== '') {
+                $this->pendingTagOptions[$code]['values'][] = $value;
+            }
+        }
+    }
+
+    private function flushTagOptions(): void
+    {
+        foreach ($this->pendingTagOptions as $pending) {
+            app(EnsureTagOptionsExist::class)->handle($pending['field'], $pending['values']);
+        }
+
+        $this->pendingTagOptions = [];
     }
 
     private function markProcessed(ImportRow $row): void

--- a/packages/ImportWizard/src/Support/EntityLinkResolver.php
+++ b/packages/ImportWizard/src/Support/EntityLinkResolver.php
@@ -8,6 +8,7 @@ use App\Models\CustomField;
 use App\Models\CustomFieldValue;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Relaticle\ImportWizard\Data\EntityLink;
 use Relaticle\ImportWizard\Data\MatchableField;
 
@@ -185,18 +186,50 @@ final class EntityLinkResolver
 
         $valueColumn = $customField->getValueColumn();
 
-        if ($valueColumn === 'json_value') {
-            return $this->resolveViaJsonColumn($link->targetEntity, $customField->getKey(), $uniqueValues);
+        $resolved = $valueColumn === 'json_value'
+            ? $this->resolveViaJsonColumn($link->targetEntity, $customField->getKey(), $uniqueValues)
+            : CustomFieldValue::query()
+                ->withoutGlobalScopes()
+                ->where('tenant_id', $this->teamId)
+                ->where('custom_field_id', $customField->id)
+                ->where('entity_type', $link->targetEntity)
+                ->whereIn($valueColumn, $uniqueValues)
+                ->pluck('entity_id', $valueColumn)
+                ->all();
+
+        return $this->rejectInaccessibleEntities($link->targetModelClass, $resolved);
+    }
+
+    /**
+     * Drop matches whose owning entity cannot be loaded for write (soft-deleted
+     * or belonging to another team). The matcher reads custom_field_values
+     * directly, bypassing model scopes; the executor loads records through the
+     * default-scoped model query, so an unfiltered match becomes a silently
+     * skipped row. Filtering here keeps the two in sync.
+     *
+     * @param  class-string<Model>  $modelClass
+     * @param  array<string, int|string>  $valueToEntityId
+     * @return array<string, int|string>
+     */
+    private function rejectInaccessibleEntities(string $modelClass, array $valueToEntityId): array
+    {
+        if ($valueToEntityId === []) {
+            return [];
         }
 
-        return CustomFieldValue::query()
-            ->withoutGlobalScopes()
-            ->where('tenant_id', $this->teamId)
-            ->where('custom_field_id', $customField->id)
-            ->where('entity_type', $link->targetEntity)
-            ->whereIn($valueColumn, $uniqueValues)
-            ->pluck('entity_id', $valueColumn)
-            ->all();
+        $keyName = (new $modelClass)->getKeyName();
+
+        $accessibleIds = $modelClass::query()
+            ->where('team_id', $this->teamId)
+            ->whereIn($keyName, array_values($valueToEntityId))
+            ->pluck($keyName)
+            ->map(fn (int|string $id): string => (string) $id)
+            ->flip();
+
+        return array_filter(
+            $valueToEntityId,
+            fn (int|string $entityId): bool => $accessibleIds->has((string) $entityId),
+        );
     }
 
     /**

--- a/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
@@ -6,10 +6,12 @@ use App\Filament\Resources\CompanyResource;
 use App\Filament\Resources\CompanyResource\Pages\ListCompanies;
 use App\Filament\Resources\CompanyResource\Pages\ViewCompany;
 use App\Models\Company;
+use App\Models\CustomField;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 
 mutates(CompanyResource::class);
 
@@ -197,4 +199,43 @@ it('denies non-team-member from viewing another team company', function (): void
     expect($this->user->can('view', $record))->toBeFalse()
         ->and($this->user->can('update', $record))->toBeFalse()
         ->and($this->user->can('delete', $record))->toBeFalse();
+});
+
+// --- Issue #282 Bug 3: adding a new tag while editing adds it to the option list ---
+
+it('adds a newly typed tags-input value to the option list when editing a company', function (): void {
+    $cf = CustomField::forceCreate([
+        'tenant_id' => $this->team->id,
+        'code' => 'edit_labels282',
+        'name' => 'Edit Labels',
+        'type' => 'tags-input',
+        'entity_type' => 'company',
+        'sort_order' => 50,
+        'active' => true,
+        'system_defined' => false,
+        'validation_rules' => [],
+        'settings' => new CustomFieldSettingsData,
+    ]);
+    $cf->options()->forceCreate([
+        'custom_field_id' => $cf->id,
+        'tenant_id' => $this->team->id,
+        'name' => 'Existing',
+        'sort_order' => 1,
+    ]);
+
+    $company = Company::factory()->recycle([$this->user, $this->team])->create();
+
+    livewire(ListCompanies::class)
+        ->callAction(
+            TestAction::make('edit')->table($company),
+            data: [
+                'name' => $company->name,
+                'custom_fields' => ['edit_labels282' => ['Existing', 'TypedDuringEdit']],
+            ],
+        )
+        ->assertHasNoActionErrors();
+
+    $optionNames = $cf->refresh()->options->pluck('name')->all();
+    expect($optionNames)->toContain('Existing')
+        ->toContain('TypedDuringEdit');
 });

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
@@ -2253,6 +2253,45 @@ it('does not auto-create record for custom field entity link', function (): void
     expect($companyCountAfter)->toBe($companyCountBefore);
 });
 
+// --- Issue #282 Bug 2: imported tags-input values become options ---
+
+it('adds a new imported tags-input value to the field option list', function (): void {
+    $cf = createTestCustomField($this, 'labels282', 'tags-input', 'company', ['Existing']);
+
+    createImportReadyStore($this, ['Name', 'Labels'], [
+        makeRow(2, ['Name' => 'Tagged Co 282', 'Labels' => 'Existing, BrandNewTag'], ['match_action' => RowMatchAction::Create->value]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Labels', target: 'custom_fields_labels282'),
+    ], ImportEntityType::Company);
+
+    runImportJob($this);
+
+    $company = Company::where('team_id', $this->team->id)->where('name', 'Tagged Co 282')->first();
+    $cfv = getTestCustomFieldValue($this, (string) $company->id, (string) $cf->id);
+
+    expect(collect($cfv->json_value)->all())->toContain('BrandNewTag');
+
+    $optionNames = $cf->refresh()->options->pluck('name')->all();
+    expect($optionNames)->toContain('Existing')
+        ->toContain('BrandNewTag');
+});
+
+it('does not duplicate an imported tag that already exists as an option (case-insensitive)', function (): void {
+    $cf = createTestCustomField($this, 'labels282b', 'tags-input', 'company', ['VIP']);
+
+    createImportReadyStore($this, ['Name', 'Labels'], [
+        makeRow(2, ['Name' => 'Dup Co 282', 'Labels' => 'vip'], ['match_action' => RowMatchAction::Create->value]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Labels', target: 'custom_fields_labels282b'),
+    ], ImportEntityType::Company);
+
+    runImportJob($this);
+
+    expect($cf->refresh()->options()->withoutGlobalScopes()->count())->toBe(1);
+});
+
 // --- Issue #282 Bug 1: soft-deleted records must not be matched ---
 
 it('does not match a soft-deleted company by domain (resolver)', function (): void {

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
@@ -19,13 +19,17 @@ use Illuminate\Support\Facades\Event;
 use Laravel\Jetstream\Events\TeamCreated;
 use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 use Relaticle\ImportWizard\Data\ColumnData;
+use Relaticle\ImportWizard\Data\EntityLink;
+use Relaticle\ImportWizard\Data\MatchableField;
 use Relaticle\ImportWizard\Enums\DateFormat;
+use Relaticle\ImportWizard\Enums\EntityLinkSource;
 use Relaticle\ImportWizard\Enums\ImportEntityType;
 use Relaticle\ImportWizard\Enums\ImportStatus;
 use Relaticle\ImportWizard\Enums\MatchBehavior;
 use Relaticle\ImportWizard\Enums\NumberFormat;
 use Relaticle\ImportWizard\Enums\RowMatchAction;
 use Relaticle\ImportWizard\Jobs\ExecuteImportJob;
+use Relaticle\ImportWizard\Jobs\ResolveMatchesJob;
 use Relaticle\ImportWizard\Models\Import;
 use Relaticle\ImportWizard\Store\ImportStore;
 use Relaticle\ImportWizard\Support\EntityLinkResolver;
@@ -2247,4 +2251,51 @@ it('does not auto-create record for custom field entity link', function (): void
 
     $companyCountAfter = Company::where('team_id', $this->team->id)->count();
     expect($companyCountAfter)->toBe($companyCountBefore);
+});
+
+// --- Issue #282 Bug 1: soft-deleted records must not be matched ---
+
+it('does not match a soft-deleted company by domain (resolver)', function (): void {
+    $domainField = CustomField::query()->withoutGlobalScopes()
+        ->where('tenant_id', $this->team->id)->where('entity_type', 'company')->where('code', 'domains')->first();
+
+    $live = Company::factory()->create(['name' => 'Live Co', 'team_id' => $this->team->id]);
+    CustomFieldValue::forceCreate(['custom_field_id' => $domainField->id, 'entity_type' => 'company', 'entity_id' => $live->id, 'tenant_id' => $this->team->id, 'json_value' => ['live282.com']]);
+
+    $trashed = Company::factory()->create(['name' => 'Trashed Co', 'team_id' => $this->team->id]);
+    CustomFieldValue::forceCreate(['custom_field_id' => $domainField->id, 'entity_type' => 'company', 'entity_id' => $trashed->id, 'tenant_id' => $this->team->id, 'json_value' => ['ghost282.com']]);
+    $trashed->delete();
+
+    $resolver = new EntityLinkResolver((string) $this->team->id);
+    $link = new EntityLink(key: 'self', source: EntityLinkSource::Relationship, targetEntity: 'company', targetModelClass: Company::class);
+    $matcher = MatchableField::domain('custom_fields_domains');
+
+    $resolved = $resolver->batchResolve($link, $matcher, ['live282.com', 'ghost282.com']);
+
+    expect((string) ($resolved['live282.com'] ?? 'null'))->toBe((string) $live->id)
+        ->and($resolved['ghost282.com'] ?? null)->toBeNull();
+});
+
+it('creates a new company when re-importing a domain whose company was soft-deleted', function (): void {
+    $domainField = CustomField::query()->withoutGlobalScopes()
+        ->where('tenant_id', $this->team->id)->where('entity_type', 'company')->where('code', 'domains')->first();
+
+    $original = Company::factory()->create(['name' => 'Acme Original 282', 'team_id' => $this->team->id]);
+    CustomFieldValue::forceCreate(['custom_field_id' => $domainField->id, 'entity_type' => 'company', 'entity_id' => $original->id, 'tenant_id' => $this->team->id, 'json_value' => ['acme282.com']]);
+    $original->delete();
+
+    createImportReadyStore($this, ['Name', 'Domain'], [
+        makeRow(2, ['Name' => 'Acme Reimport 282', 'Domain' => 'acme282.com']),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Domain', target: 'custom_fields_domains'),
+    ], ImportEntityType::Company);
+
+    (new ResolveMatchesJob($this->import->id))->handle();
+    runImportJob($this);
+
+    $import = $this->import->fresh();
+    expect($import->created_rows)->toBe(1)
+        ->and($import->skipped_rows)->toBe(0)
+        ->and(Company::where('team_id', $this->team->id)->where('name', 'Acme Reimport 282')->exists())->toBeTrue();
 });

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
@@ -2275,6 +2275,9 @@ it('adds a new imported tags-input value to the field option list', function ():
     $optionNames = $cf->refresh()->options->pluck('name')->all();
     expect($optionNames)->toContain('Existing')
         ->toContain('BrandNewTag');
+
+    $newOption = $cf->refresh()->options()->withoutGlobalScopes()->where('name', 'BrandNewTag')->first();
+    expect((int) $newOption->sort_order)->toBeGreaterThan(0);
 });
 
 it('does not duplicate an imported tag that already exists as an option (case-insensitive)', function (): void {
@@ -2290,6 +2293,21 @@ it('does not duplicate an imported tag that already exists as an option (case-in
     runImportJob($this);
 
     expect($cf->refresh()->options()->withoutGlobalScopes()->count())->toBe(1);
+});
+
+it('does not create options when importing an arbitrary email custom field', function (): void {
+    $cf = createTestCustomField($this, 'contact_emails282', 'email', 'company');
+
+    createImportReadyStore($this, ['Name', 'Emails'], [
+        makeRow(2, ['Name' => 'Email Co 282', 'Emails' => 'a@b.com, c@d.com'], ['match_action' => RowMatchAction::Create->value]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Emails', target: 'custom_fields_contact_emails282'),
+    ], ImportEntityType::Company);
+
+    runImportJob($this);
+
+    expect($cf->refresh()->options()->withoutGlobalScopes()->count())->toBe(0);
 });
 
 // --- Issue #282 Bug 1: soft-deleted records must not be matched ---

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
@@ -2316,6 +2316,8 @@ it('does not match a soft-deleted company by domain (resolver)', function (): vo
     $domainField = CustomField::query()->withoutGlobalScopes()
         ->where('tenant_id', $this->team->id)->where('entity_type', 'company')->where('code', 'domains')->first();
 
+    expect($domainField)->not->toBeNull();
+
     $live = Company::factory()->create(['name' => 'Live Co', 'team_id' => $this->team->id]);
     CustomFieldValue::forceCreate(['custom_field_id' => $domainField->id, 'entity_type' => 'company', 'entity_id' => $live->id, 'tenant_id' => $this->team->id, 'json_value' => ['live282.com']]);
 
@@ -2336,6 +2338,8 @@ it('does not match a soft-deleted company by domain (resolver)', function (): vo
 it('creates a new company when re-importing a domain whose company was soft-deleted', function (): void {
     $domainField = CustomField::query()->withoutGlobalScopes()
         ->where('tenant_id', $this->team->id)->where('entity_type', 'company')->where('code', 'domains')->first();
+
+    expect($domainField)->not->toBeNull();
 
     $original = Company::factory()->create(['name' => 'Acme Original 282', 'team_id' => $this->team->id]);
     CustomFieldValue::forceCreate(['custom_field_id' => $domainField->id, 'entity_type' => 'company', 'entity_id' => $original->id, 'tenant_id' => $this->team->id, 'json_value' => ['acme282.com']]);


### PR DESCRIPTION
Fixes the three import / custom-field issues reported in #282.

## Bugs fixed

### 1. Rows with a "Domain" value were skipped when re-importing after delete (data loss)
`Company` uses soft deletes, and a soft-deleted company keeps its `domains` custom-field value row intact. The import matcher (`EntityLinkResolver`) resolves the Domain matcher by reading `custom_field_values` directly (raw SQL / `withoutGlobalScopes()`), so it matched the **soft-deleted** company and marked the row as an Update against a record the executor can't load under the default scope — silently skipping it.

**Fix:** new `EntityLinkResolver::rejectInaccessibleEntities()` filters resolved matches through the same team-scoped, soft-delete-aware query the executor uses to load records. Trashed / cross-team matches are dropped, so the row correctly falls back to Create. Applies to all custom-field matchers (domain/email/phone).

### 2. Imported tags were not added to the field's option ("tag") list
A `tags-input` custom field accepts arbitrary values, but importing a new tag stored the value without ever creating a `CustomFieldOption`, so the tag never appeared in the field's option list (only in the record view).

**Fix:** new idempotent action `App\Actions\CustomFields\EnsureTagOptionsExist`, gated strictly to the `tags-input` type (email/phone are also arbitrary multi-choice and must not grow an option list). Wired into `ExecuteImportJob`, batched once per field per chunk (no per-row N+1).

### 3. New tags added while editing a record were not added to the list
The Filament edit form persists values via Eloquent but never created options for newly-typed tags.

**Fix:** new `CustomFieldValueObserver` (registered via `#[ObservedBy]` on `CustomFieldValue`) reuses the same `EnsureTagOptionsExist` action on save. The CSV import path uses a raw bulk upsert (no Eloquent events), so the two paths don't double-fire.

## Test plan
- New regression tests: resolver soft-delete exclusion + end-to-end re-import create (`ExecuteImportJobTest`), import tag → option creation incl. case-insensitive dedupe and email-gate (`ExecuteImportJobTest`), edit-form tag → option via the real Filament `EditAction` (`CompanyResourceTest`).
- `php artisan test tests/Feature/ImportWizard tests/Feature/Filament/App/Resources/CompanyResourceTest.php` → 368 passed, 1 pre-existing skip.
- Pint, Rector, PHPStan clean; type coverage 100%.

Closes #282.