### PR TITLE
refactor(email): move email/calendar Filament surfaces into EmailIntegration package

### DIFF
--- a/app/Filament/Resources/CompanyResource/Pages/CompanyEmailsPage.php
+++ b/app/Filament/Resources/CompanyResource/Pages/CompanyEmailsPage.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\CompanyResource\Pages;
 
-use App\Filament\Pages\BaseRecordEmailsPage;
 use App\Filament\Resources\CompanyResource;
+use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
 
 final class CompanyEmailsPage extends BaseRecordEmailsPage
 {

--- a/app/Filament/Resources/CompanyResource/RelationManagers/EmailsRelationManager.php
+++ b/app/Filament/Resources/CompanyResource/RelationManagers/EmailsRelationManager.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\CompanyResource\RelationManagers;
 
-use App\Filament\RelationManagers\BaseEmailsRelationManager;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
 
 final class EmailsRelationManager extends BaseEmailsRelationManager {}

--- a/app/Filament/Resources/CompanyResource/RelationManagers/MeetingsRelationManager.php
+++ b/app/Filament/Resources/CompanyResource/RelationManagers/MeetingsRelationManager.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\CompanyResource\RelationManagers;
 
-use App\Filament\RelationManagers\BaseMeetingsRelationManager;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseMeetingsRelationManager;
 
 final class MeetingsRelationManager extends BaseMeetingsRelationManager {}

--- a/app/Filament/Resources/OpportunityResource/Pages/OpportunityEmailsPage.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/OpportunityEmailsPage.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\OpportunityResource\Pages;
 
-use App\Filament\Pages\BaseRecordEmailsPage;
 use App\Filament\Resources\OpportunityResource;
+use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
 
 final class OpportunityEmailsPage extends BaseRecordEmailsPage
 {

--- a/app/Filament/Resources/OpportunityResource/RelationManagers/EmailsRelationManager.php
+++ b/app/Filament/Resources/OpportunityResource/RelationManagers/EmailsRelationManager.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\OpportunityResource\RelationManagers;
 
-use App\Filament\RelationManagers\BaseEmailsRelationManager;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
 
 final class EmailsRelationManager extends BaseEmailsRelationManager {}

--- a/app/Filament/Resources/OpportunityResource/RelationManagers/MeetingsRelationManager.php
+++ b/app/Filament/Resources/OpportunityResource/RelationManagers/MeetingsRelationManager.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\OpportunityResource\RelationManagers;
 
-use App\Filament\RelationManagers\BaseMeetingsRelationManager;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseMeetingsRelationManager;
 
 final class MeetingsRelationManager extends BaseMeetingsRelationManager {}

--- a/app/Filament/Resources/PeopleResource.php
+++ b/app/Filament/Resources/PeopleResource.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Resources;
 
 use App\Enums\CreationSource;
-use App\Filament\Actions\MassSendBulkAction;
 use App\Filament\Exports\PeopleExporter;
 use App\Filament\Resources\PeopleResource\Pages\ListPeople;
 use App\Filament\Resources\PeopleResource\Pages\PeopleEmailsPage;
@@ -43,6 +42,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Relaticle\ActivityLog\Filament\RelationManagers\ActivityLogRelationManager;
 use Relaticle\CustomFields\Facades\CustomFields;
+use Relaticle\EmailIntegration\Filament\Actions\MassSendBulkAction;
 
 final class PeopleResource extends Resource
 {

--- a/app/Filament/Resources/PeopleResource/Pages/PeopleEmailsPage.php
+++ b/app/Filament/Resources/PeopleResource/Pages/PeopleEmailsPage.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\PeopleResource\Pages;
 
-use App\Filament\Pages\BaseRecordEmailsPage;
 use App\Filament\Resources\PeopleResource;
+use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
 
 final class PeopleEmailsPage extends BaseRecordEmailsPage
 {

--- a/app/Filament/Resources/PeopleResource/RelationManagers/EmailsRelationManager.php
+++ b/app/Filament/Resources/PeopleResource/RelationManagers/EmailsRelationManager.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\PeopleResource\RelationManagers;
 
-use App\Filament\RelationManagers\BaseEmailsRelationManager;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
 
 final class EmailsRelationManager extends BaseEmailsRelationManager {}

--- a/app/Filament/Resources/PeopleResource/RelationManagers/MeetingsRelationManager.php
+++ b/app/Filament/Resources/PeopleResource/RelationManagers/MeetingsRelationManager.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\PeopleResource\RelationManagers;
 
-use App\Filament\RelationManagers\BaseMeetingsRelationManager;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseMeetingsRelationManager;
 
 final class MeetingsRelationManager extends BaseMeetingsRelationManager {}

--- a/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\Actions;
+namespace Relaticle\EmailIntegration\Filament\Actions;
 
 use App\Models\People;
 use Filament\Actions\BulkAction;

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\Concerns;
+namespace Relaticle\EmailIntegration\Filament\Concerns;
 
 use App\Models\User;
 use Filament\Actions\Action;

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\Pages;
+namespace Relaticle\EmailIntegration\Filament\Pages;
 
-use App\Filament\Concerns\HasEmailComposeActions;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
 use App\Models\Company;
 use App\Models\Opportunity;
 use App\Models\People;

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Pages;
 
-use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
 use App\Models\Company;
 use App\Models\Opportunity;
 use App\Models\People;
@@ -27,6 +26,7 @@ use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailShare;

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\Pages;
+namespace Relaticle\EmailIntegration\Filament\Pages;
 
 use App\Models\User;
 use Filament\Actions\Action;

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\Pages;
+namespace Relaticle\EmailIntegration\Filament\Pages;
 
 use App\Models\User;
 use Filament\Actions\Action;

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\RelationManagers;
+namespace Relaticle\EmailIntegration\Filament\RelationManagers;
 
-use App\Filament\Concerns\HasEmailComposeActions;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\RelationManagers;
 
-use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -25,6 +24,7 @@ use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailShare;

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\RelationManagers;
+namespace Relaticle\EmailIntegration\Filament\RelationManagers;
 
 use App\Models\Company;
 use App\Models\Opportunity;

--- a/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Resources;
 
-use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -20,6 +19,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Override;
+use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 

--- a/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\Resources;
+namespace Relaticle\EmailIntegration\Filament\Resources;
 
-use App\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
+use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;

--- a/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource/Pages/ManageEmailTemplates.php
+++ b/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource/Pages/ManageEmailTemplates.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Filament\Resources\EmailTemplateResource\Pages;
+namespace Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages;
 
-use App\Filament\Resources\EmailTemplateResource;
+use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ManageRecords;
 use Filament\Support\Enums\Size;

--- a/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource/Pages/ManageEmailTemplates.php
+++ b/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource/Pages/ManageEmailTemplates.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages;
 
-use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ManageRecords;
 use Filament\Support\Enums\Size;
 use Override;
+use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource;
 
 final class ManageEmailTemplates extends ManageRecords
 {

--- a/packages/EmailIntegration/src/Notifications/EmailAccessRequestedNotification.php
+++ b/packages/EmailIntegration/src/Notifications/EmailAccessRequestedNotification.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Notifications;
 
-use App\Filament\Pages\EmailAccessRequestsPage;
-use App\Filament\Pages\EmailInboxPage;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccessRequestsPage;
+use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 
 final class EmailAccessRequestedNotification extends Notification

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 use App\Filament\Exports\BaseExporter;
 use App\Filament\Imports\BaseImporter;
-use App\Filament\Pages\BaseRecordEmailsPage;
 use App\Filament\Pages\Import\ImportPage;
 use App\Filament\RelationManagers\BaseActivityTimelineRelationManager;
-use App\Filament\RelationManagers\BaseEmailsRelationManager;
-use App\Filament\RelationManagers\BaseMeetingsRelationManager;
 use App\Livewire\BaseLivewireComponent;
 use App\Mcp\Tools\BaseAttachTool;
 use App\Mcp\Tools\BaseCreateTool;
@@ -19,6 +16,9 @@ use App\Mcp\Tools\BaseShowTool;
 use App\Mcp\Tools\BaseUpdateTool;
 use App\Models\PersonalAccessToken;
 use App\Rules\ArrayExistsForTeam;
+use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseMeetingsRelationManager;
 
 arch()->preset()->php();
 

--- a/tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use App\Filament\Pages\EmailAccessRequestsPage;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccessRequestsPage;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;

--- a/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
+++ b/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Filament\RelationManagers\BaseEmailsRelationManager;
 use App\Filament\Resources\PeopleResource\Pages\ViewPeople;
 use App\Filament\Resources\PeopleResource\RelationManagers\EmailsRelationManager;
 use App\Models\People;
@@ -10,6 +9,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Notification;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Filament\Actions\MassSendBulkAction;
 use App\Filament\Resources\PeopleResource\Pages\ListPeople;
 use App\Models\People;
 use App\Models\User;
@@ -11,6 +10,7 @@ use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
+use Relaticle\EmailIntegration\Filament\Actions\MassSendBulkAction;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailBatch;


### PR DESCRIPTION
## Summary
Relocates the email/calendar Filament surfaces from `app/Filament/*` into `packages/EmailIntegration/src/Filament/*`, for consistency with the package pages already living there (`EmailAccountsPage`, `EmailOutboxPage`, etc.).

Moved + re-namespaced `App\Filament\*` → `Relaticle\EmailIntegration\Filament\*`:
- `Pages/EmailInboxPage`, `Pages/BaseRecordEmailsPage`, `Pages/EmailAccessRequestsPage`
- `Resources/EmailTemplateResource` (+ nested `Pages/ManageEmailTemplates`)
- `RelationManagers/BaseEmailsRelationManager`, `RelationManagers/BaseMeetingsRelationManager`
- `Concerns/HasEmailComposeActions`, `Actions/MassSendBulkAction`

Stay in app (CRM-resource-specific, now extend the package bases): `Company/People/OpportunityEmailsPage`, their `Emails/MeetingsRelationManager`, and the `ViewCompany/People/Opportunity` glue.

Panel discovery already covers the package dirs (`discoverPages`/`discoverResources` in `AppPanelProvider`), so no provider changes. Lang keys are unchanged — package files resolve `__()` against the app `lang/en/` tree.

Note: this is a pure relocation. `EmailIntegration` is an in-repo module (no `composer.json`) that already depends on `App\Models`, so the boundary is organizational, not a true package isolation.

## Test plan
- [x] `phpstan` — 0 errors
- [x] `pint` — clean (import ordering only)
- [x] feature tests — 342 passed (EmailIntegration + Calendar + Company/People/Opportunity resources)
- [x] arch tests — 14 passed (boundary rules still hold)
- [x] routes register under new namespaces (`email`, `email-templates`, `email-access-requests-page`)