### PR TITLE
fix(email): widen subject columns to text

### DIFF
--- a/database/migrations/2026_03_21_050430_create_emails_table.php
+++ b/database/migrations/2026_03_21_050430_create_emails_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->string('thread_id')->nullable();             // Provider's thread/conversation ID
             $table->string('in_reply_to')->nullable();           // RFC 2822 In-Reply-To (reply chain)
 
-            $table->string('subject')->nullable();
+            $table->text('subject')->nullable();
             $table->string('snippet', 255)->nullable();          // Preview text for list views
             $table->timestamp('sent_at')->nullable();
             $table->timestamp('scheduled_for')->nullable();

--- a/database/migrations/2026_03_21_054840_create_email_threads_table.php
+++ b/database/migrations/2026_03_21_054840_create_email_threads_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->foreignUlid('connected_account_id')->constrained('connected_accounts')->cascadeOnDelete();
 
             $table->string('thread_id');                     // provider thread/conversation ID
-            $table->string('subject')->nullable();
+            $table->text('subject')->nullable();
             $table->unsignedInteger('email_count')->default(0);
             $table->unsignedInteger('participant_count')->default(0);
             $table->timestamp('first_email_at')->nullable();

--- a/database/migrations/2026_03_21_054937_create_email_templates_table.php
+++ b/database/migrations/2026_03_21_054937_create_email_templates_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->foreignUlid('created_by')->constrained('users')->cascadeOnDelete();
 
             $table->string('name');
-            $table->string('subject');
+            $table->text('subject');
             $table->longText('body_html');
             $table->json('variables')->nullable();            // available placeholders
             $table->boolean('is_shared')->default(false);


### PR DESCRIPTION
## Summary

Addresses PR #237 review **warning #22**. The `subject` column was `string` (255) on three email tables. Real subjects (newsletters, deep `Re: Re:` chains) routinely exceed 255 bytes, causing Gmail sync to throw.

Changed `subject` from `string` → `text` on:
- `2026_03_21_050430_create_emails_table.php`
- `2026_03_21_054840_create_email_threads_table.php`
- `2026_03_21_054937_create_email_templates_table.php`

Migrations edited in place (PR #237 not yet merged to master). No `max:255` validation cap on subject exists elsewhere.

## Test plan
- [ ] Run migrations fresh — subject columns are `text`
- [ ] Sync a Gmail email with a >255-byte subject — no DB error