### PR TITLE
refactor(email): extract inline mark-as-read into action class

### DIFF
--- a/packages/EmailIntegration/src/Actions/MarkEmailAsReadAction.php
+++ b/packages/EmailIntegration/src/Actions/MarkEmailAsReadAction.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\User;
+use Relaticle\EmailIntegration\Models\Email;
+
+final readonly class MarkEmailAsReadAction
+{
+    public function execute(string $emailId, User $user): void
+    {
+        Email::query()
+            ->whereKey($emailId)
+            ->where('user_id', $user->getKey())
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -23,6 +23,7 @@ use Livewire\Attributes\Computed;
 use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
+use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
@@ -150,11 +151,7 @@ abstract class BaseRecordEmailsPage extends Page
         $this->selectedEmailId = $id;
 
         // Optimistically mark the email as read so the unread count updates immediately
-        Email::query()
-            ->whereKey($id)
-            ->where('user_id', $this->authUser()->getKey())
-            ->whereNull('read_at')
-            ->update(['read_at' => now()]);
+        app(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
 
         unset($this->inboxUnreadCount);
     }

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -151,7 +151,7 @@ abstract class BaseRecordEmailsPage extends Page
         $this->selectedEmailId = $id;
 
         // Optimistically mark the email as read so the unread count updates immediately
-        app(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
+        resolve(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
 
         unset($this->inboxUnreadCount);
     }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -30,6 +30,7 @@ use Livewire\Attributes\Url;
 use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
+use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
@@ -176,11 +177,7 @@ final class EmailInboxPage extends Page
     {
         $this->selectedEmailId = $id;
 
-        Email::query()
-            ->whereKey($id)
-            ->where('user_id', $this->authUser()->getKey())
-            ->whereNull('read_at')
-            ->update(['read_at' => now()]);
+        app(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
 
         unset($this->inboxUnreadCount);
     }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -177,7 +177,7 @@ final class EmailInboxPage extends Page
     {
         $this->selectedEmailId = $id;
 
-        app(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
+        resolve(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
 
         unset($this->inboxUnreadCount);
     }

--- a/packages/EmailIntegration/src/Services/HtmlSanitizerService.php
+++ b/packages/EmailIntegration/src/Services/HtmlSanitizerService.php
@@ -21,6 +21,6 @@ final readonly class HtmlSanitizerService
             ->forceAttribute('a', 'rel', 'noopener noreferrer nofollow')
             ->forceAttribute('a', 'target', '_blank');
 
-        return (new HtmlSanitizer($config))->sanitize($html);
+        return new HtmlSanitizer($config)->sanitize($html);
     }
 }


### PR DESCRIPTION
## Summary

Resolves the leftover gap in PR #237 review **issue 18** (Warnings — Action-pattern convention).

Project rule (`CLAUDE.md`): *all write operations must go through action classes.* Most of issue 18 was already addressed — sharing, privacy-tier, account-settings, and signature writes were extracted into package actions. The remaining inline write was the mark-as-read `->update(['read_at' => now()])`, duplicated in two Filament pages.

## Changes

- Add `MarkEmailAsReadAction` (`packages/EmailIntegration/src/Actions/`) encapsulating the scoped read-state update (`whereKey` + `user_id` + `whereNull('read_at')`).
- `EmailInboxPage::selectEmail` and `BaseRecordEmailsPage::selectEmail` now call the action instead of an inline query.

## Scope note

`IncrementalEmailSyncJob` also marks read inline, but it is a Job (its own entry point handling provider sync), outside issue 18's scope (Filament pages / relation managers / Livewire components).

## Test plan

- [x] `vendor/bin/pint --dirty` — passed
- [x] `vendor/bin/phpstan analyse` (changed files) — 0 errors
- [x] `php artisan test tests/Feature/EmailIntegration` — 184 passed, 551 assertions