### PR TITLE
fix(email): block cross-tenant sending in SendEmailAction (PR #237 critical #3)

### DIFF
--- a/packages/EmailIntegration/src/Actions/SendEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use App\Models\User;
 use DateTimeInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
@@ -44,8 +45,14 @@ final readonly class SendEmailAction
      */
     public function execute(array $data, ?string $linkToType = null, ?string $linkToId = null): Email
     {
+        /** @var User $user */
+        $user = auth()->user();
+
         /** @var ConnectedAccount $account */
-        $account = ConnectedAccount::query()->findOrFail($data['connected_account_id']);
+        $account = ConnectedAccount::query()
+            ->ownedBy($user, $user->currentTeam)
+            ->whereKey($data['connected_account_id'])
+            ->firstOrFail();
         $priority = $data['priority'] ?? EmailPriority::BULK;
 
         $this->assertUnderMaxQueued((string) $account->user_id);

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -81,6 +82,31 @@ it('links the queued email to a CRM record via emailables', function (): void {
         'emailable_id' => $person->id,
         'link_source' => 'manual',
     ]);
+});
+
+it('rejects sending through a connected account owned by another user', function (): void {
+    $otherUser = User::factory()->withTeam()->create();
+
+    $foreignAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $otherUser->currentTeam->id,
+        'user_id' => $otherUser->id,
+        'email_address' => 'victim@example.com',
+    ]));
+
+    expect(fn () => app(SendEmailAction::class)->execute([
+        'connected_account_id' => $foreignAccount->id,
+        'subject' => 'Impersonation attempt',
+        'body_html' => '<p>nope</p>',
+        'to' => [['email' => 'x@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]))->toThrow(ModelNotFoundException::class);
+
+    $this->assertDatabaseMissing('emails', ['subject' => 'Impersonation attempt']);
 });
 
 it('throws when the user has hit the max queued limit', function (): void {


### PR DESCRIPTION
## Summary

Fixes critical security issue #3 from the PR #237 review.

`SendEmailAction::execute()` looked up the `ConnectedAccount` by `connected_account_id` straight from the (client-controlled) Livewire compose payload, with no `user_id`/`team_id` check:

```php
$account = ConnectedAccount::query()->findOrFail($data['connected_account_id']);
```

Any authenticated user could pass another tenant's account ULID and send mail through that account — impersonation plus sender-reputation damage, since the action copies `team_id`, `user_id`, `email_address`, and `display_name` off the resolved account.

## Change

Scope the lookup to the authenticated owner using the model's existing `ownedBy` scope:

```php
$account = ConnectedAccount::query()
    ->ownedBy($user, $user->currentTeam)
    ->whereKey($data['connected_account_id'])
    ->firstOrFail();
```

Foreign or cross-user ids no longer match → `ModelNotFoundException`, no email row, no send. Guard lives in the action itself (defense-in-depth), not only the UI. All call sites run inside authenticated Filament actions, so `auth()->user()` is always present.

## Tests

- Added regression test: acting as user A, passing user B's account id throws `ModelNotFoundException` and creates no `emails` row.
- Full `tests/Feature/EmailIntegration` suite green (182 passed, 539 assertions).
- `pint` pass, `rector --dry-run` clean.