### PR TITLE
chore(email): resolve leftover TODO comments (PR #237 issue 24)

### DIFF
--- a/packages/EmailIntegration/src/Observers/ConnectedAccountObserver.php
+++ b/packages/EmailIntegration/src/Observers/ConnectedAccountObserver.php
@@ -4,23 +4,11 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Observers;
 
-use App\Models\User;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 final readonly class ConnectedAccountObserver
 {
-    public function creating(ConnectedAccount $connectedAccount): void
-    {
-        // TODO::remove this logic from observer
-        if (auth()->check()) {
-            /** @var User $user */
-            $user = auth()->user();
-            $connectedAccount->user_id = $user->getKey();
-            $connectedAccount->team_id = $user->currentTeam->getKey();
-        }
-    }
-
     public function created(ConnectedAccount $connectedAccount): void
     {
         dispatch(new InitialEmailSyncJob($connectedAccount))->afterCommit();

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,6 @@ Route::get('/team-invitations/{invitation}', AcceptTeamInvitationController::cla
     ->middleware(['signed', 'auth', 'verified', AuthenticateSession::class])
     ->name('team-invitations.accept');
 
-// TODO::Remove after check all features.
 Route::get('/email-attachments/{attachment}', EmailAttachmentController::class)
     ->middleware(['auth', 'verified', AuthenticateSession::class])
     ->name('email-attachments.download');


### PR DESCRIPTION
## Summary

Resolves issue #24 from the PR #237 review (Warnings → Convention: leftover TODO/FIXME comments).

## Changes

- **`ConnectedAccountObserver.php`** — removed the `creating()` hook and its `// TODO::remove this logic from observer` comment. The hook assigned `user_id`/`team_id` from the auth context, but both are now set explicitly by the only real creation path (`CallbackController::__invoke` via `updateOrCreate`) and by `ConnectedAccountFactory`. The hook was redundant. `created()` (initial sync dispatch) is unchanged.
- **`routes/web.php`** — removed the stale `// TODO::Remove after check all features.` comment above the `email-attachments.download` route. The route is legitimate and kept.

The third TODO cited in the review (`EmailAccountsPage.php:67`, azure setup) is already resolved — azure connect is implemented.

## Verification

- `vendor/bin/pint --dirty` — passed
- `vendor/bin/phpstan analyse` (changed files) — 0 errors
- Account creation + signatures tests pass (EmailAccountsPageTest, EmailCallbackControllerTest, CalendarAccountConnectionTest, MicrosoftAccountConnectionTest, EmailSignaturesPageTest)