### PR TITLE
fix: re-validate favicon fetcher redirect hops against SsrfGuard

### DIFF
--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -74,8 +74,16 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
                 default => 'logo.png',
             };
 
+            $response = SsrfGuard::guardedHttpClient()
+                ->timeout(15)
+                ->get($url);
+
+            if (! $response->successful()) {
+                return;
+            }
+
             $logo = $this->company
-                ->addMediaFromUrl($url)
+                ->addMediaFromString($response->body())
                 ->usingFileName($filename)
                 ->usingName('company_logo')
                 ->withCustomProperties([

--- a/app/Services/Favicon/Drivers/HighQualityDriver.php
+++ b/app/Services/Favicon/Drivers/HighQualityDriver.php
@@ -12,7 +12,11 @@ use AshAllenDesign\FaviconFetcher\Concerns\ValidatesUrls;
 use AshAllenDesign\FaviconFetcher\Contracts\Fetcher;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 
 final class HighQualityDriver implements Fetcher
 {
@@ -64,11 +68,38 @@ final class HighQualityDriver implements Fetcher
         throw new \Exception('fetchAll not supported by HighQualityDriver');
     }
 
+    /**
+     * The favicon HTTP client re-validates every redirect hop against {@see SsrfGuard}.
+     *
+     * The underlying client follows redirects by default, so validating only the
+     * initial URL would let an attacker-controlled public host redirect the request
+     * to an internal address (SSRF, CWE-918). The on_redirect callback throws a
+     * SsrfGuardException for any non-public hop, aborting the request before it is sent.
+     */
+    private function guardedHttpClient(): PendingRequest
+    {
+        return $this->httpClient()->withOptions([
+            'allow_redirects' => [
+                'max' => 5,
+                'strict' => true,
+                'referer' => false,
+                'protocols' => ['http', 'https'],
+                'on_redirect' => static function (
+                    RequestInterface $request,
+                    ResponseInterface $response,
+                    UriInterface $uri,
+                ): void {
+                    SsrfGuard::assertPublicHost((string) $uri);
+                },
+            ],
+        ]);
+    }
+
     private function tryAppleTouchIcon(string $url): ?Favicon
     {
         try {
             $response = $this->withRequestExceptionHandling(
-                fn () => $this->httpClient()->get($url)
+                fn () => $this->guardedHttpClient()->get($url)
             );
 
             if (! $response->successful()) {
@@ -103,7 +134,7 @@ final class HighQualityDriver implements Fetcher
 
             $iconUrl = $this->stripPathFromUrl($url).'/apple-touch-icon.png';
             /** @var Response $testResponse */
-            $testResponse = $this->httpClient()->head($iconUrl);
+            $testResponse = $this->guardedHttpClient()->head($iconUrl);
 
             if ($testResponse->successful()) {
                 return new Favicon(
@@ -125,7 +156,7 @@ final class HighQualityDriver implements Fetcher
     {
         try {
             $response = $this->withRequestExceptionHandling(
-                fn () => $this->httpClient()->get($url)
+                fn () => $this->guardedHttpClient()->get($url)
             );
 
             if (! $response->successful()) {
@@ -170,7 +201,7 @@ final class HighQualityDriver implements Fetcher
             }
 
             $response = $this->withRequestExceptionHandling(
-                fn () => $this->httpClient()->get($faviconUrl)
+                fn () => $this->guardedHttpClient()->get($faviconUrl)
             );
 
             if ($response->successful()) {
@@ -199,7 +230,7 @@ final class HighQualityDriver implements Fetcher
 
         try {
             $response = $this->withRequestExceptionHandling(
-                fn () => $this->httpClient()->get($faviconUrl)
+                fn () => $this->guardedHttpClient()->get($faviconUrl)
             );
 
             if ($response->successful()) {
@@ -227,7 +258,7 @@ final class HighQualityDriver implements Fetcher
 
         try {
             /** @var Response $response */
-            $response = $this->httpClient()->head($faviconUrl);
+            $response = $this->guardedHttpClient()->head($faviconUrl);
 
             return $response->successful();
         } catch (\Exception) {

--- a/app/Services/Favicon/Drivers/HighQualityDriver.php
+++ b/app/Services/Favicon/Drivers/HighQualityDriver.php
@@ -14,9 +14,6 @@ use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
 
 final class HighQualityDriver implements Fetcher
 {
@@ -69,30 +66,12 @@ final class HighQualityDriver implements Fetcher
     }
 
     /**
-     * The favicon HTTP client re-validates every redirect hop against {@see SsrfGuard}.
-     *
-     * The underlying client follows redirects by default, so validating only the
-     * initial URL would let an attacker-controlled public host redirect the request
-     * to an internal address (SSRF, CWE-918). The on_redirect callback throws a
-     * SsrfGuardException for any non-public hop, aborting the request before it is sent.
+     * The favicon-fetcher HTTP client, hardened so every redirect hop is
+     * re-validated against {@see SsrfGuard} (SSRF, CWE-918).
      */
     private function guardedHttpClient(): PendingRequest
     {
-        return $this->httpClient()->withOptions([
-            'allow_redirects' => [
-                'max' => 5,
-                'strict' => true,
-                'referer' => false,
-                'protocols' => ['http', 'https'],
-                'on_redirect' => static function (
-                    RequestInterface $request,
-                    ResponseInterface $response,
-                    UriInterface $uri,
-                ): void {
-                    SsrfGuard::assertPublicHost((string) $uri);
-                },
-            ],
-        ]);
+        return $this->httpClient()->withOptions(SsrfGuard::redirectGuardOptions());
     }
 
     private function tryAppleTouchIcon(string $url): ?Favicon

--- a/app/Services/Favicon/SsrfGuard.php
+++ b/app/Services/Favicon/SsrfGuard.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace App\Services\Favicon;
 
 use App\Exceptions\SsrfGuardException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 
 final readonly class SsrfGuard
 {
@@ -19,6 +24,51 @@ final readonly class SsrfGuard
 
             return false;
         }
+    }
+
+    /**
+     * An HTTP client that re-validates every redirect hop against this guard.
+     *
+     * The underlying client follows redirects by default, so validating only the
+     * initial URL would let an attacker-controlled public host redirect the request
+     * to an internal address (SSRF, CWE-918). Callers must still validate the initial
+     * URL with {@see self::isAllowed()} — the guard below only covers redirect hops.
+     */
+    public static function guardedHttpClient(): PendingRequest
+    {
+        return Http::withOptions(self::redirectGuardOptions());
+    }
+
+    /**
+     * Guzzle options whose on_redirect callback aborts the request before any
+     * non-public redirect target is contacted, reporting the block for parity
+     * with the initial-URL check in {@see self::isAllowed()}.
+     *
+     * @return array{allow_redirects: array<string, mixed>}
+     */
+    public static function redirectGuardOptions(): array
+    {
+        return [
+            'allow_redirects' => [
+                'max' => 5,
+                'strict' => true,
+                'referer' => false,
+                'protocols' => ['http', 'https'],
+                'on_redirect' => static function (
+                    RequestInterface $request,
+                    ResponseInterface $response,
+                    UriInterface $uri,
+                ): void {
+                    try {
+                        self::assertPublicHost((string) $uri);
+                    } catch (SsrfGuardException $exception) {
+                        report($exception);
+
+                        throw $exception;
+                    }
+                },
+            ],
+        ];
     }
 
     public static function assertPublicHost(string $url): void

--- a/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
+++ b/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
@@ -10,6 +10,8 @@ use App\Models\CustomFieldValue;
 use App\Models\User;
 use AshAllenDesign\FaviconFetcher\Facades\Favicon;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 
 mutates(FetchFaviconForCompany::class);
 
@@ -80,4 +82,38 @@ test('job rejects favicon url that resolves to private address', function (): vo
     (new FetchFaviconForCompany($company->fresh()))->handle();
 
     expect($company->fresh()->getMedia('logo'))->toHaveCount(0);
+});
+
+test('downloads the favicon through the guarded client and stores it', function (): void {
+    Storage::fake('public');
+
+    $company = Company::factory()->for($this->user->currentTeam)->create();
+
+    $domainsField = CustomField::query()
+        ->where('code', CompanyField::DOMAINS->value)
+        ->forEntity(Company::class)
+        ->firstOrFail();
+
+    CustomFieldValue::forceCreate([
+        'tenant_id' => $this->user->currentTeam->getKey(),
+        'entity_type' => 'company',
+        'entity_id' => $company->getKey(),
+        'custom_field_id' => $domainsField->getKey(),
+        'json_value' => ['example.com'],
+    ]);
+
+    $favicon = Mockery::mock(AshAllenDesign\FaviconFetcher\Favicon::class);
+    $favicon->shouldReceive('getFaviconUrl')->andReturn('https://1.1.1.1/favicon.png');
+    $favicon->shouldReceive('getIconSize')->andReturn(180);
+    $favicon->shouldReceive('getIconType')->andReturn('apple-touch-icon');
+
+    Favicon::shouldReceive('driver->fetch')->andReturn($favicon);
+
+    $pngBytes = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+    Http::fake(['https://1.1.1.1/favicon.png' => Http::response($pngBytes, 200)]);
+
+    (new FetchFaviconForCompany($company->fresh()))->handle();
+
+    Http::assertSent(fn ($request): bool => $request->url() === 'https://1.1.1.1/favicon.png');
+    expect($company->fresh()->getMedia('logo'))->toHaveCount(1);
 });

--- a/tests/Feature/Services/Favicon/HighQualityDriverTest.php
+++ b/tests/Feature/Services/Favicon/HighQualityDriverTest.php
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Exceptions\SsrfGuardException;
 use App\Services\Favicon\Drivers\HighQualityDriver;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Illuminate\Support\Facades\Http;
 
 mutates(HighQualityDriver::class);
@@ -121,4 +125,21 @@ test('refuses to fetch from private addresses', function (): void {
     expect($driver->fetch('http://127.0.0.1/'))->toBeNull()
         ->and($driver->fetch('http://10.0.0.1/'))->toBeNull()
         ->and($driver->fetch('http://169.254.169.254/'))->toBeNull();
+});
+
+test('re-validates each redirect hop against the SSRF guard', function (): void {
+    $driver = new HighQualityDriver;
+
+    $client = (new ReflectionMethod($driver, 'guardedHttpClient'))->invoke($driver);
+    $onRedirect = $client->getOptions()['allow_redirects']['on_redirect'];
+
+    $request = new Request('GET', 'https://1.1.1.1');
+    $response = new Response(302);
+
+    expect(fn () => $onRedirect($request, $response, Utils::uriFor('http://169.254.169.254/latest/meta-data/')))
+        ->toThrow(SsrfGuardException::class)
+        ->and(fn () => $onRedirect($request, $response, Utils::uriFor('http://10.0.0.1/')))
+        ->toThrow(SsrfGuardException::class)
+        ->and(fn () => $onRedirect($request, $response, Utils::uriFor('http://1.1.1.1/')))
+        ->not->toThrow(SsrfGuardException::class);
 });

--- a/tests/Feature/Services/Favicon/HighQualityDriverTest.php
+++ b/tests/Feature/Services/Favicon/HighQualityDriverTest.php
@@ -127,19 +127,14 @@ test('refuses to fetch from private addresses', function (): void {
         ->and($driver->fetch('http://169.254.169.254/'))->toBeNull();
 });
 
-test('re-validates each redirect hop against the SSRF guard', function (): void {
+test('routes favicon requests through the SSRF-guarded redirect client', function (): void {
     $driver = new HighQualityDriver;
 
-    $client = (new ReflectionMethod($driver, 'guardedHttpClient'))->invoke($driver);
-    $onRedirect = $client->getOptions()['allow_redirects']['on_redirect'];
+    $onRedirect = invade($driver)->guardedHttpClient()->getOptions()['allow_redirects']['on_redirect'];
 
     $request = new Request('GET', 'https://1.1.1.1');
     $response = new Response(302);
 
     expect(fn () => $onRedirect($request, $response, Utils::uriFor('http://169.254.169.254/latest/meta-data/')))
-        ->toThrow(SsrfGuardException::class)
-        ->and(fn () => $onRedirect($request, $response, Utils::uriFor('http://10.0.0.1/')))
-        ->toThrow(SsrfGuardException::class)
-        ->and(fn () => $onRedirect($request, $response, Utils::uriFor('http://1.1.1.1/')))
-        ->not->toThrow(SsrfGuardException::class);
+        ->toThrow(SsrfGuardException::class);
 });

--- a/tests/Feature/Services/Favicon/SsrfGuardTest.php
+++ b/tests/Feature/Services/Favicon/SsrfGuardTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use App\Exceptions\SsrfGuardException;
 use App\Services\Favicon\SsrfGuard;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 
 mutates(SsrfGuard::class);
 
@@ -53,4 +56,18 @@ test('rejects hostnames that resolve to private addresses', function (): void {
 test('accepts a clearly-public address literal', function (): void {
     SsrfGuard::assertPublicHost('http://1.1.1.1/');
     expect(true)->toBeTrue();
+});
+
+test('redirect guard blocks redirects to non-public hosts but allows public ones', function (): void {
+    $onRedirect = SsrfGuard::redirectGuardOptions()['allow_redirects']['on_redirect'];
+
+    $request = new Request('GET', 'https://1.1.1.1');
+    $response = new Response(302);
+
+    expect(fn () => $onRedirect($request, $response, Utils::uriFor('http://169.254.169.254/latest/meta-data/')))
+        ->toThrow(SsrfGuardException::class)
+        ->and(fn () => $onRedirect($request, $response, Utils::uriFor('http://10.0.0.1/')))
+        ->toThrow(SsrfGuardException::class)
+        ->and(fn () => $onRedirect($request, $response, Utils::uriFor('http://1.1.1.1/')))
+        ->not->toThrow(SsrfGuardException::class);
 });


### PR DESCRIPTION
## Summary

Hardens the company-logo favicon fetcher against a server-side request forgery
(SSRF) bypass reported privately in **GHSA-54qv-6m53-r2h4** (CWE-918).

`HighQualityDriver` ran `SsrfGuard` only on the **initial** URL it was given.
The Laravel HTTP client follows HTTP redirects by default, and the redirect
**targets were never re-validated**. A low-privilege team member who sets a
Company's `domains` field to a host they control can have it return a `302`
pointing at an internal address (cloud metadata, loopback, or any RFC1918 host);
the favicon job then issues a server-side request to that internal address —
exactly the destination `SsrfGuard` exists to block.

## Fix

All favicon requests now go through a single `guardedHttpClient()` whose Guzzle
`allow_redirects.on_redirect` callback re-runs `SsrfGuard::assertPublicHost()`
on **every** redirect hop. A non-public hop throws `SsrfGuardException`, aborting
the request before any internal address is contacted. Legitimate public
redirects are still followed (`max` 5 hops, `http`/`https` only).

## Verification

- Reproduced the original SSRF (redirect to a loopback "internal" host was
  followed and contacted) and confirmed it is now blocked before the internal
  request is sent.
- Confirmed a redirect to a public address is still allowed (no regression).
- Added a regression test (`re-validates each redirect hop against the SSRF guard`)
  asserting the installed `on_redirect` callback blocks private/link-local hops
  and permits public ones.
- `php artisan test` (favicon suites) · Pint · Rector · PHPStan · 100% type
  coverage all green.

## Follow-up (out of scope here)

The advisory also notes a DNS-rebinding TOCTOU (guard resolves via
`dns_get_record()` while the HTTP client resolves separately at connect time).
That is a narrower, non-deterministic vector and is best addressed separately by
pinning the validated IP for the connection.
