### PR TITLE
fix: restore users primary key dropped by partial ulid migration

### DIFF
--- a/database/migrations/2026_03_31_212400_restore_users_primary_key.php
+++ b/database/migrations/2026_03_31_212400_restore_users_primary_key.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Restore the PRIMARY KEY on users.id.
+ *
+ * The ULID conversion (2025_12_20_000000_migrate_to_ulid) drops every foreign
+ * key (Phase B0) and is meant to recreate the primary keys (B1) and foreign
+ * keys (B9) afterwards. On environments where that migration aborted partway,
+ * users.id was left as a plain char(26) column with no primary key.
+ *
+ * PostgreSQL then rejects ANY new foreign key referencing users.id with:
+ *   SQLSTATE[42830]: there is no unique constraint matching given keys for
+ *   referenced table "users"
+ *
+ * which blocks the agent_conversations / ai_credit_transactions /
+ * pending_actions migrations that immediately follow this one. This migration
+ * restores the missing constraint so those foreign keys can be created.
+ *
+ * It is idempotent and a no-op on healthy databases (fresh installs already
+ * have the primary key).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users') || $this->usersHasPrimaryKey()) {
+            return;
+        }
+
+        match (DB::getDriverName()) {
+            'pgsql' => DB::statement('ALTER TABLE users ADD PRIMARY KEY (id)'),
+            'mysql', 'mariadb' => DB::statement('ALTER TABLE `users` ADD PRIMARY KEY (`id`)'),
+            default => null,
+        };
+    }
+
+    private function usersHasPrimaryKey(): bool
+    {
+        return match (DB::getDriverName()) {
+            'pgsql' => (bool) DB::selectOne(
+                "SELECT 1 FROM pg_constraint WHERE conrelid = 'users'::regclass AND contype = 'p'"
+            ),
+            'mysql', 'mariadb' => (bool) DB::selectOne(
+                'SELECT 1 FROM information_schema.table_constraints
+                 WHERE table_schema = DATABASE() AND table_name = ? AND constraint_type = ?',
+                ['users', 'PRIMARY KEY']
+            ),
+            // SQLite (tests) always defines the primary key inline at create time.
+            default => true,
+        };
+    }
+};


### PR DESCRIPTION
## Problem

The production deploy fails at `2026_03_31_212425_create_agent_conversations_table`:

```
SQLSTATE[42830]: there is no unique constraint matching given keys for referenced table "users"
(SQL: alter table "agent_conversations" add constraint "agent_conversations_user_id_foreign"
 foreign key ("user_id") references "users" ("id") on delete set null)
```

## Root cause

`users.id` lost its `PRIMARY KEY` on affected databases. The ULID conversion
(`2025_12_20_000000_migrate_to_ulid`) drops every foreign key (Phase B0) and is
meant to recreate the primary keys (B1) and foreign keys (B9) afterward. Where
that migration aborted partway, `users.id` was left as a plain `char(26)` column
with no primary key.

PostgreSQL then rejects **any** new foreign key referencing `users.id`, which
blocks the `agent_conversations`, `ai_credit_transactions`, and `pending_actions`
migrations that immediately follow it.

Reproduced against a scratch Postgres DB: the error appears **only** when the
referenced column has no unique/primary constraint (type mismatches such as
`varchar` PK ↔ `char(26)` FK all succeed), confirming the missing PK is the cause.

## Fix

A corrective migration ordered to run **before** `agent_conversations` that
restores the missing primary key on `users.id`.

- **Idempotent** — checks for an existing PK first, so it is a no-op on healthy
  installs (fresh databases already have it).
- **Driver-aware** — pgsql / mysql / sqlite.
- Safe on the affected production DB: `users.id` is clean (0 null ids, 0 duplicate
  ids), so `ADD PRIMARY KEY` succeeds.

## Verification

- Reproduced the broken state on a scratch Postgres DB: FK fails before → PK added
  → both agent_conversations FKs (`user_id` null-on-delete, `team_id` cascade)
  succeed → rerun safely skips.
- Ran on the healthy local database: no-op, existing `users_pkey` untouched.
- `pint` passes.

## Note (out of scope, follow-up needed)

This deploy failure surfaced broader integrity damage on the affected database from
the same partial ULID migration: most foreign keys are missing and there are
orphaned rows that would block re-adding them. That cleanup needs its own staged,
signed-off remediation and is intentionally **not** included here — this PR only
restores the `users` primary key to unblock deploys.
