### PR TITLE
fix(auth): stop reporting transient OAuth provider errors to Sentry

### DIFF
--- a/app/Http/Controllers/Auth/CallbackController.php
+++ b/app/Http/Controllers/Auth/CallbackController.php
@@ -8,10 +8,12 @@ use App\Contracts\User\CreatesNewSocialUsers;
 use App\Models\User;
 use App\Models\UserSocialAccount;
 use Filament\Notifications\Notification;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Laravel\Socialite\Contracts\User as SocialiteUser;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
@@ -35,11 +37,31 @@ final readonly class CallbackController
             return $this->loginAndRedirect($user);
         } catch (InvalidStateException) {
             return $this->handleError('Authentication state mismatch. Please try again.');
+        } catch (RequestException $e) {
+            return $this->handleProviderRequestException($e, $provider);
         } catch (Throwable $e) {
             report($e);
 
             return $this->handleError($this->parseProviderError($e->getMessage(), $provider));
         }
+    }
+
+    private function handleProviderRequestException(RequestException $e, string $provider): RedirectResponse
+    {
+        $status = $e->getResponse()?->getStatusCode();
+
+        if ($status === 429 || ($status !== null && $status >= 500)) {
+            Log::warning('Socialite provider returned a transient error.', [
+                'provider' => $provider,
+                'status' => $status,
+            ]);
+
+            return $this->handleError(sprintf('%s is busy right now. Please wait a moment and try again.', ucfirst($provider)));
+        }
+
+        report($e);
+
+        return $this->handleError($this->parseProviderError($e->getMessage(), $provider));
     }
 
     /**

--- a/tests/Feature/Auth/SocialiteLoginTest.php
+++ b/tests/Feature/Auth/SocialiteLoginTest.php
@@ -7,6 +7,11 @@ use App\Http\Controllers\Auth\CallbackController;
 use App\Http\Controllers\Auth\RedirectController;
 use App\Models\User;
 use App\Models\UserSocialAccount;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use Illuminate\Support\Facades\Exceptions;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User as SocialiteUser;
 
@@ -107,6 +112,64 @@ test('callback from socialite provider handles error gracefully', function () {
 
     $response->assertRedirect(route('login'));
     $response->assertSessionHasErrors(['login']);
+});
+
+test('callback does not report transient provider rate limit to sentry', function () {
+    Exceptions::fake();
+
+    Socialite::fake(
+        SocialiteProvider::GITHUB->value,
+        fn () => throw new ClientException(
+            'Client error: `POST https://github.com/login/oauth/access_token` resulted in a `429 Too Many Requests` response',
+            new GuzzleRequest('POST', 'https://github.com/login/oauth/access_token'),
+            new GuzzleResponse(429),
+        ),
+    );
+
+    $response = $this->get(route('auth.socialite.callback', ['provider' => SocialiteProvider::GITHUB->value, 'code' => 'test-code']));
+
+    $response->assertRedirect(route('login'));
+
+    $errors = session('errors')->getBag('default');
+    expect($errors->first('login'))->toBe('Github is busy right now. Please wait a moment and try again.');
+
+    Exceptions::assertNothingReported();
+});
+
+test('callback does not report transient provider server error to sentry', function () {
+    Exceptions::fake();
+
+    Socialite::fake(
+        SocialiteProvider::GITHUB->value,
+        fn () => throw new ServerException(
+            'Server error: `POST https://github.com/login/oauth/access_token` resulted in a `503 Service Unavailable` response',
+            new GuzzleRequest('POST', 'https://github.com/login/oauth/access_token'),
+            new GuzzleResponse(503),
+        ),
+    );
+
+    $response = $this->get(route('auth.socialite.callback', ['provider' => SocialiteProvider::GITHUB->value, 'code' => 'test-code']));
+
+    $response->assertRedirect(route('login'));
+    Exceptions::assertNothingReported();
+});
+
+test('callback still reports actionable provider client errors to sentry', function () {
+    Exceptions::fake();
+
+    Socialite::fake(
+        SocialiteProvider::GITHUB->value,
+        fn () => throw new ClientException(
+            'Client error: `POST https://github.com/login/oauth/access_token` resulted in a `401 Unauthorized` response',
+            new GuzzleRequest('POST', 'https://github.com/login/oauth/access_token'),
+            new GuzzleResponse(401),
+        ),
+    );
+
+    $response = $this->get(route('auth.socialite.callback', ['provider' => SocialiteProvider::GITHUB->value, 'code' => 'test-code']));
+
+    $response->assertRedirect(route('login'));
+    Exceptions::assertReported(ClientException::class);
 });
 
 test('callback from socialite provider handles missing code parameter', function () {


### PR DESCRIPTION
## Problem

Sentry issue #126128782: `GuzzleHttp\Exception\ClientException` — `429 Too Many Requests` from `POST https://github.com/login/oauth/access_token`, surfacing on `/auth/callback/{provider}`.

This is GitHub rate-limiting the OAuth token-exchange call. It's transient and upstream — not an application bug. But `CallbackController`'s broad `catch (Throwable) { report($e); }` forwarded every such throttle to Sentry as an error, drowning real issues, while also showing the user a vague "Failed to authenticate with Github."

## Change

Added a `catch (RequestException)` ahead of the generic catch in `CallbackController::__invoke`:

- **429 or 5xx** → logged at `warning` level, user sees "Github is busy right now. Please wait a moment and try again." **Not** reported to Sentry.
- **Other 4xx** (401/403/etc. — genuine misconfiguration, actionable) → still reported.

## Tests

`tests/Feature/Auth/SocialiteLoginTest.php`:
- does not report transient provider rate limit to sentry (429)
- does not report transient provider server error to sentry (503)
- still reports actionable provider client errors to sentry (401)

Verified load-bearing: the two transient tests fail against the original controller and pass with the fix. `pint` and `phpstan` clean; all 35 auth tests pass.

## Notes

- This stops the Sentry noise, not the throttle itself. If these are frequent (not a one-off spike), the production egress IP is being rate-limited per OAuth app and a retry-with-backoff may be warranted — left out as scope creep until confirmed.
- Connection timeouts (`ConnectException`, a separate Guzzle hierarchy) are intentionally untouched since they couldn't be reproduced from this issue.