### PR TITLE
fix(chat): register broadcast channels independent of route cache

### DIFF
--- a/packages/Chat/src/ChatServiceProvider.php
+++ b/packages/Chat/src/ChatServiceProvider.php
@@ -63,7 +63,7 @@ final class ChatServiceProvider extends ServiceProvider
 
     private function registerChannels(): void
     {
-        $this->loadRoutesFrom(__DIR__.'/../routes/channels.php');
+        require __DIR__.'/../routes/channels.php';
     }
 
     private function registerViews(): void


### PR DESCRIPTION
## Problem

AI chat live streaming silently broke in production: every `POST /broadcasting/auth` returned **403 Forbidden**, so private-channel subscriptions failed and replies only appeared after a manual page refresh.

## Root cause

`ChatServiceProvider::registerChannels()` registered the channel definitions via `loadRoutesFrom()`, which **skips the file when routes are cached**. Production runs `php artisan route:cache` on deploy, so the `chat.conversation.{conversationId}` authorization callback was never registered. An unregistered private channel is denied by default → 403. Local dev never caches routes, so the bug was invisible there.

## Fix

`require` the channels file directly so it loads regardless of route caching (broadcast channel definitions are not part of the HTTP route cache).

## Verification

End-to-end through the real `Broadcaster::auth()` path with a real conversation + owner:

| Code | `route:cache` | channel registered | `/broadcasting/auth` |
|------|:---:|:---:|:---:|
| before (`loadRoutesFrom`) | ON (prod) | NO | **403** |
| before | OFF (dev) | YES | 200 |
| after (`require`) | ON (prod) | YES | **200** |
| after | OFF | YES | 200 |

Existing Chat/broadcast tests pass (5 passed).

## Note

Current tests can't catch this — Pest never caches routes, so `loadRoutesFrom` always loads the file under test. A process-isolated regression test (running `route:cache` in a separate boot) would be needed to guard it.