### PR TITLE
feat(email): gate EmailIntegration package behind a feature flag

### DIFF
--- a/app/Features/EmailIntegration.php
+++ b/app/Features/EmailIntegration.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Features;
+
+final readonly class EmailIntegration
+{
+    public function resolve(): bool
+    {
+        return (bool) config('relaticle.features.email_integration', true);
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -8,6 +8,7 @@ use App\ActivityLog\AppEventPalette;
 use App\ActivityLog\AppEventRenderer;
 use App\ActivityLog\MeetingEventPalette;
 use App\ActivityLog\MeetingEventRenderer;
+use App\Features\EmailIntegration;
 use App\Features\SocialAuth;
 use App\Filament\Pages\AccessTokens;
 use App\Filament\Pages\Auth\Login;
@@ -138,18 +139,10 @@ final class AppPanelProvider extends PanelProvider
                     ->url(fn (): string => $this->shouldRegisterMenuItem()
                         ? url(EditProfile::getUrl())
                         : url($panel->getPath())),
-                Action::make('email_privacy')
-                    ->label(__('filament/panel.user_menu.email_privacy'))
-                    ->icon('heroicon-m-shield-check')
-                    ->url(fn (): string => $this->shouldRegisterMenuItem()
-                        ? url(EmailPrivacySettingsPage::getUrl())
-                        : url($panel->getPath())),
             ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\Resources')
-            ->discoverResources(in: base_path('packages/EmailIntegration/src/Filament/Resources'), for: 'Relaticle\\EmailIntegration\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->discoverPages(in: base_path('packages/ImportWizard/src/Filament/Pages'), for: 'Relaticle\\ImportWizard\\Filament\\Pages')
-            ->discoverPages(in: base_path('packages/EmailIntegration/src/Filament/Pages'), for: 'Relaticle\\EmailIntegration\\Filament\\Pages')
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters')
             ->readOnlyRelationManagersOnResourceViewPagesByDefault(false)
@@ -227,6 +220,20 @@ final class AppPanelProvider extends PanelProvider
                     PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE,
                     fn (): View|Factory => view('filament.auth.social_login_buttons')
                 );
+        }
+
+        if (Feature::active(EmailIntegration::class)) {
+            $panel
+                ->discoverResources(in: base_path('packages/EmailIntegration/src/Filament/Resources'), for: 'Relaticle\\EmailIntegration\\Filament\\Resources')
+                ->discoverPages(in: base_path('packages/EmailIntegration/src/Filament/Pages'), for: 'Relaticle\\EmailIntegration\\Filament\\Pages')
+                ->userMenuItems([
+                    Action::make('email_privacy')
+                        ->label(__('filament/panel.user_menu.email_privacy'))
+                        ->icon('heroicon-m-shield-check')
+                        ->url(fn (): string => $this->shouldRegisterMenuItem()
+                            ? url(EmailPrivacySettingsPage::getUrl())
+                            : url($panel->getPath())),
+                ]);
         }
 
         $panel

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -28,6 +28,7 @@ return [
         'onboard_seed' => (bool) env('RELATICLE_FEATURE_ONBOARD_SEED', true),
         'social_auth' => (bool) env('RELATICLE_FEATURE_SOCIAL_AUTH', true),
         'documentation' => (bool) env('RELATICLE_FEATURE_DOCUMENTATION', true),
+        'email_integration' => (bool) env('RELATICLE_FEATURE_EMAIL_INTEGRATION', true),
     ],
 
 ];

--- a/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
+++ b/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration;
 
+use App\Features\EmailIntegration;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Console\Commands\DispatchOutboxCommand;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
@@ -32,6 +34,10 @@ final class EmailIntegrationServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        if (! Feature::active(EmailIntegration::class)) {
+            return;
+        }
+
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'email-integration');
 
         Email::observe(EmailObserver::class);

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailFeatureFlag.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailFeatureFlag.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Concerns;
+
+use App\Features\EmailIntegration;
+use Laravel\Pennant\Feature;
+
+trait HasEmailFeatureFlag
+{
+    /**
+     * @param  array<string, mixed>  $parameters
+     */
+    public static function canAccess(array $parameters = []): bool
+    {
+        return Feature::active(EmailIntegration::class) && parent::canAccess();
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -28,6 +28,7 @@ use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailShare;
@@ -40,6 +41,7 @@ use Relaticle\EmailIntegration\Services\EmailThreadSummaryService;
 abstract class BaseRecordEmailsPage extends Page
 {
     use HasEmailComposeActions;
+    use HasEmailFeatureFlag;
     use InteractsWithRecord;
     use WithPagination;
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
@@ -19,10 +19,12 @@ use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\CancelEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 
 final class EmailAccessRequestsPage extends Page
 {
+    use HasEmailFeatureFlag;
     use WithPagination;
 
     private const int PER_PAGE = 20;

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -21,11 +21,14 @@ use Illuminate\Support\Facades\Session;
 use Relaticle\EmailIntegration\Actions\DisconnectConnectedAccountAction;
 use Relaticle\EmailIntegration\Actions\UpdateConnectedAccountSettingsAction;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 final class EmailAccountsPage extends Page
 {
+    use HasEmailFeatureFlag;
+
     protected string $view = 'email-integration::filament.pages.email-accounts';
 
     protected static ?string $slug = 'settings/email-accounts';

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -38,6 +38,7 @@ use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
@@ -53,6 +54,7 @@ use Relaticle\EmailIntegration\Services\PrivacyService;
 
 final class EmailInboxPage extends Page
 {
+    use HasEmailFeatureFlag;
     use WithPagination;
 
     protected string $view = 'filament.pages.email-inbox';

--- a/packages/EmailIntegration/src/Filament/Pages/EmailOutboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailOutboxPage.php
@@ -24,11 +24,13 @@ use Relaticle\EmailIntegration\Actions\RetryFailedEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Enums\OutboxTab;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\Email;
 use UnitEnum;
 
 final class EmailOutboxPage extends Page implements HasTable
 {
+    use HasEmailFeatureFlag;
     use InteractsWithTable;
 
     protected string $view = 'email-integration::filament.pages.email-outbox';

--- a/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
@@ -17,10 +17,12 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Relaticle\EmailIntegration\Actions\UpdateTeamEmailPrivacySettingsAction;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\ProtectedRecipient;
 
 final class EmailPrivacySettingsPage extends Page implements HasSchemas
 {
+    use HasEmailFeatureFlag;
     use InteractsWithSchemas;
 
     protected string $view = 'email-integration::filament.pages.email-privacy-settings';

--- a/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
@@ -16,11 +16,14 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Relaticle\EmailIntegration\Actions\CreateSignatureAction;
 use Relaticle\EmailIntegration\Actions\UpdateSignatureAction;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 
 final class EmailSignaturesPage extends Page
 {
+    use HasEmailFeatureFlag;
+
     protected string $view = 'email-integration::filament.pages.email-signatures';
 
     protected static ?string $slug = 'settings/email-signatures';

--- a/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource.php
@@ -19,12 +19,15 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Override;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 
 final class EmailTemplateResource extends Resource
 {
+    use HasEmailFeatureFlag;
+
     protected static ?string $model = EmailTemplate::class;
 
     protected static ?string $recordTitleAttribute = 'name';

--- a/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
@@ -19,12 +19,15 @@ use Illuminate\Database\Eloquent\Builder;
 use Override;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Filament\Resources\MeetingResource\Pages\ListMeetings;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 
 final class MeetingResource extends Resource
 {
+    use HasEmailFeatureFlag;
+
     protected static ?string $model = Meeting::class;
 
     protected static ?string $recordTitleAttribute = 'title';

--- a/tests/Feature/EmailIntegration/EmailIntegrationFeatureFlagTest.php
+++ b/tests/Feature/EmailIntegration/EmailIntegrationFeatureFlagTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\EmailIntegration;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Laravel\Pennant\Feature;
+use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
+use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource;
+
+mutates(EmailIntegration::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    Filament::setTenant($this->user->currentTeam);
+});
+
+it('is enabled by default, resolving from config', function (): void {
+    expect(Feature::active(EmailIntegration::class))->toBeTrue();
+});
+
+it('resolves inactive when the config flag is disabled', function (): void {
+    config()->set('relaticle.features.email_integration', false);
+    Feature::flushCache();
+
+    expect(Feature::active(EmailIntegration::class))->toBeFalse();
+});
+
+it('allows access to email pages and resources when active', function (): void {
+    expect(EmailInboxPage::canAccess())->toBeTrue()
+        ->and(EmailTemplateResource::canAccess())->toBeTrue();
+});
+
+it('forbids the inbox page when the feature is inactive', function (): void {
+    Feature::deactivate(EmailIntegration::class);
+
+    livewire(EmailInboxPage::class)->assertForbidden();
+});
+
+it('gates the email template resource when the feature is inactive', function (): void {
+    Feature::deactivate(EmailIntegration::class);
+
+    expect(EmailTemplateResource::canAccess())->toBeFalse();
+});


### PR DESCRIPTION
## What

Puts the entire **EmailIntegration** package behind a Laravel Pennant feature flag, mirroring the existing `Documentation` / `SocialAuth` / `OnboardSeed` flag pattern.

- **`App\Features\EmailIntegration`** — Pennant class feature; `resolve()` reads `config('relaticle.features.email_integration')`.
- **`config/relaticle.php`** — adds `email_integration => (bool) env('RELATICLE_FEATURE_EMAIL_INTEGRATION', true)` (enabled by default, consistent with sibling flags).
- **`EmailIntegrationServiceProvider::boot()`** — short-circuits when the flag is off, gating views, the email observer, scheduled sync, routes and console commands (same shape as `DocumentationServiceProvider`).
- **`AppPanelProvider`** — email resource/page discovery and the `email_privacy` user-menu item are wrapped in a `Feature::active(...)` block (mirrors the `SocialAuth` block). Filament discovery happens in the panel, so it must be gated here rather than in the package boot.
- **`HasEmailFeatureFlag` trait** — adds a `canAccess()` gate to the 7 email pages + 2 resources for per-request defense and testability. Signature uses `array $parameters = []` to stay compatible with both Filament base `canAccess()` signatures.
- **Test** — `EmailIntegrationFeatureFlagTest` covers default-on resolution, config-off resolution, access when active, and gating (page forbidden / resource inaccessible) when inactive.

## Why

The package is being rolled out gradually and needs to be toggleable per deployment for testing before general release.

## Notes

- This is a **global** (per-deployment) flag. Per-Workspace/Team scoping (`resolve(Team $team)`) is a follow-up if exclusive single-workspace enablement in shared production is required.
- Quality gates: Pint, PHPStan, and Rector all pass on the changed files. The full test suite could not be executed in the worktree environment (no local Postgres available); tests load and run up to the DB connection.