### PR TITLE
fix(chat): scope custom-field writes to the action's tenant on approval

### DIFF
--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -108,31 +108,38 @@ final readonly class PendingActionService
         // Filament panel middleware and therefore leave no tenant context. Without one,
         // the custom-fields TenantScope no-ops and saveCustomFields() iterates EVERY
         // tenant's field definitions — writing value rows across all tenants (cross-tenant
-        // leak) and, at scale, exceeding the request timeout. Scope it to the action's team.
+        // leak) and, at scale, exceeding the request timeout. Scope it to the action's team,
+        // and restore the prior value afterward so the override never outlives this call
+        // (TenantContextService resolves its context before the Filament tenant).
+        $previousTenantId = TenantContextService::getCurrentTenantId();
         TenantContextService::setTenantId($pendingAction->team_id);
 
-        $resolved = DB::transaction(function () use ($pendingAction, $user): PendingAction {
-            /** @var PendingAction $pendingAction */
-            $pendingAction = PendingAction::query()
-                ->lockForUpdate()
-                ->findOrFail($pendingAction->getKey());
+        try {
+            $resolved = DB::transaction(function () use ($pendingAction, $user): PendingAction {
+                /** @var PendingAction $pendingAction */
+                $pendingAction = PendingAction::query()
+                    ->lockForUpdate()
+                    ->findOrFail($pendingAction->getKey());
 
-            $this->validateResolvable($pendingAction);
+                $this->validateResolvable($pendingAction);
 
-            $result = $this->executeAction($pendingAction, $user);
+                $result = $this->executeAction($pendingAction, $user);
 
-            $resultData = $result instanceof Model
-                ? ['id' => $result->getKey(), 'type' => $result->getMorphClass()]
-                : ['success' => true];
+                $resultData = $result instanceof Model
+                    ? ['id' => $result->getKey(), 'type' => $result->getMorphClass()]
+                    : ['success' => true];
 
-            $pendingAction->update([
-                'status' => PendingActionStatus::Approved,
-                'resolved_at' => now(),
-                'result_data' => $resultData,
-            ]);
+                $pendingAction->update([
+                    'status' => PendingActionStatus::Approved,
+                    'resolved_at' => now(),
+                    'result_data' => $resultData,
+                ]);
 
-            return $pendingAction->refresh();
-        });
+                return $pendingAction->refresh();
+            });
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
 
         $this->continuation->dispatchAfterApproval($resolved, 'approved');
 

--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -33,6 +33,7 @@ use Illuminate\Support\Facades\DB;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Enums\PendingActionStatus;
 use Relaticle\Chat\Models\PendingAction;
+use Relaticle\CustomFields\Services\TenantContextService;
 use RuntimeException;
 
 final readonly class PendingActionService
@@ -102,6 +103,14 @@ final readonly class PendingActionService
 
     public function approve(PendingAction $pendingAction, User $user): PendingAction
     {
+        // The action executes the underlying CRM write, which may persist custom-field
+        // values. Approvals arrive via the /chat/actions/* routes, which bypass the
+        // Filament panel middleware and therefore leave no tenant context. Without one,
+        // the custom-fields TenantScope no-ops and saveCustomFields() iterates EVERY
+        // tenant's field definitions — writing value rows across all tenants (cross-tenant
+        // leak) and, at scale, exceeding the request timeout. Scope it to the action's team.
+        TenantContextService::setTenantId($pendingAction->team_id);
+
         $resolved = DB::transaction(function () use ($pendingAction, $user): PendingAction {
             /** @var PendingAction $pendingAction */
             $pendingAction = PendingAction::query()

--- a/tests/Feature/Chat/PendingActionTenantScopeTest.php
+++ b/tests/Feature/Chat/PendingActionTenantScopeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Task\CreateTask;
+use App\Models\CustomField;
+use App\Models\CustomFieldValue;
+use App\Models\Task;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Bus;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Jobs\ContinueChatMessage;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+beforeEach(function (): void {
+    // The post-approval AI continuation is irrelevant to this scoping concern.
+    Bus::fake([ContinueChatMessage::class]);
+});
+
+/**
+ * Regression for the chat-approve cross-tenant custom-field write (and the 504 it
+ * caused at scale).
+ *
+ * Approvals run via the /chat/actions/* routes, which bypass Filament's panel
+ * middleware — so no tenant is resolvable when the action executes. Without an
+ * explicit tenant the custom-fields TenantScope no-ops and saveCustomFields()
+ * iterates EVERY tenant's field definitions. PendingActionService::approve() now
+ * sets the tenant context from the action's team before executing.
+ *
+ * The test invokes the service directly with the tenant context torn down, which
+ * faithfully reproduces the no-tenant request (an HTTP feature test cannot — the
+ * test process keeps a Filament tenant resolved, masking the bug).
+ */
+it('scopes custom-field writes to the action tenant when approving a create', function (): void {
+    // A second tenant whose Task custom fields must never be touched.
+    $otherTeam = User::factory()->withPersonalTeam()->create()->currentTeam;
+
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    $ownTaskFieldCount = CustomField::query()->withoutGlobalScopes()
+        ->where('entity_type', 'task')
+        ->where('tenant_id', $team->getKey())
+        ->count();
+
+    $globalTaskFieldCount = CustomField::query()->withoutGlobalScopes()
+        ->where('entity_type', 'task')
+        ->count();
+
+    // Preconditions: both tenants own Task fields, so an unscoped write would leak.
+    expect($ownTaskFieldCount)->toBeGreaterThan(0)
+        ->and($globalTaskFieldCount)->toBeGreaterThan($ownTaskFieldCount);
+
+    // An empty custom_fields map still drives saveCustomFields() across every defined field.
+    $pending = PendingAction::query()->create([
+        'team_id' => $team->getKey(),
+        'user_id' => $user->getKey(),
+        'conversation_id' => null,
+        'message_id' => null,
+        'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create,
+        'entity_type' => 'task',
+        'action_data' => ['title' => 'Tenant Scoped Task', 'custom_fields' => []],
+        'display_data' => [],
+        'status' => PendingActionStatus::Pending,
+        'expires_at' => now()->addMinutes(15),
+    ]);
+
+    // Reproduce the real request condition: no resolvable tenant when the action runs.
+    Filament::setTenant(null);
+    TenantContextService::setTenantId(null);
+
+    app(PendingActionService::class)->approve($pending, $user);
+
+    $task = Task::query()->withoutGlobalScopes()
+        ->where('team_id', $team->getKey())
+        ->where('title', 'Tenant Scoped Task')
+        ->sole();
+
+    $otherTenantFieldIds = CustomField::query()->withoutGlobalScopes()
+        ->where('tenant_id', $otherTeam->getKey())
+        ->pluck('id');
+
+    // Correctness: not a single value row written against another tenant's fields.
+    $leaked = CustomFieldValue::query()->withoutGlobalScopes()
+        ->where('entity_id', $task->getKey())
+        ->whereIn('custom_field_id', $otherTenantFieldIds)
+        ->count();
+
+    expect($leaked)->toBe(0);
+
+    // Bound: the write touches at most this tenant's own fields, never the global set.
+    $written = CustomFieldValue::query()->withoutGlobalScopes()
+        ->where('entity_id', $task->getKey())
+        ->count();
+
+    expect($written)->toBeLessThanOrEqual($ownTaskFieldCount);
+});


### PR DESCRIPTION
## Problem

Approving an AI-proposed **create/update of a record that carries custom fields** (e.g. a task) intermittently returned **504 Gateway Timeout** on `POST /chat/actions/{id}/approve`. Reproduced on production: the approve took **~175s**.

## Root cause

The `/chat/actions/*` routes use only `web` + `auth:web` — they bypass Filament's panel middleware, so **no tenant context is established** for the request. The custom-fields `TenantScope` resolves the tenant via `TenantContextService::getCurrentTenantId()`, which returns `null` here and the scope **no-ops**:

```php
// TenantScope::apply()
$tenantId = TenantContextService::getCurrentTenantId();
if ($tenantId === null) { return; } // no filter → ALL tenants' fields
```

The action then runs `saveCustomFields()`, which iterates **every** custom-field definition for the entity and writes a value row per field:

```php
$this->customFields()->each(fn (CustomField $cf) =>
    $this->saveCustomFieldValue($cf, $customFields[$cf->code] ?? null)); // null for untouched fields too
```

Unscoped, `customFields()` returns **every tenant's** Task fields. On production that's ~13,244 definitions globally (each tenant has ~7), so one task create performed ~13k inserts (~12ms each ≈ 175s) **and** wrote `custom_field_values` referencing other tenants' field definitions — a cross-tenant leak. It only manifests for entities created **with custom fields filled**, which is why a person create (no/few fields) was fine and task creation hung.

Measured locally (custom-field count inflated in a rolled-back tx):

| Task custom fields | `Task::create` w/ a custom field |
|---|---|
| 8 (one tenant) | 130 ms |
| 5,000 | 22.7 s |
| 13,244 (prod global) | 62.5 s |

## Fix

Set the custom-fields tenant context from the action's team in `PendingActionService::approve()` before executing the action — mirroring the existing `SetApiTeamContext` middleware the REST/MCP API already uses for the same reason. One line; the controller is unchanged.

```php
public function approve(PendingAction $pendingAction, User $user): PendingAction
{
    TenantContextService::setTenantId($pendingAction->team_id);
    // …
}
```

Scoped, the loop runs over the tenant's own ~7 fields (~130ms) and writes only that tenant's value rows.

## Scope checked (other non-panel writers)

- **REST/MCP API** — already covered by `SetApiTeamContext` (sets + clears the context). ✓
- **ImportWizard** — threads `teamId` into every query/write explicitly; never uses the unscoped `custom_fields` path. ✓
- **Chat `restore`** — only un-deletes soft-deleted rows (scoped by `team_id`), no custom-field write. ✓
- **Chat tool proposal/validation** (`CustomFieldsSchemaDescriber`, `CustomFieldsRequestValidator`) — already `where('tenant_id', …)`. ✓
- So `approve()` was the only unscoped writer.

## Tests

New `PendingActionTenantScopeTest` sets up two tenants with Task fields, tears down the tenant context (faithfully reproducing the no-tenant request — an HTTP feature test can't, because the test process keeps a Filament tenant resolved), approves a create, and asserts **zero** value rows reference the other tenant and the write is bounded to the acting tenant's field count.

Verified load-bearing: without the fix the test fails (`Failed asserting that 4 is identical to 0` — the 4 leaked rows); with it, it passes. Full Chat suite green (442 passed). `pint` + `phpstan` clean.

## Follow-ups (not in this PR)

- The custom-fields `TenantScope` arguably should **fail closed** (return no rows when multi-tenancy is on but no tenant is resolvable) rather than leak all tenants — a defense-in-depth change in `relaticle/custom-fields`.
- Worth auditing why some tenants accumulated duplicate default field definitions (the default-field provisioner).