### PR TITLE
fix(chat): harden AI approval flow against lost state and rate limits

### DIFF
--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -898,7 +898,8 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
             .listen('.stream.failed', (e) => this.handleStreamFailed(e))
             .listen('.conversation.resolved', (e) => this.handleConversationResolved(e))
             .listen('.follow_ups', (e) => this.handleFollowUps(e))
-            .listen('.pending_actions_superseded', (e) => this.handlePendingActionsSuperseded(e));
+            .listen('.pending_actions_superseded', (e) => this.handlePendingActionsSuperseded(e))
+            .listen('.chat.paused', (e) => this.handleChatPaused(e));
 
         return readyPromise;
     },
@@ -1431,6 +1432,19 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
         this.queuedSend = null;
         this.clearStreamTimeout();
         this.restoreInputFocus();
+    },
+
+    handleChatPaused(event) {
+        const nowIso = new Date().toISOString();
+        this.messages.push({
+            role: 'assistant',
+            content: event?.message || 'Paused. Say "continue" to keep going.',
+            pending_actions: [], paywall: null, sessionExpired: false,
+            rendered: true, prerendered: false, copiedAt: 0, follow_ups: [],
+            created_at: nowIso,
+        });
+        this.isStreaming = false;
+        this.$nextTick(() => this.restoreInputFocus());
     },
 
     restoreInputFocus() {

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -79,6 +79,15 @@ final class CrmAssistant implements Agent, Conversational, HasMiddleware, HasPro
      */
     public array $supersededProposals = [];
 
+    /**
+     * Actions already resolved (approved/rejected/expired/superseded) since the
+     * last assistant turn, injected so the model knows their outcome even if the
+     * approval continuation never journaled them into the transcript.
+     *
+     * @var list<array{operation: string, entity_type: string, status: string, label: string|null, record_id: string|null}>
+     */
+    public array $resolvedActions = [];
+
     public function withConversationId(?string $conversationId): self
     {
         $this->conversationId = $conversationId;
@@ -112,6 +121,7 @@ For any create, update, or delete operation:
 - The tool returns a pending_action proposal -- do NOT tell the user the action was completed
 - Tell the user you've proposed the action and ask them to review the proposal card above
 - Wait for the user to approve or reject before proceeding
+- If a multi-step sequence pauses, tell the user it paused and that they can say "continue" to resume; then resume from the resolved actions when they do
 
 ## Formatting
 - Use markdown for rich text formatting
@@ -135,9 +145,17 @@ When status=approved, use record_id to compose the next step of the user's origi
 ## Superseded Proposals
 
 A <superseded_proposals> block in this turn's context means the user moved on without approving or rejecting those proposals. Treat them as abandoned: do NOT silently re-propose the same operation. If the user's new message is unrelated, just handle it. If it relates to the abandoned proposal, briefly acknowledge ("I see you moved on from the earlier proposal to delete X") and ask what they want now -- do not auto-retry.
+
+## Resolved Actions
+
+A <resolved_actions> block lists proposals the user has ALREADY approved or rejected
+since your last reply. They are final -- never re-propose them. When an item is
+"approved" and carries an id, use that id to continue any multi-step request the user
+started (e.g. propose the next item, or link to the just-created record). When an item
+is "rejected", do not retry it; ask what the user wants instead.
 PROMPT;
 
-        $suffix = $this->mentionsBlock().$this->supersededBlock();
+        $suffix = $this->mentionsBlock().$this->supersededBlock().$this->resolvedBlock();
 
         return $suffix === '' ? $base : $base.$suffix;
     }
@@ -191,6 +209,36 @@ PROMPT;
         return "\n".implode("\n", $lines);
     }
 
+    private function resolvedBlock(): string
+    {
+        if ($this->resolvedActions === []) {
+            return '';
+        }
+
+        $lines = [
+            '',
+            '<resolved_actions>',
+            'These proposals were already decided by the user. Do not re-propose them.',
+            'Use an approved record id to continue any multi-step request still in progress.',
+        ];
+
+        foreach ($this->resolvedActions as $action) {
+            $label = $action['label'] !== null
+                ? '"'.$this->sanitizeLabel($action['label']).'"'
+                : '(unnamed)';
+
+            $idPart = ($action['status'] === 'approved' && isset($action['record_id']) && $action['record_id'] !== '')
+                ? " (id: {$action['record_id']})"
+                : '';
+
+            $lines[] = "- {$action['status']}: {$action['operation']} {$action['entity_type']} {$label}{$idPart}";
+        }
+
+        $lines[] = '</resolved_actions>';
+
+        return "\n".implode("\n", $lines);
+    }
+
     /**
      * Set the per-turn mention context that will be appended to instructions().
      *
@@ -209,6 +257,16 @@ PROMPT;
     public function withSupersededProposals(array $proposals): self
     {
         $this->supersededProposals = $proposals;
+
+        return $this;
+    }
+
+    /**
+     * @param  list<array{operation: string, entity_type: string, status: string, label: string|null, record_id: string|null}>  $resolved
+     */
+    public function withResolvedActions(array $resolved): self
+    {
+        $this->resolvedActions = $resolved;
 
         return $this;
     }

--- a/packages/Chat/src/Events/ChatPaused.php
+++ b/packages/Chat/src/Events/ChatPaused.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+
+final class ChatPaused implements ShouldBroadcastNow
+{
+    use InteractsWithSockets;
+
+    public function __construct(
+        public readonly string $conversationId,
+        public readonly string $message,
+    ) {}
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("chat.conversation.{$this->conversationId}"),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'chat.paused';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'conversationId' => $this->conversationId,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/packages/Chat/src/Jobs/ContinueChatMessage.php
+++ b/packages/Chat/src/Jobs/ContinueChatMessage.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\Attributes\MaxExceptions;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
@@ -146,8 +147,10 @@ final class ContinueChatMessage implements ShouldQueue
                     resolutionKey: $this->resolutionKey(),
                 );
             });
-        } catch (RateLimitedException|ProviderOverloadedException $e) {
-            if ($this->attempts() < self::MAX_RATE_LIMIT_RETRIES) {
+        } catch (Throwable $e) {
+            // Rate-limit / overloaded errors are transient -> release with backoff;
+            // anything else rethrows and fails fast.
+            if ($this->isRateLimited($e) && $this->attempts() < self::MAX_RATE_LIMIT_RETRIES) {
                 ChatTelemetry::breadcrumb('continuation.rate_limited_retry', ['attempt' => $this->attempts()]);
                 $this->release($this->retryDelaySeconds($this->attempts()));
 
@@ -165,6 +168,21 @@ final class ContinueChatMessage implements ShouldQueue
         return (int) min(2 ** $attempts, 30);
     }
 
+    /**
+     * The provider surfaces a 429 as a typed RateLimitedException on its wrapped
+     * (non-streaming) path, but as a raw HTTP-client RequestException on the
+     * streaming path. Treat both — plus overloaded (529/503) — as retryable.
+     */
+    public function isRateLimited(?Throwable $e): bool
+    {
+        if ($e instanceof RateLimitedException || $e instanceof ProviderOverloadedException) {
+            return true;
+        }
+
+        return $e instanceof RequestException
+            && in_array($e->response->status(), [429, 529, 503], true);
+    }
+
     public function failed(?Throwable $exception): void
     {
         resolve(CreditService::class)->settleReservedMinimum(
@@ -179,7 +197,7 @@ final class ContinueChatMessage implements ShouldQueue
             'exception' => $exception?->getMessage(),
         ]);
 
-        $message = ($exception instanceof RateLimitedException || $exception instanceof ProviderOverloadedException)
+        $message = $this->isRateLimited($exception)
             ? 'The assistant is being rate-limited. Please try again in a moment — anything you already approved was saved.'
             : 'Could not continue the conversation. Please try again.';
 

--- a/packages/Chat/src/Jobs/ContinueChatMessage.php
+++ b/packages/Chat/src/Jobs/ContinueChatMessage.php
@@ -13,6 +13,8 @@ use Illuminate\Queue\Attributes\MaxExceptions;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
 use Relaticle\Chat\Agents\CrmAssistant;
@@ -21,6 +23,7 @@ use Relaticle\Chat\Events\ChatStreamFailed;
 use Relaticle\Chat\Events\ConversationResolved;
 use Relaticle\Chat\Services\AiModelResolver;
 use Relaticle\Chat\Services\CreditService;
+use Relaticle\Chat\Services\PendingActionService;
 use Relaticle\Chat\Support\ChatTelemetry;
 use Throwable;
 
@@ -29,6 +32,8 @@ use Throwable;
 final class ContinueChatMessage implements ShouldQueue
 {
     use Queueable;
+
+    private const int MAX_RATE_LIMIT_RETRIES = 5;
 
     public function __construct(
         public readonly User $user,
@@ -73,7 +78,7 @@ final class ContinueChatMessage implements ShouldQueue
         );
         ChatTelemetry::breadcrumb('continuation.started', ['prompt_length' => strlen($this->prompt)]);
 
-        if (! $creditService->reserveCredit($this->team)) {
+        if ($this->attempts() === 1 && ! $creditService->reserveCredit($this->team)) {
             ChatTelemetry::breadcrumb('continuation.credits_exhausted', []);
             broadcast(new ChatStreamFailed(
                 conversationId: $this->conversationId,
@@ -90,6 +95,10 @@ final class ContinueChatMessage implements ShouldQueue
             $agent = resolve(CrmAssistant::class);
             $agent->withConversationId($this->conversationId);
             $agent->continue($this->conversationId, as: $this->user);
+            $agent->withResolvedActions(
+                resolve(PendingActionService::class)
+                    ->resolvedSinceLastAssistantMessage($this->conversationId),
+            );
 
             $channel = new PrivateChannel("chat.conversation.{$this->conversationId}");
         } catch (Throwable $e) {
@@ -137,9 +146,23 @@ final class ContinueChatMessage implements ShouldQueue
                     resolutionKey: $this->resolutionKey(),
                 );
             });
+        } catch (RateLimitedException|ProviderOverloadedException $e) {
+            if ($this->attempts() < self::MAX_RATE_LIMIT_RETRIES) {
+                ChatTelemetry::breadcrumb('continuation.rate_limited_retry', ['attempt' => $this->attempts()]);
+                $this->release($this->retryDelaySeconds($this->attempts()));
+
+                return;
+            }
+
+            throw $e;
         } finally {
             $this->releaseAuth();
         }
+    }
+
+    public function retryDelaySeconds(int $attempts): int
+    {
+        return (int) min(2 ** $attempts, 30);
     }
 
     public function failed(?Throwable $exception): void
@@ -156,9 +179,13 @@ final class ContinueChatMessage implements ShouldQueue
             'exception' => $exception?->getMessage(),
         ]);
 
+        $message = ($exception instanceof RateLimitedException || $exception instanceof ProviderOverloadedException)
+            ? 'The assistant is being rate-limited. Please try again in a moment — anything you already approved was saved.'
+            : 'Could not continue the conversation. Please try again.';
+
         broadcast(new ChatStreamFailed(
             conversationId: $this->conversationId,
-            message: 'Could not continue the conversation. Please try again.',
+            message: $message,
         ));
     }
 

--- a/packages/Chat/src/Jobs/ProcessChatMessage.php
+++ b/packages/Chat/src/Jobs/ProcessChatMessage.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\Attributes\MaxExceptions;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
@@ -207,10 +208,12 @@ final class ProcessChatMessage implements ShouldQueue
                 $this->materializeAssistantDocument($streamedResponse);
                 $this->broadcastFollowUps($streamedResponse);
             });
-        } catch (RateLimitedException|ProviderOverloadedException $e) {
+        } catch (Throwable $e) {
+            // Rate-limit / overloaded errors are transient -> release with backoff.
             // release() does not count against MaxExceptions(1); attempts() increments
             // each retry. Bounded by this cap AND the job's retryUntil() (now+3min).
-            if ($this->attempts() < self::MAX_RATE_LIMIT_RETRIES) {
+            // Anything else rethrows and fails fast, exactly as before.
+            if ($this->isRateLimited($e) && $this->attempts() < self::MAX_RATE_LIMIT_RETRIES) {
                 ChatTelemetry::breadcrumb('stream.rate_limited_retry', ['attempt' => $this->attempts()]);
                 $this->release($this->retryDelaySeconds($this->attempts()));
 
@@ -228,6 +231,21 @@ final class ProcessChatMessage implements ShouldQueue
         return (int) min(2 ** $attempts, 30);
     }
 
+    /**
+     * The provider surfaces a 429 as a typed RateLimitedException on its wrapped
+     * (non-streaming) path, but as a raw HTTP-client RequestException on the
+     * streaming path. Treat both — plus overloaded (529/503) — as retryable.
+     */
+    public function isRateLimited(?Throwable $e): bool
+    {
+        if ($e instanceof RateLimitedException || $e instanceof ProviderOverloadedException) {
+            return true;
+        }
+
+        return $e instanceof RequestException
+            && in_array($e->response->status(), [429, 529, 503], true);
+    }
+
     public function failed(?Throwable $exception): void
     {
         resolve(CreditService::class)->settleReservedMinimum(
@@ -243,7 +261,7 @@ final class ProcessChatMessage implements ShouldQueue
             'class' => $exception instanceof Throwable ? $exception::class : null,
         ]);
 
-        $message = ($exception instanceof RateLimitedException || $exception instanceof ProviderOverloadedException)
+        $message = $this->isRateLimited($exception)
             ? 'The assistant is being rate-limited. Please try again in a moment — anything you already approved was saved.'
             : 'The assistant encountered an error. Please try again.';
 

--- a/packages/Chat/src/Jobs/ProcessChatMessage.php
+++ b/packages/Chat/src/Jobs/ProcessChatMessage.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Laravel\Ai\Exceptions\ProviderOverloadedException;
+use Laravel\Ai\Exceptions\RateLimitedException;
 use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\StreamedAgentResponse;
 use Laravel\Ai\Streaming\Events\StreamEvent;
@@ -38,6 +40,8 @@ use Throwable;
 final class ProcessChatMessage implements ShouldQueue
 {
     use Queueable;
+
+    private const int MAX_RATE_LIMIT_RETRIES = 5;
 
     /**
      * @param  array{provider: string|null, model: string|null}  $resolved
@@ -91,8 +95,8 @@ final class ProcessChatMessage implements ShouldQueue
         );
         ChatTelemetry::breadcrumb('job.started', ['message_length' => strlen($this->message)]);
 
-        $superseded = resolve(PendingActionService::class)
-            ->supersedePendingForConversation($this->conversationId);
+        $pendingActions = resolve(PendingActionService::class);
+        $superseded = $pendingActions->supersedePendingForConversation($this->conversationId);
 
         if ($superseded !== []) {
             ChatTelemetry::breadcrumb('pending_actions.superseded', [
@@ -113,6 +117,9 @@ final class ProcessChatMessage implements ShouldQueue
             $agent->continue($this->conversationId, as: $this->user);
             $agent->withMentions($this->mentions);
             $agent->withSupersededProposals($this->summarizeSuperseded($superseded));
+            $agent->withResolvedActions(
+                $pendingActions->resolvedSinceLastAssistantMessage($this->conversationId),
+            );
 
             $channel = new PrivateChannel("chat.conversation.{$this->conversationId}");
         } catch (Throwable $e) {
@@ -200,9 +207,25 @@ final class ProcessChatMessage implements ShouldQueue
                 $this->materializeAssistantDocument($streamedResponse);
                 $this->broadcastFollowUps($streamedResponse);
             });
+        } catch (RateLimitedException|ProviderOverloadedException $e) {
+            // release() does not count against MaxExceptions(1); attempts() increments
+            // each retry. Bounded by this cap AND the job's retryUntil() (now+3min).
+            if ($this->attempts() < self::MAX_RATE_LIMIT_RETRIES) {
+                ChatTelemetry::breadcrumb('stream.rate_limited_retry', ['attempt' => $this->attempts()]);
+                $this->release($this->retryDelaySeconds($this->attempts()));
+
+                return;
+            }
+
+            throw $e;
         } finally {
             $this->releaseAuth();
         }
+    }
+
+    public function retryDelaySeconds(int $attempts): int
+    {
+        return (int) min(2 ** $attempts, 30);
     }
 
     public function failed(?Throwable $exception): void
@@ -220,9 +243,13 @@ final class ProcessChatMessage implements ShouldQueue
             'class' => $exception instanceof Throwable ? $exception::class : null,
         ]);
 
+        $message = ($exception instanceof RateLimitedException || $exception instanceof ProviderOverloadedException)
+            ? 'The assistant is being rate-limited. Please try again in a moment — anything you already approved was saved.'
+            : 'The assistant encountered an error. Please try again.';
+
         broadcast(new ChatStreamFailed(
             conversationId: $this->conversationId,
-            message: 'The assistant encountered an error. Please try again.',
+            message: $message,
         ));
     }
 

--- a/packages/Chat/src/Services/ApprovalContinuationService.php
+++ b/packages/Chat/src/Services/ApprovalContinuationService.php
@@ -8,6 +8,7 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Relaticle\Chat\Events\ChatPaused;
 use Relaticle\Chat\Jobs\ContinueChatMessage;
 use Relaticle\Chat\Models\PendingAction;
 
@@ -25,6 +26,13 @@ final readonly class ApprovalContinuationService
         }
 
         if ($this->chainCapReached($pendingAction->conversation_id)) {
+            if ($pendingAction->conversation_id !== null) {
+                broadcast(new ChatPaused(
+                    conversationId: (string) $pendingAction->conversation_id,
+                    message: 'Paused after several approvals. Say "continue" to keep going.',
+                ));
+            }
+
             return;
         }
 

--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -251,6 +251,73 @@ final readonly class PendingActionService
         });
     }
 
+    /**
+     * Actions on this conversation resolved AFTER the latest assistant message —
+     * i.e. decisions the replayed transcript does not yet reflect. Used to inject
+     * a <resolved_actions> block so the model's knowledge of approvals does not
+     * depend on the AI continuation having successfully journaled them.
+     *
+     * @return list<array{operation: string, entity_type: string, status: string, label: string|null, record_id: string|null}>
+     */
+    public function resolvedSinceLastAssistantMessage(string $conversationId): array
+    {
+        $lastAssistantAt = DB::table('agent_conversation_messages')
+            ->where('conversation_id', $conversationId)
+            ->where('role', 'assistant')
+            ->latest('created_at')
+            ->orderByDesc('id')
+            ->value('created_at');
+
+        $query = PendingAction::query()
+            ->where('conversation_id', $conversationId)
+            ->whereIn('status', [
+                PendingActionStatus::Approved->value,
+                PendingActionStatus::Rejected->value,
+                PendingActionStatus::Expired->value,
+                PendingActionStatus::Superseded->value,
+            ])
+            ->whereNotNull('resolved_at');
+
+        if ($lastAssistantAt !== null) {
+            $query->where('resolved_at', '>', $lastAssistantAt);
+        }
+
+        $actions = $query->oldest('resolved_at')->limit(20)->get();
+
+        return array_values(array_map(fn (PendingAction $action): array => [
+            'operation' => $action->operation->value,
+            'entity_type' => $action->entity_type,
+            'status' => $action->status->value,
+            'label' => $this->resolveActionLabel($action),
+            'record_id' => $this->resolveResultRecordId($action),
+        ], $actions->all()));
+    }
+
+    private function resolveActionLabel(PendingAction $action): ?string
+    {
+        $display = $action->display_data;
+        $data = $action->action_data;
+
+        foreach (['name', 'title'] as $field) {
+            if (isset($display[$field]) && is_string($display[$field]) && $display[$field] !== '') {
+                return $display[$field];
+            }
+            if (isset($data[$field]) && is_string($data[$field]) && $data[$field] !== '') {
+                return $data[$field];
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveResultRecordId(PendingAction $action): ?string
+    {
+        $resultData = $action->result_data;
+        $recordId = is_array($resultData) ? ($resultData['id'] ?? null) : null;
+
+        return is_string($recordId) && $recordId !== '' ? $recordId : null;
+    }
+
     private function validateResolvable(PendingAction $pendingAction): void
     {
         if ($pendingAction->isPending() && $pendingAction->isExpired()) {

--- a/tests/Feature/Chat/ChainCapPauseTest.php
+++ b/tests/Feature/Chat/ChainCapPauseTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Task\CreateTask;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Events\ChatPaused;
+use Relaticle\Chat\Jobs\ContinueChatMessage;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\ApprovalContinuationService;
+
+uses(LazilyRefreshDatabase::class);
+
+it('broadcasts ChatPaused and dispatches no continuation when the chain cap is hit', function (): void {
+    Bus::fake();
+    Event::fake([ChatPaused::class]);
+
+    $user = User::factory()->withPersonalTeam()->create();
+    DB::table('agent_conversations')->insert([
+        'id' => 'conv-cap', 'user_id' => $user->getKey(), 'team_id' => $user->currentTeam->getKey(),
+        'title' => 'T', 'created_at' => now(), 'updated_at' => now(),
+    ]);
+
+    foreach (range(1, 5) as $i) {
+        DB::table('agent_conversation_messages')->insert([
+            'id' => (string) Str::ulid(), 'conversation_id' => 'conv-cap', 'user_id' => $user->getKey(),
+            'agent' => 'crm', 'role' => 'user', 'content' => '[approval]', 'attachments' => '[]',
+            'tool_calls' => '[]', 'tool_results' => '[]', 'usage' => '{}', 'meta' => '{}',
+            'created_at' => now()->addSeconds($i), 'updated_at' => now()->addSeconds($i),
+        ]);
+    }
+
+    $action = PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
+        'conversation_id' => 'conv-cap', 'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
+        'action_data' => ['title' => 'Sixth'], 'display_data' => [],
+        'status' => PendingActionStatus::Approved, 'expires_at' => now(), 'resolved_at' => now(),
+        'result_data' => ['id' => 'six'],
+    ]);
+
+    resolve(ApprovalContinuationService::class)->dispatchAfterApproval($action, 'approved');
+
+    Bus::assertNotDispatched(ContinueChatMessage::class);
+    Event::assertDispatched(ChatPaused::class, fn (ChatPaused $e): bool => $e->conversationId === 'conv-cap');
+});

--- a/tests/Feature/Chat/ChatRateLimitTest.php
+++ b/tests/Feature/Chat/ChatRateLimitTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Laravel\Ai\Exceptions\RateLimitedException;
+use Relaticle\Chat\Events\ChatStreamFailed;
+use Relaticle\Chat\Jobs\ContinueChatMessage;
+use Relaticle\Chat\Jobs\ProcessChatMessage;
+
+uses(LazilyRefreshDatabase::class);
+
+function seedRateLimitConversation(string $id, User $user): void
+{
+    DB::table('agent_conversations')->insert([
+        'id' => $id,
+        'user_id' => $user->getKey(),
+        'team_id' => $user->currentTeam->getKey(),
+        'title' => 'T',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('computes capped exponential backoff', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $job = new ProcessChatMessage(
+        user: $user, team: $user->currentTeam, message: 'hi', conversationId: 'c-1',
+        resolved: ['provider' => null, 'model' => 'auto'], turnId: '01TURNAAAAAAAAAAAAAAAAAAAAA',
+    );
+
+    expect($job->retryDelaySeconds(1))->toBe(2)
+        ->and($job->retryDelaySeconds(3))->toBe(8)
+        ->and($job->retryDelaySeconds(10))->toBe(30);
+});
+
+it('broadcasts a rate-limit-specific message when a rate-limited job ultimately fails', function (): void {
+    Event::fake([ChatStreamFailed::class]);
+
+    $user = User::factory()->withPersonalTeam()->create();
+    seedRateLimitConversation('c-1', $user);
+    $job = new ProcessChatMessage(
+        user: $user, team: $user->currentTeam, message: 'hi', conversationId: 'c-1',
+        resolved: ['provider' => null, 'model' => 'auto'], turnId: '01TURNBBBBBBBBBBBBBBBBBBBBB',
+    );
+
+    $job->failed(new RateLimitedException('rate limited', 429));
+
+    Event::assertDispatched(ChatStreamFailed::class, fn (ChatStreamFailed $e): bool => str_contains($e->message, 'rate-limited'));
+});
+
+it('broadcasts a rate-limit message when a rate-limited continuation ultimately fails', function (): void {
+    Event::fake([ChatStreamFailed::class]);
+
+    $user = User::factory()->withPersonalTeam()->create();
+    seedRateLimitConversation('c-1', $user);
+    $job = new ContinueChatMessage(
+        user: $user, team: $user->currentTeam, conversationId: 'c-1',
+        prompt: '[approval]', turnId: '01TURNCCCCCCCCCCCCCCCCCCCCC',
+    );
+
+    $job->failed(new RateLimitedException('rate limited', 429));
+
+    Event::assertDispatched(ChatStreamFailed::class, fn (ChatStreamFailed $e): bool => str_contains($e->message, 'rate-limited'));
+});

--- a/tests/Feature/Chat/ChatRateLimitTest.php
+++ b/tests/Feature/Chat/ChatRateLimitTest.php
@@ -3,7 +3,10 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response as ClientResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Laravel\Ai\Exceptions\RateLimitedException;
@@ -23,6 +26,11 @@ function seedRateLimitConversation(string $id, User $user): void
         'created_at' => now(),
         'updated_at' => now(),
     ]);
+}
+
+function httpClientException(int $status): RequestException
+{
+    return new RequestException(new ClientResponse(new Psr7Response($status)));
 }
 
 it('computes capped exponential backoff', function (): void {
@@ -48,6 +56,42 @@ it('broadcasts a rate-limit-specific message when a rate-limited job ultimately 
     );
 
     $job->failed(new RateLimitedException('rate limited', 429));
+
+    Event::assertDispatched(ChatStreamFailed::class, fn (ChatStreamFailed $e): bool => str_contains($e->message, 'rate-limited'));
+});
+
+it('treats a raw streaming 429/529/503 RequestException as rate-limited, but not a 400', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $job = new ProcessChatMessage(
+        user: $user, team: $user->currentTeam, message: 'hi', conversationId: 'c-1',
+        resolved: ['provider' => null, 'model' => 'auto'], turnId: '01TURNDDDDDDDDDDDDDDDDDDDDD',
+    );
+    $cont = new ContinueChatMessage(
+        user: $user, team: $user->currentTeam, conversationId: 'c-1',
+        prompt: '[approval]', turnId: '01TURNEEEEEEEEEEEEEEEEEEEEE',
+    );
+
+    expect($job->isRateLimited(httpClientException(429)))->toBeTrue()
+        ->and($job->isRateLimited(httpClientException(529)))->toBeTrue()
+        ->and($job->isRateLimited(httpClientException(503)))->toBeTrue()
+        ->and($job->isRateLimited(httpClientException(400)))->toBeFalse()
+        ->and($job->isRateLimited(new RuntimeException('boom')))->toBeFalse()
+        ->and($job->isRateLimited(null))->toBeFalse()
+        ->and($cont->isRateLimited(httpClientException(429)))->toBeTrue()
+        ->and($cont->isRateLimited(httpClientException(400)))->toBeFalse();
+});
+
+it('broadcasts the rate-limit message for a raw 429 RequestException failure', function (): void {
+    Event::fake([ChatStreamFailed::class]);
+
+    $user = User::factory()->withPersonalTeam()->create();
+    seedRateLimitConversation('c-1', $user);
+    $job = new ProcessChatMessage(
+        user: $user, team: $user->currentTeam, message: 'hi', conversationId: 'c-1',
+        resolved: ['provider' => null, 'model' => 'auto'], turnId: '01TURNFFFFFFFFFFFFFFFFFFFFF',
+    );
+
+    $job->failed(httpClientException(429));
 
     Event::assertDispatched(ChatStreamFailed::class, fn (ChatStreamFailed $e): bool => str_contains($e->message, 'rate-limited'));
 });

--- a/tests/Feature/Chat/CrmAssistantResolvedBlockTest.php
+++ b/tests/Feature/Chat/CrmAssistantResolvedBlockTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Chat\Agents\CrmAssistant;
+
+it('renders a resolved_actions block when set', function (): void {
+    $instructions = (new CrmAssistant)
+        ->withResolvedActions([
+            ['operation' => 'create', 'entity_type' => 'task', 'status' => 'approved', 'label' => 'Review Q3', 'record_id' => '01ABC'],
+            ['operation' => 'create', 'entity_type' => 'person', 'status' => 'rejected', 'label' => 'Sarah', 'record_id' => null],
+        ])
+        ->instructions();
+
+    expect($instructions)->toContain('<resolved_actions>')
+        ->and($instructions)->toContain('approved: create task "Review Q3" (id: 01ABC)')
+        ->and($instructions)->toContain('rejected: create person "Sarah"')
+        ->and($instructions)->not->toContain('rejected: create person "Sarah" (id:');
+});
+
+it('omits the resolved_actions block when empty', function (): void {
+    // The prose mentions the <resolved_actions> tag; the rendered block has a
+    // unique content marker that must be absent when there are no resolved actions.
+    expect((new CrmAssistant)->instructions())
+        ->not->toContain('These proposals were already decided by the user.');
+});

--- a/tests/Feature/Chat/ResolvedActionsContextTest.php
+++ b/tests/Feature/Chat/ResolvedActionsContextTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Task\CreateTask;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Jobs\ContinueChatMessage;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\PendingActionService;
+
+uses(LazilyRefreshDatabase::class);
+
+function seedResolvedConv(string $id, User $user): void
+{
+    DB::table('agent_conversations')->insert([
+        'id' => $id,
+        'user_id' => $user->getKey(),
+        'team_id' => $user->currentTeam->getKey(),
+        'title' => 'T',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+function seedResolvedAssistantMsg(string $conversationId, User $user, DateTimeInterface $at): void
+{
+    DB::table('agent_conversation_messages')->insert([
+        'id' => (string) Str::ulid(),
+        'conversation_id' => $conversationId,
+        'user_id' => $user->getKey(),
+        'agent' => 'crm',
+        'role' => 'assistant',
+        'content' => 'ok',
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '{}',
+        'meta' => '{}',
+        'created_at' => $at,
+        'updated_at' => $at,
+    ]);
+}
+
+it('surfaces only actions resolved after the last assistant message', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    seedResolvedConv('conv-1', $user);
+
+    seedResolvedAssistantMsg('conv-1', $user, now()->subMinutes(5));
+
+    PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
+        'conversation_id' => 'conv-1', 'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
+        'action_data' => ['title' => 'Stale'], 'display_data' => [],
+        'status' => PendingActionStatus::Approved, 'expires_at' => now(),
+        'resolved_at' => now()->subMinutes(10), 'result_data' => ['id' => 'old-id'],
+    ]);
+
+    PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
+        'conversation_id' => 'conv-1', 'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
+        'action_data' => ['title' => 'Fresh Task'], 'display_data' => [],
+        'status' => PendingActionStatus::Approved, 'expires_at' => now(),
+        'resolved_at' => now()->subMinute(), 'result_data' => ['id' => 'new-id'],
+    ]);
+
+    $resolved = resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage('conv-1');
+
+    expect($resolved)->toHaveCount(1)
+        ->and($resolved[0]['label'])->toBe('Fresh Task')
+        ->and($resolved[0]['status'])->toBe('approved')
+        ->and($resolved[0]['record_id'])->toBe('new-id')
+        ->and($resolved[0]['operation'])->toBe('create')
+        ->and($resolved[0]['entity_type'])->toBe('task');
+});
+
+it('returns an empty list for another conversation', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    seedResolvedConv('conv-1', $user);
+
+    PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
+        'conversation_id' => 'conv-1', 'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
+        'action_data' => ['title' => 'X'], 'display_data' => [],
+        'status' => PendingActionStatus::Approved, 'expires_at' => now(),
+        'resolved_at' => now(), 'result_data' => ['id' => 'x'],
+    ]);
+
+    expect(resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage('other-conv'))->toBe([]);
+});
+
+it('surfaces an approval even when the continuation never journals it (Bug A)', function (): void {
+    Bus::fake([ContinueChatMessage::class]);
+
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    seedResolvedConv('conv-A', $user);
+    seedResolvedAssistantMsg('conv-A', $user, now()->subMinutes(2));
+
+    $pending = PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
+        'conversation_id' => 'conv-A', 'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
+        'action_data' => ['title' => 'Review Q3 sales pipeline'], 'display_data' => [],
+        'status' => PendingActionStatus::Pending, 'expires_at' => now()->addMinutes(15),
+    ]);
+
+    resolve(PendingActionService::class)->approve($pending, $user);
+
+    $resolved = resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage('conv-A');
+
+    expect($resolved)->toHaveCount(1)
+        ->and($resolved[0]['status'])->toBe('approved')
+        ->and($resolved[0]['label'])->toBe('Review Q3 sales pipeline');
+});

--- a/tests/Unit/Chat/TerminalBroadcastInvariantTest.php
+++ b/tests/Unit/Chat/TerminalBroadcastInvariantTest.php
@@ -26,7 +26,9 @@ it('settles or broadcasts on every ContinueChatMessage failure exit', function (
     $failedPos = strpos($source, 'public function failed(');
     expect($failedPos)->not->toBeFalse();
 
-    $failedBody = substr($source, (int) $failedPos, 600);
+    // Scan from failed() to end of file rather than a fixed window: failed() is the
+    // last method that settles/broadcasts, so both markers only appear in its body.
+    $failedBody = substr($source, (int) $failedPos);
     expect($failedBody)->toContain('settleReservedMinimum')
         ->and($failedBody)->toContain('new ChatStreamFailed(');
 });


### PR DESCRIPTION
## What & why

The in-app CRM chat assistant broke during a bulk "create 50 tasks one-by-one" flow (from a reported transcript): after approving a proposal it kept insisting *"I still need your approval on Task 1/50"*, then surfaced a generic *"The assistant encountered an error."* Root-caused to two defects plus a silent stall. This fixes all three.

### Fix 1 — Resolved-action context (Bug A: lost approval state)

Approvals were journaled into the LLM transcript **only** by the `ContinueChatMessage` continuation, which `RememberConversation` persists only on a *successful* stream. When the continuation threw (429) or was skipped by the chain cap, the approval never entered the transcript, so the model replayed a history ending at the *pending* proposal and re-asked for approval.

Now a `<resolved_actions>` block is injected into the system prompt each turn, built from the authoritative `pending_actions` table and scoped to "resolved after the last assistant message" (self-limiting, **no schema change**). Mirrors the existing `<superseded_proposals>` plumbing.

### Fix 2 — 429 resilience (Bug B: opaque provider errors)

`RateLimitedException` (429) thrown from `$agent->stream()` propagated to `failed()` and broadcast the generic error with no retry (429 doesn't fail over to the second provider). Both jobs now catch `RateLimitedException`/`ProviderOverloadedException`, `release()` with capped exponential backoff (attempts-gated, bounded by `retryUntil`), and broadcast an honest "being rate-limited" message. `ContinueChatMessage` reserves credit only on attempt 1 to avoid double charges across retries.

### Fix 3 — Explicit pause

When the auto-continue chain hits `CHAIN_HARD_CAP` it previously stopped silently. It now broadcasts a `ChatPaused` event and the UI renders a *"Paused — say continue to resume"* notice; Fix 1 lets the model resume from where it left off.

## Tests

- New: `ResolvedActionsContextTest` (incl. a Bug A regression that fails on `main`), `CrmAssistantResolvedBlockTest`, `ChatRateLimitTest`, `ChainCapPauseTest`.
- Full Chat suite: **451 passed / 1103 assertions**. PHPStan (`packages/Chat`) clean, Pint clean, Rector clean.

## Manual verification still needed

The blade pause-notice handler (`handleChatPaused`) has no automated seam — needs a browser check: approve 5 proposals in a row → confirm the pause bubble appears → "continue" resumes.

## Notes

- Adjusted two test assertions (test layer, not production): the `CrmAssistant` "omits block" check (the new prose legitimately names the `<resolved_actions>` tag) and `TerminalBroadcastInvariantTest`'s brittle fixed-width window.
