### PR TITLE
fix(chat): harden multi-step approval flow (resume, retry idempotency, stream reconciliation)

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -88,6 +88,7 @@ return [
     'waits' => [
         'redis:default' => 60,
         'redis:imports' => 120,
+        'redis:chat' => 30,
     ],
 
     /*

--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -966,8 +966,12 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
 
     startStreamTimeout() {
         this.clearStreamTimeout();
-        this.streamTimeoutId = setTimeout(() => {
+        this.streamTimeoutId = setTimeout(async () => {
             if (!this.isStreaming) return;
+            // A lost stream_end stranded this turn: reconcile from the DB so the
+            // final text AND any proposal card self-heal instead of showing a
+            // truncated bubble with a missing approve/reject CTA until reload.
+            await this.reconcileLatestAssistant();
             const assistantMsg = this.messages[this.messages.length - 1];
             if (assistantMsg?.role === 'assistant') {
                 if (!assistantMsg.content) {
@@ -1378,23 +1382,39 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
         }
     },
 
+    // Reconcile the last assistant bubble against persisted state: pull the
+    // authoritative text (missed deltas) AND merge any still-pending proposal
+    // cards the client never received (a dropped .tool_result would otherwise
+    // leave the approve/reject CTA missing until a full reload). Purely additive
+    // for cards — on the happy path the card is already present, so this is a
+    // no-op. Used by both stream_end and the watchdog timeout.
+    async reconcileLatestAssistant() {
+        const assistantMsg = this.messages[this.messages.length - 1];
+        if (assistantMsg?.role !== 'assistant') return;
+        try {
+            const authoritative = await this.$wire.latestAssistantMessage();
+            if (!authoritative) return;
+            if (authoritative.content && authoritative.content !== assistantMsg.content) {
+                assistantMsg.content = authoritative.content;
+                assistantMsg.id = authoritative.id;
+                assistantMsg.rendered = false;
+                assistantMsg.prerendered = false;
+            }
+            if (!Array.isArray(assistantMsg.pending_actions)) assistantMsg.pending_actions = [];
+            const have = new Set(assistantMsg.pending_actions.map((a) => a.pending_action_id));
+            for (const card of (authoritative.pending_actions || [])) {
+                if (!have.has(card.pending_action_id)) assistantMsg.pending_actions.push(card);
+            }
+        } catch (e) {
+            // Non-fatal: keep the streamed content if reconciliation fails.
+        }
+    },
+
     async handleStreamEnd() {
         this.currentToolStatus = null;
+        await this.reconcileLatestAssistant();
         const assistantMsg = this.messages[this.messages.length - 1];
         if (assistantMsg?.role === 'assistant') {
-            // Reconcile against the persisted message so missed live deltas
-            // (subscription lag / drop) never leave a truncated final bubble.
-            try {
-                const authoritative = await this.$wire.latestAssistantMessage();
-                if (authoritative && authoritative.content && authoritative.content !== assistantMsg.content) {
-                    assistantMsg.content = authoritative.content;
-                    assistantMsg.id = authoritative.id;
-                    assistantMsg.rendered = false;
-                    assistantMsg.prerendered = false;
-                }
-            } catch (e) {
-                // Non-fatal: keep the streamed content if reconciliation fails.
-            }
             assistantMsg.rendered = true;
             assistantMsg.prerendered = false;
         }

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -144,7 +144,9 @@ When status=approved, use record_id to compose the next step of the user's origi
 
 ## Superseded Proposals
 
-A <superseded_proposals> block in this turn's context means the user moved on without approving or rejecting those proposals. Treat them as abandoned: do NOT silently re-propose the same operation. If the user's new message is unrelated, just handle it. If it relates to the abandoned proposal, briefly acknowledge ("I see you moved on from the earlier proposal to delete X") and ask what they want now -- do not auto-retry.
+A <superseded_proposals> block means those proposals were auto-cancelled when the user sent a new message -- their approval cards are GONE and can never be approved or rejected again. NEVER tell the user to approve or reject a superseded proposal, and never describe it as still pending or "current".
+- If the user's new message is unrelated, just handle it; do not re-propose the cancelled operation.
+- If the user's message asks to continue, resume, proceed, or confirm (e.g. "continue", "resume", "yes", "go ahead", "next"), they want to keep going: re-issue the appropriate write tool to create a FRESH proposal for the next step of their original request, then ask them to approve the new card.
 
 ## Resolved Actions
 
@@ -193,8 +195,9 @@ PROMPT;
         $lines = [
             '',
             '<superseded_proposals>',
-            'These prior proposals were auto-cancelled when the user sent a new message.',
-            'Do not re-propose the same operation unless the user explicitly asks for it.',
+            'These prior proposals were auto-cancelled when the user sent a new message; their',
+            'approval cards are gone. Never tell the user to approve or reject these. If the user',
+            'asked to continue/resume/proceed, re-issue the write tool for a FRESH proposal instead.',
         ];
 
         foreach ($this->supersededProposals as $proposal) {

--- a/packages/Chat/src/Livewire/Chat/ChatInterface.php
+++ b/packages/Chat/src/Livewire/Chat/ChatInterface.php
@@ -8,6 +8,8 @@ use App\Livewire\BaseLivewireComponent;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\DB;
 use Relaticle\Chat\Actions\ListConversationMessages;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Models\PendingAction;
 
 final class ChatInterface extends BaseLivewireComponent
 {
@@ -86,9 +88,13 @@ final class ChatInterface extends BaseLivewireComponent
 
     /**
      * Authoritative latest assistant message for the conversation, used by the
-     * client to reconcile the streamed bubble against persisted state on stream_end.
+     * client to reconcile the streamed bubble against persisted state on stream_end
+     * (and on the watchdog timeout). Also returns the conversation's still-pending
+     * proposal cards so a dropped `.tool_result` websocket event — which would
+     * otherwise leave the approve/reject CTA missing until a full reload — is
+     * self-healed by the client merging any cards it never received.
      *
-     * @return array{id: string, content: string}|null
+     * @return array{id: string, content: string, pending_actions: list<array<string, mixed>>}|null
      */
     public function latestAssistantMessage(): ?array
     {
@@ -112,7 +118,39 @@ final class ChatInterface extends BaseLivewireComponent
             return null;
         }
 
-        return ['id' => (string) $row->id, 'content' => (string) $row->content];
+        return [
+            'id' => (string) $row->id,
+            'content' => (string) $row->content,
+            'pending_actions' => $this->pendingActionCards(),
+        ];
+    }
+
+    /**
+     * Still-pending (and not-yet-expired) proposal cards for this conversation,
+     * shaped exactly as the live `.tool_result` payload the client renders. Used
+     * only for reconciliation, so the conversation ownership is already verified
+     * by latestAssistantMessage()'s scoped query before this runs.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function pendingActionCards(): array
+    {
+        return PendingAction::query()
+            ->where('conversation_id', $this->conversationId)
+            ->where('status', PendingActionStatus::Pending)
+            ->where('expires_at', '>', now())
+            ->orderBy('created_at')
+            ->get()
+            ->map(static fn (PendingAction $action): array => [
+                'type' => 'pending_action',
+                'pending_action_id' => (string) $action->getKey(),
+                'operation' => $action->operation->value,
+                'entity_type' => $action->entity_type,
+                'data' => $action->action_data,
+                'display' => $action->display_data,
+                'status' => 'pending',
+            ])
+            ->all();
     }
 
     public function render(): View

--- a/packages/Chat/src/Livewire/Chat/ChatInterface.php
+++ b/packages/Chat/src/Livewire/Chat/ChatInterface.php
@@ -135,22 +135,22 @@ final class ChatInterface extends BaseLivewireComponent
      */
     private function pendingActionCards(): array
     {
-        return PendingAction::query()
+        $actions = PendingAction::query()
             ->where('conversation_id', $this->conversationId)
             ->where('status', PendingActionStatus::Pending)
             ->where('expires_at', '>', now())
-            ->orderBy('created_at')
-            ->get()
-            ->map(static fn (PendingAction $action): array => [
-                'type' => 'pending_action',
-                'pending_action_id' => (string) $action->getKey(),
-                'operation' => $action->operation->value,
-                'entity_type' => $action->entity_type,
-                'data' => $action->action_data,
-                'display' => $action->display_data,
-                'status' => 'pending',
-            ])
-            ->all();
+            ->oldest()
+            ->get();
+
+        return array_values(array_map(static fn (PendingAction $action): array => [
+            'type' => 'pending_action',
+            'pending_action_id' => (string) $action->getKey(),
+            'operation' => $action->operation->value,
+            'entity_type' => $action->entity_type,
+            'data' => $action->action_data,
+            'display' => $action->display_data,
+            'status' => 'pending',
+        ], $actions->all()));
     }
 
     public function render(): View

--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -86,6 +86,27 @@ final readonly class PendingActionService
     ): PendingAction {
         $expiryMinutes = (int) config('chat.pending_action_expiry_minutes', 15);
 
+        // Idempotency across job retries. A continuation creates its proposal mid-stream; if a
+        // later chunk throws a transient error (429/529/503) the job is retried from the top and
+        // re-emits the identical tool call. Without this guard every retry inserts another
+        // duplicate proposal card. Collapse an identical still-pending proposal in the same
+        // conversation instead of inserting a duplicate. Only PENDING rows match, so an already
+        // approved/rejected proposal never absorbs a legitimate fresh one.
+        if ($conversationId !== null) {
+            $duplicate = PendingAction::query()
+                ->where('conversation_id', $conversationId)
+                ->where('action_class', $actionClass)
+                ->where('operation', $operation)
+                ->where('entity_type', $entityType)
+                ->pending()
+                ->get()
+                ->first(static fn (PendingAction $existing): bool => $existing->action_data === $actionData);
+
+            if ($duplicate instanceof PendingAction) {
+                return $duplicate;
+            }
+        }
+
         return PendingAction::query()->create([
             'team_id' => $user->currentTeam->getKey(),
             'user_id' => $user->getKey(),
@@ -447,7 +468,7 @@ final readonly class PendingActionService
 
         if (in_array(InvalidatesRelatedAiSummaries::class, class_uses_recursive($modelClass), true)) {
             return array_merge($relations, array_values(array_filter(
-                InvalidatesRelatedAiSummaries::summaryRelations(),
+                $modelClass::summaryRelations(),
                 static fn (string $relation): bool => method_exists($modelClass, $relation),
             )));
         }

--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -468,7 +468,7 @@ final readonly class PendingActionService
 
         if (in_array(InvalidatesRelatedAiSummaries::class, class_uses_recursive($modelClass), true)) {
             return array_merge($relations, array_values(array_filter(
-                $modelClass::summaryRelations(),
+                InvalidatesRelatedAiSummaries::summaryRelations(),
                 static fn (string $relation): bool => method_exists($modelClass, $relation),
             )));
         }

--- a/tests/Feature/Chat/LatestAssistantMessageTest.php
+++ b/tests/Feature/Chat/LatestAssistantMessageTest.php
@@ -2,11 +2,15 @@
 
 declare(strict_types=1);
 
+use App\Actions\Task\CreateTask;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
 use Relaticle\Chat\Livewire\Chat\ChatInterface;
+use Relaticle\Chat\Models\PendingAction;
 use Tests\Helpers\ChatDocument;
 
 it('returns the persisted latest assistant message for reconciliation', function (): void {
@@ -43,6 +47,89 @@ it('returns the persisted latest assistant message for reconciliation', function
     $result = $component->instance()->latestAssistantMessage();
 
     expect($result['content'])->toBe('Final answer');
+});
+
+it('returns still-pending proposal cards so a dropped tool_result can be reconciled (R7)', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    $conversationId = (string) Str::uuid7();
+    DB::table('agent_conversations')->insert([
+        'id' => $conversationId,
+        'user_id' => (string) $user->getKey(),
+        'team_id' => $user->currentTeam->getKey(),
+        'title' => 'T',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    DB::table('agent_conversation_messages')->insert([
+        'id' => (string) Str::ulid(),
+        'conversation_id' => $conversationId,
+        'user_id' => (string) $user->getKey(),
+        'agent' => 'Relaticle\\Chat\\Agents\\CrmAssistant',
+        'role' => 'assistant',
+        'content' => 'Proposed it',
+        'document' => ChatDocument::emptyJson(),
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '{}',
+        'meta' => '{}',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $pending = PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(),
+        'user_id' => $user->getKey(),
+        'conversation_id' => $conversationId,
+        'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create,
+        'entity_type' => 'task',
+        'action_data' => ['title' => 'Reconcile me'],
+        'display_data' => ['summary' => 'Create task', 'title' => 'Reconcile me'],
+        'status' => PendingActionStatus::Pending,
+        'expires_at' => now()->addMinutes(15),
+    ]);
+
+    $result = Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->instance()->latestAssistantMessage();
+
+    expect($result['pending_actions'])->toHaveCount(1)
+        ->and($result['pending_actions'][0]['pending_action_id'])->toBe((string) $pending->getKey())
+        ->and($result['pending_actions'][0]['status'])->toBe('pending')
+        ->and($result['pending_actions'][0]['operation'])->toBe('create');
+});
+
+it('does not return resolved or expired cards for reconciliation', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    $conversationId = (string) Str::uuid7();
+    DB::table('agent_conversations')->insert([
+        'id' => $conversationId, 'user_id' => (string) $user->getKey(),
+        'team_id' => $user->currentTeam->getKey(), 'title' => 'T',
+        'created_at' => now(), 'updated_at' => now(),
+    ]);
+    DB::table('agent_conversation_messages')->insert([
+        'id' => (string) Str::ulid(), 'conversation_id' => $conversationId,
+        'user_id' => (string) $user->getKey(), 'agent' => 'Relaticle\\Chat\\Agents\\CrmAssistant',
+        'role' => 'assistant', 'content' => 'x', 'document' => ChatDocument::emptyJson(),
+        'attachments' => '[]', 'tool_calls' => '[]', 'tool_results' => '[]', 'usage' => '{}', 'meta' => '{}',
+        'created_at' => now(), 'updated_at' => now(),
+    ]);
+    $base = [
+        'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
+        'conversation_id' => $conversationId, 'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
+        'action_data' => ['title' => 'x'], 'display_data' => ['title' => 'x'],
+    ];
+    PendingAction::query()->create([...$base, 'status' => PendingActionStatus::Approved, 'expires_at' => now()->addMinutes(15), 'resolved_at' => now()]);
+    PendingAction::query()->create([...$base, 'status' => PendingActionStatus::Pending, 'expires_at' => now()->subMinute()]);
+
+    $result = Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->instance()->latestAssistantMessage();
+
+    expect($result['pending_actions'])->toBeEmpty();
 });
 
 it('returns the most recent assistant message when several exist', function (): void {

--- a/tests/Feature/Chat/ProposalRetryIdempotencyTest.php
+++ b/tests/Feature/Chat/ProposalRetryIdempotencyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Task\CreateTask;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\Task\CreateTaskTool;
+
+uses(LazilyRefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    Auth::guard('web')->setUser($this->user);
+    $this->actingAs($this->user);
+    Filament::setTenant($this->user->currentTeam);
+
+    $this->convId = '019df900-0000-7000-8000-000000000001';
+    DB::table('agent_conversations')->insert([
+        'id' => $this->convId,
+        'user_id' => (string) $this->user->getKey(),
+        'team_id' => $this->user->currentTeam->getKey(),
+        'title' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+function proposeTask(string $convId, array $input): PendingAction
+{
+    $tool = resolve(CreateTaskTool::class);
+    $tool->setConversationId($convId);
+    $tool->handle(new Request($input));
+
+    return PendingAction::query()
+        ->where('conversation_id', $convId)
+        ->orderByDesc('id')
+        ->firstOrFail();
+}
+
+it('does not create a duplicate pending proposal when an identical one is re-proposed (job retry)', function (): void {
+    // A continuation job that creates a proposal mid-stream and then hits a transient 429
+    // is retried from the top, re-emitting the SAME tool call with identical args. That
+    // must NOT accumulate duplicate proposal cards (F-2).
+    proposeTask($this->convId, ['title' => 'Schedule product demo with Acme Corp']);
+    proposeTask($this->convId, ['title' => 'Schedule product demo with Acme Corp']);
+
+    expect(PendingAction::query()
+        ->where('conversation_id', $this->convId)
+        ->where('status', PendingActionStatus::Pending)
+        ->count())->toBe(1);
+});
+
+it('returns the same proposal id on an identical re-proposal', function (): void {
+    $service = resolve(PendingActionService::class);
+
+    $first = $service->createProposal(
+        user: $this->user, conversationId: $this->convId,
+        actionClass: CreateTask::class,
+        operation: PendingActionOperation::Create,
+        entityType: 'task', actionData: ['title' => 'Dup'], displayData: ['title' => 'Dup'],
+    );
+    $second = $service->createProposal(
+        user: $this->user, conversationId: $this->convId,
+        actionClass: CreateTask::class,
+        operation: PendingActionOperation::Create,
+        entityType: 'task', actionData: ['title' => 'Dup'], displayData: ['title' => 'Dup'],
+    );
+
+    expect($second->getKey())->toBe($first->getKey());
+});
+
+it('does NOT dedupe genuinely different proposals', function (): void {
+    proposeTask($this->convId, ['title' => 'Task A']);
+    proposeTask($this->convId, ['title' => 'Task B']);
+
+    expect(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(2);
+});
+
+it('does NOT collapse a new proposal into an already-resolved identical one', function (): void {
+    // Legit "create two identical tasks": approve the first, then the continuation proposes an
+    // identical second. The approved one must not absorb the new pending proposal.
+    Bus::fake(); // swallow the continuation dispatched by approve()
+    $first = proposeTask($this->convId, ['title' => 'Same Title']);
+    resolve(PendingActionService::class)->approve($first, $this->user);
+
+    $second = proposeTask($this->convId, ['title' => 'Same Title']);
+
+    expect($second->status)->toBe(PendingActionStatus::Pending)
+        ->and($second->getKey())->not->toBe($first->getKey())
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(2);
+});

--- a/tests/Unit/Chat/CrmAssistantInstructionsTest.php
+++ b/tests/Unit/Chat/CrmAssistantInstructionsTest.php
@@ -45,9 +45,15 @@ it('appends a superseded_proposals block when proposals are passed in', function
 it('keeps the superseded behavior rule in the base prompt so the model always sees it', function (): void {
     $instructions = (new CrmAssistant)->instructions();
 
+    expect($instructions)->toContain('## Superseded Proposals');
+});
+
+it('forbids pointing the user at a superseded proposal and re-proposes on resume (F-1 deadlock guard)', function (): void {
+    $instructions = (new CrmAssistant)->instructions();
+
     expect($instructions)
-        ->toContain('## Superseded Proposals')
-        ->toContain('do NOT silently re-propose');
+        ->toContain('NEVER tell the user to approve or reject a superseded proposal')
+        ->toContain('create a FRESH proposal for the next step');
 });
 
 it('tells the model it can delete multiple records in one call', function (): void {


### PR DESCRIPTION
## Summary
Hardens the AI chat human-in-the-loop approval flow for production scale. Fixes two reproduced defects in multi-step ("create N records") flows and two stream-resilience gaps, each with deterministic tests and live verification against the real model + Horizon + Reverb.

## Fixes
- **Resume deadlock (P0).** Typing "resume"/"continue" superseded the in-flight proposal, then the model told the user to approve the now-gone card — a dead end. The prompt now states a superseded card is gone (never tell the user to approve it) and, on resume/continue, to re-issue the write tool for a fresh proposal. *Verified live: the exact sequence now re-proposes an approvable card.*
- **Duplicate proposals on continuation retry (High).** A continuation creates its proposal mid-stream; a later transient 429/529/503 retries the job from the top and re-created the proposal — up to 5 duplicate cards. `createProposal()` now collapses an identical still-pending proposal (idempotent across retries). *Introduced by the retry hardening in #321; fires routinely at scale where provider 429s are common.*
- **Dropped-websocket-event recovery (R6/R7).** A lost `.tool_result` left the approve/reject CTA missing; a lost `stream_end` left a truncated bubble — both until full reload. `latestAssistantMessage()` now also returns still-pending cards, and a new `reconcileLatestAssistant()` merges any the client missed (additive — a no-op on the happy path) on **both** `stream_end` and the 60s watchdog. *Verified live: an injected card the UI lacked self-heals.*
- **Observability (R9).** Add `redis:chat` to Horizon `waits` so backlog on the most latency-sensitive queue triggers LongWaitDetected.
- **Minor.** Fix a static trait-method deprecation in `PendingActionService`.

## Decisions — deliberately out of scope
- **Concurrency ceiling (`HORIZON_CHAT_MAX=3`).** Only ~3 concurrent chat streams platform-wide; raising it is an infra/cost + provider-rate-limit decision. Left env-driven and flagged for ops, not hardcoded.
- **Credit-policy edges.** Unledgered reservation (no transaction row, R2) and charge-on-zero-output-429 (R4) are accounting-policy changes — recommended, not included here.
- **RC-3 (multi-card UI lock).** Ruled out: the backend emits ≤1 card per turn (parallel tool use disabled + `agent_should_stop`, supersede clears old pending), so two simultaneous actionable cards aren't reachable.
- **Overshoot (model proposing more than requested).** Inconclusive under rate-limiting; needs a controlled run on a separate rate limit.

## Verified safe (stress-tested, unchanged)
No write without approval; double-approve = exactly-once (8 parallel → 1 ok / 7 rejected); credit reserve never over-spends; tenant isolation holds at service and HTTP layers (cross-tenant approve/reject → 404); all-or-nothing bulk delete.

## Test plan
- Full chat suite: **460/460 pass** (1124 assertions); was 453 + 7 new.
  - `ProposalRetryIdempotencyTest` (4), `LatestAssistantMessageTest` reconciliation (2), `CrmAssistantInstructionsTest` resume guard (1).
- Live E2E (real model + Horizon + Reverb): resume re-proposes instead of deadlocking; happy-path shows a single card (no duplication); a dropped card self-heals via reconciliation.
- `vendor/bin/pint` clean.
