### PR TITLE
fix(email): clean up disconnected accounts and hide their emails

### DIFF
--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -56,5 +56,9 @@ return [
             'title' => 'Calendar sync queued.',
             'body' => 'New events should appear within a minute.',
         ],
+        'disconnected' => [
+            'title' => 'Account disconnected.',
+            'body' => 'The account and its signatures have been removed.',
+        ],
     ],
 ];

--- a/packages/EmailIntegration/resources/views/filament/pages/email-signatures.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-signatures.blade.php
@@ -12,7 +12,7 @@
                             @endif
                         </div>
                         <p class="text-xs text-gray-500 dark:text-gray-400">
-                            {{ $signature->connectedAccount->email_address }}
+                            {{ $signature->connectedAccount?->email_address }}
                         </p>
                         <div class="prose prose-xs dark:prose-invert mt-2 max-w-none rounded border border-gray-100 bg-gray-50 px-3 py-2 text-xs dark:border-gray-700 dark:bg-gray-800">
                             {!! app(\Relaticle\EmailIntegration\Services\HtmlSanitizerService::class)->sanitizeRichText($signature->content_html) !!}

--- a/packages/EmailIntegration/src/Actions/DisconnectConnectedAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/DisconnectConnectedAccountAction.php
@@ -10,6 +10,11 @@ final readonly class DisconnectConnectedAccountAction
 {
     public function execute(ConnectedAccount $account): void
     {
+        // Account is soft-deleted, so the DB-level cascade on email_signatures never
+        // fires. Remove dependent signatures explicitly to avoid orphaned rows whose
+        // connectedAccount relation resolves to null on the signatures page.
+        $account->signatures()->delete();
+
         $account->delete();
     }
 }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -80,6 +80,8 @@ final class EmailAccountsPage extends Page
             ->icon('heroicon-o-plus')
             ->color('info')
             ->size(Size::Small)
+            // Outlook/Azure connection is hidden for now; re-enable when the provider is ready.
+            ->hidden()
             ->url(fn (): string => route('email-accounts.redirect', ['provider' => 'azure']), true);
     }
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -255,6 +255,14 @@ final class EmailAccountsPage extends Page
                 $account = $this->findOwnedAccountOrFail($arguments);
 
                 resolve(DisconnectConnectedAccountAction::class)->execute($account);
+
+                $this->connectedAccounts = $this->getAccounts();
+
+                Notification::make()
+                    ->success()
+                    ->title(__('filament/pages/email-accounts.notifications.disconnected.title'))
+                    ->body(__('filament/pages/email-accounts.notifications.disconnected.body'))
+                    ->send();
             });
     }
 

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -12,6 +12,7 @@ use App\Models\User;
 use Database\Factories\EmailFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -28,6 +29,7 @@ use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPriority;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
+use Relaticle\EmailIntegration\Models\Scopes\ActiveAccountScope;
 use Relaticle\EmailIntegration\Observers\EmailObserver;
 
 /**
@@ -57,6 +59,7 @@ use Relaticle\EmailIntegration\Observers\EmailObserver;
  * @property EmailPriority $priority
  */
 #[ObservedBy(EmailObserver::class)]
+#[ScopedBy([ActiveAccountScope::class])]
 final class Email extends Model
 {
     /**

--- a/packages/EmailIntegration/src/Models/Scopes/ActiveAccountScope.php
+++ b/packages/EmailIntegration/src/Models/Scopes/ActiveAccountScope.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+/**
+ * Hides emails whose connected account has been disconnected (soft-deleted).
+ *
+ * The whereHas runs against the ConnectedAccount relation, so its own
+ * SoftDeletingScope applies automatically — a trashed account fails the
+ * existence check and its emails drop out of every query. Opt out with
+ * ->withoutGlobalScope(ActiveAccountScope::class) for audit/admin views.
+ *
+ * @template TModel of Model
+ *
+ * @implements Scope<TModel>
+ */
+final readonly class ActiveAccountScope implements Scope
+{
+    /**
+     * @param  Builder<covariant TModel>  $builder
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->whereHas('connectedAccount');
+    }
+}

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -116,9 +116,9 @@ it('only loads the authenticated user\'s accounts in the current team on mount',
         ->not->toContain($otherAccount->id);
 });
 
-it('renders both Connect Gmail and Connect Outlook actions', function (): void {
+it('renders Connect Gmail and hides Connect Outlook for now', function (): void {
     livewire(EmailAccountsPage::class)
         ->assertActionExists('connectGmail')
-        ->assertActionExists('connectAzure')
-        ->assertActionVisible('connectAzure');
+        ->assertActionVisible('connectGmail')
+        ->assertActionHidden('connectAzure');
 });

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\EmailSignature;
 
 mutates(EmailAccountsPage::class);
 
@@ -66,6 +67,21 @@ it('deletes the authenticated user\'s account on disconnect', function (): void 
     $this->assertSoftDeleted(ConnectedAccount::class, [
         'id' => $this->account->id,
     ]);
+});
+
+it('deletes dependent signatures and refreshes the listing on disconnect', function (): void {
+    $signature = EmailSignature::withoutEvents(fn () => EmailSignature::factory()->create([
+        'connected_account_id' => $this->account->id,
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    livewire(EmailAccountsPage::class)
+        ->callAction('disconnect', arguments: ['account_id' => $this->account->id])
+        ->assertSet('connectedAccounts', fn ($accounts): bool => $accounts->isEmpty());
+
+    $this->assertSoftDeleted(ConnectedAccount::class, ['id' => $this->account->id]);
+    $this->assertDatabaseMissing(EmailSignature::class, ['id' => $signature->id]);
 });
 
 it('does not delete another user\'s account on disconnect', function (): void {

--- a/tests/Feature/EmailIntegration/EmailActiveAccountScopeTest.php
+++ b/tests/Feature/EmailIntegration/EmailActiveAccountScopeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\Scopes\ActiveAccountScope;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    $this->team = $this->user->currentTeam;
+    Filament::setTenant($this->team);
+
+    $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    $this->email = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->getKey(),
+    ]);
+});
+
+it('shows emails while the connected account is active', function (): void {
+    expect(Email::query()->whereKey($this->email->id)->exists())->toBeTrue();
+});
+
+it('hides emails once the connected account is disconnected', function (): void {
+    $this->account->delete();
+
+    expect(Email::query()->whereKey($this->email->id)->exists())->toBeFalse();
+});
+
+it('still exposes the emails when the scope is removed for audit views', function (): void {
+    $this->account->delete();
+
+    expect(
+        Email::query()
+            ->withoutGlobalScope(ActiveAccountScope::class)
+            ->whereKey($this->email->id)
+            ->exists()
+    )->toBeTrue();
+});


### PR DESCRIPTION
## What

Fixes broken behavior when an email account is disconnected (soft-deleted), plus hides the not-yet-ready Outlook connector.

### 1. Disconnect cleanup + listing refresh
- `DisconnectConnectedAccountAction` now deletes the account's signatures before soft-deleting it. The account uses `SoftDeletes`, so the DB-level `cascadeOnDelete` on `email_signatures` never fired — leaving orphaned signature rows whose `connectedAccount` relation resolved to `null`, crashing the Signatures page (`Attempt to read property "email_address" on null`).
- `EmailAccountsPage::disconnectAction` now refreshes `$this->connectedAccounts` and sends a success notification, so the disconnected account disappears from the list immediately instead of lingering until reload.
- Signatures Blade made null-safe (`connectedAccount?->email_address`) as defense-in-depth for any pre-existing orphans.

### 2. Hide emails from disconnected accounts
- New `ActiveAccountScope` global scope on `Email`, attached via `#[ScopedBy([ActiveAccountScope::class])]`. It applies `whereHas('connectedAccount')`, so the relation's `SoftDeletingScope` automatically excludes emails whose account is trashed — across inbox, outbox, counts, and relation managers.
- A soft-deleted account's emails are **not** auto-hidden by Eloquent otherwise: the soft-delete scope only filters the `ConnectedAccount` model itself, not the separate `Email` rows that reference it.
- Audit/admin views can opt out with `->withoutGlobalScope(ActiveAccountScope::class)`.

### 3. Hide Connect Outlook
- `connectAzureAction` marked `->hidden()` for now; re-enable by removing one line when the provider is ready.

## Tests
- `EmailAccountsPageTest`: disconnect deletes dependent signatures + refreshes listing; Connect Outlook hidden.
- `EmailActiveAccountScopeTest`: emails visible while account active, hidden after disconnect, recoverable without the global scope.
- Full email + calendar suites pass (246 tests).

## Follow-up (not in this PR)
Reconnecting a disconnected account still mints a **new** `ConnectedAccount` (the `updateOrCreate` lookup in `CallbackController` runs under the soft-delete scope and misses the trashed row), triggering a fresh sync and duplicate emails. Fix is to `withTrashed()` + restore the existing row on reconnect.