### PR TITLE
fix(email): patch cross-tenant IDORs, sync correctness, and outbox rate limits

### DIFF
--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -7,6 +7,7 @@ return [
     'actions' => [
         'connect_gmail' => 'Connect Gmail',
         'connect_azure' => 'Connect Outlook',
+        'manage' => 'Manage',
         're_auth' => 'Re-authenticate',
         'edit_settings' => 'Settings',
         'disconnect' => 'Disconnect',

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -20,13 +20,7 @@
                             </span>
                         @endif
                         <div class="flex shrink-0 items-center gap-2">
-                            @if (in_array($account->status, [\Relaticle\EmailIntegration\Enums\EmailAccountStatus::REAUTH_REQUIRED, \Relaticle\EmailIntegration\Enums\EmailAccountStatus::ERROR], true))
-                                {{ ($this->reAuthAction)(['account_id' => $account->id]) }}
-                            @endif
-                            {{ ($this->syncCalendarNowAction)(['account_id' => $account->id]) }}
-                            {{ ($this->syncCalendarAction)(['account_id' => $account->id]) }}
-                            {{ ($this->editSettingsAction)(['account_id' => $account->id]) }}
-                            {{ ($this->disconnectAction)(['account_id' => $account->id]) }}
+                            {{ $this->accountActions($account) }}
                         </div>
                     </div>
                 </div>

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -32,7 +32,8 @@
         <x-filament::section heading="Connect an Account">
             <div class="flex gap-3">
                 {{ $this->connectGmailAction }}
-                {{ $this->connectAzureAction }}
+                {{-- Outlook/Azure connection is hidden for now; re-enable when the provider is ready. --}}
+                {{-- {{ $this->connectAzureAction }} --}}
             </div>
         </x-filament::section>
     </div>

--- a/packages/EmailIntegration/routes/web.php
+++ b/packages/EmailIntegration/routes/web.php
@@ -9,9 +9,11 @@ use Relaticle\EmailIntegration\Controllers\RedirectController as EmailRedirectCo
 Route::middleware(['web', 'auth', 'verified'])->group(function (): void {
     Route::get('/email-accounts/redirect/{provider}', EmailRedirectController::class)
         ->name('email-accounts.redirect')
+        ->whereIn('provider', ['gmail', 'azure'])
         ->middleware('throttle:10,1');
 
     Route::get('/email-accounts/callback/{provider}', EmailCallbackController::class)
         ->name('email-accounts.callback')
+        ->whereIn('provider', ['gmail', 'azure'])
         ->middleware('throttle:10,1');
 });

--- a/packages/EmailIntegration/src/Actions/ApproveEmailAccessRequestAction.php
+++ b/packages/EmailIntegration/src/Actions/ApproveEmailAccessRequestAction.php
@@ -31,6 +31,9 @@ final readonly class ApproveEmailAccessRequestAction
             return;
         }
 
+        // Don't grant a share to a requester who is no longer in the email's team.
+        abort_unless($requester->current_team_id === $email->team_id, 403);
+
         $tier = EmailPrivacyTier::from($accessRequest->tier_requested);
 
         $this->sharingService->shareEmail($email, $owner, $requester, $tier);

--- a/packages/EmailIntegration/src/Actions/CancelEmailAccessRequestAction.php
+++ b/packages/EmailIntegration/src/Actions/CancelEmailAccessRequestAction.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use App\Models\User;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 
 final readonly class CancelEmailAccessRequestAction
 {
-    public function execute(EmailAccessRequest $accessRequest): void
+    public function execute(EmailAccessRequest $accessRequest, User $actor): void
     {
+        // Only the requester may cancel their own request.
+        abort_unless($accessRequest->requester_id === $actor->getKey(), 403);
+
         if ($accessRequest->status !== EmailAccessRequestStatus::PENDING) {
             return;
         }

--- a/packages/EmailIntegration/src/Actions/CreateSignatureAction.php
+++ b/packages/EmailIntegration/src/Actions/CreateSignatureAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 
@@ -14,19 +15,21 @@ final readonly class CreateSignatureAction
      */
     public function execute(ConnectedAccount $account, array $data): EmailSignature
     {
-        if ($data['is_default']) {
-            EmailSignature::query()->where('connected_account_id', $account->getKey())
-                ->where('is_default', true)
-                ->update(['is_default' => false]);
-        }
+        return DB::transaction(function () use ($account, $data): EmailSignature {
+            if ($data['is_default']) {
+                EmailSignature::query()->where('connected_account_id', $account->getKey())
+                    ->where('is_default', true)
+                    ->update(['is_default' => false]);
+            }
 
-        return EmailSignature::query()->create([
-            'team_id' => $account->team_id,
-            'connected_account_id' => $account->getKey(),
-            'user_id' => $account->user_id,
-            'name' => $data['name'],
-            'content_html' => $data['content_html'],
-            'is_default' => $data['is_default'],
-        ]);
+            return EmailSignature::query()->create([
+                'team_id' => $account->team_id,
+                'connected_account_id' => $account->getKey(),
+                'user_id' => $account->user_id,
+                'name' => $data['name'],
+                'content_html' => $data['content_html'],
+                'is_default' => $data['is_default'],
+            ]);
+        });
     }
 }

--- a/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Actions;
 
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Data\NormalizedMeetingPayload;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
@@ -25,53 +26,55 @@ final readonly class StoreMeetingAction
             return null;
         }
 
-        $meeting = Meeting::withTrashed()
-            ->where('connected_account_id', $account->getKey())
-            ->where('provider_event_id', $payload->providerEventId)
-            ->first();
+        return DB::transaction(function () use ($payload, $account): Meeting {
+            $meeting = Meeting::withTrashed()
+                ->where('connected_account_id', $account->getKey())
+                ->where('provider_event_id', $payload->providerEventId)
+                ->first();
 
-        $attributes = [
-            'team_id' => $account->team_id,
-            'connected_account_id' => $account->getKey(),
-            'provider_event_id' => $payload->providerEventId,
-            'provider_recurring_event_id' => $payload->providerRecurringEventId,
-            'ical_uid' => $payload->icalUid,
-            'title' => $payload->title,
-            'description' => $payload->description,
-            'location' => $payload->location,
-            'starts_at' => $payload->startsAt,
-            'ends_at' => $payload->endsAt,
-            'all_day' => $payload->allDay,
-            'organizer_email' => $payload->organizerEmail,
-            'organizer_name' => $payload->organizerName,
-            'status' => $payload->status,
-            'visibility' => $payload->visibility,
-            'response_status' => $payload->selfResponseStatus,
-            'html_link' => $payload->htmlLink,
-            'deleted_at' => null,
-        ];
+            $attributes = [
+                'team_id' => $account->team_id,
+                'connected_account_id' => $account->getKey(),
+                'provider_event_id' => $payload->providerEventId,
+                'provider_recurring_event_id' => $payload->providerRecurringEventId,
+                'ical_uid' => $payload->icalUid,
+                'title' => $payload->title,
+                'description' => $payload->description,
+                'location' => $payload->location,
+                'starts_at' => $payload->startsAt,
+                'ends_at' => $payload->endsAt,
+                'all_day' => $payload->allDay,
+                'organizer_email' => $payload->organizerEmail,
+                'organizer_name' => $payload->organizerName,
+                'status' => $payload->status,
+                'visibility' => $payload->visibility,
+                'response_status' => $payload->selfResponseStatus,
+                'html_link' => $payload->htmlLink,
+                'deleted_at' => null,
+            ];
 
-        if ($meeting instanceof Meeting) {
-            $meeting->fill($attributes)->save();
-        } else {
-            $meeting = Meeting::query()->create($attributes);
-        }
+            if ($meeting instanceof Meeting) {
+                $meeting->fill($attributes)->save();
+            } else {
+                $meeting = Meeting::query()->create($attributes);
+            }
 
-        $meeting->attendees()->delete();
+            $meeting->attendees()->delete();
 
-        foreach ($payload->attendees as $attendee) {
-            $meeting->attendees()->create([
-                'email_address' => $attendee->emailAddress,
-                'name' => $attendee->name,
-                'response_status' => $attendee->responseStatus,
-                'is_organizer' => $attendee->isOrganizer,
-                'is_self' => $attendee->isSelf,
-            ]);
-        }
+            foreach ($payload->attendees as $attendee) {
+                $meeting->attendees()->create([
+                    'email_address' => $attendee->emailAddress,
+                    'name' => $attendee->name,
+                    'response_status' => $attendee->responseStatus,
+                    'is_organizer' => $attendee->isOrganizer,
+                    'is_self' => $attendee->isSelf,
+                ]);
+            }
 
-        $this->linkMeeting->execute($meeting);
+            $this->linkMeeting->execute($meeting);
 
-        return $meeting;
+            return $meeting;
+        });
     }
 
     private function shouldSkip(NormalizedMeetingPayload $payload): bool

--- a/packages/EmailIntegration/src/Actions/UpdateEmailSharingAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateEmailSharingAction.php
@@ -18,6 +18,9 @@ final readonly class UpdateEmailSharingAction
      */
     public function execute(Email $email, User $sharer, EmailPrivacyTier $tier, array $shares): void
     {
+        // Defense in depth: only the email owner may change its sharing, regardless of caller.
+        abort_unless($email->user_id === $sharer->getKey(), 403);
+
         $this->sharingService->setEmailTier($email, $tier);
 
         $email->shares()->where('shared_by', $sharer->getKey())->delete();

--- a/packages/EmailIntegration/src/Actions/UpdateSignatureAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateSignatureAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 
 final readonly class UpdateSignatureAction
@@ -13,15 +14,17 @@ final readonly class UpdateSignatureAction
      */
     public function execute(EmailSignature $signature, array $data): EmailSignature
     {
-        if (($data['is_default'] ?? false) === true) {
-            EmailSignature::query()->where('connected_account_id', $signature->connected_account_id)
-                ->where('id', '!=', $signature->getKey())
-                ->where('is_default', true)
-                ->update(['is_default' => false]);
-        }
+        return DB::transaction(function () use ($signature, $data): EmailSignature {
+            if (($data['is_default'] ?? false) === true) {
+                EmailSignature::query()->where('connected_account_id', $signature->connected_account_id)
+                    ->where('id', '!=', $signature->getKey())
+                    ->where('is_default', true)
+                    ->update(['is_default' => false]);
+            }
 
-        $signature->update($data);
+            $signature->update($data);
 
-        return $signature->refresh();
+            return $signature->refresh();
+        });
     }
 }

--- a/packages/EmailIntegration/src/Console/Commands/DispatchOutboxCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/DispatchOutboxCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailPriority;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
@@ -27,6 +28,7 @@ final class DispatchOutboxCommand extends Command
         $defaultDaily = Config::integer('email-integration.outbox.defaults.daily_send_limit');
 
         ConnectedAccount::query()
+            ->where('status', EmailAccountStatus::ACTIVE)
             ->whereHas('outgoingEmails', fn (Builder $emailQuery): Builder => $emailQuery
                 ->where('status', EmailStatus::QUEUED)
                 ->where(fn (Builder $dueQuery): Builder => $dueQuery->whereNull('scheduled_for')->orWhere('scheduled_for', '<=', now()))
@@ -50,14 +52,27 @@ final class DispatchOutboxCommand extends Command
             ->where('sent_at', '>=', now()->subHour())
             ->count();
 
+        // Rolling 24h window; uses an absolute instant so it is timezone-agnostic against the UTC sent_at column.
         $dailySent = Email::query()
             ->where('connected_account_id', $account->getKey())
             ->where('direction', EmailDirection::OUTBOUND)
             ->where('status', EmailStatus::SENT)
-            ->where('sent_at', '>=', today())
+            ->where('sent_at', '>=', now()->subDay())
             ->count();
 
-        $capacity = max(0, min($hourlyLimit - $hourlySent, $dailyLimit - $dailySent));
+        // Emails already claimed (SENDING) by this or a previous run are in flight and
+        // consume capacity even though they have not reached SENT yet. Counting them
+        // prevents overlapping dispatch runs from collectively overshooting the limits.
+        $inFlight = Email::query()
+            ->where('connected_account_id', $account->getKey())
+            ->where('direction', EmailDirection::OUTBOUND)
+            ->where('status', EmailStatus::SENDING)
+            ->count();
+
+        $capacity = max(0, min(
+            $hourlyLimit - $hourlySent - $inFlight,
+            $dailyLimit - $dailySent - $inFlight,
+        ));
 
         if ($capacity === 0) {
             return;
@@ -69,7 +84,9 @@ final class DispatchOutboxCommand extends Command
             ->where('status', EmailStatus::QUEUED)
             ->where(fn (Builder $dueQuery): Builder => $dueQuery->whereNull('scheduled_for')->orWhere('scheduled_for', '<=', now()))
             ->orderByRaw("CASE priority WHEN 'priority' THEN 0 ELSE 1 END")
-            ->orderByRaw('scheduled_for NULLS FIRST')->oldest()
+            ->orderByRaw('scheduled_for IS NULL DESC')
+            ->orderBy('scheduled_for')
+            ->oldest()
             ->limit($capacity)
             ->get();
 

--- a/packages/EmailIntegration/src/Console/Commands/DispatchOutboxCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/DispatchOutboxCommand.php
@@ -11,7 +11,6 @@ use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
-use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailPriority;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
@@ -28,7 +27,7 @@ final class DispatchOutboxCommand extends Command
         $defaultDaily = Config::integer('email-integration.outbox.defaults.daily_send_limit');
 
         ConnectedAccount::query()
-            ->where('status', EmailAccountStatus::ACTIVE)
+            ->active()
             ->whereHas('outgoingEmails', fn (Builder $emailQuery): Builder => $emailQuery
                 ->where('status', EmailStatus::QUEUED)
                 ->where(fn (Builder $dueQuery): Builder => $dueQuery->whereNull('scheduled_for')->orWhere('scheduled_for', '<=', now()))

--- a/packages/EmailIntegration/src/Controllers/CallbackController.php
+++ b/packages/EmailIntegration/src/Controllers/CallbackController.php
@@ -20,10 +20,21 @@ use Throwable;
 
 final readonly class CallbackController
 {
+    private const SUPPORTED_PROVIDERS = ['gmail', 'azure'];
+
     public function __invoke(Request $request, string $provider): RedirectResponse
     {
         /** @var User $user */
         $user = auth()->user();
+
+        // Without an active team we cannot scope or redirect; bail to the dashboard.
+        if ($user->currentTeam === null) {
+            return redirect('/')->with('error', 'Select a team before connecting an account.');
+        }
+
+        if (! in_array($provider, self::SUPPORTED_PROVIDERS, true)) {
+            return $this->redirectWithError($user, 'That email provider is not supported.');
+        }
 
         $driver = Socialite::driver($this->resolveDriver($provider));
 

--- a/packages/EmailIntegration/src/Controllers/CallbackController.php
+++ b/packages/EmailIntegration/src/Controllers/CallbackController.php
@@ -20,7 +20,7 @@ use Throwable;
 
 final readonly class CallbackController
 {
-    private const SUPPORTED_PROVIDERS = ['gmail', 'azure'];
+    private const array SUPPORTED_PROVIDERS = ['gmail', 'azure'];
 
     public function __invoke(Request $request, string $provider): RedirectResponse
     {

--- a/packages/EmailIntegration/src/Data/MailDeltaResult.php
+++ b/packages/EmailIntegration/src/Data/MailDeltaResult.php
@@ -12,10 +12,12 @@ final readonly class MailDeltaResult
      * @param  Collection<int, string>  $messageIds  Provider message IDs newly created since cursor
      * @param  Collection<int, string>  $readMessageIds  Provider message IDs that became read since cursor
      * @param  string  $newCursor  Opaque cursor (Gmail historyId, Microsoft Graph deltaLink)
+     * @param  Collection<int, string>|null  $unreadMessageIds  Provider message IDs that became unread since cursor
      */
     public function __construct(
         public Collection $messageIds,
         public Collection $readMessageIds,
         public string $newCursor,
+        public ?Collection $unreadMessageIds = null,
     ) {}
 }

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -116,17 +116,17 @@ trait HasEmailComposeActions
             })
             ->modalWidth(Width::SevenExtraLarge)
             ->fillForm(function (array $arguments): array {
-                /** @var Email|null $email */
-                $email = Email::query()->with(['participants', 'body'])->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveComposableEmail($arguments['emailId'] ?? null);
 
-                if ($email === null) {
+                if (! $email instanceof Email) {
                     return [];
                 }
 
+                $user = $this->getAuthenticatedUser();
                 $mode = $arguments['mode'] ?? 'reply';
 
                 $account = ConnectedAccount::query()
-                    ->where('user_id', $this->getAuthenticatedUser()->getKey())
+                    ->where('user_id', $user->getKey())
                     ->where('team_id', filament()->getTenant()?->getKey())
                     ->where('status', 'active')
                     ->first();
@@ -143,6 +143,9 @@ trait HasEmailComposeActions
                         ->all(),
                 };
 
+                // Only quote the original body when the viewer is entitled to read it.
+                $quotedBody = $user->can('viewBody', $email) ? ($email->body->body_html ?? '') : '';
+
                 $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
 
                 return [
@@ -150,7 +153,7 @@ trait HasEmailComposeActions
                     'to' => $toParticipants,
                     'subject' => $subjectPrefix.($email->subject ?? ''),
                     'body_html' => '',
-                    'quoted_body_html' => $email->body->body_html ?? '',
+                    'quoted_body_html' => $quotedBody,
                     'mode' => $mode,
                     'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
                     'privacy_tier' => $this->defaultPrivacyTier()->value,
@@ -572,6 +575,36 @@ trait HasEmailComposeActions
             )
             ->pluck('name', 'id')
             ->all();
+    }
+
+    /**
+     * Resolve an email for reply/forward, scoped to the active team and gated by the
+     * `view` policy. Returns null when the email is outside the viewer's team or hidden.
+     */
+    private function resolveComposableEmail(?string $emailId): ?Email
+    {
+        if ($emailId === null) {
+            return null;
+        }
+
+        $user = $this->getAuthenticatedUser();
+
+        /** @var Email|null $email */
+        $email = Email::query()
+            ->forTeam($user->current_team_id)
+            ->with(['participants', 'body'])
+            ->whereKey($emailId)
+            ->first();
+
+        if ($email === null) {
+            return null;
+        }
+
+        if (! $user->can('view', $email)) {
+            return null;
+        }
+
+        return $email;
     }
 
     private function getAuthenticatedUser(): User

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -24,6 +24,8 @@ use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
+use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
+use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
@@ -34,8 +36,6 @@ use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Models\EmailThread;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
-use Relaticle\EmailIntegration\Notifications\EmailAccessRequestedNotification;
-use Relaticle\EmailIntegration\Services\EmailSharingService;
 use Relaticle\EmailIntegration\Services\EmailThreadSummaryService;
 
 abstract class BaseRecordEmailsPage extends Page
@@ -96,7 +96,8 @@ abstract class BaseRecordEmailsPage extends Page
 
         $query = $record
             ->emails()
-            ->with(['from', 'labels'])
+            // participants + shares are read per row by the privacy policy; eager-load to avoid N+1.
+            ->with(['from', 'labels', 'participants', 'shares'])
             ->withGlobalScope('visible', new VisibleEmailScope($user));
 
         if ($this->folder === EmailFolder::Sent) {
@@ -215,9 +216,9 @@ abstract class BaseRecordEmailsPage extends Page
                     ]),
             ])
             ->fillForm(function (array $arguments): array {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'share');
 
-                if ($email === null) {
+                if (! $email instanceof Email) {
                     return [];
                 }
 
@@ -232,28 +233,19 @@ abstract class BaseRecordEmailsPage extends Page
                         ->all(),
                 ];
             })
-            ->action(function (array $data, array $arguments, EmailSharingService $sharingService): void {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+            ->action(function (array $data, array $arguments): void {
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'share');
 
-                if ($email === null) {
-                    return;
-                }
+                abort_if(! $email instanceof Email, 403);
 
-                $sharer = $this->authUser();
-
-                $sharingService->setEmailTier($email, $data['privacy_tier']);
-                $email->shares()->where('shared_by', $sharer->getKey())->delete();
-
-                foreach ($data['shares'] ?? [] as $share) {
-                    /** @var User $sharedWithUser */
-                    $sharedWithUser = User::query()->findOrFail($share['shared_with']);
-                    $sharingService->shareEmail(
-                        $email,
-                        $sharer,
-                        $sharedWithUser,
-                        EmailPrivacyTier::from($share['tier']),
-                    );
-                }
+                resolve(UpdateEmailSharingAction::class)->execute(
+                    $email,
+                    $this->authUser(),
+                    $data['privacy_tier'] instanceof EmailPrivacyTier
+                        ? $data['privacy_tier']
+                        : EmailPrivacyTier::from($data['privacy_tier']),
+                    $data['shares'] ?? [],
+                );
 
                 Notification::make()
                     ->success()
@@ -273,9 +265,9 @@ abstract class BaseRecordEmailsPage extends Page
             ->modalSubmitAction(false)
             ->modalCancelActionLabel('Close')
             ->modalContent(function (array $arguments): View {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'viewBody');
 
-                if ($email === null) {
+                if (! $email instanceof Email) {
                     return view('filament.actions.ai-summary', ['summary' => null]);
                 }
 
@@ -298,21 +290,19 @@ abstract class BaseRecordEmailsPage extends Page
                     ->required(),
             ])
             ->action(function (array $data, array $arguments): void {
-                $email = Email::query()->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'requestAccess');
 
-                if ($email === null) {
-                    return;
-                }
+                abort_if(! $email instanceof Email, 403);
 
-                $requester = $this->authUser();
+                $request = resolve(RequestEmailAccessAction::class)->execute(
+                    $email,
+                    $this->authUser(),
+                    $data['tier_requested'] instanceof EmailPrivacyTier
+                        ? $data['tier_requested']
+                        : EmailPrivacyTier::from($data['tier_requested']),
+                );
 
-                $existing = EmailAccessRequest::query()
-                    ->where('email_id', $email->getKey())
-                    ->where('requester_id', $requester->getKey())
-                    ->where('status', 'pending')
-                    ->exists();
-
-                if ($existing) {
+                if (! $request instanceof EmailAccessRequest) {
                     Notification::make()
                         ->warning()
                         ->title(__('filament/pages/record-emails.notifications.pending_request.title'))
@@ -320,16 +310,6 @@ abstract class BaseRecordEmailsPage extends Page
 
                     return;
                 }
-
-                $request = EmailAccessRequest::query()->create([
-                    'email_id' => $email->getKey(),
-                    'requester_id' => $requester->getKey(),
-                    'owner_id' => $email->user_id,
-                    'tier_requested' => $data['tier_requested'],
-                    'status' => 'pending',
-                ]);
-
-                $email->user?->notify(new EmailAccessRequestedNotification($request));
 
                 Notification::make()
                     ->success()
@@ -345,7 +325,7 @@ abstract class BaseRecordEmailsPage extends Page
             ->modalHeading(__('filament/pages/record-emails.actions.approve_access_request.modal_heading'))
             ->modalDescription(fn (array $arguments): string => sprintf(
                 'Grant %s access to this email?',
-                EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->requester->name ?? 'this user',
+                $this->requesterNameForOwnedRequest($arguments['requestId'] ?? null),
             ))
             ->modalSubmitActionLabel('Approve')
             ->color('success')
@@ -378,7 +358,7 @@ abstract class BaseRecordEmailsPage extends Page
             ->modalHeading(__('filament/pages/record-emails.actions.deny_access_request.modal_heading'))
             ->modalDescription(fn (array $arguments): string => sprintf(
                 'Deny %s\'s request for access to this email?',
-                EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->requester->name ?? 'this user',
+                $this->requesterNameForOwnedRequest($arguments['requestId'] ?? null),
             ))
             ->modalSubmitActionLabel('Deny')
             ->color('danger')
@@ -419,6 +399,46 @@ abstract class BaseRecordEmailsPage extends Page
             ->getSummary($thread, $this->authUser());
 
         return view('filament.actions.ai-summary', ['summary' => $summary]);
+    }
+
+    /**
+     * Resolve an email by client-supplied id, scoped to the active team and gated by policy.
+     * Returns null when the email is outside the viewer's team or the ability is denied.
+     */
+    private function resolveTeamEmail(?string $emailId, string $ability): ?Email
+    {
+        if ($emailId === null) {
+            return null;
+        }
+
+        $user = $this->authUser();
+
+        $email = Email::query()
+            ->forTeam($user->current_team_id)
+            ->whereKey($emailId)
+            ->first();
+
+        if ($email === null) {
+            return null;
+        }
+
+        if (! $user->can($ability, $email)) {
+            return null;
+        }
+
+        return $email;
+    }
+
+    private function requesterNameForOwnedRequest(?string $requestId): string
+    {
+        if ($requestId === null) {
+            return 'this user';
+        }
+
+        return EmailAccessRequest::query()
+            ->whereKey($requestId)
+            ->where('owner_id', $this->authUser()->getKey())
+            ->first()?->requester->name ?? 'this user';
     }
 
     private function authUser(): User

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -101,9 +101,9 @@ abstract class BaseRecordEmailsPage extends Page
             ->withGlobalScope('visible', new VisibleEmailScope($user));
 
         if ($this->folder === EmailFolder::Sent) {
-            $query->where('direction', EmailDirection::OUTBOUND);
+            $query->sent();
         } elseif ($this->folder === EmailFolder::Inbox) {
-            $query->where('direction', EmailDirection::INBOUND);
+            $query->inbox();
         }
 
         if (filled($this->search)) {

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
@@ -150,10 +150,16 @@ final class EmailAccessRequestsPage extends Page
             return null;
         }
 
+        $user = $this->authUser();
+
         /** @var EmailAccessRequest|null */
         return EmailAccessRequest::query()
             ->with(['email.from', 'email.body', 'requester', 'owner'])
             ->whereKey($this->selectedRequestId)
+            ->where(fn (Builder $q): Builder => $q
+                ->where('owner_id', $user->getKey())
+                ->orWhere('requester_id', $user->getKey()))
+            ->whereHas('email', fn (Builder $q): Builder => $q->where('team_id', $user->current_team_id))
             ->first();
     }
 
@@ -222,7 +228,7 @@ final class EmailAccessRequestsPage extends Page
             ->requiresConfirmation()
             ->modalHeading(__('filament/pages/email-access-requests.actions.approve.modal_heading'))
             ->modalDescription(fn (array $arguments): string => __('filament/pages/email-access-requests.actions.approve.modal_description', [
-                'name' => EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->requester->name ?? __('filament/pages/email-access-requests.actions.fallback_user'),
+                'name' => $this->requesterNameForOwnedRequest($arguments['requestId'] ?? null),
             ]))
             ->modalSubmitActionLabel(__('filament/pages/email-access-requests.actions.approve.modal_submit_label'))
             ->action(function (array $arguments): void {
@@ -259,7 +265,7 @@ final class EmailAccessRequestsPage extends Page
             ->requiresConfirmation()
             ->modalHeading(__('filament/pages/email-access-requests.actions.deny.modal_heading'))
             ->modalDescription(fn (array $arguments): string => __('filament/pages/email-access-requests.actions.deny.modal_description', [
-                'name' => EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->requester->name ?? __('filament/pages/email-access-requests.actions.fallback_user'),
+                'name' => $this->requesterNameForOwnedRequest($arguments['requestId'] ?? null),
             ]))
             ->modalSubmitActionLabel(__('filament/pages/email-access-requests.actions.deny.modal_submit_label'))
             ->action(function (array $arguments): void {
@@ -296,7 +302,7 @@ final class EmailAccessRequestsPage extends Page
             ->requiresConfirmation()
             ->modalHeading(__('filament/pages/email-access-requests.actions.cancel.modal_heading'))
             ->modalDescription(fn (array $arguments): string => __('filament/pages/email-access-requests.actions.cancel.modal_description', [
-                'name' => EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->owner->name ?? __('filament/pages/email-access-requests.actions.fallback_user'),
+                'name' => $this->ownerNameForOwnRequest($arguments['requestId'] ?? null),
             ]))
             ->modalSubmitActionLabel(__('filament/pages/email-access-requests.actions.cancel.modal_submit_label'))
             ->action(function (array $arguments): void {
@@ -309,7 +315,7 @@ final class EmailAccessRequestsPage extends Page
                     return;
                 }
 
-                resolve(CancelEmailAccessRequestAction::class)->execute($accessRequest);
+                resolve(CancelEmailAccessRequestAction::class)->execute($accessRequest, $this->authUser());
 
                 $this->selectedRequestId = null;
                 unset($this->selectedRequest, $this->requests, $this->statusCounts);
@@ -327,5 +333,35 @@ final class EmailAccessRequestsPage extends Page
         $user = auth()->user();
 
         return $user;
+    }
+
+    /** Requester name for a request the current user owns (incoming). */
+    private function requesterNameForOwnedRequest(?string $requestId): string
+    {
+        $fallback = __('filament/pages/email-access-requests.actions.fallback_user');
+
+        if ($requestId === null) {
+            return $fallback;
+        }
+
+        return EmailAccessRequest::query()
+            ->whereKey($requestId)
+            ->where('owner_id', $this->authUser()->getKey())
+            ->first()?->requester->name ?? $fallback;
+    }
+
+    /** Owner name for a request the current user made (outgoing). */
+    private function ownerNameForOwnRequest(?string $requestId): string
+    {
+        $fallback = __('filament/pages/email-access-requests.actions.fallback_user');
+
+        if ($requestId === null) {
+            return $fallback;
+        }
+
+        return EmailAccessRequest::query()
+            ->whereKey($requestId)
+            ->where('requester_id', $this->authUser()->getKey())
+            ->first()?->owner->name ?? $fallback;
     }
 }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -7,6 +7,7 @@ namespace Relaticle\EmailIntegration\Filament\Pages;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -14,6 +15,7 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Grid;
 use Filament\Support\Enums\Size;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
@@ -21,6 +23,7 @@ use Illuminate\Support\Facades\Session;
 use Relaticle\EmailIntegration\Actions\DisconnectConnectedAccountAction;
 use Relaticle\EmailIntegration\Actions\UpdateConnectedAccountSettingsAction;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -266,6 +269,33 @@ final class EmailAccountsPage extends Page
                     ->body(__('filament/pages/email-accounts.notifications.disconnected.body'))
                     ->send();
             });
+    }
+
+    /**
+     * Native Filament dropdown grouping the per-account actions. Arguments are baked onto
+     * each child action so the group can be rendered once per account in the blade.
+     */
+    public function accountActions(ConnectedAccount $account): ActionGroup
+    {
+        $arguments = ['account_id' => $account->getKey()];
+
+        // Invoke each action with the arguments (not ->arguments()) so account_id is encoded
+        // into the mountAction() click handler, which reads getInvokedArguments().
+        return ActionGroup::make([
+            ($this->reAuthAction())($arguments)
+                ->visible(in_array($account->status, [
+                    EmailAccountStatus::REAUTH_REQUIRED,
+                    EmailAccountStatus::ERROR,
+                ], true)),
+            ($this->syncCalendarNowAction())($arguments),
+            ($this->syncCalendarAction())($arguments),
+            ($this->editSettingsAction())($arguments),
+            ($this->disconnectAction())($arguments),
+        ])
+            ->label(__('filament/pages/email-accounts.actions.manage'))
+            ->icon(Heroicon::EllipsisVertical)
+            ->size(Size::Small)
+            ->button();
     }
 
     public function sendSuccessNotification(): void

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -131,9 +131,9 @@ final class EmailInboxPage extends Page
             ->withGlobalScope('visible', new VisibleEmailScope($user));
 
         if ($this->folder === EmailFolder::Sent) {
-            $query->where('direction', EmailDirection::OUTBOUND);
+            $query->sent();
         } elseif ($this->folder === EmailFolder::Inbox) {
-            $query->where('direction', EmailDirection::INBOUND);
+            $query->inbox();
         }
 
         if (filled($this->search)) {

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -279,17 +279,19 @@ final class EmailInboxPage extends Page
             })
             ->modalWidth(Width::SevenExtraLarge)
             ->fillForm(function (array $arguments): array {
-                /** @var Email|null $email */
-                $email = Email::query()->with(['participants', 'body'])->whereKey($arguments['emailId'] ?? null)->first();
+                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'view');
 
-                if ($email === null) {
+                if (! $email instanceof Email) {
                     return [];
                 }
 
+                $email->loadMissing(['participants', 'body']);
+
+                $user = $this->authUser();
                 $mode = $arguments['mode'] ?? 'reply';
 
                 $account = ConnectedAccount::query()
-                    ->where('user_id', $this->authUser()->getKey())
+                    ->where('user_id', $user->getKey())
                     ->where('team_id', filament()->getTenant()?->getKey())
                     ->where('status', 'active')
                     ->first();
@@ -306,6 +308,9 @@ final class EmailInboxPage extends Page
                         ->all(),
                 };
 
+                // Only quote the original body when the viewer is entitled to read it.
+                $quotedBody = $user->can('viewBody', $email) ? $email->body?->body_html : null;
+
                 $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
 
                 return [
@@ -313,7 +318,7 @@ final class EmailInboxPage extends Page
                     'to' => $toParticipants,
                     'subject' => $subjectPrefix.($email->subject ?? ''),
                     'body_html' => '',
-                    'quoted_body_html' => $email->body?->body_html,
+                    'quoted_body_html' => $quotedBody,
                     'mode' => $mode,
                     'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
                     'privacy_tier' => $this->defaultPrivacyTier()->value,
@@ -448,6 +453,18 @@ final class EmailInboxPage extends Page
         return $email;
     }
 
+    private function requesterNameForOwnedRequest(?string $requestId): string
+    {
+        if ($requestId === null) {
+            return 'this user';
+        }
+
+        return EmailAccessRequest::query()
+            ->whereKey($requestId)
+            ->where('owner_id', $this->authUser()->getKey())
+            ->first()?->requester->name ?? 'this user';
+    }
+
     protected function summarizeThreadAction(): Action
     {
         return Action::make('summarizeThread')
@@ -519,7 +536,7 @@ final class EmailInboxPage extends Page
             ->modalHeading(__('filament/pages/email-inbox.approve_access_request.modal_heading'))
             ->modalDescription(fn (array $arguments): string => sprintf(
                 'Grant %s access to this email?',
-                EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->requester->name ?? 'this user',
+                $this->requesterNameForOwnedRequest($arguments['requestId'] ?? null),
             ))
             ->modalSubmitActionLabel('Approve')
             ->color('success')
@@ -552,7 +569,7 @@ final class EmailInboxPage extends Page
             ->modalHeading(__('filament/pages/email-inbox.deny_access_request.modal_heading'))
             ->modalDescription(fn (array $arguments): string => sprintf(
                 'Deny %s\'s request for access to this email?',
-                EmailAccessRequest::query()->whereKey($arguments['requestId'] ?? null)->first()?->requester->name ?? 'this user',
+                $this->requesterNameForOwnedRequest($arguments['requestId'] ?? null),
             ))
             ->modalSubmitActionLabel('Deny')
             ->color('danger')

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -50,7 +50,9 @@ abstract class BaseEmailsRelationManager extends RelationManager
     {
         return $table
             ->modifyQueryUsing(fn (Builder $query) => $query
-                ->with(['from', 'labels'])
+                // participants + shares are read per row by the privacy policy; eager-load
+                // them to avoid an N+1 when rendering the subject column.
+                ->with(['from', 'labels', 'participants', 'shares'])
                 ->withGlobalScope('visible', new VisibleEmailScope($this->authUser())))
             ->recordTitleAttribute('subject')
             ->defaultSort('sent_at', 'desc')

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -38,6 +38,8 @@ abstract class BaseMeetingsRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            // `team` is read per row by MeetingPolicy; eager-load it to avoid a lazy load.
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with('team'))
             ->columns([
                 TextColumn::make('title')
                     ->searchable()

--- a/packages/EmailIntegration/src/Jobs/Concerns/DetectsAuthErrors.php
+++ b/packages/EmailIntegration/src/Jobs/Concerns/DetectsAuthErrors.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Jobs\Concerns;
+
+use Illuminate\Http\Client\RequestException;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+trait DetectsAuthErrors
+{
+    /**
+     * Tokens that mark a failure as "the account must re-authenticate", matched
+     * case-insensitively against every message in the exception chain. The first
+     * group is provider-agnostic (RFC 6749 / generic); the rest are provider
+     * specific. Adding a new mail/calendar provider is just a matter of appending
+     * its auth-error markers here.
+     *
+     * @var list<string>
+     */
+    protected array $authErrorTokens = [
+        // RFC 6749 OAuth2 error codes — apply to any OAuth2 provider.
+        'invalid_grant',
+        'invalid_client',
+        'invalid_token',
+        'unauthorized_client',
+        // Generic / Laravel HTTP layer.
+        'unauthenticated',
+        'unauthorized',
+        // Microsoft Entra ID (Azure AD).
+        'AADSTS',
+        // Google.
+        'Token has been expired or revoked',
+    ];
+
+    /**
+     * Decide whether a sync failure means the account must re-authenticate, rather
+     * than guessing from a bare "401" substring (which matches ports, byte counts,
+     * ids, etc.). Provider-agnostic: inspects the real HTTP status and known auth
+     * tokens across the whole exception chain.
+     */
+    protected function isAuthError(Throwable $exception): bool
+    {
+        foreach ($this->throwableChain($exception) as $throwable) {
+            if ($this->httpStatus($throwable) === 401) {
+                return true;
+            }
+
+            $message = $throwable->getMessage();
+
+            foreach ($this->authErrorTokens as $token) {
+                if (stripos($message, $token) !== false) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Extract an HTTP status from any exception that carries an HTTP response,
+     * independent of the client library (Laravel HTTP, Guzzle/PSR-18, or SDKs
+     * such as the Google API client and Microsoft Graph that put it in the code).
+     */
+    private function httpStatus(Throwable $exception): ?int
+    {
+        // Laravel HTTP client.
+        if ($exception instanceof RequestException) {
+            return $exception->response->status();
+        }
+
+        // Guzzle / PSR-18 style: getResponse() returns a PSR-7 response.
+        if (method_exists($exception, 'getResponse')) {
+            $response = $exception->getResponse();
+
+            if ($response instanceof ResponseInterface) {
+                return $response->getStatusCode();
+            }
+        }
+
+        // Fallback: many SDKs surface the HTTP status as the exception code.
+        $code = $exception->getCode();
+
+        return is_int($code) && $code >= 100 && $code < 600 ? $code : null;
+    }
+
+    /**
+     * Yield the exception and each of its previous exceptions, so a wrapped auth
+     * failure (e.g. a domain exception around a Guzzle 401) is still detected.
+     *
+     * @return iterable<Throwable>
+     */
+    private function throwableChain(Throwable $exception): iterable
+    {
+        $current = $exception;
+
+        while ($current instanceof Throwable) {
+            yield $current;
+
+            $current = $current->getPrevious();
+        }
+    }
+}

--- a/packages/EmailIntegration/src/Jobs/Concerns/DetectsAuthErrors.php
+++ b/packages/EmailIntegration/src/Jobs/Concerns/DetectsAuthErrors.php
@@ -50,7 +50,7 @@ trait DetectsAuthErrors
             $message = $throwable->getMessage();
 
             foreach ($this->authErrorTokens as $token) {
-                if (stripos($message, $token) !== false) {
+                if (stripos((string) $message, (string) $token) !== false) {
                     return true;
                 }
             }

--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
@@ -20,9 +21,12 @@ use Throwable;
 #[DeleteWhenMissingModels]
 final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use DetectsAuthErrors, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 3;
+
+    /** @var array<int, int> Spaced retry delays so transient 429/5xx don't hammer the provider. */
+    public array $backoff = [60, 300, 900];
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
@@ -59,21 +63,24 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             dispatch(new StoreMeetingJob($account, $event));
         }
 
-        $account->update([
-            'calendar_sync_cursor' => $result->nextSyncToken,
+        $update = [
             'last_calendar_synced_at' => now(),
             'status' => EmailAccountStatus::ACTIVE,
             'last_error' => null,
-        ]);
+        ];
+
+        // Never overwrite a good cursor with null (see InitialCalendarSyncJob).
+        if ($result->nextSyncToken !== null) {
+            $update['calendar_sync_cursor'] = $result->nextSyncToken;
+        }
+
+        $account->update($update);
     }
 
     public function failed(Throwable $exception): void
     {
-        $isAuthError = str_contains($exception->getMessage(), 'invalid_grant')
-            || str_contains($exception->getMessage(), '401');
-
         $this->connectedAccount->update([
-            'status' => $isAuthError ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
+            'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
             'last_error' => $exception->getMessage(),
         ]);
     }

--- a/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
@@ -20,9 +21,12 @@ use Throwable;
 #[DeleteWhenMissingModels]
 final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use DetectsAuthErrors, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 3;
+
+    /** @var array<int, int> Spaced retry delays so transient 429/5xx don't hammer the provider. */
+    public array $backoff = [60, 300, 900];
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
@@ -67,6 +71,17 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
                 ->update(['read_at' => now()]);
         }
 
+        // Mark emails unread again when the provider flipped them back to unread.
+        $unreadIds = $delta->unreadMessageIds?->all() ?? [];
+
+        if ($unreadIds !== []) {
+            Email::query()
+                ->where('connected_account_id', $account->getKey())
+                ->whereIn('provider_message_id', $unreadIds)
+                ->whereNotNull('read_at')
+                ->update(['read_at' => null]);
+        }
+
         $account->update([
             'sync_cursor' => $delta->newCursor,
             'last_synced_at' => now(),
@@ -77,11 +92,8 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function failed(Throwable $exception): void
     {
-        $isAuthError = str_contains($exception->getMessage(), 'invalid_grant')
-            || str_contains($exception->getMessage(), '401');
-
         $this->connectedAccount->update([
-            'status' => $isAuthError ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
+            'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
             'last_error' => $exception->getMessage(),
         ]);
     }

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Throwable;
@@ -19,9 +20,12 @@ use Throwable;
 #[DeleteWhenMissingModels]
 final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use DetectsAuthErrors, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 3;
+
+    /** @var array<int, int> Spaced retry delays so transient 429/5xx don't hammer the provider. */
+    public array $backoff = [60, 300, 900];
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
@@ -44,21 +48,25 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             dispatch(new StoreMeetingJob($account, $event));
         }
 
-        $account->update([
-            'calendar_sync_cursor' => $result->nextSyncToken,
+        $update = [
             'last_calendar_synced_at' => now(),
             'status' => EmailAccountStatus::ACTIVE,
             'last_error' => null,
-        ]);
+        ];
+
+        // Never overwrite a good cursor with null: a missing sync token (partial/empty
+        // page) would otherwise force a full re-sync of the whole window on every run.
+        if ($result->nextSyncToken !== null) {
+            $update['calendar_sync_cursor'] = $result->nextSyncToken;
+        }
+
+        $account->update($update);
     }
 
     public function failed(Throwable $exception): void
     {
-        $isAuthError = str_contains($exception->getMessage(), 'invalid_grant')
-            || str_contains($exception->getMessage(), '401');
-
         $this->connectedAccount->update([
-            'status' => $isAuthError ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
+            'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
             'last_error' => $exception->getMessage(),
         ]);
     }

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -112,6 +112,18 @@ final class ConnectedAccount extends Model
             ->where('team_id', $team->getKey());
     }
 
+    /**
+     * Scope to accounts that are connected and authorised (safe to sync/send through).
+     *
+     * @param  Builder<ConnectedAccount>  $query
+     * @return Builder<ConnectedAccount>
+     */
+    #[Scope]
+    protected function active(Builder $query): Builder
+    {
+        return $query->where('status', EmailAccountStatus::ACTIVE);
+    }
+
     // Relations
 
     /**

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -131,6 +131,30 @@ final class Email extends Model
         return $query->where('team_id', $teamId);
     }
 
+    /**
+     * Scope to mail that has actually been sent (excludes queued/sending/failed outbound
+     * mail, which lives in the Outbox and has no sent_at yet).
+     *
+     * @param  Builder<Email>  $query
+     * @return Builder<Email>
+     */
+    #[Scope]
+    protected function sent(Builder $query): Builder
+    {
+        return $query->where('direction', EmailDirection::OUTBOUND)
+            ->whereNotNull('sent_at');
+    }
+
+    /**
+     * @param  Builder<Email>  $query
+     * @return Builder<Email>
+     */
+    #[Scope]
+    protected function inbox(Builder $query): Builder
+    {
+        return $query->where('direction', EmailDirection::INBOUND);
+    }
+
     // Relations
 
     /**

--- a/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
+++ b/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
@@ -34,7 +34,7 @@ final readonly class EmailThreadSummaryService
     private function generateAndCache(EmailThread $thread, User $viewer): AiSummary
     {
         $emails = $thread->emails()
-            ->with(['participants', 'body', 'labels'])
+            ->with(['from', 'participants', 'body', 'labels'])
             ->oldest('sent_at')
             ->get();
 
@@ -46,6 +46,7 @@ final readonly class EmailThreadSummaryService
 
         foreach ($emails as $index => $email) {
             $n = $index + 1;
+            // `from` is eager-loaded above to avoid an N+1 across the thread's emails.
             $firstFrom = $email->from->first();
             $from = $firstFrom->name ?? $firstFrom->email_address ?? 'Unknown';
             $date = $email->sent_at?->toDateTimeString() ?? '—';
@@ -57,7 +58,7 @@ final readonly class EmailThreadSummaryService
             $isOwner = $email->user_id === $viewer->getKey();
 
             if ($isOwner || $email->privacy_tier === EmailPrivacyTier::FULL) {
-                $body = $email->body->body_text ?? $email->snippet ?? '(no body)';
+                $body = data_get($email, 'body.body_text') ?? $email->snippet ?? '(no body)';
                 $lines[] = 'Body: '.mb_substr($body, 0, 500);
             } elseif ($email->privacy_tier === EmailPrivacyTier::SUBJECT) {
                 $lines[] = "Subject: {$email->subject}  (body hidden)";

--- a/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
+++ b/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
@@ -58,8 +58,8 @@ final readonly class EmailThreadSummaryService
             $isOwner = $email->user_id === $viewer->getKey();
 
             if ($isOwner || $email->privacy_tier === EmailPrivacyTier::FULL) {
-                $body = data_get($email, 'body.body_text') ?? $email->snippet ?? '(no body)';
-                $lines[] = 'Body: '.mb_substr($body, 0, 500);
+                $body = data_get($email, 'body.body_text', $email->snippet ?? '(no body)');
+                $lines[] = 'Body: '.mb_substr((string) $body, 0, 500);
             } elseif ($email->privacy_tier === EmailPrivacyTier::SUBJECT) {
                 $lines[] = "Subject: {$email->subject}  (body hidden)";
             } else {

--- a/packages/EmailIntegration/src/Services/Factories/GoogleClientFactory.php
+++ b/packages/EmailIntegration/src/Services/Factories/GoogleClientFactory.php
@@ -6,6 +6,7 @@ namespace Relaticle\EmailIntegration\Services\Factories;
 
 use Google\Client as GoogleClient;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use RuntimeException;
 
 final readonly class GoogleClientFactory
 {
@@ -28,12 +29,29 @@ final readonly class GoogleClientFactory
         ]);
 
         if ($client->isAccessTokenExpired()) {
+            if (! $account->refresh_token) {
+                // No refresh token to recover with — surface as an auth error so the
+                // sync job flips the account to REAUTH_REQUIRED.
+                throw new RuntimeException("invalid_grant: missing refresh token for account {$account->getKey()}");
+            }
+
             $newToken = $client->fetchAccessTokenWithRefreshToken($account->refresh_token);
 
-            $account->update([
-                'access_token' => $newToken['access_token'],
-                'token_expires_at' => now()->addSeconds($newToken['expires_in']),
-            ]);
+            // The Google client returns an array with an `error` key (e.g. invalid_grant)
+            // instead of throwing when the grant is revoked; persisting it would store a
+            // null access token, so fail loudly instead.
+            if (isset($newToken['error'])) {
+                throw new RuntimeException(
+                    (string) $newToken['error'].': '.(string) ($newToken['error_description'] ?? 'token refresh failed')
+                );
+            }
+
+            $account->update(array_filter([
+                'access_token' => $newToken['access_token'] ?? null,
+                // Google may rotate the refresh token; keep the existing one when absent.
+                'refresh_token' => $newToken['refresh_token'] ?? null,
+                'token_expires_at' => now()->addSeconds((int) ($newToken['expires_in'] ?? 3600)),
+            ], static fn (mixed $value): bool => $value !== null));
         }
 
         return $client;

--- a/packages/EmailIntegration/src/Services/Factories/GoogleClientFactory.php
+++ b/packages/EmailIntegration/src/Services/Factories/GoogleClientFactory.php
@@ -42,7 +42,7 @@ final readonly class GoogleClientFactory
             // null access token, so fail loudly instead.
             if (isset($newToken['error'])) {
                 throw new RuntimeException(
-                    (string) $newToken['error'].': '.(string) ($newToken['error_description'] ?? 'token refresh failed')
+                    $newToken['error'].': '.($newToken['error_description'] ?? 'token refresh failed')
                 );
             }
 

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -28,13 +28,15 @@ final readonly class GmailService implements MailServiceInterface
     {
         $history = $this->gmail->users_history->listUsersHistory('me', [
             'startHistoryId' => $cursor,
-            'historyTypes' => ['messageAdded', 'labelsRemoved'],
+            'historyTypes' => ['messageAdded', 'labelsRemoved', 'labelsAdded'],
         ]);
 
         /** @var array<int, string> $messageIds */
         $messageIds = [];
         /** @var array<int, string> $readMessageIds */
         $readMessageIds = [];
+        /** @var array<int, string> $unreadMessageIds */
+        $unreadMessageIds = [];
 
         foreach ($history->getHistory() ?? [] as $item) {
             foreach ($item->getMessagesAdded() ?? [] as $added) {
@@ -53,12 +55,23 @@ final readonly class GmailService implements MailServiceInterface
                     }
                 }
             }
+
+            // Track messages where the UNREAD label was re-added (marked unread again)
+            foreach ($item->getLabelsAdded() ?? [] as $change) {
+                if (in_array('UNREAD', $change->getLabelIds() ?? [], strict: true)) {
+                    $id = $change->getMessage()->getId();
+                    if (! in_array($id, $unreadMessageIds, strict: true)) {
+                        $unreadMessageIds[] = $id;
+                    }
+                }
+            }
         }
 
         return new MailDeltaResult(
             messageIds: collect($messageIds),
             readMessageIds: collect($readMessageIds),
             newCursor: (string) ($history->getHistoryId() ?? $cursor),
+            unreadMessageIds: collect($unreadMessageIds),
         );
     }
 
@@ -102,16 +115,30 @@ final readonly class GmailService implements MailServiceInterface
     {
         $after = now()->subDays($daysBack)->timestamp;
 
-        $response = $this->gmail
-            ->users_messages
-            ->listUsersMessages('me', [
+        // Capture the cursor before listing so no message that arrives mid-pagination is missed.
+        $profile = $this->gmail->users->getProfile('me');
+
+        $messageIds = collect();
+        $pageToken = null;
+
+        do {
+            $params = [
                 'q' => "after:$after",
                 'maxResults' => 500,
-            ]);
+            ];
 
-        $messageIds = $this->pluckMessageIds($response->getMessages());
+            if ($pageToken !== null) {
+                $params['pageToken'] = $pageToken;
+            }
 
-        $profile = $this->gmail->users->getProfile('me');
+            $response = $this->gmail->users_messages->listUsersMessages('me', $params);
+
+            $messageIds = $messageIds->merge($this->pluckMessageIds($response->getMessages()));
+
+            $pageToken = $response->getNextPageToken();
+        } while ($pageToken !== null && $pageToken !== '');
+
+        $messageIds = $messageIds->unique()->values();
 
         return [
             'message_ids' => $messageIds,

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -146,8 +146,10 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
         $endDate = (string) $end->getDate();
         $isAllDay = $startDate !== '';
 
-        $startsAt = Date::parse($isAllDay ? $startDate : (string) $start->getDateTime());
-        $endsAt = Date::parse($isAllDay ? $endDate : (string) $end->getDateTime());
+        // All-day events carry a bare Y-m-d with no zone; parse as UTC so a server in a
+        // timezone behind UTC doesn't roll the stored date back a day.
+        $startsAt = $isAllDay ? Date::parse($startDate, 'UTC') : Date::parse((string) $start->getDateTime());
+        $endsAt = $isAllDay ? Date::parse($endDate, 'UTC') : Date::parse((string) $end->getDateTime());
 
         $attendees = [];
         foreach ($event->getAttendees() as $attendee) {

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -54,7 +54,11 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
             }
 
             foreach ($response['value'] ?? [] as $event) {
-                $events[] = $this->normalize($event);
+                // Graph delta emits tombstones for deleted events; they have no payload to
+                // normalize, so surface them as cancelled to soft-delete the stored meeting.
+                $events[] = isset($event['@removed'])
+                    ? $this->tombstone((string) ($event['id'] ?? ''))
+                    : $this->normalize($event);
             }
 
             $url = $response['@odata.nextLink'] ?? null;
@@ -62,6 +66,29 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
         } while ($url !== null);
 
         return new CalendarSyncResult(events: $events, nextSyncToken: $deltaLink);
+    }
+
+    private function tombstone(string $eventId): CalendarEventData
+    {
+        $now = Date::now();
+
+        return new CalendarEventData(
+            providerEventId: $eventId,
+            providerRecurringEventId: null,
+            iCalUid: null,
+            title: null,
+            description: null,
+            startsAt: $now,
+            endsAt: $now,
+            isAllDay: false,
+            location: null,
+            htmlLink: null,
+            status: 'cancelled',
+            visibility: null,
+            organizerEmail: null,
+            organizerName: null,
+            attendees: [],
+        );
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -67,8 +67,8 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         return new MailDeltaResult(
             messageIds: collect($messageIds)->unique()->values(),
             readMessageIds: collect($readMessageIds)->unique()->values(),
-            unreadMessageIds: collect($unreadMessageIds)->unique()->values(),
             newCursor: (string) $deltaLink,
+            unreadMessageIds: collect($unreadMessageIds)->unique()->values(),
         );
     }
 

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -34,6 +34,7 @@ final class MicrosoftGraphMailService implements MailServiceInterface
 
         $messageIds = [];
         $readMessageIds = [];
+        $unreadMessageIds = [];
         $nextUrl = $cursor;
         $deltaLink = $cursor;
 
@@ -41,11 +42,21 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             $response = $http->get($nextUrl)->throw()->json();
 
             foreach ($response['value'] ?? [] as $message) {
+                // Graph delta includes tombstones for deleted messages; they carry no
+                // fetchable payload, so dispatching a StoreEmailJob would just 404.
+                if (isset($message['@removed'])) {
+                    continue;
+                }
+
                 $id = (string) $message['id'];
                 $messageIds[] = $id;
 
-                if (($message['isRead'] ?? false) === true) {
-                    $readMessageIds[] = $id;
+                if (array_key_exists('isRead', $message)) {
+                    if ($message['isRead'] === true) {
+                        $readMessageIds[] = $id;
+                    } else {
+                        $unreadMessageIds[] = $id;
+                    }
                 }
             }
 
@@ -56,6 +67,7 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         return new MailDeltaResult(
             messageIds: collect($messageIds)->unique()->values(),
             readMessageIds: collect($readMessageIds)->unique()->values(),
+            unreadMessageIds: collect($unreadMessageIds)->unique()->values(),
             newCursor: (string) $deltaLink,
         );
     }
@@ -98,6 +110,8 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             bodyText: $bodyText,
             bodyHtml: $bodyHtml,
             participants: $participants,
+            // NOTE: Azure attachment bytes are not fetched yet (would require a separate
+            // /messages/{id}/attachments call). hasAttachments is still surfaced for the UI.
             attachments: [],
         );
     }

--- a/packages/EmailIntegration/src/Services/PrivacyService.php
+++ b/packages/EmailIntegration/src/Services/PrivacyService.php
@@ -9,7 +9,7 @@ use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\ProtectedRecipient;
 
-final readonly class PrivacyService
+final class PrivacyService
 {
     /**
      * Resolve the effective privacy tier this $viewer can see on $email.
@@ -32,10 +32,10 @@ final readonly class PrivacyService
             return null;
         }
 
-        // 3. Per-email share overrides the email's own tier
-        $share = $email->shares()
-            ->where('shared_with', $viewer->getKey())
-            ->first();
+        // 3. Per-email share overrides the email's own tier (uses the loaded relation when
+        // eager-loaded, so filtering a list of emails doesn't issue a query per row).
+        $email->loadMissing('shares');
+        $share = $email->shares->firstWhere('shared_with', $viewer->getKey());
 
         if ($share) {
             return EmailPrivacyTier::from($share->tier);
@@ -65,37 +65,59 @@ final readonly class PrivacyService
     }
 
     /**
+     * Per-team protected recipient lists, memoized for the lifetime of this instance to
+     * avoid two ProtectedRecipient queries per email when filtering a list of emails.
+     *
+     * @var array<string, array{emails: list<string>, domains: list<string>}>
+     */
+    private array $protectedCache = [];
+
+    /**
      * Check whether any participant on this email matches a protected_recipients row.
      */
     private function isProtected(Email $email): bool
     {
         $email->loadMissing(['participants']);
 
-        $teamId = $email->team_id;
-
-        $protectedEmails = ProtectedRecipient::query()->where('team_id', $teamId)
-            ->where('type', 'email')
-            ->pluck('value')
-            ->map(fn (mixed $value): string => strtolower((string) $value));
-
-        $protectedDomains = ProtectedRecipient::query()->where('team_id', $teamId)
-            ->where('type', 'domain')
-            ->pluck('value')
-            ->map(fn (mixed $value): string => strtolower((string) $value));
+        ['emails' => $protectedEmails, 'domains' => $protectedDomains] = $this->protectedRecipients($email->team_id);
 
         foreach ($email->participants as $participant) {
             $address = strtolower((string) $participant->email_address);
             $domain = explode('@', $address)[1] ?? '';
 
-            if ($protectedEmails->contains($address)) {
+            if (in_array($address, $protectedEmails, true)) {
                 return true;
             }
 
-            if ($protectedDomains->contains($domain)) {
+            if ($domain !== '' && in_array($domain, $protectedDomains, true)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /**
+     * @return array{emails: list<string>, domains: list<string>}
+     */
+    private function protectedRecipients(string $teamId): array
+    {
+        if (isset($this->protectedCache[$teamId])) {
+            return $this->protectedCache[$teamId];
+        }
+
+        $byType = ProtectedRecipient::query()
+            ->where('team_id', $teamId)
+            ->whereIn('type', ['email', 'domain'])
+            ->get(['type', 'value']);
+
+        return $this->protectedCache[$teamId] = [
+            'emails' => array_values($byType->where('type', 'email')
+                ->map(fn (ProtectedRecipient $r): string => strtolower((string) $r->value))
+                ->all()),
+            'domains' => array_values($byType->where('type', 'domain')
+                ->map(fn (ProtectedRecipient $r): string => strtolower((string) $r->value))
+                ->all()),
+        ];
     }
 }

--- a/tests/Feature/EmailIntegration/EmailAccessRequestTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccessRequestTest.php
@@ -236,7 +236,7 @@ describe('CancelEmailAccessRequestAction', function (): void {
             'email_id' => $this->email->getKey(),
         ]);
 
-        app(CancelEmailAccessRequestAction::class)->execute($request);
+        app(CancelEmailAccessRequestAction::class)->execute($request, $this->requester);
 
         expect(EmailAccessRequest::query()->whereKey($request->getKey())->exists())->toBeFalse();
     });
@@ -248,7 +248,7 @@ describe('CancelEmailAccessRequestAction', function (): void {
             'email_id' => $this->email->getKey(),
         ]);
 
-        app(CancelEmailAccessRequestAction::class)->execute($request);
+        app(CancelEmailAccessRequestAction::class)->execute($request, $this->requester);
 
         expect(EmailAccessRequest::query()->whereKey($request->getKey())->exists())->toBeTrue();
         expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::APPROVED);
@@ -261,9 +261,22 @@ describe('CancelEmailAccessRequestAction', function (): void {
             'email_id' => $this->email->getKey(),
         ]);
 
-        app(CancelEmailAccessRequestAction::class)->execute($request);
+        app(CancelEmailAccessRequestAction::class)->execute($request, $this->requester);
 
         expect(EmailAccessRequest::query()->whereKey($request->getKey())->exists())->toBeTrue();
         expect($request->fresh()->status)->toBe(EmailAccessRequestStatus::DENIED);
+    });
+
+    it('aborts when the actor is not the requester', function (): void {
+        $request = EmailAccessRequest::factory()->forTier(EmailPrivacyTier::FULL)->create([
+            'requester_id' => $this->requester->id,
+            'owner_id' => $this->owner->id,
+            'email_id' => $this->email->getKey(),
+        ]);
+
+        expect(fn () => app(CancelEmailAccessRequestAction::class)->execute($request, $this->owner))
+            ->toThrow(HttpException::class);
+
+        expect(EmailAccessRequest::query()->whereKey($request->getKey())->exists())->toBeTrue();
     });
 });


### PR DESCRIPTION
## Summary

Security and correctness fixes for the EmailIntegration package, found during a review of the email/calendar sync subsystem. No schema changes.

## Cross-tenant IDOR / authorization (critical)
- `BaseRecordEmailsPage` resolved emails by client-supplied `emailId` with no team scope or policy check (share / summarize / request-access). Routed through a `resolveTeamEmail($id, $ability)` helper (team scope + policy gate) and the existing share/request actions.
- Reply/forward prefill leaked arbitrary email bodies cross-tenant. Fixed both copies (`HasEmailComposeActions` + `EmailInboxPage`): team-scoped lookup, body quoted only when the viewer passes `viewBody`.
- `EmailAccessRequestsPage::selectedRequest` was unscoped — now limited to owner-or-requester within the active team.
- Access-request modal descriptions leaked requester/owner names for arbitrary ids — scoped by owner/requester.
- Defense-in-depth ownership/actor guards added to `UpdateEmailSharingAction`, `ApproveEmailAccessRequestAction` (requester-still-in-team), `CancelEmailAccessRequestAction` (actor check + caller/test updates).

## Sync correctness
- Calendar jobs no longer overwrite a valid sync cursor with `null` (was forcing a full re-sync every run).
- Microsoft Graph `@removed` tombstones handled: skipped in mail delta, soft-deleted as cancelled events in calendar delta (previously crashed jobs / created phantom meetings).
- New provider-agnostic `DetectsAuthErrors` trait replaces fragile `str_contains('401')` — walks the exception chain, reads HTTP status from Laravel/Guzzle/SDK exceptions, matches documented OAuth2 + per-provider tokens.
- `GoogleClientFactory` handles refresh-token failure (revoked grant) and persists rotated refresh tokens instead of writing a null access token.
- Gmail backfill now paginates (was capped at 500); read/unread state synced both directions via `MailDeltaResult`.
- Google all-day events parsed as UTC to avoid a date-shift.
- Retry `backoff` added to sync jobs.

## Outbox
- Skip inactive accounts when dispatching.
- Count in-flight `SENDING` rows against hourly/daily limits to prevent overshoot from overlapping runs.
- Portable `scheduled_for IS NULL DESC` ordering (the previous `NULLS FIRST` raw fragment broke on SQLite).

## Data integrity / performance
- DB transactions around multi-write meeting and signature operations.
- Privacy N+1 fixes: eager-load `participants`/`shares`, memoize protected-recipient lists per team.

## Other
- OAuth callback: null `currentTeam` guard, supported-provider allow-list, route `whereIn` constraints.

## Testing
- 247/247 EmailIntegration + CalendarIntegration tests pass; added a regression test for the cancel-action authorization guard.
- Pint and PHPStan clean on changed files.