### PR TITLE
fix(email): privacy tier select cleanup + email integration hardening

### DIFF
--- a/app/Livewire/App/Email/UserEmailPrivacySettings.php
+++ b/app/Livewire/App/Email/UserEmailPrivacySettings.php
@@ -51,7 +51,6 @@ final class UserEmailPrivacySettings extends BaseLivewireComponent
                             ->options(
                                 collect(EmailPrivacyTier::cases())
                                     ->mapWithKeys(fn (EmailPrivacyTier $tier): array => [$tier->value => $tier->getLabel()])
-                                    ->prepend(__('email/privacy-settings.sharing_preference.use_workspace_default'), '')
                                     ->all()
                             )
                             ->placeholder(__('email/privacy-settings.sharing_preference.use_workspace_default')),


### PR DESCRIPTION
## What

Brings the email-integration review work onto the calendar-integration branch. Tip commit removes a redundant **"Use workspace default"** option from the user privacy tier select — the select placeholder already renders that label for the empty value, so the prepended option duplicated it.

Also included (prior commits on this branch):
- **Privacy/security**: patch cross-tenant IDORs, `ActiveAccountScope` to hide emails from disconnected accounts, scoped Sent-folder filtering for unsent outbound mail.
- **Accounts UI**: group account actions into a native Filament dropdown; hide/comment out Connect Outlook for now; refresh signature listing on disconnect.
- **Sync/outbox**: `DetectsAuthErrors` concern for sync jobs, active() scope for outbox account filter, outbox rate-limit fixes, eager-load team in meetings relation manager.
- **Tests**: `EmailActiveAccountScopeTest`, plus updates to access-request and accounts-page tests.

## Why

Consolidates privacy, IDOR, and UX fixes from the email-integration review and removes the duplicate tier option that confused the default-sharing UI.