### PR TITLE
fix(email): keep default signature when applying a template in compose

### DIFF
--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -250,7 +250,7 @@ trait HasEmailComposeActions
                         ->placeholder(__('filament/concerns/email-compose.fields.template.placeholder'))
                         ->options(fn (): array => $this->templateOptions())
                         ->live()
-                        ->afterStateUpdated(function (?string $state, Set $set): void {
+                        ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
                             if ($state === null) {
                                 return;
                             }
@@ -266,7 +266,22 @@ trait HasEmailComposeActions
                                 ->render($template, $this->getCrmRecord());
 
                             $set('subject', $rendered['subject']);
-                            $set('body_html', $rendered['body_html']);
+
+                            $body = $rendered['body_html'];
+
+                            // Preserve the signature below the template body so picking a
+                            // template never wipes the user's signature.
+                            $sig = $this->resolveComposeSignature(
+                                $get('connected_account_id'),
+                                $get('signature_id'),
+                            );
+
+                            if ($sig !== null) {
+                                $set('signature_id', $sig->getKey());
+                                $body .= '<hr>'.$sig->content_html;
+                            }
+
+                            $set('body_html', $body);
                         }),
                 ]),
 
@@ -544,6 +559,34 @@ trait HasEmailComposeActions
             ->pluck('email_address')
             ->values()
             ->all();
+    }
+
+    /**
+     * Resolve the signature to attach when composing: the explicitly selected
+     * one, else the chosen account's default, else the active account's default.
+     */
+    private function resolveComposeSignature(?string $accountId, ?string $signatureId): ?EmailSignature
+    {
+        if (filled($signatureId)) {
+            return EmailSignature::query()->whereKey($signatureId)->first();
+        }
+
+        if (blank($accountId)) {
+            $accountId = ConnectedAccount::query()
+                ->where('user_id', $this->getAuthenticatedUser()->getKey())
+                ->where('team_id', filament()->getTenant()?->getKey())
+                ->where('status', 'active')
+                ->value('id');
+        }
+
+        if (blank($accountId)) {
+            return null;
+        }
+
+        return EmailSignature::query()
+            ->where('connected_account_id', $accountId)
+            ->where('is_default', true)
+            ->first();
     }
 
     /**

--- a/tests/Feature/EmailIntegration/ComposeEmailFormTest.php
+++ b/tests/Feature/EmailIntegration/ComposeEmailFormTest.php
@@ -12,6 +12,8 @@ use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailSignature;
+use Relaticle\EmailIntegration\Models\EmailTemplate;
 
 mutates(EmailsRelationManager::class);
 
@@ -90,6 +92,37 @@ it('requires at least one recipient in the to field', function (): void {
             'body_html' => '<p>Hi</p>',
         ])
         ->assertHasActionErrors(['to' => 'required']);
+});
+
+it('keeps the default signature in the body when a template is selected', function (): void {
+    $signature = EmailSignature::factory()->create([
+        'connected_account_id' => $this->account->id,
+        'content_html' => '<p>Best, Test Sender</p>',
+        'is_default' => true,
+    ]);
+
+    $template = EmailTemplate::factory()->create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->user->id,
+        'subject' => 'Promo subject',
+        'body_html' => '<p>Template body here</p>',
+    ]);
+
+    livewire(EmailsRelationManager::class, [
+        'ownerRecord' => $this->person,
+        'pageClass' => ViewPeople::class,
+    ])
+        ->mountAction('composeEmail')
+        ->set('mountedActions.0.data.template_id', $template->id)
+        ->assertSet('mountedActions.0.data.subject', 'Promo subject')
+        ->assertSet('mountedActions.0.data.signature_id', $signature->id)
+        ->assertSet('mountedActions.0.data.body_html', function (mixed $body): bool {
+            // RichEditor holds state as a ProseMirror doc array; serialise to compare.
+            $json = json_encode($body);
+
+            return str_contains($json, 'Template body here')
+                && str_contains($json, 'Best, Test Sender');
+        });
 });
 
 it('is hidden when user has no active connected account', function (): void {


### PR DESCRIPTION
## What

Selecting a template in the compose form no longer wipes the default signature.

Previously the template `Select` `afterStateUpdated` callback did `$set('body_html', $rendered['body_html'])`, blindly overwriting the body — including the default signature loaded on form open.

Now the callback appends the signature below the rendered template body (`template <hr> signature`), via a new `resolveComposeSignature()` helper that resolves, in order:
1. the explicitly selected signature (`signature_id`),
2. the chosen account's default signature,
3. the active account's default signature (same query `fillForm` uses).

This makes signature resolution robust even when form state isn't populated yet.

## Why

Users compose an email, the default signature pre-fills the body, then they pick a template and lose the signature.

## Tests

Added `ComposeEmailFormTest`: *keeps the default signature in the body when a template is selected* — asserts the body contains both the template content and the signature after selecting a template, and that `signature_id` is set. Full file: 5/5 pass.

> Note: this branch also carries the prior email-integration fixes already merged onto it (active-account scoping, outbox/sent filtering, IDOR patches, account dropdown UI, etc.).