### PR TITLE
fix(analytics): restore auth funnel pageviews and add signup event

### DIFF
--- a/app/Filament/Pages/Auth/Register.php
+++ b/app/Filament/Pages/Auth/Register.php
@@ -65,6 +65,8 @@ final class Register extends BaseRegister
             event(new Verified($user));
         }
 
+        session()->put('fathom.track_signup', true);
+
         return $user;
     }
 }

--- a/resources/views/filament/app/analytics.blade.php
+++ b/resources/views/filament/app/analytics.blade.php
@@ -7,6 +7,15 @@
 <script>
 window.addEventListener('load', function() {
     function normalizeUrl(pathname) {
+        // Panel-level pages carry no tenant slug — track them as-is so the
+        // auth funnel (/login, /register, …) doesn't collapse into /dashboard.
+        var tenantless = ['/login', '/register', '/forgot-password', '/password-reset', '/email-verification', '/two-factor-authentication', '/new', '/logout'];
+        for (var i = 0; i < tenantless.length; i++) {
+            if (pathname === tenantless[i] || pathname.indexOf(tenantless[i] + '/') === 0) {
+                return pathname;
+            }
+        }
+
         // Remove tenant slug: /my-team/people → /people
         pathname = pathname.replace(/^\/[^\/]+/, '');
 
@@ -29,6 +38,15 @@ window.addEventListener('load', function() {
 
     // Initial track
     setTimeout(track, 100);
+
+    @if(session()->pull('fathom.track_signup'))
+    // One-time conversion event, flagged during registration
+    setTimeout(function () {
+        if (typeof fathom !== 'undefined') {
+            fathom.trackEvent('signup');
+        }
+    }, 150);
+    @endif
 
     // SPA navigation
     document.addEventListener('livewire:navigated', track);

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -24,3 +24,43 @@ it('registers a new user without creating a team', function (): void {
         ->and($user->ownedTeams)->toHaveCount(0)
         ->and($user->personalTeam())->toBeNull();
 });
+
+it('flags the session for signup analytics tracking on registration', function (): void {
+    livewire(Register::class)
+        ->fillForm([
+            'name' => 'Jane Doe',
+            'email' => 'jane-track@gmail.com',
+            'password' => 'Password123!',
+            'passwordConfirmation' => 'Password123!',
+        ])
+        ->call('register')
+        ->assertHasNoFormErrors();
+
+    expect(session()->get('fathom.track_signup'))->toBeTrue();
+});
+
+it('renders the signup event once and clears the flag', function (): void {
+    $this->app['env'] = 'production';
+    config(['services.fathom.site_id' => 'TESTSITE']);
+    session()->put('fathom.track_signup', true);
+
+    $html = view('filament.app.analytics')->render();
+
+    expect($html)->toContain("fathom.trackEvent('signup')")
+        ->and(session()->has('fathom.track_signup'))->toBeFalse();
+
+    $again = view('filament.app.analytics')->render();
+
+    expect($again)->not->toContain("trackEvent('signup')");
+});
+
+it('keeps panel auth pages out of tenant-slug normalization', function (): void {
+    $this->app['env'] = 'production';
+    config(['services.fathom.site_id' => 'TESTSITE']);
+
+    $html = view('filament.app.analytics')->render();
+
+    expect($html)->toContain("'/register'")
+        ->and($html)->toContain("'/login'")
+        ->and($html)->toContain("'/email-verification'");
+});


### PR DESCRIPTION
## Problem

The Fathom tracker in `analytics.blade.php` strips the first path segment as a tenant slug on **every** URL (`/my-team/people` → `/people`). Since the panel moved to slug-based URLs (~April), that rule also rewrote `/register` and `/login` → `/dashboard`, so the auth funnel vanished from analytics.

Evidence (Fathom `/register` uniques): Dec **756** → Mar **170** → Apr/May **5**. That's a tracking artifact, not a demand collapse — and it makes signup attribution impossible right before the launch campaign.

## Changes

1. **Auth/system paths bypass slug normalization** — `/login`, `/register`, `/forgot-password`, `/password-reset`, `/email-verification`, `/two-factor-authentication`, `/new`, `/logout` are tracked as-is. Tenant-scoped resource URLs still normalize exactly as before.
2. **`signup` conversion event** — `Register::handleRegistration()` flags the session; the analytics partial emits `fathom.trackEvent('signup')` once on the first page after registration, then clears the flag (`session()->pull`, so it can't double-fire). Anonymous and cookieless — no consent surface change.

Verified against the [Fathom events docs](https://usefathom.com/docs/features/events): `trackEvent(name)` auto-creates the event on first fire, and the call sits in a `load` handler after the deferred script so `fathom` is defined.

## Why now

This is the primary conversion metric for the AI-launch campaign (first posts June 16). Without it there is no channel → signup attribution. **Should merge/deploy before June 16.**

## Test plan

- `vendor/bin/pest tests/Feature/Auth/RegistrationTest.php` — 4 passed, 16 assertions
  - registers a user without a team (existing)
  - flags the session for signup tracking on registration
  - renders the `signup` event once and clears the flag (no double-fire)
  - keeps panel auth pages out of tenant-slug normalization
- `phpstan` 0 errors · `pint` clean

Note: events only fire under `app()->isProduction()` with `FATHOM_ANALYTICS_SITE_ID` set, matching the existing guard.