### PR TITLE
chore: update relaticle/activity-log to v1.1.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8999,16 +8999,16 @@
         },
         {
             "name": "relaticle/activity-log",
-            "version": "v1.0.1",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/relaticle/activity-log.git",
-                "reference": "04725b4351a2f87e2a9c39356e3e9fd487f86148"
+                "reference": "692465d217f28b5e9a75745abcf084044ada9556"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/relaticle/activity-log/zipball/04725b4351a2f87e2a9c39356e3e9fd487f86148",
-                "reference": "04725b4351a2f87e2a9c39356e3e9fd487f86148",
+                "url": "https://api.github.com/repos/relaticle/activity-log/zipball/692465d217f28b5e9a75745abcf084044ada9556",
+                "reference": "692465d217f28b5e9a75745abcf084044ada9556",
                 "shasum": ""
             },
             "require": {
@@ -9047,9 +9047,9 @@
             "description": "Reusable Filament plugin that renders a unified activity-log timeline for any Eloquent model",
             "support": {
                 "issues": "https://github.com/relaticle/activity-log/issues",
-                "source": "https://github.com/relaticle/activity-log/tree/v1.0.1"
+                "source": "https://github.com/relaticle/activity-log/tree/v1.1.0"
             },
-            "time": "2026-04-29T12:06:53+00:00"
+            "time": "2026-06-13T14:10:39+00:00"
         },
         {
             "name": "relaticle/custom-fields",


### PR DESCRIPTION
## What

Bumps `relaticle/activity-log` from **v1.0.1 → v1.1.0** (latest tag) in `composer.lock`. Constraint `^1.0` in `composer.json` already allows it — no manifest change needed.

## Why

Pull in the latest activity-log release.

## Verification

- `composer update relaticle/activity-log --with-dependencies` — successful, assets republished.
- App boots clean; `Relaticle\ActivityLog\ActivityLogServiceProvider` loads.
- ActivityLog test suite not run to green locally — test postgres (5432) was not running in this environment.

> Note: base `feat/activity-log` is behind `main`, so this PR also carries main's commits. The activity-log bump is the only change authored here (`composer.lock`).