### PR TITLE
Refine custom-field-changes activity icon layout

### DIFF
--- a/resources/views/activity-log/custom-field-changes.blade.php
+++ b/resources/views/activity-log/custom-field-changes.blade.php
@@ -1,6 +1,8 @@
-<div class="flex items-start gap-3 py-2">
-    <div class="flex size-8 items-center justify-center rounded-full bg-primary-50 text-primary-600 dark:bg-primary-400/10">
-        <x-heroicon-o-adjustments-horizontal class="size-4" />
+<div class="flex items-start gap-3 px-2 py-2">
+    <div class="flex w-7 shrink-0 justify-center pt-0.5">
+        <div class="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary-50 text-primary-600 dark:bg-primary-400/10">
+            <x-heroicon-o-adjustments-horizontal class="size-3.5" />
+        </div>
     </div>
     <div class="flex-1 text-sm text-gray-700 dark:text-gray-300">
         <div class="font-medium text-gray-900 dark:text-white">


### PR DESCRIPTION
## What

Adjusts the icon layout in the custom-field-changes activity-log entry:

- Wraps the icon in a fixed `w-7` column, centered with `pt-0.5` top alignment
- Shrinks the avatar (`size-8` → `size-6`) and icon (`size-4` → `size-3.5`)
- Adds horizontal padding (`px-2`) to the row

## Why

Aligns the icon sizing and spacing with other activity-log entry types for visual consistency.