### PR TITLE
fix(activity-log): render arbitrary-value custom fields as plain labels

### DIFF
--- a/app/Observers/CustomFieldValueObserver.php
+++ b/app/Observers/CustomFieldValueObserver.php
@@ -111,11 +111,14 @@ final readonly class CustomFieldValueObserver
         $ids = is_iterable($value) ? collect($value) : collect();
 
         $labels = $ids
-            ->map(fn (mixed $id): ?string => $this->optionLabel($field, $id))
-            ->filter()
+            // Arbitrary-value fields (link, tags-input) store raw strings rather than
+            // option IDs, so no option matches — fall back to the value itself instead
+            // of leaking escaped JSON.
+            ->map(fn (mixed $id): string => $this->optionLabel($field, $id) ?? (string) $id)
+            ->filter(fn (string $label): bool => $label !== '')
             ->all();
 
-        return $labels === [] ? (string) json_encode($value) : implode(', ', $labels);
+        return implode(', ', $labels);
     }
 
     private function isEmpty(mixed $value): bool

--- a/tests/Feature/ActivityLog/CustomFieldActivityTest.php
+++ b/tests/Feature/ActivityLog/CustomFieldActivityTest.php
@@ -68,6 +68,33 @@ it('logs a custom_field_changes activity when a value is updated', function (): 
         ->and($activity->properties['custom_field_changes'][0]['new']['label'])->toBe('linkedin');
 });
 
+it('renders link-field values as plain URLs, not escaped JSON', function (): void {
+    $linkField = CustomField::query()->create([
+        'tenant_id' => $this->team->getKey(),
+        'custom_field_section_id' => $this->field->custom_field_section_id,
+        'entity_type' => 'company',
+        'code' => 'website',
+        'name' => 'Website',
+        'type' => 'link',
+        'sort_order' => 2,
+        'active' => true,
+        'validation_rules' => [],
+    ]);
+
+    $company = Company::factory()->for($this->team)->create();
+    Activity::withoutGlobalScopes()->delete();
+
+    $company->saveCustomFields(['website' => ['https://www.linkedin.com/company/airbnb']]);
+
+    $activity = Activity::query()->latest('id')->first();
+    $change = $activity->properties['custom_field_changes'][0];
+
+    expect($change['code'])->toBe('website')
+        ->and($change['new']['label'])->toBe('https://www.linkedin.com/company/airbnb')
+        ->and($change['new']['label'])->not->toContain('\\/')
+        ->and($change['new']['label'])->not->toContain('[');
+});
+
 it('does not log when saving an empty value for a previously empty field', function (): void {
     $company = Company::factory()->for($this->team)->create();
     Activity::withoutGlobalScopes()->delete();


### PR DESCRIPTION
## Problem

Link custom fields (LinkedIn, domains — seeded defaults on nearly every tenant) render as escaped JSON in the activity timeline instead of the URL:

```
LinkedIn: ["https:\/\/www.linkedin.com\/company\/airbnb"] → ["www.linkedin.com\/company\/airbnb"]
```

Fails AC #2 ("proper old → new diff with proper labels"). Text/toggle fields render fine.

## Cause

`LinkFieldType` is declared `FieldSchema::multiChoice()->withArbitraryValues()`, so its dataType is `MULTI_CHOICE` and `CustomFieldValueObserver::describe()` routes it through `multiOptionLabels()` — which resolves each value as an **option ID**. But arbitrary-value fields (link, tags-input) store **raw strings**, not IDs, so no option matches and the code falls back to `json_encode($value)`, leaking escaped JSON.

The `json_encode` fallback dates to the original observer commit (`64ab9947`); its scope was single/multi-choice, booleans, and dates — arbitrary-value fields were never handled.

## Fix

In `multiOptionLabels()`, fall back to the raw value as its own label instead of `json_encode`:

```php
->map(fn (mixed $id): string => $this->optionLabel($field, $id) ?? (string) $id)
```

- Real choice fields still resolve to option names (unchanged).
- Link / tags-input fields now show their plain strings.

Only behavior change for real choice fields: a deleted/orphaned option ID now renders as a bare number rather than being silently dropped — rare and historical-only.

## Tests

Added `renders link-field values as plain URLs, not escaped JSON` to `CustomFieldActivityTest`. Full activity-log suite passes (3/3). Pint, PHPStan, rector clean.