### PR TITLE
Normalize onboard seed URLs to www without https scheme

### DIFF
--- a/packages/OnboardSeed/resources/fixtures/companies/airbnb.yaml
+++ b/packages/OnboardSeed/resources/fixtures/companies/airbnb.yaml
@@ -1,5 +1,5 @@
 name: Airbnb
 custom_fields:
-  domains: https://airbnb.com
+  domains: www.airbnb.com
   icp: true
-  linkedin: https://www.linkedin.com/company/airbnb
+  linkedin: www.linkedin.com/company/airbnb

--- a/packages/OnboardSeed/resources/fixtures/companies/apple.yaml
+++ b/packages/OnboardSeed/resources/fixtures/companies/apple.yaml
@@ -1,5 +1,5 @@
 name: Apple
 custom_fields:
-  domains: https://apple.com
+  domains: www.apple.com
   icp: true
-  linkedin: https://www.linkedin.com/company/apple
+  linkedin: www.linkedin.com/company/apple

--- a/packages/OnboardSeed/resources/fixtures/companies/figma.yaml
+++ b/packages/OnboardSeed/resources/fixtures/companies/figma.yaml
@@ -1,5 +1,5 @@
 name: Figma
 custom_fields:
-  domains: https://figma.com
+  domains: www.figma.com
   icp: true
-  linkedin: https://www.linkedin.com/company/figma
+  linkedin: www.linkedin.com/company/figma

--- a/packages/OnboardSeed/resources/fixtures/companies/notion.yaml
+++ b/packages/OnboardSeed/resources/fixtures/companies/notion.yaml
@@ -1,5 +1,5 @@
 name: Notion
 custom_fields:
-  domains: https://notion.com
+  domains: www.notion.com
   icp: true
-  linkedin: https://www.linkedin.com/company/notion-so
+  linkedin: www.linkedin.com/company/notion-so

--- a/packages/OnboardSeed/resources/fixtures/fundraising/companies/a16z.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/companies/a16z.yaml
@@ -1,5 +1,5 @@
 name: Andreessen Horowitz
 custom_fields:
-  domains: https://a16z.com
+  domains: www.a16z.com
   icp: true
-  linkedin: https://www.linkedin.com/company/andreessen-horowitz
+  linkedin: www.linkedin.com/company/andreessen-horowitz

--- a/packages/OnboardSeed/resources/fixtures/fundraising/companies/benchmark.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/companies/benchmark.yaml
@@ -1,5 +1,5 @@
 name: Benchmark
 custom_fields:
-  domains: https://benchmark.com
+  domains: www.benchmark.com
   icp: true
-  linkedin: https://www.linkedin.com/company/benchmark
+  linkedin: www.linkedin.com/company/benchmark

--- a/packages/OnboardSeed/resources/fixtures/fundraising/companies/greylock.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/companies/greylock.yaml
@@ -1,5 +1,5 @@
 name: Greylock Partners
 custom_fields:
-  domains: https://greylock.com
+  domains: www.greylock.com
   icp: true
-  linkedin: https://www.linkedin.com/company/greylock-partners
+  linkedin: www.linkedin.com/company/greylock-partners

--- a/packages/OnboardSeed/resources/fixtures/fundraising/companies/sequoia.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/companies/sequoia.yaml
@@ -1,5 +1,5 @@
 name: Sequoia Capital
 custom_fields:
-  domains: https://sequoiacap.com
+  domains: www.sequoiacap.com
   icp: true
-  linkedin: https://www.linkedin.com/company/sequoia-capital
+  linkedin: www.linkedin.com/company/sequoia-capital

--- a/packages/OnboardSeed/resources/fixtures/fundraising/people/alfred.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/people/alfred.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - alfred@sequoiacap.com
   phone_number: "+14155550201"
   job_title: Partner
-  linkedin: https://www.linkedin.com/in/alfredlin/
+  linkedin: www.linkedin.com/in/alfredlin/

--- a/packages/OnboardSeed/resources/fixtures/fundraising/people/marc.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/people/marc.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - marc@a16z.com
   phone_number: "+14155550203"
   job_title: Co-founder & General Partner
-  linkedin: https://www.linkedin.com/in/marcandreessen/
+  linkedin: www.linkedin.com/in/marcandreessen/

--- a/packages/OnboardSeed/resources/fixtures/fundraising/people/peter.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/people/peter.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - peter@benchmark.com
   phone_number: "+14155550202"
   job_title: General Partner
-  linkedin: https://www.linkedin.com/in/peterfenton/
+  linkedin: www.linkedin.com/in/peterfenton/

--- a/packages/OnboardSeed/resources/fixtures/fundraising/people/reid.yaml
+++ b/packages/OnboardSeed/resources/fixtures/fundraising/people/reid.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - reid@greylock.com
   phone_number: "+14155550204"
   job_title: Partner
-  linkedin: https://www.linkedin.com/in/reidhoffman/
+  linkedin: www.linkedin.com/in/reidhoffman/

--- a/packages/OnboardSeed/resources/fixtures/general/companies/atlas_design.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/companies/atlas_design.yaml
@@ -1,5 +1,5 @@
 name: Atlas Design Studio
 custom_fields:
-  domains: https://atlasdesignstudio.com
+  domains: www.atlasdesignstudio.com
   icp: true
-  linkedin: https://www.linkedin.com/company/atlas-design-studio
+  linkedin: www.linkedin.com/company/atlas-design-studio

--- a/packages/OnboardSeed/resources/fixtures/general/companies/coastal_media.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/companies/coastal_media.yaml
@@ -1,5 +1,5 @@
 name: Coastal Media
 custom_fields:
-  domains: https://coastalmedia.co
+  domains: www.coastalmedia.co
   icp: true
-  linkedin: https://www.linkedin.com/company/coastal-media
+  linkedin: www.linkedin.com/company/coastal-media

--- a/packages/OnboardSeed/resources/fixtures/general/companies/horizon_labs.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/companies/horizon_labs.yaml
@@ -1,5 +1,5 @@
 name: Horizon Labs
 custom_fields:
-  domains: https://horizonlabs.io
+  domains: www.horizonlabs.io
   icp: true
-  linkedin: https://www.linkedin.com/company/horizon-labs
+  linkedin: www.linkedin.com/company/horizon-labs

--- a/packages/OnboardSeed/resources/fixtures/general/companies/summit_group.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/companies/summit_group.yaml
@@ -1,5 +1,5 @@
 name: Summit Group
 custom_fields:
-  domains: https://summitgroupadvisors.com
+  domains: www.summitgroupadvisors.com
   icp: false
-  linkedin: https://www.linkedin.com/company/summit-group-advisors
+  linkedin: www.linkedin.com/company/summit-group-advisors

--- a/packages/OnboardSeed/resources/fixtures/general/people/liam.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/people/liam.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - liam@coastalmedia.co
   phone_number: "+14155550158"
   job_title: Head of Partnerships
-  linkedin: https://www.linkedin.com/in/liamobrien/
+  linkedin: www.linkedin.com/in/liamobrien/

--- a/packages/OnboardSeed/resources/fixtures/general/people/noah.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/people/noah.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - noah@atlasdesignstudio.com
   phone_number: "+14155550135"
   job_title: Creative Director
-  linkedin: https://www.linkedin.com/in/noahbennett/
+  linkedin: www.linkedin.com/in/noahbennett/

--- a/packages/OnboardSeed/resources/fixtures/general/people/olivia.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/people/olivia.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - olivia@horizonlabs.io
   phone_number: "+14155550120"
   job_title: Managing Director
-  linkedin: https://www.linkedin.com/in/oliviacarter/
+  linkedin: www.linkedin.com/in/oliviacarter/

--- a/packages/OnboardSeed/resources/fixtures/general/people/sophia.yaml
+++ b/packages/OnboardSeed/resources/fixtures/general/people/sophia.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - sophia@summitgroupadvisors.com
   phone_number: "+14155550142"
   job_title: Senior Consultant
-  linkedin: https://www.linkedin.com/in/sophiapatel/
+  linkedin: www.linkedin.com/in/sophiapatel/

--- a/packages/OnboardSeed/resources/fixtures/marketing/companies/canva.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/companies/canva.yaml
@@ -1,5 +1,5 @@
 name: Canva
 custom_fields:
-  domains: https://canva.com
+  domains: www.canva.com
   icp: false
-  linkedin: https://www.linkedin.com/company/canva
+  linkedin: www.linkedin.com/company/canva

--- a/packages/OnboardSeed/resources/fixtures/marketing/companies/clearbit.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/companies/clearbit.yaml
@@ -1,5 +1,5 @@
 name: Clearbit
 custom_fields:
-  domains: https://clearbit.com
+  domains: www.clearbit.com
   icp: true
-  linkedin: https://www.linkedin.com/company/clearbit
+  linkedin: www.linkedin.com/company/clearbit

--- a/packages/OnboardSeed/resources/fixtures/marketing/companies/hubspot.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/companies/hubspot.yaml
@@ -1,5 +1,5 @@
 name: HubSpot
 custom_fields:
-  domains: https://hubspot.com
+  domains: www.hubspot.com
   icp: true
-  linkedin: https://www.linkedin.com/company/hubspot
+  linkedin: www.linkedin.com/company/hubspot

--- a/packages/OnboardSeed/resources/fixtures/marketing/companies/mailchimp.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/companies/mailchimp.yaml
@@ -1,5 +1,5 @@
 name: Mailchimp
 custom_fields:
-  domains: https://mailchimp.com
+  domains: www.mailchimp.com
   icp: true
-  linkedin: https://www.linkedin.com/company/mailchimp
+  linkedin: www.linkedin.com/company/mailchimp

--- a/packages/OnboardSeed/resources/fixtures/marketing/people/alex.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/people/alex.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - alex@clearbit.com
   phone_number: "+14155550201"
   job_title: Marketing Director
-  linkedin: https://www.linkedin.com/in/alexmartinez/
+  linkedin: www.linkedin.com/in/alexmartinez/

--- a/packages/OnboardSeed/resources/fixtures/marketing/people/david.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/people/david.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - david@mailchimp.com
   phone_number: "+14155550203"
   job_title: Content Lead
-  linkedin: https://www.linkedin.com/in/davidokonkwo/
+  linkedin: www.linkedin.com/in/davidokonkwo/

--- a/packages/OnboardSeed/resources/fixtures/marketing/people/lisa.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/people/lisa.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - lisa@canva.com
   phone_number: "+14155550204"
   job_title: Brand Strategist
-  linkedin: https://www.linkedin.com/in/lisawang/
+  linkedin: www.linkedin.com/in/lisawang/

--- a/packages/OnboardSeed/resources/fixtures/marketing/people/rachel.yaml
+++ b/packages/OnboardSeed/resources/fixtures/marketing/people/rachel.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - rachel@hubspot.com
   phone_number: "+14155550202"
   job_title: Partnership Manager
-  linkedin: https://www.linkedin.com/in/rachelkim/
+  linkedin: www.linkedin.com/in/rachelkim/

--- a/packages/OnboardSeed/resources/fixtures/people/brian.yaml
+++ b/packages/OnboardSeed/resources/fixtures/people/brian.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - brian@airbnb.com
   phone_number: "+14155550100"
   job_title: CEO & Co-founder
-  linkedin: https://www.linkedin.com/in/brianchesky/
+  linkedin: www.linkedin.com/in/brianchesky/

--- a/packages/OnboardSeed/resources/fixtures/people/dylan.yaml
+++ b/packages/OnboardSeed/resources/fixtures/people/dylan.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - dylan@figma.com
   phone_number: "+14155550101"
   job_title: CEO
-  linkedin: https://www.linkedin.com/in/dylanfield/
+  linkedin: www.linkedin.com/in/dylanfield/

--- a/packages/OnboardSeed/resources/fixtures/people/ivan.yaml
+++ b/packages/OnboardSeed/resources/fixtures/people/ivan.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - ivan@notion.com
   phone_number: "+14155550102"
   job_title: Co-founder
-  linkedin: https://www.linkedin.com/in/ivzhao/
+  linkedin: www.linkedin.com/in/ivzhao/

--- a/packages/OnboardSeed/resources/fixtures/people/tim.yaml
+++ b/packages/OnboardSeed/resources/fixtures/people/tim.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - tim@apple.com
   phone_number: "+14155550103"
   job_title: CEO
-  linkedin: https://www.linkedin.com/in/timcook/
+  linkedin: www.linkedin.com/in/timcook/

--- a/packages/OnboardSeed/resources/fixtures/recruiting/companies/linear.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/companies/linear.yaml
@@ -1,5 +1,5 @@
 name: Linear
 custom_fields:
-  domains: https://linear.app
+  domains: www.linear.app
   icp: true
-  linkedin: https://www.linkedin.com/company/linear-app
+  linkedin: www.linkedin.com/company/linear-app

--- a/packages/OnboardSeed/resources/fixtures/recruiting/companies/stripe.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/companies/stripe.yaml
@@ -1,5 +1,5 @@
 name: Stripe
 custom_fields:
-  domains: https://stripe.com
+  domains: www.stripe.com
   icp: true
-  linkedin: https://www.linkedin.com/company/stripe
+  linkedin: www.linkedin.com/company/stripe

--- a/packages/OnboardSeed/resources/fixtures/recruiting/companies/supabase.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/companies/supabase.yaml
@@ -1,5 +1,5 @@
 name: Supabase
 custom_fields:
-  domains: https://supabase.com
+  domains: www.supabase.com
   icp: true
-  linkedin: https://www.linkedin.com/company/supabase
+  linkedin: www.linkedin.com/company/supabase

--- a/packages/OnboardSeed/resources/fixtures/recruiting/companies/vercel.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/companies/vercel.yaml
@@ -1,5 +1,5 @@
 name: Vercel
 custom_fields:
-  domains: https://vercel.com
+  domains: www.vercel.com
   icp: true
-  linkedin: https://www.linkedin.com/company/vercel
+  linkedin: www.linkedin.com/company/vercel

--- a/packages/OnboardSeed/resources/fixtures/recruiting/people/emma.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/people/emma.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - emma.thompson@proton.me
   phone_number: "+14155550147"
   job_title: Engineering Manager
-  linkedin: https://www.linkedin.com/in/emmathompson/
+  linkedin: www.linkedin.com/in/emmathompson/

--- a/packages/OnboardSeed/resources/fixtures/recruiting/people/james.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/people/james.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - james.park@hey.com
   phone_number: "+14155550158"
   job_title: Backend Developer
-  linkedin: https://www.linkedin.com/in/jamespark/
+  linkedin: www.linkedin.com/in/jamespark/

--- a/packages/OnboardSeed/resources/fixtures/recruiting/people/marcus.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/people/marcus.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - marcus.rivera@outlook.com
   phone_number: "+14155550134"
   job_title: Product Designer
-  linkedin: https://www.linkedin.com/in/marcusrivera/
+  linkedin: www.linkedin.com/in/marcusrivera/

--- a/packages/OnboardSeed/resources/fixtures/recruiting/people/sarah.yaml
+++ b/packages/OnboardSeed/resources/fixtures/recruiting/people/sarah.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - sarah.chen@gmail.com
   phone_number: "+14155550121"
   job_title: Senior Software Engineer
-  linkedin: https://www.linkedin.com/in/sarahchen/
+  linkedin: www.linkedin.com/in/sarahchen/

--- a/packages/OnboardSeed/resources/fixtures/sales/companies/airbnb.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/companies/airbnb.yaml
@@ -1,5 +1,5 @@
 name: Airbnb
 custom_fields:
-  domains: https://airbnb.com
+  domains: www.airbnb.com
   icp: true
-  linkedin: https://www.linkedin.com/company/airbnb
+  linkedin: www.linkedin.com/company/airbnb

--- a/packages/OnboardSeed/resources/fixtures/sales/companies/apple.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/companies/apple.yaml
@@ -1,5 +1,5 @@
 name: Apple
 custom_fields:
-  domains: https://apple.com
+  domains: www.apple.com
   icp: true
-  linkedin: https://www.linkedin.com/company/apple
+  linkedin: www.linkedin.com/company/apple

--- a/packages/OnboardSeed/resources/fixtures/sales/companies/figma.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/companies/figma.yaml
@@ -1,5 +1,5 @@
 name: Figma
 custom_fields:
-  domains: https://figma.com
+  domains: www.figma.com
   icp: true
-  linkedin: https://www.linkedin.com/company/figma
+  linkedin: www.linkedin.com/company/figma

--- a/packages/OnboardSeed/resources/fixtures/sales/companies/notion.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/companies/notion.yaml
@@ -1,5 +1,5 @@
 name: Notion
 custom_fields:
-  domains: https://notion.com
+  domains: www.notion.com
   icp: true
-  linkedin: https://www.linkedin.com/company/notion-so
+  linkedin: www.linkedin.com/company/notion-so

--- a/packages/OnboardSeed/resources/fixtures/sales/people/brian.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/brian.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - brian@airbnb.com
   phone_number: "+14155550100"
   job_title: CEO & Co-founder
-  linkedin: https://www.linkedin.com/in/brianchesky/
+  linkedin: www.linkedin.com/in/brianchesky/

--- a/packages/OnboardSeed/resources/fixtures/sales/people/dylan.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/dylan.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - dylan@figma.com
   phone_number: "+14155550101"
   job_title: CEO
-  linkedin: https://www.linkedin.com/in/dylanfield/
+  linkedin: www.linkedin.com/in/dylanfield/

--- a/packages/OnboardSeed/resources/fixtures/sales/people/ivan.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/ivan.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - ivan@notion.com
   phone_number: "+14155550102"
   job_title: Co-founder
-  linkedin: https://www.linkedin.com/in/ivzhao/
+  linkedin: www.linkedin.com/in/ivzhao/

--- a/packages/OnboardSeed/resources/fixtures/sales/people/tim.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/tim.yaml
@@ -5,4 +5,4 @@ custom_fields:
     - tim@apple.com
   phone_number: "+14155550103"
   job_title: CEO
-  linkedin: https://www.linkedin.com/in/timcook/
+  linkedin: www.linkedin.com/in/timcook/

--- a/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
+++ b/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
@@ -427,9 +427,9 @@ it('seeds custom field values correctly for sales', function (): void {
         ->get()
         ->keyBy('custom_field_id');
 
-    expect($appleValues[$companyFields['domains']]->json_value)->toContain('https://apple.com')
+    expect($appleValues[$companyFields['domains']]->json_value)->toContain('www.apple.com')
         ->and($appleValues[$companyFields['icp']]->boolean_value)->toBeTrue()
-        ->and($appleValues[$companyFields['linkedin']]->json_value)->toContain('https://www.linkedin.com/company/apple');
+        ->and($appleValues[$companyFields['linkedin']]->json_value)->toContain('www.linkedin.com/company/apple');
 });
 
 it('subsequent teams still require use case selection', function (): void {


### PR DESCRIPTION
## What

Strips the `https://` scheme from all URL values in the OnboardSeed demo fixtures and ensures a `www.` prefix instead.

- Company `domains` (e.g. `https://figma.com` → `www.figma.com`) — scheme removed, `www.` added.
- `linkedin` URLs (people + companies) — scheme removed, existing `www.` kept (no double `www.`).

48 fixture files across all sets (sales, general, fundraising, marketing, recruiting, and root), 72 lines changed.

## Why

Display demo seed data as cleaner, scheme-less `www.` URLs in seeded workspaces.

## Notes

- Values only — no seeder logic touched.
- These fixtures feed the onboarding seed path (first/personal team creation → `CreateTeamCustomFields` → `OnboardSeeder`).