### PR TITLE
fix(sysadmin): drop unreachable 'Untitled' placeholder on conversation title (#337)

### DIFF
--- a/packages/SystemAdmin/src/Filament/Resources/AgentConversationResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AgentConversationResource.php
@@ -41,7 +41,7 @@ final class AgentConversationResource extends Resource
         return $schema
             ->components([
                 Section::make([
-                    TextEntry::make('title')->placeholder('Untitled'),
+                    TextEntry::make('title'),
                     TextEntry::make('team.name')->label('Team')->placeholder('—'),
                     TextEntry::make('user.name')->label('User')->placeholder('—'),
                     TextEntry::make('messages_count')->label('Messages')->state(fn (AgentConversation $record): int => $record->messages()->count()),
@@ -61,7 +61,6 @@ final class AgentConversationResource extends Resource
                     ->dateTime()
                     ->sortable(),
                 TextColumn::make('title')
-                    ->placeholder('Untitled')
                     ->limit(50)
                     ->searchable(),
                 TextColumn::make('team.name')

--- a/tests/Feature/SystemAdmin/AgentConversationResourceTest.php
+++ b/tests/Feature/SystemAdmin/AgentConversationResourceTest.php
@@ -71,3 +71,22 @@ it('shows a conversation detail page', function (): void {
     livewire(ViewAgentConversation::class, ['record' => $conversation->getKey()])
         ->assertSuccessful();
 });
+
+it('renders the stored title in the table without an Untitled placeholder', function (): void {
+    $conversation = seedAdminConversation('Real conversation title');
+
+    livewire(ListAgentConversations::class)
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords([$conversation])
+        ->assertTableColumnStateSet('title', 'Real conversation title', record: $conversation)
+        ->assertDontSee('Untitled');
+});
+
+it('renders the stored title on the detail page without an Untitled placeholder', function (): void {
+    $conversation = seedAdminConversation('Detail page title');
+
+    livewire(ViewAgentConversation::class, ['record' => $conversation->getKey()])
+        ->assertSuccessful()
+        ->assertSee('Detail page title')
+        ->assertDontSee('Untitled');
+});


### PR DESCRIPTION
Fixes #337.

## What was happening

`agent_conversations.title` is `NOT NULL` at the DB level, and every conversation gets a title at creation time — `ChatController` seeds it from the first message via `TitleSanitizer::clean($parsed['text'])`. Filament placeholders only render when the column state is `null`, so the `->placeholder('Untitled')` on the title (table column + infolist entry) was dead-defensive: there's no normal data path that can reach it.

## What this PR does

Removes the two unreachable `->placeholder('Untitled')` calls and adds regression tests that assert the stored title actually renders — in both the list table and the detail infolist — so the placeholder doesn't quietly creep back in. I deliberately left the `'—'` placeholders on `team.name` / `user.name` alone, since those relations *are* nullable and the placeholder there is reachable.

```
4 passed (21 assertions) — tests/Feature/SystemAdmin/AgentConversationResourceTest.php
60 passed — tests/Feature/SystemAdmin (full suite, no regressions)
```

## One open question for you

This is the smaller of the two directions you sketched in the issue, and I picked it because it's the zero-risk, no-migration slice. But there's a real product call underneath that's yours to make, not mine — so I didn't presume it.

The empty-string edge you flagged is genuinely live: `TitleSanitizer::clean()` returns a `string` and can collapse to `''` (e.g. a rename to all-whitespace via `RenameConversation`, or a first message that's only bidi/whitespace chars sneaking past the `!== ''` check before sanitization). An empty title renders as a blank cell here, not "Untitled". And the chat side already treats that state as real — `ChatInterface::conversationTitle()` degrades `trim($title) === ''` to `null`, and the model docblock even types `title` as `string|null`.

So there's a coherent case for **direction 1** instead: make `title` nullable, normalize `''` → `null` at the write paths, and bring the placeholder back as an *honest* fallback. That's a migration + a couple of write-path touches, which felt too opinionated to ship uninvited. If that's the way you'd rather go, say the word and I'll turn it around as a follow-up PR (or fold it into this one) — whichever you prefer.

---

Small bit of context: I run [Choreless](https://choreless.dev) — we do exactly this kind of unglamorous-but-fiddly correctness work (edge cases, spec compliance, the bugs nobody volunteers for). Spotted #337 while looking at the repo, figured I'd just fix it. Hope it's useful either way.

— Charles
