### PR TITLE
fix(arch): wire EmailIntegration package into arch coverage

### DIFF
--- a/.ai/guidelines/relaticle/architecture.md
+++ b/.ai/guidelines/relaticle/architecture.md
@@ -14,6 +14,7 @@ no composer.json of their own). Service providers are registered in
 | `packages/ImportWizard` | CSV import flows |
 | `packages/Documentation` | Public docs pages |
 | `packages/OnboardSeed` | Demo/onboarding data seeding |
+| `packages/EmailIntegration` | Email + calendar sync (Gmail/Microsoft Graph), sharing, privacy |
 
 Create a new package only for a genuinely separable subsystem with its own panel,
 routes, or lifecycle — not for a new CRM entity (those go in `app/`). Package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ no composer.json of their own). Service providers are registered in
 | `packages/ImportWizard` | CSV import flows |
 | `packages/Documentation` | Public docs pages |
 | `packages/OnboardSeed` | Demo/onboarding data seeding |
+| `packages/EmailIntegration` | Email + calendar sync (Gmail/Microsoft Graph), sharing, privacy |
 
 Create a new package only for a genuinely separable subsystem with its own panel,
 routes, or lifecycle — not for a new CRM entity (those go in `app/`). Package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ no composer.json of their own). Service providers are registered in
 | `packages/ImportWizard` | CSV import flows |
 | `packages/Documentation` | Public docs pages |
 | `packages/OnboardSeed` | Demo/onboarding data seeding |
+| `packages/EmailIntegration` | Email + calendar sync (Gmail/Microsoft Graph), sharing, privacy |
 
 Create a new package only for a genuinely separable subsystem with its own panel,
 routes, or lifecycle — not for a new CRM entity (those go in `app/`). Package

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -17,6 +17,7 @@ no composer.json of their own). Service providers are registered in
 | `packages/ImportWizard` | CSV import flows |
 | `packages/Documentation` | Public docs pages |
 | `packages/OnboardSeed` | Demo/onboarding data seeding |
+| `packages/EmailIntegration` | Email + calendar sync (Gmail/Microsoft Graph), sharing, privacy |
 
 Create a new package only for a genuinely separable subsystem with its own panel,
 routes, or lifecycle — not for a new CRM entity (those go in `app/`). Package

--- a/packages/EmailIntegration/src/Services/Factories/NormalizedMeetingPayloadFactory.php
+++ b/packages/EmailIntegration/src/Services/Factories/NormalizedMeetingPayloadFactory.php
@@ -11,7 +11,7 @@ use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
 use Relaticle\EmailIntegration\Enums\CalendarVisibility;
 
-final class NormalizedMeetingPayloadFactory
+final readonly class NormalizedMeetingPayloadFactory
 {
     public function fromCalendarEvent(CalendarEventData $event, string $accountEmail): NormalizedMeetingPayload
     {

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -164,6 +164,8 @@ $packageServiceLayers = [
     'Relaticle\Chat\Services',
     'Relaticle\Chat\Support',
     'Relaticle\Documentation\Services',
+    'Relaticle\EmailIntegration\Actions',
+    'Relaticle\EmailIntegration\Services',
     'Relaticle\ImportWizard\Support',
     'Relaticle\OnboardSeed\Support',
 ];
@@ -182,6 +184,11 @@ arch('package service layers avoid mutation')
         'Relaticle\Chat\Support\ProviderRateGate',
         'Relaticle\Chat\Support\TitleSanitizer',
         'Relaticle\Documentation\Services\DocumentationService',
+        // Legitimate per-instance memoization caches — intentionally mutable, not tech debt:
+        'Relaticle\EmailIntegration\Services\MicrosoftGraphMailService',
+        'Relaticle\EmailIntegration\Services\PrivacyService',
+        // Exceptions necessarily extend a base throwable:
+        'Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired',
         'Relaticle\ImportWizard\Support\DataTypeInferencer',
         'Relaticle\ImportWizard\Support\EntityLinkResolver',
         'Relaticle\ImportWizard\Support\EntityLinkStorage\CustomFieldValueStorage',
@@ -198,7 +205,11 @@ arch('package service layers avoid mutation')
 arch('package service layers avoid inheritance')
     ->expect($packageServiceLayers)
     ->classes()
-    ->toExtendNothing();
+    ->toExtendNothing()
+    ->ignoring([
+        // Exceptions necessarily extend a base throwable:
+        'Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired',
+    ]);
 
 arch('main app must not depend on SystemAdmin module')
     ->expect('App')

--- a/tests/Arch/ConventionsTest.php
+++ b/tests/Arch/ConventionsTest.php
@@ -132,6 +132,7 @@ it('forces a conscious arch-coverage decision when a package is added', function
         [
             'Relaticle\Chat',
             'Relaticle\Documentation',
+            'Relaticle\EmailIntegration',
             'Relaticle\ImportWizard',
             'Relaticle\OnboardSeed',
             'Relaticle\SystemAdmin',


### PR DESCRIPTION
## Why

CI was red on **Code Quality Checks** and **Tests (Shard 1/5)**. Both failures shared one root cause: the `feat/email-calendar-integration` branch added the `Relaticle\EmailIntegration` package but never wired it into the architecture-test coverage. `tests/Arch/ConventionsTest.php` deliberately fails when the package list changes without a conscious arch decision, and that test runs in both the dedicated arch job and inside the pest shards (only `Browser` is excluded), so it broke shard 1 too.

## Changes

- **`tests/Arch/ConventionsTest.php`** — add `Relaticle\EmailIntegration` to the expected package list.
- **`tests/Arch/ArchTest.php`** — register `Relaticle\EmailIntegration\Actions` + `Services` in `$packageServiceLayers` so the readonly/no-inheritance rules cover them. Grandfather the two intentionally-mutable memoization-cache services (`MicrosoftGraphMailService`, `PrivacyService`) and the `CalendarSyncTokenExpired` exception (must extend a throwable).
- **`NormalizedMeetingPayloadFactory`** — make `final readonly` (no mutable state) so it passes the new coverage cleanly rather than being grandfathered.
- **`.ai/guidelines/relaticle/architecture.md`** — add EmailIntegration to the package table; recompiled `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` via `boost:update`.

## Verification

`pint`, `rector --dry-run`, `phpstan`, type-coverage (100%), and `pest tests/Arch/` (24/24) all pass.