### PR TITLE
chore: support Conductor workspace setup

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,13 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# Conductor creates each workspace as a git worktree and copies the untracked
+# `.env` from the base checkout (the tracked `.env.*` files come with the
+# worktree). Pin the copy pattern so it does not depend on the per-user default.
+file_include_globs = ".env"
+
+[scripts]
+# Mirrors polyscope.json: link + secure the Herd site, then install deps and
+# point .env at this workspace's hostname. Scripts run from the workspace dir.
+setup = "herd link && herd secure && bin/setup-workspace.sh"
+archive = "herd unsecure && herd unlink"
+run = 'open "https://$(basename "$CONDUCTOR_WORKSPACE_PATH").test"'

--- a/bin/setup-workspace.sh
+++ b/bin/setup-workspace.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-# Bootstrap a Polyscope workspace: refresh dependencies and point .env at
-# the workspace's own hostname.
+# Bootstrap a parallel workspace (Polyscope or Conductor): install dependencies
+# and point .env at the workspace's own hostname. Both orchestrators copy a
+# working `.env` from the base checkout and run this from the workspace dir.
 #
-# Polyscope creates each workspace as a copy-on-write clone of the base repo
-# (vendor/, node_modules/, and .env are copied). The database stays shared
-# across workspaces. We rewrite APP_URL and SESSION_DOMAIN so absolute URLs
-# and session cookies match `<workspace>.test`, and blank APP_PANEL_DOMAIN
-# and SYSADMIN_DOMAIN so both panels serve path-based at `<workspace>.test/app`
-# and `<workspace>.test/sysadmin` — the copied `*.relaticle.test` values would
-# route to the base checkout, not the clone.
+# - Polyscope copy-on-write clones the base repo (vendor/, node_modules/, .env
+#   copied), so composer/npm below are fast refreshes.
+# - Conductor creates a git worktree and copies only `.env`, so composer/npm
+#   below do full installs of the absent vendor/ and node_modules/.
 #
-# Mac-only: uses BSD sed (`sed -i ''`). Polyscope itself is macOS-only.
+# The database stays shared across workspaces. We rewrite APP_URL and
+# SESSION_DOMAIN so absolute URLs and session cookies match `<workspace>.test`,
+# and blank APP_PANEL_DOMAIN and SYSADMIN_DOMAIN so both panels serve path-based
+# at `<workspace>.test/app` and `<workspace>.test/sysadmin` — the copied
+# `*.relaticle.test` values would route to the base checkout, not the workspace.
+#
+# Mac-only: uses BSD sed (`sed -i ''`). Both orchestrators are macOS-only.
 
 set -euo pipefail
 


### PR DESCRIPTION
Adds `.conductor/settings.toml` so Conductor provisions workspaces the same way Polyscope does — `herd link && herd secure && bin/setup-workspace.sh` on setup, `herd unsecure && herd unlink` on archive, a `run` script that opens the workspace URL, and a pinned `.env` copy glob (`file_include_globs`). Generalizes `bin/setup-workspace.sh`'s header to cover both Polyscope (copy-on-write clone) and Conductor (git worktree) workspaces; the install logic was already orchestrator-agnostic, so no behavioral change for Polyscope. Verified end-to-end by running the real setup chain in a Conductor worktree: deps installed, `.env` rewritten, and `https://albuquerque.test` now boots (root 200, `/app` → 302 login) instead of the missing-`vendor` fatal.