### PR TITLE
refactor(email): use Filament action for reply/forward buttons

### DIFF
--- a/packages/EmailIntegration/config/email-integration.php
+++ b/packages/EmailIntegration/config/email-integration.php
@@ -38,9 +38,9 @@ return [
      * Sync settings — override via .env
      */
     'sync' => [
-        'initial_days' => env('EMAIL_SYNC_INITIAL_DAYS', 90),
+        'initial_days' => (int) env('EMAIL_SYNC_INITIAL_DAYS', 90),
         'interval_minutes' => env('EMAIL_SYNC_INTERVAL_MINUTES', 5),
-        'batch_size' => env('EMAIL_SYNC_BATCH_SIZE', 50),
+        'batch_size' => (int) env('EMAIL_SYNC_BATCH_SIZE', 50),
     ],
 
     /*

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -102,10 +102,21 @@ trait HasEmailComposeActions
             });
     }
 
-    protected function replyForwardEmailAction(): Action
+    public function replyForwardEmailAction(): Action
     {
         return Action::make('replyForwardEmail')
             ->slideOver()
+            ->link()
+            ->hiddenLabel()
+            ->icon(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
+                'reply_all' => 'heroicon-o-arrow-uturn-right',
+                'reply' => 'heroicon-o-arrow-uturn-left',
+                'forward' => 'heroicon-o-arrow-right',
+                default => 'heroicon-o-arrow-uturn-right',
+            })
+            ->extraAttributes([
+                'class' => 'p-2',
+            ])
             ->modalHeading(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
                 'reply_all' => 'Reply All',
                 'forward' => 'Forward',

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -193,6 +193,9 @@ abstract class BaseEmailsRelationManager extends RelationManager
                 ViewAction::make()
                     ->modalHeading(__('filament/relation-managers/emails.actions.view.modal_heading'))
                     ->modalWidth(Width::SevenExtraLarge)
+                    ->registerModalActions([
+                        $this->replyForwardEmailAction(),
+                    ])
                     ->slideOver(),
 
                 ActionGroup::make([

--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -155,30 +155,10 @@
                     x-data
                     class="flex items-center divide-x divide-gray-200 dark:divide-gray-700 overflow-hidden rounded-lg ring-1 ring-gray-200 dark:ring-gray-700"
                 >
-                    <button
-                        type="button"
-                        title="Reply"
-                        x-on:click="$dispatch('reply-email', { emailId: '{{ $record->id }}', mode: 'reply' })"
-                        class="flex items-center justify-center bg-white dark:bg-gray-800 p-2 text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-200"
-                    >
-                        <x-heroicon-o-arrow-uturn-left class="h-4 w-4" />
-                    </button>
-                    <button
-                        type="button"
-                        title="Reply All"
-                        x-on:click="$dispatch('reply-email', { emailId: '{{ $record->id }}', mode: 'reply_all' })"
-                        class="flex items-center justify-center bg-white dark:bg-gray-800 p-2 text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-200"
-                    >
-                        <x-heroicon-o-arrow-uturn-left class="h-4 w-4 scale-x-[-1]" />
-                    </button>
-                    <button
-                        type="button"
-                        title="Forward"
-                        x-on:click="$dispatch('reply-email', { emailId: '{{ $record->id }}', mode: 'forward' })"
-                        class="flex items-center justify-center bg-white dark:bg-gray-800 p-2 text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-200"
-                    >
-                        <x-heroicon-o-arrow-right class="h-4 w-4" />
-                    </button>
+                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'reply']) }}
+                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'reply_all']) }}
+                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'forward']) }}
+
                 </div>
             @endif
 

--- a/resources/views/filament/emails/email-view.blade.php
+++ b/resources/views/filament/emails/email-view.blade.php
@@ -153,30 +153,9 @@
                     x-data
                     class="flex items-center divide-x divide-gray-200 dark:divide-gray-700 overflow-hidden rounded-lg ring-1 ring-gray-200 dark:ring-gray-700"
                 >
-                    <button
-                        type="button"
-                        title="Reply"
-                        x-on:click="$dispatch('reply-email', { emailId: '{{ $record->id }}', mode: 'reply' })"
-                        class="flex items-center justify-center bg-white dark:bg-gray-800 p-2 text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-200"
-                    >
-                        <x-heroicon-o-arrow-uturn-left class="h-4 w-4" />
-                    </button>
-                    <button
-                        type="button"
-                        title="Reply All"
-                        x-on:click="$dispatch('reply-email', { emailId: '{{ $record->id }}', mode: 'reply_all' })"
-                        class="flex items-center justify-center bg-white dark:bg-gray-800 p-2 text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-200"
-                    >
-                        <x-heroicon-o-arrow-uturn-left class="h-4 w-4 scale-x-[-1]" />
-                    </button>
-                    <button
-                        type="button"
-                        title="Forward"
-                        x-on:click="$dispatch('reply-email', { emailId: '{{ $record->id }}', mode: 'forward' })"
-                        class="flex items-center justify-center bg-white dark:bg-gray-800 p-2 text-gray-500 dark:text-gray-400 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-700 dark:hover:text-gray-200"
-                    >
-                        <x-heroicon-o-arrow-right class="h-4 w-4" />
-                    </button>
+                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'reply']) }}
+                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'reply_all']) }}
+                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'forward']) }}
                 </div>
             @endif
 

--- a/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
+++ b/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Filament\Resources\PeopleResource\Pages\ViewPeople;
+use App\Filament\Resources\PeopleResource\RelationManagers\EmailsRelationManager;
+use App\Models\People;
 use App\Models\User;
 use App\Support\EmailHtmlSanitizer;
+use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Livewire\Features\SupportTesting\Testable;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -19,6 +24,12 @@ beforeEach(function (): void {
         'team_id' => $this->team->id,
         'user_id' => $this->owner->id,
     ]));
+
+    $this->person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Jane Doe',
+        'creator_id' => $this->owner->id,
+    ]);
 
     $this->actingAs($this->owner);
     Filament::setTenant($this->team);
@@ -39,7 +50,22 @@ function makeEmailWithBody(string $html): Email
         'body_html' => $html,
     ]);
 
+    test()->person->emails()->attach($email);
+
     return $email->fresh(['body', 'participants', 'labels', 'attachments']);
+}
+
+/**
+ * Render the email-view partial through its real entry point: the
+ * EmailsRelationManager's ViewAction modal, where the partial is bound to the
+ * Livewire component that exposes the reply/forward action it calls.
+ */
+function mountEmailView(Email $email): Testable
+{
+    return livewire(EmailsRelationManager::class, [
+        'ownerRecord' => test()->person,
+        'pageClass' => ViewPeople::class,
+    ])->mountAction(TestAction::make('view')->table($email));
 }
 
 const MALICIOUS_BODY = '<p>hello <b>world</b></p>'
@@ -51,14 +77,12 @@ const MALICIOUS_BODY = '<p>hello <b>world</b></p>'
 it('strips scripts, event handlers and javascript urls from the email view', function (): void {
     $email = makeEmailWithBody(MALICIOUS_BODY);
 
-    $html = view('filament.emails.email-view', ['record' => $email])->render();
-
-    expect($html)
-        ->not->toContain('onerror')
-        ->not->toContain('onload="alert')
-        ->not->toContain('javascript:')
-        ->not->toContain('document.cookie')
-        ->and($html)->toContain('hello');
+    mountEmailView($email)
+        ->assertMountedActionModalDontSeeHtml('onerror')
+        ->assertMountedActionModalDontSeeHtml('onload="alert')
+        ->assertMountedActionModalDontSeeHtml('javascript:')
+        ->assertMountedActionModalDontSeeHtml('document.cookie')
+        ->assertMountedActionModalSeeHtml('hello');
 });
 
 it('preserves inline styles and presentational attributes used by email layouts', function (): void {
@@ -69,25 +93,21 @@ it('preserves inline styles and presentational attributes used by email layouts'
         .'</td></tr></table>'
     );
 
-    $html = view('filament.emails.email-view', ['record' => $email])->render();
-
-    expect($html)
-        ->toContain('bgcolor=&quot;#eeeeee&quot;')
-        ->toContain('style=&quot;color:#ff0000;padding:10px&quot;')
-        ->toContain('class=&quot;lead&quot;')
-        ->toContain('align=&quot;center&quot;');
+    mountEmailView($email)
+        ->assertMountedActionModalSeeHtml('bgcolor=&quot;#eeeeee&quot;')
+        ->assertMountedActionModalSeeHtml('style=&quot;color:#ff0000;padding:10px&quot;')
+        ->assertMountedActionModalSeeHtml('class=&quot;lead&quot;')
+        ->assertMountedActionModalSeeHtml('align=&quot;center&quot;');
 });
 
 it('renders the email view iframe without a same-origin sandbox', function (): void {
     $email = makeEmailWithBody('<p>body</p>');
 
-    $html = view('filament.emails.email-view', ['record' => $email])->render();
-
-    expect($html)
-        ->toContain('<iframe')
-        ->toContain('sandbox="allow-popups allow-popups-to-escape-sandbox"')
-        ->toContain('referrerpolicy="no-referrer"')
-        ->not->toContain('allow-same-origin');
+    mountEmailView($email)
+        ->assertMountedActionModalSeeHtml('<iframe')
+        ->assertMountedActionModalSeeHtml('sandbox="allow-popups allow-popups-to-escape-sandbox"')
+        ->assertMountedActionModalSeeHtml('referrerpolicy="no-referrer"')
+        ->assertMountedActionModalDontSeeHtml('allow-same-origin');
 });
 
 it('strips dangerous markup in the threaded email view', function (): void {


### PR DESCRIPTION
## Summary
- Replace hand-rolled reply / reply-all / forward HTML buttons in both email views with the shared `replyForwardEmailAction`, registered as a modal action on `ViewAction`
- Make `replyForwardEmailAction` public and add per-mode `link()`/icon styling
- Cast `EMAIL_SYNC_INITIAL_DAYS` and `EMAIL_SYNC_BATCH_SIZE` env values to `int`

## Notes
Tests not run per request.