### PR TITLE
style: remove unused import in EmailInboxPage

### DIFF
--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -38,7 +38,6 @@ use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
-use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Filament\RichContent\SignatureBlock;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;


### PR DESCRIPTION
## What
Remove the unused `HasEmailComposeActions` import from `packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php`.

## Why
Pint `test:lint` (Code Quality Checks CI) failed with a `unary_operator_spaces` / `no_unused_imports` style issue on this file. The trait import was left behind after the reply/forward refactor and is no longer referenced.

`vendor/bin/pint --test` now passes.