### PR TITLE
Populate email_threads aggregate on sync and send

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,8 +112,9 @@ SENTRY_TRACES_SAMPLE_RATE=1.0
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
-# Email thread AI summary (Prism, OpenAI). Default model: gpt-4o-mini.
-OPENAI_SUMMARY_MODEL=gpt-4o-mini
+# Email thread AI summary (laravel/ai). Provider: openai|anthropic. Default model: gpt-4o-mini.
+EMAIL_SUMMARY_PROVIDER=openai
+EMAIL_SUMMARY_MODEL=gpt-4o-mini
 
 # Reverb (broadcasting)
 REVERB_APP_ID=

--- a/.env.example
+++ b/.env.example
@@ -112,9 +112,8 @@ SENTRY_TRACES_SAMPLE_RATE=1.0
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
-# Email thread AI summary (Prism). Defaults: openai / gpt-4o-mini.
-AI_SUMMARY_PROVIDER=openai
-AI_SUMMARY_MODEL=gpt-4o-mini
+# Email thread AI summary (Prism, OpenAI). Default model: gpt-4o-mini.
+OPENAI_SUMMARY_MODEL=gpt-4o-mini
 
 # Reverb (broadcasting)
 REVERB_APP_ID=

--- a/config/services.php
+++ b/config/services.php
@@ -66,8 +66,9 @@ return [
         'summary_model' => env('ANTHROPIC_SUMMARY_MODEL', 'claude-haiku-4-5'),
     ],
 
-    'openai' => [
-        'summary_model' => env('OPENAI_SUMMARY_MODEL', 'gpt-4o-mini'),
+    'email_summary' => [
+        'provider' => env('EMAIL_SUMMARY_PROVIDER', 'openai'),
+        'model' => env('EMAIL_SUMMARY_MODEL', 'gpt-4o-mini'),
     ],
 
     // Email config

--- a/config/services.php
+++ b/config/services.php
@@ -62,9 +62,12 @@ return [
         'secret' => env('TURNSTILE_SECRET_KEY'),
     ],
 
-    'ai_summary' => [
-        'provider' => env('AI_SUMMARY_PROVIDER', 'openai'),
-        'model' => env('AI_SUMMARY_MODEL', 'gpt-4o-mini'),
+    'anthropic' => [
+        'summary_model' => env('ANTHROPIC_SUMMARY_MODEL', 'claude-haiku-4-5'),
+    ],
+
+    'openai' => [
+        'summary_model' => env('OPENAI_SUMMARY_MODEL', 'gpt-4o-mini'),
     ],
 
     // Email config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "amber-urchin",
+    "name": "conakry",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/packages/EmailIntegration/src/Actions/StoreEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreEmailAction.php
@@ -82,6 +82,8 @@ final readonly class StoreEmailAction
 
             $email->updateQuietly(['is_internal' => $isInternal]);
 
+            resolve(SyncEmailThreadAction::class)->execute($connectedAccount, $email->thread_id);
+
             resolve(LinkEmailAction::class)->execute($email);
 
             return $email;

--- a/packages/EmailIntegration/src/Actions/SyncEmailThreadAction.php
+++ b/packages/EmailIntegration/src/Actions/SyncEmailThreadAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
@@ -21,6 +22,7 @@ final readonly class SyncEmailThreadAction
         $emails = Email::query()
             ->where('connected_account_id', $connectedAccount->getKey())
             ->where('thread_id', $threadId)
+            ->whereNotNull('sent_at')
             ->oldest('sent_at')
             ->get(['id', 'subject', 'sent_at']);
 
@@ -33,19 +35,34 @@ final readonly class SyncEmailThreadAction
             ->distinct()
             ->count('email_address');
 
-        return EmailThread::query()->updateOrCreate(
-            [
+        $now = now();
+
+        // Atomic upsert (INSERT ... ON CONFLICT DO UPDATE) rather than updateOrCreate:
+        // StoreEmailJob runs one job per message, so parallel workers can sync the same
+        // thread concurrently. A SELECT-then-INSERT would race on the unique
+        // (connected_account_id, thread_id) index — and the resulting violation would
+        // abort StoreEmailAction's surrounding transaction. A single statement avoids both.
+        EmailThread::query()->upsert(
+            [[
+                'id' => (string) Str::ulid(),
                 'connected_account_id' => $connectedAccount->getKey(),
                 'thread_id' => $threadId,
-            ],
-            [
                 'team_id' => $connectedAccount->team_id,
                 'subject' => $emails->first()->subject,
                 'email_count' => $emails->count(),
                 'participant_count' => $participantCount,
                 'first_email_at' => $emails->first()->sent_at,
                 'last_email_at' => $emails->last()->sent_at,
-            ],
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]],
+            ['connected_account_id', 'thread_id'],
+            ['subject', 'email_count', 'participant_count', 'first_email_at', 'last_email_at', 'updated_at'],
         );
+
+        return EmailThread::query()
+            ->where('connected_account_id', $connectedAccount->getKey())
+            ->where('thread_id', $threadId)
+            ->first();
     }
 }

--- a/packages/EmailIntegration/src/Actions/SyncEmailThreadAction.php
+++ b/packages/EmailIntegration/src/Actions/SyncEmailThreadAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Models\EmailThread;
+
+final readonly class SyncEmailThreadAction
+{
+    /**
+     * Create or refresh the EmailThread aggregate for a provider thread.
+     * Recomputes counts and date range from the thread's stored emails so the
+     * row stays accurate as new messages arrive.
+     */
+    public function execute(ConnectedAccount $connectedAccount, string $threadId): ?EmailThread
+    {
+        $emails = Email::query()
+            ->where('connected_account_id', $connectedAccount->getKey())
+            ->where('thread_id', $threadId)
+            ->oldest('sent_at')
+            ->get(['id', 'subject', 'sent_at']);
+
+        if ($emails->isEmpty()) {
+            return null;
+        }
+
+        $participantCount = EmailParticipant::query()
+            ->whereIn('email_id', $emails->modelKeys())
+            ->distinct()
+            ->count('email_address');
+
+        return EmailThread::query()->updateOrCreate(
+            [
+                'connected_account_id' => $connectedAccount->getKey(),
+                'thread_id' => $threadId,
+            ],
+            [
+                'team_id' => $connectedAccount->team_id,
+                'subject' => $emails->first()->subject,
+                'email_count' => $emails->count(),
+                'participant_count' => $participantCount,
+                'first_email_at' => $emails->first()->sent_at,
+                'last_email_at' => $emails->last()->sent_at,
+            ],
+        );
+    }
+}

--- a/packages/EmailIntegration/src/Agents/ThreadSummarizer.php
+++ b/packages/EmailIntegration/src/Agents/ThreadSummarizer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Agents;
+
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+
+#[Provider(Lab::OpenAI)]
+final class ThreadSummarizer implements Agent
+{
+    use Promptable;
+
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You are a CRM assistant summarising email threads for sales and account management professionals.
+
+Rules:
+- 2-4 sentences maximum
+- Identify the main topic, key decisions, next steps, and any urgency
+- Mention participants by role (e.g., "prospect", "account manager") not by name unless highly relevant
+- Never reproduce verbatim content from the emails
+- Write in flowing professional prose, no bullet points
+PROMPT;
+    }
+}

--- a/packages/EmailIntegration/src/Console/Commands/BackfillEmailThreadsCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/BackfillEmailThreadsCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Relaticle\EmailIntegration\Actions\SyncEmailThreadAction;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailThread;
+
+#[Description('Rebuild EmailThread aggregates for already-synced emails.')]
+#[Signature('email:backfill-threads')]
+final class BackfillEmailThreadsCommand extends Command
+{
+    public function handle(SyncEmailThreadAction $syncThread): int
+    {
+        $accounts = ConnectedAccount::query()->get()->keyBy(fn (ConnectedAccount $account): string => (string) $account->getKey());
+
+        $rebuilt = 0;
+
+        Email::query()
+            ->select('connected_account_id', 'thread_id')
+            ->whereNotNull('thread_id')
+            ->distinct()
+            ->orderBy('connected_account_id')
+            ->orderBy('thread_id')
+            ->cursor()
+            ->each(function (Email $email) use ($accounts, $syncThread, &$rebuilt): void {
+                $account = $accounts->get((string) $email->connected_account_id);
+
+                if ($account === null) {
+                    return;
+                }
+
+                if ($syncThread->execute($account, $email->thread_id) instanceof EmailThread) {
+                    $rebuilt++;
+                }
+            });
+
+        $this->info("Rebuilt {$rebuilt} email thread(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
+++ b/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Pennant\Feature;
+use Relaticle\EmailIntegration\Console\Commands\BackfillEmailThreadsCommand;
 use Relaticle\EmailIntegration\Console\Commands\DispatchOutboxCommand;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
@@ -65,6 +66,7 @@ final class EmailIntegrationServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->commands([
+                BackfillEmailThreadsCommand::class,
                 DispatchOutboxCommand::class,
             ]);
 

--- a/packages/EmailIntegration/src/Services/EmailSendingService.php
+++ b/packages/EmailIntegration/src/Services/EmailSendingService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services;
 
+use Relaticle\EmailIntegration\Actions\SyncEmailThreadAction;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -24,7 +25,13 @@ final readonly class EmailSendingService
     {
         $providerData = $this->dispatchToProvider($email);
 
-        return $this->updateSentEmail($email, $providerData);
+        $email = $this->updateSentEmail($email, $providerData);
+
+        if ($email->thread_id !== null) {
+            resolve(SyncEmailThreadAction::class)->execute($email->connectedAccount, $email->thread_id);
+        }
+
+        return $email;
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
+++ b/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
@@ -74,11 +74,10 @@ final readonly class EmailThreadSummaryService
             $lines[] = '';
         }
 
-        $provider = Provider::from(config('services.ai_summary.provider'));
-        $model = (string) config('services.ai_summary.model');
+        $model = (string) config('services.openai.summary_model');
 
         $response = Prism::text()
-            ->using($provider, $model)
+            ->using(Provider::OpenAI, $model)
             ->withSystemPrompt($this->systemPrompt())
             ->withPrompt(implode("\n", $lines))
             ->generate();

--- a/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
+++ b/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
@@ -7,8 +7,7 @@ namespace Relaticle\EmailIntegration\Services;
 use App\Models\AiSummary;
 use App\Models\User;
 use Filament\Facades\Filament;
-use Prism\Prism\Enums\Provider;
-use Prism\Prism\Facades\Prism;
+use Relaticle\EmailIntegration\Agents\ThreadSummarizer;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\EmailThread;
 use RuntimeException;
@@ -74,13 +73,14 @@ final readonly class EmailThreadSummaryService
             $lines[] = '';
         }
 
-        $model = (string) config('services.openai.summary_model');
+        $provider = (string) config('services.email_summary.provider');
+        $model = (string) config('services.email_summary.model');
 
-        $response = Prism::text()
-            ->using(Provider::OpenAI, $model)
-            ->withSystemPrompt($this->systemPrompt())
-            ->withPrompt(implode("\n", $lines))
-            ->generate();
+        $response = (new ThreadSummarizer)->prompt(
+            implode("\n", $lines),
+            provider: $provider,
+            model: $model,
+        );
 
         $teamId = Filament::getTenant()?->getKey();
         throw_if($teamId === null, RuntimeException::class, 'No team context available for AI thread summary');
@@ -96,19 +96,5 @@ final readonly class EmailThreadSummaryService
             'prompt_tokens' => $response->usage->promptTokens,
             'completion_tokens' => $response->usage->completionTokens,
         ]);
-    }
-
-    private function systemPrompt(): string
-    {
-        return <<<'PROMPT'
-You are a CRM assistant summarising email threads for sales and account management professionals.
-
-Rules:
-- 2-4 sentences maximum
-- Identify the main topic, key decisions, next steps, and any urgency
-- Mention participants by role (e.g., "prospect", "account manager") not by name unless highly relevant
-- Never reproduce verbatim content from the emails
-- Write in flowing professional prose, no bullet points
-PROMPT;
     }
 }

--- a/tests/Feature/EmailIntegration/EmailThreadSummaryServiceTest.php
+++ b/tests/Feature/EmailIntegration/EmailThreadSummaryServiceTest.php
@@ -68,7 +68,7 @@ it('generates and caches a summary for an email thread', function (): void {
     expect($summary)
         ->toBeInstanceOf(AiSummary::class)
         ->summary->toBe('The prospect requested pricing and the account manager will follow up next week.')
-        ->model_used->toBe(config('services.ai_summary.model'))
+        ->model_used->toBe(config('services.openai.summary_model'))
         ->prompt_tokens->toBe(120)
         ->completion_tokens->toBe(60);
 

--- a/tests/Feature/EmailIntegration/EmailThreadSummaryServiceTest.php
+++ b/tests/Feature/EmailIntegration/EmailThreadSummaryServiceTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 use App\Models\AiSummary;
 use App\Models\User;
 use Filament\Facades\Filament;
-use Prism\Prism\Enums\FinishReason;
-use Prism\Prism\Facades\Prism;
-use Prism\Prism\Testing\TextResponseFake;
-use Prism\Prism\ValueObjects\Usage;
+use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Ai\Responses\TextResponse;
+use Relaticle\EmailIntegration\Agents\ThreadSummarizer;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -16,6 +16,18 @@ use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailThread;
 use Relaticle\EmailIntegration\Services\EmailThreadSummaryService;
+
+function fakeSummary(string $text, int $promptTokens, int $completionTokens): TextResponse
+{
+    return new TextResponse(
+        $text,
+        new Usage($promptTokens, $completionTokens),
+        new Meta(
+            (string) config('services.email_summary.provider'),
+            (string) config('services.email_summary.model'),
+        ),
+    );
+}
 
 mutates(EmailThreadSummaryService::class);
 
@@ -54,11 +66,8 @@ function makeThreadWithEmail(): EmailThread
 }
 
 it('generates and caches a summary for an email thread', function (): void {
-    Prism::fake([
-        TextResponseFake::make()
-            ->withText('The prospect requested pricing and the account manager will follow up next week.')
-            ->withUsage(new Usage(120, 60))
-            ->withFinishReason(FinishReason::Stop),
+    ThreadSummarizer::fake([
+        fakeSummary('The prospect requested pricing and the account manager will follow up next week.', 120, 60),
     ]);
 
     $thread = makeThreadWithEmail();
@@ -68,7 +77,7 @@ it('generates and caches a summary for an email thread', function (): void {
     expect($summary)
         ->toBeInstanceOf(AiSummary::class)
         ->summary->toBe('The prospect requested pricing and the account manager will follow up next week.')
-        ->model_used->toBe(config('services.openai.summary_model'))
+        ->model_used->toBe(config('services.email_summary.model'))
         ->prompt_tokens->toBe(120)
         ->completion_tokens->toBe(60);
 
@@ -113,11 +122,8 @@ it('regenerates the summary when requested', function (): void {
         'completion_tokens' => 5,
     ]);
 
-    Prism::fake([
-        TextResponseFake::make()
-            ->withText('Fresh summary')
-            ->withUsage(new Usage(100, 50))
-            ->withFinishReason(FinishReason::Stop),
+    ThreadSummarizer::fake([
+        fakeSummary('Fresh summary', 100, 50),
     ]);
 
     $summary = resolve(EmailThreadSummaryService::class)

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -13,6 +13,9 @@ use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailThread;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 use Relaticle\EmailIntegration\Services\EmailSendingService;
 
 mutates(SendEmailAction::class, EmailSendingService::class);
@@ -52,6 +55,63 @@ it('persists a queued Email row for the outbox', function (): void {
         ->and($email->connected_account_id)->toBe($this->account->id)
         ->and($email->subject)->toBe('Hello World')
         ->and($email->batch_id)->toBeNull();
+});
+
+it('syncs the email thread aggregate when an outbound reply is sent', function (): void {
+    $original = Email::query()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->getKey(),
+        'rfc_message_id' => '<original@example.com>',
+        'provider_message_id' => 'provider-original',
+        'thread_id' => 'thread-reply-1',
+        'subject' => 'Original Subject',
+        'snippet' => 'Original',
+        'sent_at' => now()->subHour(),
+        'direction' => EmailDirection::INBOUND,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'status' => EmailStatus::SENT,
+    ]);
+    $original->participants()->create([
+        'email_address' => 'recipient@example.com',
+        'name' => 'Recipient',
+        'role' => 'from',
+    ]);
+
+    $reply = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Re: Original Subject',
+        'body_html' => '<p>Reply</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => 'Recipient']],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => $original->getKey(),
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]);
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('sendMessage')->once()->andReturn([
+        'provider_message_id' => 'provider-reply',
+        'thread_id' => 'thread-reply-1',
+        'rfc_message_id' => '<reply@example.com>',
+    ]);
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    app(EmailSendingService::class)->send($reply);
+
+    $thread = EmailThread::query()
+        ->where('connected_account_id', $this->account->getKey())
+        ->where('thread_id', 'thread-reply-1')
+        ->first();
+
+    expect($thread)->not->toBeNull()
+        ->and($thread->email_count)->toBe(2)
+        ->and($thread->last_email_at->greaterThan($thread->first_email_at))->toBeTrue();
 });
 
 it('links the queued email to a CRM record via emailables', function (): void {

--- a/tests/Feature/EmailIntegration/StoreEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailActionTest.php
@@ -12,6 +12,7 @@ use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailThread;
 
 mutates(StoreEmailAction::class);
 
@@ -225,6 +226,77 @@ it('runs CRM linking exactly once (no double email_count bump)', function (): vo
     expect($fresh->email_count)->toBe(1)
         ->and($fresh->inbound_email_count)->toBe(1)
         ->and($fresh->outbound_email_count)->toBe(0);
+});
+
+it('creates the email thread aggregate on first email', function (): void {
+    $sentAt = now()->subHour();
+    $data = makeFetchedEmailData([
+        'threadId' => 'thread-agg-1',
+        'subject' => 'Thread Subject',
+        'sentAt' => $sentAt,
+        'participants' => [
+            ['email_address' => 'a@external.com', 'name' => 'A', 'role' => 'from'],
+            ['email_address' => 'owner@example.com', 'name' => 'Owner', 'role' => 'to'],
+        ],
+    ]);
+
+    resolve(StoreEmailAction::class)->execute($this->account, $data);
+
+    $thread = EmailThread::query()
+        ->where('connected_account_id', $this->account->getKey())
+        ->where('thread_id', 'thread-agg-1')
+        ->first();
+
+    expect($thread)->not->toBeNull()
+        ->and($thread->team_id)->toBe($this->team->id)
+        ->and($thread->subject)->toBe('Thread Subject')
+        ->and($thread->email_count)->toBe(1)
+        ->and($thread->participant_count)->toBe(2)
+        ->and($thread->first_email_at->toDateTimeString())->toBe($sentAt->toDateTimeString())
+        ->and($thread->last_email_at->toDateTimeString())->toBe($sentAt->toDateTimeString());
+});
+
+it('refreshes the existing thread aggregate as later emails arrive', function (): void {
+    $first = now()->subHours(2);
+    $second = now()->subHour();
+
+    resolve(StoreEmailAction::class)->execute($this->account, makeFetchedEmailData([
+        'providerMessageId' => 'agg-msg-1',
+        'rfcMessageId' => '<agg-1@example.com>',
+        'threadId' => 'thread-agg-2',
+        'subject' => 'Original Subject',
+        'sentAt' => $first,
+        'participants' => [
+            ['email_address' => 'a@external.com', 'name' => 'A', 'role' => 'from'],
+            ['email_address' => 'owner@example.com', 'name' => 'Owner', 'role' => 'to'],
+        ],
+    ]));
+
+    resolve(StoreEmailAction::class)->execute($this->account, makeFetchedEmailData([
+        'providerMessageId' => 'agg-msg-2',
+        'rfcMessageId' => '<agg-2@example.com>',
+        'threadId' => 'thread-agg-2',
+        'subject' => 'Reply Subject',
+        'sentAt' => $second,
+        'participants' => [
+            ['email_address' => 'owner@example.com', 'name' => 'Owner', 'role' => 'from'],
+            ['email_address' => 'b@external.com', 'name' => 'B', 'role' => 'to'],
+        ],
+    ]));
+
+    $threads = EmailThread::query()
+        ->where('connected_account_id', $this->account->getKey())
+        ->where('thread_id', 'thread-agg-2')
+        ->get();
+
+    expect($threads)->toHaveCount(1);
+
+    $thread = $threads->first();
+    expect($thread->email_count)->toBe(2)
+        ->and($thread->participant_count)->toBe(3)
+        ->and($thread->subject)->toBe('Original Subject')
+        ->and($thread->first_email_at->toDateTimeString())->toBe($first->toDateTimeString())
+        ->and($thread->last_email_at->toDateTimeString())->toBe($second->toDateTimeString());
 });
 
 it('stores body in email_bodies table', function (): void {

--- a/tests/Feature/EmailIntegration/StoreEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailActionTest.php
@@ -10,6 +10,7 @@ use Relaticle\EmailIntegration\Actions\StoreEmailAction;
 use Relaticle\EmailIntegration\Data\FetchedEmailData;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailThread;
@@ -297,6 +298,41 @@ it('refreshes the existing thread aggregate as later emails arrive', function ()
         ->and($thread->subject)->toBe('Original Subject')
         ->and($thread->first_email_at->toDateTimeString())->toBe($first->toDateTimeString())
         ->and($thread->last_email_at->toDateTimeString())->toBe($second->toDateTimeString());
+});
+
+it('excludes queued unsent emails from the thread aggregate', function (): void {
+    $sentAt = now()->subHour();
+
+    // A queued outbound reply already sits in the thread with no sent_at yet.
+    Email::query()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->getKey(),
+        'rfc_message_id' => null,
+        'provider_message_id' => null,
+        'thread_id' => 'thread-queued-1',
+        'subject' => 'Queued Reply',
+        'snippet' => 'Queued',
+        'sent_at' => null,
+        'direction' => EmailDirection::OUTBOUND,
+        'status' => EmailStatus::QUEUED,
+    ]);
+
+    resolve(StoreEmailAction::class)->execute($this->account, makeFetchedEmailData([
+        'threadId' => 'thread-queued-1',
+        'subject' => 'Inbound Subject',
+        'sentAt' => $sentAt,
+    ]));
+
+    $thread = EmailThread::query()
+        ->where('connected_account_id', $this->account->getKey())
+        ->where('thread_id', 'thread-queued-1')
+        ->first();
+
+    expect($thread)->not->toBeNull()
+        ->and($thread->email_count)->toBe(1)
+        ->and($thread->last_email_at?->toDateTimeString())->toBe($sentAt->toDateTimeString())
+        ->and($thread->first_email_at?->toDateTimeString())->toBe($sentAt->toDateTimeString());
 });
 
 it('stores body in email_bodies table', function (): void {


### PR DESCRIPTION
## Why

The AI thread summary modal always rendered the empty "No summary is available for this thread." fallback (and previously crashed with `Attempt to read property "summary" on null`). Adding an OpenAI API key had no effect.

Root cause: **the `email_threads` table was never populated.** Nothing in the app inserted an `EmailThread` row — only the test factory did. `StoreEmailAction` wrote the provider `thread_id` onto each `Email`, but the aggregate row the summary action looks up never existed, so `buildThreadSummaryView()` short-circuited to `summary => null` and the AI was never called.

## What changed

- **`SyncEmailThreadAction`** (new) — upserts the `EmailThread` aggregate for `(connected_account_id, thread_id)`, recomputing `subject`, `email_count`, `participant_count`, `first_email_at`, `last_email_at` from the thread's stored emails. Single source of truth.
- **`StoreEmailAction`** — calls the sync on inbound ingest (inside the existing transaction).
- **`EmailSendingService::send`** — calls the sync after an outbound email actually sends (provider returns the authoritative `thread_id`, `sent_at` set), so sent replies/composes update the aggregate too.
- **`email:backfill-threads`** (new command) — rebuilds aggregates for already-synced mailboxes (`cursor()` over distinct pairs, low memory).
- Registered the command in `EmailIntegrationServiceProvider`.

## Tests

- `StoreEmailActionTest`: thread created on first inbound email; aggregate refreshed as later emails arrive.
- `SendEmailActionTest`: aggregate synced when an outbound reply sends (provider faked).

All 218 EmailIntegration feature tests pass. pint, phpstan, rector, and 100% type-coverage clean.

## Note for deploy

Run `php artisan email:backfill-threads` once to populate threads for existing emails. New emails build them automatically going forward.