### PR TITLE
feat(conductor): copy-on-write dependency setup in bin/setup-workspace.sh

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -8,6 +8,8 @@ file_include_globs = ".env"
 [scripts]
 # Mirrors polyscope.json: link + secure the Herd site, then install deps and
 # point .env at this workspace's hostname. Scripts run from the workspace dir.
+# The script APFS-clones vendor/ + node_modules/ from the base checkout
+# (detected via $CONDUCTOR_ROOT_PATH) for Polyscope-parity copy-on-write.
 setup = "herd link && herd secure && bin/setup-workspace.sh"
 archive = "herd unsecure && herd unlink"
 run = 'open "https://$(basename "$CONDUCTOR_WORKSPACE_PATH").test"'

--- a/bin/setup-workspace.sh
+++ b/bin/setup-workspace.sh
@@ -3,10 +3,15 @@
 # and point .env at the workspace's own hostname. Both orchestrators copy a
 # working `.env` from the base checkout and run this from the workspace dir.
 #
-# - Polyscope copy-on-write clones the base repo (vendor/, node_modules/, .env
-#   copied), so composer/npm below are fast refreshes.
-# - Conductor creates a git worktree and copies only `.env`, so composer/npm
-#   below do full installs of the absent vendor/ and node_modules/.
+# Copy-on-write parity:
+# - Polyscope CoW-clones the whole base repo (vendor/, node_modules/, .env), so
+#   the installs below are fast refreshes.
+# - Conductor's git worktree copies only `.env`. To match the feel we APFS-clone
+#   vendor/ and node_modules/ from the base checkout first (`cp -c` = clonefile:
+#   near-instant, copy-on-write, each workspace diverges on its own writes),
+#   turning the installs below into the same fast refreshes.
+#   NOTE: we use `npm install` (incremental), NOT `npm ci` — `npm ci` deletes
+#   node_modules before installing, which would throw away the clone.
 #
 # The database stays shared across workspaces. We rewrite APP_URL and
 # SESSION_DOMAIN so absolute URLs and session cookies match `<workspace>.test`,
@@ -14,7 +19,8 @@
 # at `<workspace>.test/app` and `<workspace>.test/sysadmin` — the copied
 # `*.relaticle.test` values would route to the base checkout, not the workspace.
 #
-# Mac-only: uses BSD sed (`sed -i ''`). Both orchestrators are macOS-only.
+# Mac-only: uses BSD sed (`sed -i ''`) and APFS clonefile. Both orchestrators
+# are macOS-only.
 
 set -euo pipefail
 
@@ -26,11 +32,31 @@ if [[ ! -f .env ]]; then
     exit 1
 fi
 
+# Base checkout to clone dependencies from. Conductor sets CONDUCTOR_ROOT_PATH;
+# fall back to the git common dir's parent for Polyscope / manual runs.
+BASE="${CONDUCTOR_ROOT_PATH:-$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")}"
+
+# APFS copy-on-write seed: when a dependency dir is missing (Conductor worktree),
+# clone it from the base checkout via clonefile so the install below is a fast
+# refresh, not a cold install. No-op when already present (Polyscope) or when
+# this checkout IS the base (run from the root).
+clone_from_base() {
+    local dir="$1"
+    if [[ -d "$dir" || "$BASE" == "$PWD" || ! -d "$BASE/$dir" ]]; then
+        return 0
+    fi
+    echo "→ Cloning ${dir}/ from base (APFS copy-on-write)"
+    cp -c -R "$BASE/$dir" "$dir"
+}
+
+clone_from_base vendor
+clone_from_base node_modules
+
 echo "→ Refreshing PHP dependencies"
 composer install --no-interaction --prefer-dist
 
 echo "→ Refreshing JS dependencies"
-npm ci
+npm install --no-audit --no-fund
 
 echo "→ Pointing .env at ${WORKSPACE_HOST}"
 sed -i '' "s|^APP_URL=.*|APP_URL=https://${WORKSPACE_HOST}|" .env


### PR DESCRIPTION
## What

APFS-clone `vendor/` + `node_modules/` from the base checkout (`cp -c` clonefile) before installing, so a fresh Conductor worktree gets Polyscope-parity instant deps instead of a cold `composer`/`npm install`.

## How

- Base checkout detected via `CONDUCTOR_ROOT_PATH` (fallback: git common dir parent).
- Uses `npm install`, **not** `npm ci`, so the clone is not wiped.

## Files

- `.conductor/settings.toml`
- `bin/setup-workspace.sh`