### PR TITLE
feat(email): add icon to AI thread summary modal

### DIFF
--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -261,6 +261,7 @@ abstract class BaseRecordEmailsPage extends Page
             ->icon('heroicon-o-sparkles')
             ->color('gray')
             ->modalHeading(__('filament/pages/record-emails.actions.summarize_thread.modal_heading'))
+            ->modalIcon('heroicon-o-sparkles')
             ->modalSubmitAction(false)
             ->modalCancelActionLabel('Close')
             ->modalContent(function (array $arguments): View {

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -486,6 +486,7 @@ final class EmailInboxPage extends Page
             ->icon('heroicon-o-sparkles')
             ->color('gray')
             ->modalHeading(__('filament/pages/email-inbox.summarize_thread.modal_heading'))
+            ->modalIcon('heroicon-o-sparkles')
             ->modalSubmitAction(false)
             ->modalCancelActionLabel('Close')
             ->modalContent(function (array $arguments): View {

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -205,6 +205,7 @@ abstract class BaseEmailsRelationManager extends RelationManager
                         ->color('gray')
                         ->visible(fn (Email $record): bool => $record->user_id === $this->authUser()->getKey() || $this->authUser()->can('viewBody', $record))
                         ->modalHeading(__('filament/relation-managers/emails.actions.summarize_thread.modal_heading'))
+                        ->modalIcon('heroicon-o-sparkles')
                         ->modalSubmitAction(false)
                         ->modalCancelActionLabel('Close')
                         ->modalContent(fn (Email $record): View => $this->buildThreadSummaryView($record)),


### PR DESCRIPTION
## What

Added `->modalIcon('heroicon-o-sparkles')` to all three `summarizeThread` actions so the **AI Thread Summary** modal header shows an icon next to the heading.

- `EmailInboxPage.php`
- `BaseRecordEmailsPage.php`
- `BaseEmailsRelationManager.php`

## Why

The modal heading rendered with no icon, inconsistent with the action button (which already uses `heroicon-o-sparkles`). Icon matches the action trigger for visual continuity.

## Verification

Walked the live app: opened the **Summarize Thread** modal on the Email inbox page — sparkles icon now renders in `fi-modal-icon-bg` next to the "AI Thread Summary" heading.