### PR TITLE
feat(chat): No Dead Ends - escort, citations, reporting, schema mgmt

### DIFF
--- a/app/Actions/Company/ListCompanies.php
+++ b/app/Actions/Company/ListCompanies.php
@@ -10,6 +10,7 @@ use App\Models\Company;
 use App\Models\User;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
@@ -41,6 +42,8 @@ final readonly class ListCompanies
             ->allowedFilters(
                 AllowedFilter::partial('name'),
                 AllowedFilter::custom('custom_fields', new CustomFieldFilter('company')),
+                AllowedFilter::callback('created_after', fn (Builder $query, string $value) => $query->whereDate('companies.created_at', '>=', $value)),
+                AllowedFilter::callback('created_before', fn (Builder $query, string $value) => $query->whereDate('companies.created_at', '<=', $value)),
             )
             ->allowedFields('id', 'name', 'creator_id', 'account_owner_id', 'created_at', 'updated_at')
             ->allowedIncludes(

--- a/app/Actions/CustomFields/AddCustomFieldOptions.php
+++ b/app/Actions/CustomFields/AddCustomFieldOptions.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\CustomFields;
+
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+final readonly class AddCustomFieldOptions
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function execute(User $user, array $data): Model
+    {
+        abort_unless($user->ownsTeam($user->currentTeam), 403, 'Only team owners can manage custom field definitions.');
+
+        $fieldId = $data['_record_id'] ?? null;
+
+        abort_if(! is_string($fieldId) && ! is_int($fieldId), 422, 'Missing field ID (_record_id).');
+
+        $teamId = $user->currentTeam->getKey();
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            $field = CustomField::query()
+                ->withoutGlobalScope(CustomFieldsActivableScope::class)
+                ->where('tenant_id', $teamId)
+                ->findOrFail($fieldId);
+
+            abort_unless(
+                in_array($field->type, CreateCustomField::CHOICE_TYPES, true),
+                422,
+                "Field type \"{$field->type}\" does not support options. Only select, multi-select, radio, checkbox-list, and toggle-buttons fields can have options.",
+            );
+
+            $newOptions = is_array($data['options'] ?? null) ? $data['options'] : [];
+            abort_if($newOptions === [], 422, 'At least one option must be provided.');
+
+            $maxOptions = (int) config('chat.max_field_options', 50);
+            $existingCount = $field->options()->withoutGlobalScopes()->count();
+
+            abort_if(
+                ($existingCount + count($newOptions)) > $maxOptions,
+                422,
+                "Adding these options would exceed the limit of {$maxOptions} options per field.",
+            );
+
+            $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+            $nextSortOrder = (int) $field->options()->withoutGlobalScopes()->max('sort_order') + 1;
+
+            foreach (array_values($newOptions) as $index => $option) {
+                $optionName = is_array($option) ? (string) ($option['name'] ?? '') : (string) $option;
+                $field->options()->create([
+                    $tenantKey => $teamId,
+                    'name' => $optionName,
+                    'sort_order' => $nextSortOrder + $index,
+                ]);
+            }
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+
+        return $field->refresh()->load('options');
+    }
+}

--- a/app/Actions/CustomFields/CreateCustomField.php
+++ b/app/Actions/CustomFields/CreateCustomField.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\CustomFields;
+
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Relaticle\CustomFields\Data\CustomFieldSettingsData;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+use Relaticle\CustomFields\Support\CodeGenerator;
+
+final readonly class CreateCustomField
+{
+    /** @var list<string> */
+    public const array ALLOWED_TYPES = [
+        'text',
+        'number',
+        'email',
+        'phone',
+        'link',
+        'textarea',
+        'checkbox',
+        'checkbox-list',
+        'date',
+        'date-time',
+        'select',
+        'multi-select',
+        'tags-input',
+        'toggle',
+        'toggle-buttons',
+        'radio',
+        'color-picker',
+    ];
+
+    /** @var list<string> Types that require user-managed options. */
+    public const array CHOICE_TYPES = [
+        'select',
+        'multi-select',
+        'radio',
+        'checkbox-list',
+        'toggle-buttons',
+    ];
+
+    /** @var list<string> */
+    public const array VALID_ENTITY_TYPES = [
+        'company',
+        'people',
+        'opportunity',
+        'task',
+        'note',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function execute(User $user, array $data): CustomField
+    {
+        abort_unless($user->ownsTeam($user->currentTeam), 403, 'Only team owners can manage custom field definitions.');
+
+        $type = (string) ($data['type'] ?? '');
+        $entityType = (string) ($data['entity_type'] ?? '');
+        $name = (string) ($data['name'] ?? '');
+
+        abort_unless(
+            in_array($type, self::ALLOWED_TYPES, true),
+            422,
+            "Field type \"{$type}\" is not allowed via chat. Allowed types: ".implode(', ', self::ALLOWED_TYPES).'.',
+        );
+
+        abort_unless(
+            in_array($entityType, self::VALID_ENTITY_TYPES, true),
+            422,
+            "Entity type \"{$entityType}\" is not valid. Valid types: ".implode(', ', self::VALID_ENTITY_TYPES).'.',
+        );
+
+        $options = is_array($data['options'] ?? null) ? $data['options'] : [];
+        $isChoiceType = $this->isChoiceType($type);
+
+        abort_if($isChoiceType && $options === [], 422, "Field type \"{$type}\" requires at least one option.");
+
+        abort_if(! $isChoiceType && $options !== [], 422, "Field type \"{$type}\" does not support options.");
+
+        $teamId = $user->currentTeam->getKey();
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            $maxFields = (int) config('chat.max_custom_fields_per_entity', 50);
+            $existingCount = CustomField::query()
+                ->withoutGlobalScope(CustomFieldsActivableScope::class)
+                ->where('tenant_id', $teamId)
+                ->where('entity_type', $entityType)
+                ->count();
+
+            abort_if(
+                $existingCount >= $maxFields,
+                422,
+                "Cannot create more than {$maxFields} custom fields per entity type.",
+            );
+
+            if ($isChoiceType) {
+                $maxOptions = (int) config('chat.max_field_options', 50);
+                abort_if(
+                    count($options) > $maxOptions,
+                    422,
+                    "Cannot create more than {$maxOptions} options per field.",
+                );
+            }
+
+            $code = (string) ($data['code'] ?? '');
+
+            if ($code === '') {
+                $code = CodeGenerator::generateUniqueFieldCode($name, $entityType);
+            }
+
+            $nextSortOrder = (int) CustomField::query()
+                ->withoutGlobalScope(CustomFieldsActivableScope::class)
+                ->where('tenant_id', $teamId)
+                ->where('entity_type', $entityType)
+                ->max('sort_order') + 1;
+
+            $field = DB::transaction(function () use ($teamId, $entityType, $type, $name, $code, $nextSortOrder, $options, $isChoiceType): CustomField {
+                $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+
+                /** @var CustomField $created */
+                $created = CustomField::query()->create([
+                    $tenantKey => $teamId,
+                    'entity_type' => $entityType,
+                    'type' => $type,
+                    'name' => $name,
+                    'code' => $code,
+                    'sort_order' => $nextSortOrder,
+                    'active' => true,
+                    'system_defined' => false,
+                    'validation_rules' => [],
+                    'settings' => new CustomFieldSettingsData,
+                ]);
+
+                if ($isChoiceType) {
+                    foreach (array_values($options) as $index => $option) {
+                        $optionName = is_array($option) ? (string) ($option['name'] ?? '') : (string) $option;
+                        $created->options()->create([
+                            $tenantKey => $teamId,
+                            'name' => $optionName,
+                            'sort_order' => $index,
+                        ]);
+                    }
+                }
+
+                return $created;
+            });
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+
+        return $field->load('options');
+    }
+
+    private function isChoiceType(string $type): bool
+    {
+        return in_array($type, self::CHOICE_TYPES, true);
+    }
+}

--- a/app/Actions/CustomFields/UpdateCustomField.php
+++ b/app/Actions/CustomFields/UpdateCustomField.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\CustomFields;
+
+use App\Models\CustomField;
+use App\Models\User;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+final readonly class UpdateCustomField
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function execute(User $user, CustomField $field, array $data): CustomField
+    {
+        abort_unless($user->ownsTeam($user->currentTeam), 403, 'Only team owners can manage custom field definitions.');
+        abort_if($field->isSystemDefined(), 422, 'System-defined custom fields cannot be modified.');
+
+        $teamId = $user->currentTeam->getKey();
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            $attributes = array_filter([
+                'name' => isset($data['name']) && is_string($data['name']) && $data['name'] !== '' ? $data['name'] : null,
+                'active' => isset($data['active']) ? (bool) $data['active'] : null,
+            ], fn (mixed $v): bool => $v !== null);
+
+            if ($attributes !== []) {
+                $field->update($attributes);
+            }
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+
+        return $field->refresh()->load('options');
+    }
+}

--- a/app/Actions/Opportunity/AggregateOpportunities.php
+++ b/app/Actions/Opportunity/AggregateOpportunities.php
@@ -13,9 +13,15 @@ use Illuminate\Support\Facades\DB;
 final readonly class AggregateOpportunities
 {
     /**
+     * Cap on the number of grouped rows returned. Grand totals are computed
+     * separately so they stay accurate even when groups exceed this cap.
+     */
+    private const int MAX_GROUPS = 100;
+
+    /**
      * Aggregate opportunities by stage or company.
      *
-     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float, truncated: bool}
      */
     public function execute(
         User $user,
@@ -35,7 +41,7 @@ final readonly class AggregateOpportunities
     }
 
     /**
-     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float, truncated: bool}
      */
     private function byStage(mixed $teamId, ?string $dateFrom, ?string $dateTo): array
     {
@@ -53,23 +59,16 @@ final readonly class AggregateOpportunities
             : '0 as total_amount';
         $amountBindings = $amountFieldId !== null ? [$amountFieldId] : [];
 
-        if ($stageFieldId === null) {
-            $rows = DB::select(
-                "SELECT 'Unspecified' as label, COUNT(*) as count, {$amountSelect}
-                 FROM opportunities o
-                 {$amountJoin}
-                 WHERE o.team_id = ? AND o.deleted_at IS NULL{$dateClause}
-                 LIMIT 100",
-                [...$amountBindings, $teamId, ...$dateBindings],
-            );
+        $totals = $this->grandTotals($teamId, $amountFieldId, $dateFrom, $dateTo);
 
+        if ($stageFieldId === null) {
             $mappedRows = [[
                 'label' => 'Unspecified',
-                'count' => (int) ($rows[0]->count ?? 0),
-                'total_amount' => (float) ($rows[0]->total_amount ?? 0),
+                'count' => $totals['count'],
+                'total_amount' => $totals['amount'],
             ]];
 
-            return $this->buildResult('stage', $mappedRows);
+            return $this->buildResult('stage', $mappedRows, $totals['count'], $totals['amount']);
         }
 
         $rows = DB::select(
@@ -80,7 +79,7 @@ final readonly class AggregateOpportunities
              WHERE o.team_id = ? AND o.deleted_at IS NULL{$dateClause}
              GROUP BY stage_cfv.string_value
              ORDER BY count DESC
-             LIMIT 100",
+             LIMIT ".self::MAX_GROUPS,
             [$stageFieldId, ...$amountBindings, $teamId, ...$dateBindings],
         );
 
@@ -101,11 +100,11 @@ final readonly class AggregateOpportunities
             ];
         }
 
-        return $this->buildResult('stage', $mappedRows);
+        return $this->buildResult('stage', $mappedRows, $totals['count'], $totals['amount']);
     }
 
     /**
-     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float, truncated: bool}
      */
     private function byCompany(mixed $teamId, ?string $dateFrom, ?string $dateTo): array
     {
@@ -130,7 +129,7 @@ final readonly class AggregateOpportunities
              WHERE o.team_id = ? AND o.deleted_at IS NULL{$dateClause}
              GROUP BY c.id, c.name
              ORDER BY count DESC
-             LIMIT 100",
+             LIMIT ".self::MAX_GROUPS,
             [...$amountBindings, $teamId, ...$dateBindings],
         );
 
@@ -143,7 +142,43 @@ final readonly class AggregateOpportunities
             ];
         }
 
-        return $this->buildResult('company', $mappedRows);
+        $totals = $this->grandTotals($teamId, $amountFieldId, $dateFrom, $dateTo);
+
+        return $this->buildResult('company', $mappedRows, $totals['count'], $totals['amount']);
+    }
+
+    /**
+     * Grand totals across ALL matching opportunities, independent of the grouped
+     * row cap, so reported counts and pipeline value stay correct when the number
+     * of groups exceeds the cap.
+     *
+     * @return array{count: int, amount: float}
+     */
+    private function grandTotals(mixed $teamId, mixed $amountFieldId, ?string $dateFrom, ?string $dateTo): array
+    {
+        $dateClause = $this->dateClause($dateFrom, $dateTo);
+        $dateBindings = $this->dateBindings($dateFrom, $dateTo);
+
+        $amountJoin = $amountFieldId !== null
+            ? "LEFT JOIN custom_field_values amount_cfv ON amount_cfv.entity_id = o.id AND amount_cfv.entity_type = 'opportunity' AND amount_cfv.custom_field_id = ?"
+            : '';
+        $amountSelect = $amountFieldId !== null
+            ? 'COALESCE(SUM(amount_cfv.float_value), 0) as total_amount'
+            : '0 as total_amount';
+        $amountBindings = $amountFieldId !== null ? [$amountFieldId] : [];
+
+        $row = DB::select(
+            "SELECT COUNT(*) as count, {$amountSelect}
+             FROM opportunities o
+             {$amountJoin}
+             WHERE o.team_id = ? AND o.deleted_at IS NULL{$dateClause}",
+            [...$amountBindings, $teamId, ...$dateBindings],
+        );
+
+        return [
+            'count' => (int) ($row[0]->count ?? 0),
+            'amount' => (float) ($row[0]->total_amount ?? 0),
+        ];
     }
 
     private function resolveFieldId(mixed $teamId, string $code): mixed
@@ -192,23 +227,16 @@ final readonly class AggregateOpportunities
 
     /**
      * @param  list<array{label: string, count: int, total_amount: float}>  $rows
-     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float, truncated: bool}
      */
-    private function buildResult(string $groupBy, array $rows): array
+    private function buildResult(string $groupBy, array $rows, int $totalCount, float $totalAmount): array
     {
-        $totalCount = 0;
-        $totalAmount = 0.0;
-
-        foreach ($rows as $row) {
-            $totalCount += $row['count'];
-            $totalAmount += $row['total_amount'];
-        }
-
         return [
             'group_by' => $groupBy,
             'rows' => $rows,
             'total_count' => $totalCount,
             'total_amount' => $totalAmount,
+            'truncated' => count($rows) >= self::MAX_GROUPS,
         ];
     }
 }

--- a/app/Actions/Opportunity/AggregateOpportunities.php
+++ b/app/Actions/Opportunity/AggregateOpportunities.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Opportunity;
+
+use App\Enums\CustomFields\OpportunityField;
+use App\Models\CustomField;
+use App\Models\Opportunity;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+final readonly class AggregateOpportunities
+{
+    /**
+     * Aggregate opportunities by stage or company.
+     *
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     */
+    public function execute(
+        User $user,
+        string $groupBy,
+        ?string $dateFrom = null,
+        ?string $dateTo = null,
+    ): array {
+        abort_unless($user->can('viewAny', Opportunity::class), 403);
+
+        $teamId = $user->currentTeam->getKey();
+
+        return match ($groupBy) {
+            'stage' => $this->byStage($teamId, $dateFrom, $dateTo),
+            'company' => $this->byCompany($teamId, $dateFrom, $dateTo),
+            default => abort(422, "Invalid group_by value: {$groupBy}. Must be 'stage' or 'company'."),
+        };
+    }
+
+    /**
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     */
+    private function byStage(mixed $teamId, ?string $dateFrom, ?string $dateTo): array
+    {
+        $stageFieldId = $this->resolveFieldId($teamId, OpportunityField::STAGE->value);
+        $amountFieldId = $this->resolveFieldId($teamId, OpportunityField::AMOUNT->value);
+
+        $dateClause = $this->dateClause($dateFrom, $dateTo);
+        $dateBindings = $this->dateBindings($dateFrom, $dateTo);
+
+        $amountJoin = $amountFieldId !== null
+            ? "LEFT JOIN custom_field_values amount_cfv ON amount_cfv.entity_id = o.id AND amount_cfv.entity_type = 'opportunity' AND amount_cfv.custom_field_id = ?"
+            : '';
+        $amountSelect = $amountFieldId !== null
+            ? 'COALESCE(SUM(amount_cfv.float_value), 0) as total_amount'
+            : '0 as total_amount';
+        $amountBindings = $amountFieldId !== null ? [$amountFieldId] : [];
+
+        if ($stageFieldId === null) {
+            $rows = DB::select(
+                "SELECT 'Unspecified' as label, COUNT(*) as count, {$amountSelect}
+                 FROM opportunities o
+                 {$amountJoin}
+                 WHERE o.team_id = ? AND o.deleted_at IS NULL{$dateClause}
+                 LIMIT 100",
+                [...$amountBindings, $teamId, ...$dateBindings],
+            );
+
+            $mappedRows = [[
+                'label' => 'Unspecified',
+                'count' => (int) ($rows[0]->count ?? 0),
+                'total_amount' => (float) ($rows[0]->total_amount ?? 0),
+            ]];
+
+            return $this->buildResult('stage', $mappedRows);
+        }
+
+        $rows = DB::select(
+            "SELECT stage_cfv.string_value as stage_option_id, COUNT(*) as count, {$amountSelect}
+             FROM opportunities o
+             LEFT JOIN custom_field_values stage_cfv ON stage_cfv.entity_id = o.id AND stage_cfv.entity_type = 'opportunity' AND stage_cfv.custom_field_id = ?
+             {$amountJoin}
+             WHERE o.team_id = ? AND o.deleted_at IS NULL{$dateClause}
+             GROUP BY stage_cfv.string_value
+             ORDER BY count DESC
+             LIMIT 100",
+            [$stageFieldId, ...$amountBindings, $teamId, ...$dateBindings],
+        );
+
+        $stageOptions = DB::table('custom_field_options')
+            ->where('custom_field_id', $stageFieldId)
+            ->pluck('name', 'id');
+
+        $mappedRows = [];
+        foreach ($rows as $row) {
+            $optionId = $row->stage_option_id;
+            $label = ($optionId !== null && isset($stageOptions[$optionId]))
+                ? (string) $stageOptions[$optionId]
+                : 'Unspecified';
+            $mappedRows[] = [
+                'label' => $label,
+                'count' => (int) $row->count,
+                'total_amount' => (float) $row->total_amount,
+            ];
+        }
+
+        return $this->buildResult('stage', $mappedRows);
+    }
+
+    /**
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     */
+    private function byCompany(mixed $teamId, ?string $dateFrom, ?string $dateTo): array
+    {
+        $amountFieldId = $this->resolveFieldId($teamId, OpportunityField::AMOUNT->value);
+
+        $dateClause = $this->dateClause($dateFrom, $dateTo);
+        $dateBindings = $this->dateBindings($dateFrom, $dateTo);
+
+        $amountJoin = $amountFieldId !== null
+            ? "LEFT JOIN custom_field_values amount_cfv ON amount_cfv.entity_id = o.id AND amount_cfv.entity_type = 'opportunity' AND amount_cfv.custom_field_id = ?"
+            : '';
+        $amountSelect = $amountFieldId !== null
+            ? 'COALESCE(SUM(amount_cfv.float_value), 0) as total_amount'
+            : '0 as total_amount';
+        $amountBindings = $amountFieldId !== null ? [$amountFieldId] : [];
+
+        $rows = DB::select(
+            "SELECT COALESCE(c.name, 'No Company') as label, COUNT(*) as count, {$amountSelect}
+             FROM opportunities o
+             LEFT JOIN companies c ON c.id = o.company_id AND c.deleted_at IS NULL
+             {$amountJoin}
+             WHERE o.team_id = ? AND o.deleted_at IS NULL{$dateClause}
+             GROUP BY c.id, c.name
+             ORDER BY count DESC
+             LIMIT 100",
+            [...$amountBindings, $teamId, ...$dateBindings],
+        );
+
+        $mappedRows = [];
+        foreach ($rows as $row) {
+            $mappedRows[] = [
+                'label' => (string) $row->label,
+                'count' => (int) $row->count,
+                'total_amount' => (float) $row->total_amount,
+            ];
+        }
+
+        return $this->buildResult('company', $mappedRows);
+    }
+
+    private function resolveFieldId(mixed $teamId, string $code): mixed
+    {
+        return CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $teamId)
+            ->where('entity_type', 'opportunity')
+            ->where('code', $code)
+            ->active()
+            ->value('id');
+    }
+
+    private function dateClause(?string $dateFrom, ?string $dateTo): string
+    {
+        $clause = '';
+
+        if ($dateFrom !== null) {
+            $clause .= ' AND o.created_at >= ?';
+        }
+
+        if ($dateTo !== null) {
+            $clause .= ' AND o.created_at <= ?';
+        }
+
+        return $clause;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function dateBindings(?string $dateFrom, ?string $dateTo): array
+    {
+        $bindings = [];
+
+        if ($dateFrom !== null) {
+            $bindings[] = $dateFrom;
+        }
+
+        if ($dateTo !== null) {
+            $bindings[] = $dateTo.' 23:59:59';
+        }
+
+        return $bindings;
+    }
+
+    /**
+     * @param  list<array{label: string, count: int, total_amount: float}>  $rows
+     * @return array{group_by: string, rows: list<array{label: string, count: int, total_amount: float}>, total_count: int, total_amount: float}
+     */
+    private function buildResult(string $groupBy, array $rows): array
+    {
+        $totalCount = 0;
+        $totalAmount = 0.0;
+
+        foreach ($rows as $row) {
+            $totalCount += $row['count'];
+            $totalAmount += $row['total_amount'];
+        }
+
+        return [
+            'group_by' => $groupBy,
+            'rows' => $rows,
+            'total_count' => $totalCount,
+            'total_amount' => $totalAmount,
+        ];
+    }
+}

--- a/app/Actions/Opportunity/ListOpportunities.php
+++ b/app/Actions/Opportunity/ListOpportunities.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as DbBuilder;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
@@ -46,6 +47,12 @@ final readonly class ListOpportunities
                 AllowedFilter::custom('custom_fields', new CustomFieldFilter('opportunity')),
                 AllowedFilter::callback('created_after', fn (Builder $query, string $value) => $query->whereDate('opportunities.created_at', '>=', $value)),
                 AllowedFilter::callback('created_before', fn (Builder $query, string $value) => $query->whereDate('opportunities.created_at', '<=', $value)),
+                AllowedFilter::callback('stale_days', fn (Builder $query, string $value) => $query->whereNotExists(
+                    fn (DbBuilder $sub) => $sub->from('activity_log')
+                        ->where('activity_log.subject_type', 'opportunity')
+                        ->whereColumn('activity_log.subject_id', 'opportunities.id')
+                        ->where('activity_log.created_at', '>=', now()->subDays((int) $value))
+                )),
             )
             ->allowedFields('id', 'name', 'company_id', 'contact_id', 'creator_id', 'created_at', 'updated_at')
             ->allowedIncludes(

--- a/app/Actions/Opportunity/ListOpportunities.php
+++ b/app/Actions/Opportunity/ListOpportunities.php
@@ -47,12 +47,17 @@ final readonly class ListOpportunities
                 AllowedFilter::custom('custom_fields', new CustomFieldFilter('opportunity')),
                 AllowedFilter::callback('created_after', fn (Builder $query, string $value) => $query->whereDate('opportunities.created_at', '>=', $value)),
                 AllowedFilter::callback('created_before', fn (Builder $query, string $value) => $query->whereDate('opportunities.created_at', '<=', $value)),
-                AllowedFilter::callback('stale_days', fn (Builder $query, string $value) => $query->whereNotExists(
-                    fn (DbBuilder $sub) => $sub->from('activity_log')
-                        ->where('activity_log.subject_type', 'opportunity')
-                        ->whereColumn('activity_log.subject_id', 'opportunities.id')
-                        ->where('activity_log.created_at', '>=', now()->subDays((int) $value))
-                )),
+                AllowedFilter::callback('stale_days', function (Builder $query, string $value) use ($user): void {
+                    $teamId = $user->currentTeam->getKey();
+
+                    $query->whereNotExists(
+                        fn (DbBuilder $sub) => $sub->from('activity_log')
+                            ->where('activity_log.team_id', $teamId)
+                            ->where('activity_log.subject_type', 'opportunity')
+                            ->whereColumn('activity_log.subject_id', 'opportunities.id')
+                            ->where('activity_log.created_at', '>=', now()->subDays((int) $value))
+                    );
+                }),
             )
             ->allowedFields('id', 'name', 'company_id', 'contact_id', 'creator_id', 'created_at', 'updated_at')
             ->allowedIncludes(

--- a/app/Actions/Opportunity/ListOpportunities.php
+++ b/app/Actions/Opportunity/ListOpportunities.php
@@ -10,6 +10,7 @@ use App\Models\Opportunity;
 use App\Models\User;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
@@ -43,6 +44,8 @@ final readonly class ListOpportunities
                 AllowedFilter::exact('company_id'),
                 AllowedFilter::exact('contact_id'),
                 AllowedFilter::custom('custom_fields', new CustomFieldFilter('opportunity')),
+                AllowedFilter::callback('created_after', fn (Builder $query, string $value) => $query->whereDate('opportunities.created_at', '>=', $value)),
+                AllowedFilter::callback('created_before', fn (Builder $query, string $value) => $query->whereDate('opportunities.created_at', '<=', $value)),
             )
             ->allowedFields('id', 'name', 'company_id', 'contact_id', 'creator_id', 'created_at', 'updated_at')
             ->allowedIncludes(

--- a/app/Actions/People/ListPeople.php
+++ b/app/Actions/People/ListPeople.php
@@ -10,6 +10,7 @@ use App\Models\People;
 use App\Models\User;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
@@ -42,6 +43,8 @@ final readonly class ListPeople
                 AllowedFilter::partial('name'),
                 AllowedFilter::exact('company_id'),
                 AllowedFilter::custom('custom_fields', new CustomFieldFilter('people')),
+                AllowedFilter::callback('created_after', fn (Builder $query, string $value) => $query->whereDate('people.created_at', '>=', $value)),
+                AllowedFilter::callback('created_before', fn (Builder $query, string $value) => $query->whereDate('people.created_at', '<=', $value)),
             )
             ->allowedFields('id', 'name', 'company_id', 'creator_id', 'created_at', 'updated_at')
             ->allowedIncludes(

--- a/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
+++ b/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
@@ -32,6 +32,21 @@ final class ViewCompany extends ViewRecord
     {
         return [
             GenerateRecordSummaryAction::make(),
+            Action::make('askAboutThis')
+                ->label(__('filament/resources/company.pages.view.actions.ask_about_this.label'))
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('gray')
+                ->action(function (Company $record): void {
+                    $mention = Js::from([
+                        'type' => 'company',
+                        'id' => (string) $record->getKey(),
+                        'label' => $record->name,
+                    ]);
+                    $this->js("
+                        sessionStorage.setItem('chat:mention', JSON.stringify({$mention}));
+                        window.Livewire.dispatch('chat:open-panel');
+                    ");
+                }),
             EditAction::make()->icon('heroicon-o-pencil-square')->label(__('filament/resources/company.pages.view.actions.edit.label')),
             ActionGroup::make([
                 ActionGroup::make([

--- a/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
@@ -29,6 +29,21 @@ final class ViewOpportunity extends ViewRecord
     {
         return [
             GenerateRecordSummaryAction::make(),
+            Action::make('askAboutThis')
+                ->label(__('filament/resources/opportunity.pages.view.actions.ask_about_this.label'))
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('gray')
+                ->action(function (Opportunity $record): void {
+                    $mention = Js::from([
+                        'type' => 'opportunity',
+                        'id' => (string) $record->getKey(),
+                        'label' => $record->name,
+                    ]);
+                    $this->js("
+                        sessionStorage.setItem('chat:mention', JSON.stringify({$mention}));
+                        window.Livewire.dispatch('chat:open-panel');
+                    ");
+                }),
             EditAction::make()->icon('heroicon-o-pencil-square')->label(__('filament/resources/opportunity.pages.view.actions.edit.label')),
             ActionGroup::make([
                 ActionGroup::make([

--- a/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
+++ b/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
@@ -30,6 +30,21 @@ final class ViewPeople extends ViewRecord
     {
         return [
             GenerateRecordSummaryAction::make(),
+            Action::make('askAboutThis')
+                ->label(__('filament/resources/person.pages.view.actions.ask_about_this.label'))
+                ->icon('heroicon-o-chat-bubble-left-right')
+                ->color('gray')
+                ->action(function (People $record): void {
+                    $mention = Js::from([
+                        'type' => 'people',
+                        'id' => (string) $record->getKey(),
+                        'label' => $record->name,
+                    ]);
+                    $this->js("
+                        sessionStorage.setItem('chat:mention', JSON.stringify({$mention}));
+                        window.Livewire.dispatch('chat:open-panel');
+                    ");
+                }),
             EditAction::make()->icon('heroicon-o-pencil-square')->label(__('filament/resources/person.pages.view.actions.edit.label')),
             ActionGroup::make([
                 ActionGroup::make([

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -271,6 +271,7 @@ final class AppServiceProvider extends ServiceProvider
             'task' => Task::class,
             'note' => Note::class,
             'system_administrator' => SystemAdministrator::class,
+            'custom_field' => CustomField::class,
         ]);
 
         // Use custom models for custom-fields package

--- a/lang/en/filament/resources/company.php
+++ b/lang/en/filament/resources/company.php
@@ -57,6 +57,9 @@ return [
                 'edit' => [
                     'label' => 'Edit',
                 ],
+                'ask_about_this' => [
+                    'label' => 'Ask about this',
+                ],
                 'copy_page_url' => [
                     'label' => 'Copy page URL',
                 ],

--- a/lang/en/filament/resources/opportunity.php
+++ b/lang/en/filament/resources/opportunity.php
@@ -52,6 +52,9 @@ return [
                 'edit' => [
                     'label' => 'Edit',
                 ],
+                'ask_about_this' => [
+                    'label' => 'Ask about this',
+                ],
                 'copy_page_url' => [
                     'label' => 'Copy page URL',
                 ],

--- a/lang/en/filament/resources/person.php
+++ b/lang/en/filament/resources/person.php
@@ -57,6 +57,9 @@ return [
                 'edit' => [
                     'label' => 'Edit',
                 ],
+                'ask_about_this' => [
+                    'label' => 'Ask about this',
+                ],
                 'copy_page_url' => [
                     'label' => 'Copy page URL',
                 ],

--- a/lang/fr/filament/resources/company.php
+++ b/lang/fr/filament/resources/company.php
@@ -54,6 +54,9 @@ return [
                 'edit' => [
                     'label' => 'Modifier',
                 ],
+                'ask_about_this' => [
+                    'label' => 'Demander à propos de ceci',
+                ],
                 'copy_page_url' => [
                     'label' => "Copier l'URL de la page",
                 ],

--- a/packages/Chat/config/chat.php
+++ b/packages/Chat/config/chat.php
@@ -69,4 +69,18 @@ return [
 
     'provider_starts_per_second' => (int) env('CHAT_PROVIDER_STARTS_PER_SECOND', 8),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Field Schema Caps
+    |--------------------------------------------------------------------------
+    |
+    | Maximum number of custom fields per entity type (across all entities of
+    | that type for a tenant) and maximum options per choice field. Enforced
+    | server-side in the action layer — never via prompt text only.
+    */
+
+    'max_custom_fields_per_entity' => (int) env('CHAT_MAX_CUSTOM_FIELDS_PER_ENTITY', 50),
+
+    'max_field_options' => (int) env('CHAT_MAX_FIELD_OPTIONS', 50),
+
 ];

--- a/packages/Chat/config/chat.php
+++ b/packages/Chat/config/chat.php
@@ -6,6 +6,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Batch Write Cap
+    |--------------------------------------------------------------------------
+    |
+    | Maximum number of records that may be created or deleted in a single
+    | tool call. Enforced server-side in the tool layer (never via prompt text).
+    | Override with CHAT_MAX_BATCH_SIZE in .env for local testing.
+    */
+
+    'max_batch_size' => (int) env('CHAT_MAX_BATCH_SIZE', 25),
+
+    /*
+    |--------------------------------------------------------------------------
     | Tool Call Credit Bonus
     |--------------------------------------------------------------------------
     */

--- a/packages/Chat/resources/js/chat-editor.js
+++ b/packages/Chat/resources/js/chat-editor.js
@@ -50,6 +50,10 @@ export function chatEditor({ initialDocument, placeholder, onSubmit, onChange, a
                         id: { default: null },
                         type: { default: null },
                         label: { default: null },
+                        // Server-resolved record URL captured from the mention picker.
+                        // Persisted in the document JSON so a just-sent message can render
+                        // a clickable chip before the authoritative server mentions arrive.
+                        url: { default: null },
                     };
                 },
                 parseHTML() {

--- a/packages/Chat/resources/js/chat-mention-suggestion.js
+++ b/packages/Chat/resources/js/chat-mention-suggestion.js
@@ -78,7 +78,7 @@ export function createMentionSuggestion() {
             const body = await res.json();
             if (myToken !== fetchToken) return null;
             return {
-                results: (body.data || []).map((item) => ({ type: item.type, id: item.id, label: item.name })),
+                results: (body.data || []).map((item) => ({ type: item.type, id: item.id, label: item.name, url: item.url ?? null })),
                 error: false,
             };
         } catch (_e) {
@@ -152,7 +152,7 @@ export function createMentionSuggestion() {
 
                     activeIndex = 0;
                     items = [];
-                    onSelect = (item) => props.command({ id: item.id, type: item.type, label: item.label });
+                    onSelect = (item) => props.command({ id: item.id, type: item.type, label: item.label, url: item.url ?? null });
 
                     document.body.appendChild(renderPopup({
                         query: props.query, fetching: true, error: false,
@@ -169,7 +169,7 @@ export function createMentionSuggestion() {
 
                 onUpdate: (props) => {
                     clientRect = props.clientRect;
-                    onSelect = (item) => props.command({ id: item.id, type: item.type, label: item.label });
+                    onSelect = (item) => props.command({ id: item.id, type: item.type, label: item.label, url: item.url ?? null });
 
                     if (!props.query || props.query.length < MIN_QUERY_LENGTH) {
                         if (popupEl?.parentNode) popupEl.parentNode.removeChild(popupEl);

--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -713,31 +713,76 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
         if (!message.document || (Array.isArray(message.document.content) && message.document.content.length === 0)) {
             return this.escapeHtml(message.content ?? '');
         }
-        return this.walkDocumentToHtml(message.document);
+
+        // Server-resolved mention URLs are authoritative. When a message carries a
+        // `mentions` array (loaded from the backend) links are rendered ONLY from
+        // it — never from the client-controlled document. A just-sent (optimistic)
+        // message has no server mentions yet, so it falls back to the picker URL
+        // stored on the node, which is still scheme-validated before use.
+        const serverMentions = Array.isArray(message.mentions) ? message.mentions : null;
+        const mentionUrls = {};
+        (serverMentions ?? []).forEach((m) => {
+            if (m && m.id != null && m.url) {
+                mentionUrls[String(m.id)] = m.url;
+            }
+        });
+
+        return this.walkDocumentToHtml(message.document, { mentionUrls, allowNodeUrl: serverMentions === null });
     },
 
-    walkDocumentToHtml(node) {
+    walkDocumentToHtml(node, ctx = {}) {
         if (!node) return '';
         if (node.type === 'doc') {
-            return (node.content ?? []).map((c) => this.walkDocumentToHtml(c)).join('');
+            return (node.content ?? []).map((c) => this.walkDocumentToHtml(c, ctx)).join('');
         }
         if (node.type === 'paragraph') {
-            const children = (node.content ?? []).map((c) => this.walkDocumentToHtml(c)).join('');
+            const children = (node.content ?? []).map((c) => this.walkDocumentToHtml(c, ctx)).join('');
             return `<p>${children}</p>`;
         }
         if (node.type === 'text') {
             return this.escapeHtml(node.text ?? '');
         }
         if (node.type === 'mention') {
-            const id = this.escapeAttr(node.attrs?.id ?? '');
-            const type = this.escapeAttr(node.attrs?.type ?? '');
-            const label = this.escapeHtml(node.attrs?.label ?? '');
-            return `<span data-mention-id="${id}" data-mention-type="${type}" class="inline-flex items-center rounded-md bg-primary-100 px-1.5 py-0.5 text-xs text-primary-800 dark:bg-primary-900/30 dark:text-primary-200">@${label}</span>`;
+            return this.renderMentionNode(node, ctx);
         }
         if (node.type === 'hardBreak') {
             return '<br>';
         }
         return '';
+    },
+
+    renderMentionNode(node, ctx = {}) {
+        const id = node.attrs?.id ?? '';
+        const idAttr = this.escapeAttr(id);
+        const type = this.escapeAttr(node.attrs?.type ?? '');
+        const label = this.escapeHtml(node.attrs?.label ?? '');
+        const baseClass = 'inline-flex items-center rounded-md bg-primary-100 px-1.5 py-0.5 text-xs text-primary-800 dark:bg-primary-900/30 dark:text-primary-200';
+
+        let url = ctx.mentionUrls?.[String(id)] ?? null;
+        if (!url && ctx.allowNodeUrl) {
+            url = node.attrs?.url ?? null;
+        }
+
+        if (url && this.isSafeUrl(url)) {
+            const href = this.escapeAttr(url);
+            return `<a href="${href}" target="_blank" rel="noopener noreferrer" data-mention-id="${idAttr}" data-mention-type="${type}" class="${baseClass} no-underline transition-colors hover:bg-primary-200 dark:hover:bg-primary-900/60">@${label}</a>`;
+        }
+
+        return `<span data-mention-id="${idAttr}" data-mention-type="${type}" class="${baseClass}">@${label}</span>`;
+    },
+
+    isSafeUrl(url) {
+        if (typeof url !== 'string' || url === '') return false;
+        // Root-relative ("/app/...") URLs are same-origin and safe; reject the
+        // protocol-relative "//host" form which would point off-origin.
+        if (url.startsWith('//')) return false;
+        if (url.startsWith('/')) return true;
+        try {
+            const parsed = new URL(url, window.location.origin);
+            return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        } catch (_) {
+            return false;
+        }
     },
 
     escapeHtml(str) {

--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -927,6 +927,34 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
                 if (action) action.error = 'Could not complete the action. Please try again.';
             }),
         ];
+
+        // Pre-seed a mention chip when "Ask about this" action stores a mention
+        // in sessionStorage before opening the side panel. The chat:focus-editor
+        // event fires after the panel becomes visible and the editor is mounted.
+        this.mentionHandler = (e) => {
+            if (e.detail?.context !== this.context) return;
+            try {
+                const raw = sessionStorage.getItem('chat:mention');
+                if (!raw) return;
+                sessionStorage.removeItem('chat:mention');
+                const m = JSON.parse(raw);
+                if (!m?.type || !m?.id || !m?.label) return;
+                this.$nextTick(() => {
+                    this.localEditor()?.setDocument?.({
+                        type: 'doc',
+                        content: [{
+                            type: 'paragraph',
+                            content: [{
+                                type: 'mention',
+                                attrs: { type: m.type, id: m.id, label: m.label },
+                            }],
+                        }],
+                    });
+                    this.localEditor()?.focus?.();
+                });
+            } catch (_) { /* sessionStorage unavailable or malformed payload */ }
+        };
+        window.addEventListener('chat:focus-editor', this.mentionHandler);
     },
 
     loadEarlier() {
@@ -1004,6 +1032,7 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
         window.removeEventListener('beforeunload', this.beforeUnloadHandler);
         window.removeEventListener('chat:renamed', this.renamedHandler);
         window.removeEventListener('keydown', this.approvalKeyHandler);
+        window.removeEventListener('chat:focus-editor', this.mentionHandler);
         (this._proposalListeners || []).forEach((off) => typeof off === 'function' && off());
     },
 

--- a/packages/Chat/src/Actions/ListConversationMessages.php
+++ b/packages/Chat/src/Actions/ListConversationMessages.php
@@ -19,7 +19,7 @@ final readonly class ListConversationMessages
     ) {}
 
     /**
-     * @return array<int, array{id: string, role: string, content: string, document: array<string, mixed>, created_at: ?string, pending_actions: array<int, mixed>, feedback: ?array{rating: string, category: ?string}, mentions: list<array{type: string, id: string, label: string}>}>
+     * @return array<int, array{id: string, role: string, content: string, document: array<string, mixed>, created_at: ?string, pending_actions: array<int, mixed>, feedback: ?array{rating: string, category: ?string}, mentions: list<array{type: string, id: string, label: string, url: ?string}>}>
      */
     public function execute(User $user, string $conversationId, ?string $beforeMessageId = null, int $limit = 50): array
     {
@@ -105,6 +105,7 @@ final readonly class ListConversationMessages
                         'type' => (string) $row->type,
                         'id' => (string) $row->record_id,
                         'label' => (string) $row->label,
+                        'url' => $this->resolver->urlFor((string) $row->type, (string) $row->record_id),
                     ])
                     ->all()
             ),

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -24,6 +24,9 @@ use Relaticle\Chat\Tools\Company\DeleteCompanyTool as ChatDeleteCompanyTool;
 use Relaticle\Chat\Tools\Company\GetCompanyTool as ChatGetCompanyTool;
 use Relaticle\Chat\Tools\Company\ListCompaniesTool as ChatListCompaniesTool;
 use Relaticle\Chat\Tools\Company\UpdateCompanyTool as ChatUpdateCompanyTool;
+use Relaticle\Chat\Tools\CustomField\AddCustomFieldOptionsTool;
+use Relaticle\Chat\Tools\CustomField\CreateCustomFieldTool;
+use Relaticle\Chat\Tools\CustomField\UpdateCustomFieldTool;
 use Relaticle\Chat\Tools\GetCrmSummaryTool;
 use Relaticle\Chat\Tools\GuideToPageTool;
 use Relaticle\Chat\Tools\ListTeamMembersTool;
@@ -164,7 +167,11 @@ Records have core fields (set directly in the write tool schemas, e.g. a company
 
 ## No Dead Ends
 Some actions cannot be performed here but ARE available elsewhere in the workspace. NEVER reply that something is impossible or "not supported by this assistant". Instead, call GuideToPageTool with the right destination and give the user a direct link to do it themselves:
-- Creating, editing, or DELETING a custom field DEFINITION (the field itself, not its value) -> destination "custom_fields". You CAN set custom field VALUES on records directly; you CANNOT create/rename/delete the field definitions -- link the user to manage them.
+- Custom field DEFINITIONS — creating, renaming, toggling active, or adding options:
+  - If the user is a team owner/admin: you CAN propose these operations via CreateCustomFieldTool, UpdateCustomFieldTool, and AddCustomFieldOptionsTool (all proposal-gated, require approval). Use them directly — do not escort an owner to the settings page for these operations.
+  - If the user is NOT a team owner: you CANNOT create or modify field definitions. Call GuideToPageTool with destination "custom_fields" so they can ask their team owner to do it.
+  - DELETING a custom field definition: you CANNOT delete field definitions from chat (for any user). Call GuideToPageTool with destination "custom_fields" to escort the user there.
+  - You CAN always set custom field VALUES on records directly (custom_fields parameter on create/update tools) — this is unrelated to field definition management.
 - Importing many records at once from a file (bulk creation) -> the matching "import_*" destination.
 - Inviting or managing team members -> "team_members".
 GuideToPageTool returns a page URL (not a record id). You MAY render that URL as a markdown link, e.g. "You can manage those in [Custom Fields settings](URL)." Rule 6 (never expose raw record IDs) still applies to everything else; record citations via `url` from read tool results are handled in the Citations section.
@@ -469,6 +476,11 @@ PROMPT;
             ChatCreateNoteTool::class,
             ChatUpdateNoteTool::class,
             ChatDeleteNoteTool::class,
+
+            // Schema management tools (admin-only, proposal-gated)
+            CreateCustomFieldTool::class,
+            UpdateCustomFieldTool::class,
+            AddCustomFieldOptionsTool::class,
         ];
     }
 

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -138,7 +138,7 @@ You can propose creating, updating, or deleting CRM records -- but these require
 3. For lists, present results in a compact table format. For single records, show key fields clearly.
 4. Never fabricate data. If a search returns no results, say so.
 5. Use entity names the user would recognize: "companies" not "organizations", "people" or "contacts" interchangeably, "opportunities" or "deals" interchangeably, "tasks", "notes".
-6. Never expose record IDs to the user. IDs in tool results are internal-only -- use them silently for follow-up tool calls (chaining writes, mentioning records to other tools) but do NOT include them in your prose response, in tables, or in markdown links to the user. Refer to records by their human name only.
+6. Never expose raw record IDs to the user. IDs in tool results are internal-only -- use them silently for follow-up tool calls (chaining writes, mentioning records to other tools). You MAY render a record's human name as a markdown link using its `url` from tool results (see Citations below), but never print the raw ID string in prose, tables, or link text.
 7. If the user's request is ambiguous, ask for clarification rather than guessing -- but ask ONCE: batch every clarifying question into a single message. Never ask about something you can resolve yourself; when only one record can match (e.g. the CRM has a single company), proceed with it and state the assumption instead of asking. When the user accepts an offer you just made ("yes", "do it", "go ahead"), execute exactly what you offered -- never re-ask for details your own offer already named.
 8. Be concise. Don't over-explain CRM concepts the user likely knows.
 9. Never narrate tool usage ("Let me fetch that", "I'll now look it up", "Let me check"). Call tools silently and reply once with the outcome.
@@ -165,7 +165,7 @@ Some actions cannot be performed here but ARE available elsewhere in the workspa
 - Creating, editing, or DELETING a custom field DEFINITION (the field itself, not its value) -> destination "custom_fields". You CAN set custom field VALUES on records directly; you CANNOT create/rename/delete the field definitions -- link the user to manage them.
 - Importing many records at once from a file (bulk creation) -> the matching "import_*" destination.
 - Inviting or managing team members -> "team_members".
-GuideToPageTool returns a page URL (not a record id). You MAY render that URL as a markdown link, e.g. "You can manage those in [Custom Fields settings](URL)." This navigation link is the ONLY link you include in replies; Rule 6 (never expose record IDs) still applies to everything else.
+GuideToPageTool returns a page URL (not a record id). You MAY render that URL as a markdown link, e.g. "You can manage those in [Custom Fields settings](URL)." Rule 6 (never expose raw record IDs) still applies to everything else; record citations via `url` from read tool results are handled in the Citations section.
 
 ## Formatting
 - Use markdown for rich text formatting
@@ -194,6 +194,13 @@ since your last reply. They are final -- never re-propose them. When an item is
 "approved" and carries an id, use that id to continue any multi-step request the user
 started (e.g. propose the next item, or link to the just-created record). When an item
 is "rejected", do not retry it; ask what the user wants instead.
+
+## Citations
+
+Read tool results include a `url` field per record. When you name a record in prose, render it as a markdown link using that url: `[Record Name](url)`. Rules:
+- Never show the raw ID -- always use the human name as the link text.
+- Only link records that actually appeared in tool results this turn -- never invent or guess a url.
+- If a record has no url (null), refer to it by name only without a link.
 PROMPT;
     }
 

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -168,7 +168,7 @@ Records have core fields (set directly in the write tool schemas, e.g. a company
 ## No Dead Ends
 Some actions cannot be performed here but ARE available elsewhere in the workspace. NEVER reply that something is impossible or "not supported by this assistant". Instead, call GuideToPageTool with the right destination and give the user a direct link to do it themselves:
 - Custom field DEFINITIONS — creating, renaming, toggling active, or adding options:
-  - If the user is a team owner/admin: you CAN propose these operations via CreateCustomFieldTool, UpdateCustomFieldTool, and AddCustomFieldOptionsTool (all proposal-gated, require approval). Use them directly — do not escort an owner to the settings page for these operations.
+  - If the user is a team owner/admin: you CAN propose these operations via CreateCustomFieldTool, UpdateCustomFieldTool, and AddCustomFieldOptionsTool (all proposal-gated, require approval). Use them directly — do not escort an owner to the settings page for these operations. To update or add options to an EXISTING field, identify it by its `entity_type` and its `code` (the machine code shown in the custom_fields field list for that entity) — you do not need a numeric/internal ID.
   - If the user is NOT a team owner: you CANNOT create or modify field definitions. Call GuideToPageTool with destination "custom_fields" so they can ask their team owner to do it.
   - DELETING a custom field definition: you CANNOT delete field definitions from chat (for any user). Call GuideToPageTool with destination "custom_fields" to escort the user there.
   - You CAN always set custom field VALUES on records directly (custom_fields parameter on create/update tools) — this is unrelated to field definition management.

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -24,6 +24,7 @@ use Relaticle\Chat\Tools\Company\GetCompanyTool as ChatGetCompanyTool;
 use Relaticle\Chat\Tools\Company\ListCompaniesTool as ChatListCompaniesTool;
 use Relaticle\Chat\Tools\Company\UpdateCompanyTool as ChatUpdateCompanyTool;
 use Relaticle\Chat\Tools\GetCrmSummaryTool;
+use Relaticle\Chat\Tools\GuideToPageTool;
 use Relaticle\Chat\Tools\ListTeamMembersTool;
 use Relaticle\Chat\Tools\Note\CreateNoteTool as ChatCreateNoteTool;
 use Relaticle\Chat\Tools\Note\DeleteNoteTool as ChatDeleteNoteTool;
@@ -158,6 +159,13 @@ Records have core fields (set directly in the write tool schemas, e.g. a company
 - Before claiming a field doesn't exist, check the write tool schema AND the custom fields description. If the field exists, use it.
 - If a field truly does not exist on the entity, say so in your FIRST reply and offer the closest real action. Never suggest creating a custom field that duplicates a core field.
 - If the user pushes back that a field exists, re-check the tool schema once and answer definitively. Do not apologize and then repeat the same conclusion -- either correct yourself with the real field, or explain concretely what IS available.
+
+## No Dead Ends
+Some actions cannot be performed here but ARE available elsewhere in the workspace. NEVER reply that something is impossible or "not supported by this assistant". Instead, call GuideToPageTool with the right destination and give the user a direct link to do it themselves:
+- Creating, editing, or DELETING a custom field DEFINITION (the field itself, not its value) -> destination "custom_fields". You CAN set custom field VALUES on records directly; you CANNOT create/rename/delete the field definitions -- link the user to manage them.
+- Importing many records at once from a file (bulk creation) -> the matching "import_*" destination.
+- Inviting or managing team members -> "team_members".
+GuideToPageTool returns a page URL (not a record id). You MAY render that URL as a markdown link, e.g. "You can manage those in [Custom Fields settings](URL)." This navigation link is the ONLY link you include in replies; Rule 6 (never expose record IDs) still applies to everything else.
 
 ## Formatting
 - Use markdown for rich text formatting
@@ -433,6 +441,7 @@ PROMPT;
             SearchCrmTool::class,
             GetCrmSummaryTool::class,
             ListTeamMembersTool::class,
+            GuideToPageTool::class,
 
             // Write tools
             ChatCreateCompanyTool::class,

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -18,6 +18,7 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Promptable;
 use Relaticle\Chat\Support\PromptText;
+use Relaticle\Chat\Tools\AggregateCrmTool;
 use Relaticle\Chat\Tools\Company\CreateCompanyTool as ChatCreateCompanyTool;
 use Relaticle\Chat\Tools\Company\DeleteCompanyTool as ChatDeleteCompanyTool;
 use Relaticle\Chat\Tools\Company\GetCompanyTool as ChatGetCompanyTool;
@@ -130,6 +131,7 @@ You are the Relaticle CRM Assistant, a helpful AI that helps users manage their 
 
 ## Capabilities
 You can read and search all CRM data (companies, people, opportunities, tasks, notes).
+You can aggregate pipeline data by stage or company (counts + total value) using AggregateCrmTool.
 You can propose creating, updating, or deleting CRM records -- but these require user approval.
 
 ## Rules
@@ -449,6 +451,7 @@ PROMPT;
             GetCrmSummaryTool::class,
             ListTeamMembersTool::class,
             GuideToPageTool::class,
+            AggregateCrmTool::class,
 
             // Write tools
             ChatCreateCompanyTool::class,

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -26,6 +26,7 @@ use Relaticle\Chat\Tools\Company\ListCompaniesTool as ChatListCompaniesTool;
 use Relaticle\Chat\Tools\Company\UpdateCompanyTool as ChatUpdateCompanyTool;
 use Relaticle\Chat\Tools\CustomField\AddCustomFieldOptionsTool;
 use Relaticle\Chat\Tools\CustomField\CreateCustomFieldTool;
+use Relaticle\Chat\Tools\CustomField\ListCustomFieldsTool;
 use Relaticle\Chat\Tools\CustomField\UpdateCustomFieldTool;
 use Relaticle\Chat\Tools\GetCrmSummaryTool;
 use Relaticle\Chat\Tools\GuideToPageTool;
@@ -135,6 +136,7 @@ You are the Relaticle CRM Assistant, a helpful AI that helps users manage their 
 ## Capabilities
 You can read and search all CRM data (companies, people, opportunities, tasks, notes).
 You can aggregate pipeline data by stage or company (counts + total value) using AggregateCrmTool.
+You can list the workspace's custom field definitions (ListCustomFieldsTool) — use it to answer "what custom fields do I have" and to look up a field's entity_type + code.
 You can propose creating, updating, or deleting CRM records -- but these require user approval.
 
 ## Rules
@@ -168,7 +170,7 @@ Records have core fields (set directly in the write tool schemas, e.g. a company
 ## No Dead Ends
 Some actions cannot be performed here but ARE available elsewhere in the workspace. NEVER reply that something is impossible or "not supported by this assistant". Instead, call GuideToPageTool with the right destination and give the user a direct link to do it themselves:
 - Custom field DEFINITIONS — creating, renaming, toggling active, or adding options:
-  - If the user is a team owner/admin: you CAN propose these operations via CreateCustomFieldTool, UpdateCustomFieldTool, and AddCustomFieldOptionsTool (all proposal-gated, require approval). Use them directly — do not escort an owner to the settings page for these operations. To update or add options to an EXISTING field, identify it by its `entity_type` and its `code` (the machine code shown in the custom_fields field list for that entity) — you do not need a numeric/internal ID.
+  - If the user is a team owner/admin: you CAN propose these operations via CreateCustomFieldTool, UpdateCustomFieldTool, and AddCustomFieldOptionsTool (all proposal-gated, require approval). Use them directly — do not escort an owner to the settings page for these operations. To update or add options to an EXISTING field, identify it by its `entity_type` and its `code` — you do not need a numeric/internal ID. If you don't already know the code, call ListCustomFieldsTool to look it up; never escort the user to settings just to find a field.
   - If the user is NOT a team owner: you CANNOT create or modify field definitions. Call GuideToPageTool with destination "custom_fields" so they can ask their team owner to do it.
   - DELETING a custom field definition: you CANNOT delete field definitions from chat (for any user). Call GuideToPageTool with destination "custom_fields" to escort the user there.
   - You CAN always set custom field VALUES on records directly (custom_fields parameter on create/update tools) — this is unrelated to field definition management.
@@ -457,6 +459,7 @@ PROMPT;
             SearchCrmTool::class,
             GetCrmSummaryTool::class,
             ListTeamMembersTool::class,
+            ListCustomFieldsTool::class,
             GuideToPageTool::class,
             AggregateCrmTool::class,
 

--- a/packages/Chat/src/Http/Controllers/ChatController.php
+++ b/packages/Chat/src/Http/Controllers/ChatController.php
@@ -28,6 +28,7 @@ use Relaticle\Chat\Services\AiModelResolver;
 use Relaticle\Chat\Services\CreditService;
 use Relaticle\Chat\Services\TipTapDocumentParser;
 use Relaticle\Chat\Support\LikePattern;
+use Relaticle\Chat\Support\RecordReferenceResolver;
 use Relaticle\Chat\Support\TitleSanitizer;
 
 final readonly class ChatController
@@ -288,7 +289,7 @@ final readonly class ChatController
         return response()->json(['superseded' => $superseded]);
     }
 
-    public function mentions(Request $request): JsonResponse
+    public function mentions(Request $request, RecordReferenceResolver $resolver): JsonResponse
     {
         $validated = $request->validate([
             'q' => ['required', 'string', 'min:2', 'max:100'],
@@ -315,7 +316,7 @@ final readonly class ChatController
                 ->get(['id', 'name', 'team_id'])
                 ->filter(fn (People $r): bool => $user->can('view', $r))
                 ->values()
-                ->map(fn (People $r): array => ['id' => $r->id, 'name' => $r->name, 'type' => 'people'])
+                ->map(fn (People $r): array => ['id' => $r->id, 'name' => $r->name, 'type' => 'people', 'url' => $resolver->urlFor('people', (string) $r->id)])
         );
 
         $results = $results->merge(
@@ -330,7 +331,7 @@ final readonly class ChatController
                 ->get(['id', 'name', 'team_id'])
                 ->filter(fn (Company $r): bool => $user->can('view', $r))
                 ->values()
-                ->map(fn (Company $r): array => ['id' => $r->id, 'name' => $r->name, 'type' => 'company'])
+                ->map(fn (Company $r): array => ['id' => $r->id, 'name' => $r->name, 'type' => 'company', 'url' => $resolver->urlFor('company', (string) $r->id)])
         );
 
         $results = $results->merge(
@@ -345,7 +346,7 @@ final readonly class ChatController
                 ->get(['id', 'name', 'team_id'])
                 ->filter(fn (Opportunity $r): bool => $user->can('view', $r))
                 ->values()
-                ->map(fn (Opportunity $r): array => ['id' => $r->id, 'name' => $r->name, 'type' => 'opportunity'])
+                ->map(fn (Opportunity $r): array => ['id' => $r->id, 'name' => $r->name, 'type' => 'opportunity', 'url' => $resolver->urlFor('opportunity', (string) $r->id)])
         );
 
         $results = $results->merge(
@@ -360,7 +361,7 @@ final readonly class ChatController
                 ->get(['id', 'title', 'team_id'])
                 ->filter(fn (Task $r): bool => $user->can('view', $r))
                 ->values()
-                ->map(fn (Task $r): array => ['id' => $r->id, 'name' => $r->title, 'type' => 'task'])
+                ->map(fn (Task $r): array => ['id' => $r->id, 'name' => $r->title, 'type' => 'task', 'url' => $resolver->urlFor('task', (string) $r->id)])
         );
 
         $results = $results->merge(
@@ -375,7 +376,7 @@ final readonly class ChatController
                 ->get(['id', 'title', 'team_id'])
                 ->filter(fn (Note $r): bool => $user->can('view', $r))
                 ->values()
-                ->map(fn (Note $r): array => ['id' => $r->id, 'name' => $r->title, 'type' => 'note'])
+                ->map(fn (Note $r): array => ['id' => $r->id, 'name' => $r->title, 'type' => 'note', 'url' => $resolver->urlFor('note', (string) $r->id)])
         );
 
         return response()->json(['data' => $results->take(15)->values()]);

--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -7,6 +7,9 @@ namespace Relaticle\Chat\Services;
 use App\Actions\Company\CreateCompany;
 use App\Actions\Company\DeleteCompany;
 use App\Actions\Company\UpdateCompany;
+use App\Actions\CustomFields\AddCustomFieldOptions;
+use App\Actions\CustomFields\CreateCustomField;
+use App\Actions\CustomFields\UpdateCustomField;
 use App\Actions\Note\CreateNote;
 use App\Actions\Note\DeleteNote;
 use App\Actions\Note\UpdateNote;
@@ -22,6 +25,7 @@ use App\Actions\Task\UpdateTask;
 use App\Enums\CreationSource;
 use App\Models\Company;
 use App\Models\Concerns\InvalidatesRelatedAiSummaries;
+use App\Models\CustomField;
 use App\Models\Note;
 use App\Models\Opportunity;
 use App\Models\People;
@@ -32,6 +36,7 @@ use Illuminate\Support\Facades\DB;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Enums\PendingActionStatus;
 use Relaticle\Chat\Models\PendingAction;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
 use Relaticle\CustomFields\Services\TenantContextService;
 use RuntimeException;
 
@@ -44,6 +49,7 @@ final readonly class PendingActionService
         Opportunity::class,
         Task::class,
         Note::class,
+        CustomField::class,
     ];
 
     /** @var list<class-string> */
@@ -63,6 +69,9 @@ final readonly class PendingActionService
         CreateNote::class,
         UpdateNote::class,
         DeleteNote::class,
+        CreateCustomField::class,
+        UpdateCustomField::class,
+        AddCustomFieldOptions::class,
     ];
 
     /**
@@ -633,9 +642,21 @@ final readonly class PendingActionService
 
         throw_if(! is_string($recordId) && ! is_int($recordId), RuntimeException::class, 'Missing or invalid _record_id in action data');
 
-        return $modelClass::query()
-            ->where('team_id', $pendingAction->team_id)
-            ->findOrFail($recordId);
+        // CustomField uses tenant_id (from the custom-fields package) rather than the
+        // team_id column used by all other CRM models. Scope the lookup accordingly.
+        $tenantColumn = $modelClass === CustomField::class
+            ? (string) config('custom-fields.database.column_names.tenant_foreign_key', 'tenant_id')
+            : 'team_id';
+
+        $query = $modelClass::query()->where($tenantColumn, $pendingAction->team_id);
+
+        // CustomField has a global active scope that would exclude deactivated fields;
+        // skip it so an update-to-deactivate proposal can find the field regardless.
+        if ($modelClass === CustomField::class) {
+            $query->withoutGlobalScope(CustomFieldsActivableScope::class);
+        }
+
+        return $query->findOrFail($recordId);
     }
 
     /**

--- a/packages/Chat/src/Support/DestinationResolver.php
+++ b/packages/Chat/src/Support/DestinationResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Support;
+
+use App\Filament\Pages\EditTeam;
+use App\Models\Team;
+use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
+use Relaticle\ImportWizard\Filament\Pages\ImportCompanies;
+use Relaticle\ImportWizard\Filament\Pages\ImportNotes;
+use Relaticle\ImportWizard\Filament\Pages\ImportOpportunities;
+use Relaticle\ImportWizard\Filament\Pages\ImportPeople;
+use Relaticle\ImportWizard\Filament\Pages\ImportTasks;
+use Throwable;
+
+final readonly class DestinationResolver
+{
+    /** @var list<string> */
+    public const array DESTINATIONS = [
+        'custom_fields',
+        'import_companies',
+        'import_people',
+        'import_opportunities',
+        'import_tasks',
+        'import_notes',
+        'team_members',
+    ];
+
+    /**
+     * Resolve a destination key to an absolute app-panel URL for the given team.
+     *
+     * Passes the panel and tenant explicitly so this works inside the queued chat
+     * job, where no Filament panel/tenant is bound. Returns null when the
+     * destination is unknown or the URL cannot be built.
+     */
+    public function resolve(string $destination, Team $team): ?string
+    {
+        try {
+            return match ($destination) {
+                'custom_fields' => CustomFieldsManagementPage::getUrl(panel: 'app', tenant: $team),
+                'import_companies' => ImportCompanies::getUrl(panel: 'app', tenant: $team),
+                'import_people' => ImportPeople::getUrl(panel: 'app', tenant: $team),
+                'import_opportunities' => ImportOpportunities::getUrl(panel: 'app', tenant: $team),
+                'import_tasks' => ImportTasks::getUrl(panel: 'app', tenant: $team),
+                'import_notes' => ImportNotes::getUrl(panel: 'app', tenant: $team),
+                'team_members' => EditTeam::getUrl(panel: 'app', tenant: $team),
+                default => null,
+            };
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/packages/Chat/src/Support/RecordReferenceResolver.php
+++ b/packages/Chat/src/Support/RecordReferenceResolver.php
@@ -47,6 +47,22 @@ final readonly class RecordReferenceResolver
      */
     public function resolve(string $entityType, string $recordId): ?array
     {
+        $url = $this->urlFor($entityType, $recordId);
+
+        if ($url === null) {
+            return null;
+        }
+
+        return [
+            'id' => $recordId,
+            'type' => $entityType,
+            'url' => $url,
+            'label' => $this->resolveLabel($entityType, $recordId),
+        ];
+    }
+
+    public function urlFor(string $entityType, string $recordId): ?string
+    {
         $authUser = auth()->user();
 
         if (! $authUser instanceof User) {
@@ -60,7 +76,7 @@ final readonly class RecordReferenceResolver
         }
 
         try {
-            $url = match ($entityType) {
+            return match ($entityType) {
                 'company' => CompanyResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
                 'people' => PeopleResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
                 'opportunity' => OpportunityResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
@@ -71,17 +87,6 @@ final readonly class RecordReferenceResolver
         } catch (Throwable) {
             return null;
         }
-
-        if ($url === null) {
-            return null;
-        }
-
-        return [
-            'id' => $recordId,
-            'type' => $entityType,
-            'url' => $url,
-            'label' => $this->resolveLabel($entityType, $recordId),
-        ];
     }
 
     private function resolveLabel(string $entityType, string $recordId): ?string

--- a/packages/Chat/src/Support/RecordReferenceResolver.php
+++ b/packages/Chat/src/Support/RecordReferenceResolver.php
@@ -14,6 +14,7 @@ use App\Models\Note;
 use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\Task;
+use App\Models\User;
 use Throwable;
 
 final readonly class RecordReferenceResolver
@@ -46,13 +47,25 @@ final readonly class RecordReferenceResolver
      */
     public function resolve(string $entityType, string $recordId): ?array
     {
+        $authUser = auth()->user();
+
+        if (! $authUser instanceof User) {
+            return null;
+        }
+
+        $team = $authUser->currentTeam;
+
+        if ($team === null) {
+            return null;
+        }
+
         try {
             $url = match ($entityType) {
-                'company' => CompanyResource::getUrl('view', ['record' => $recordId]),
-                'people' => PeopleResource::getUrl('view', ['record' => $recordId]),
-                'opportunity' => OpportunityResource::getUrl('view', ['record' => $recordId]),
-                'task' => TaskResource::getUrl('index'),
-                'note' => NoteResource::getUrl('index'),
+                'company' => CompanyResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
+                'people' => PeopleResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
+                'opportunity' => OpportunityResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
+                'task' => TaskResource::getUrl('index', panel: 'app', tenant: $team),
+                'note' => NoteResource::getUrl('index', panel: 'app', tenant: $team),
                 default => null,
             };
         } catch (Throwable) {

--- a/packages/Chat/src/Tools/AggregateCrmTool.php
+++ b/packages/Chat/src/Tools/AggregateCrmTool.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools;
+
+use App\Actions\Opportunity\AggregateOpportunities;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class AggregateCrmTool implements Tool
+{
+    public function description(): string
+    {
+        return 'Aggregate opportunities by stage or company: count and total pipeline value per group, with optional date range. Use for "pipeline by stage", "deals by company", "total value", "how many deals" questions.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'group_by' => $schema->string()->description('How to group results. Use "stage" to see pipeline by deal stage, or "company" to see deals grouped by company.'),
+            'date_from' => $schema->string()->description('Optional start date (YYYY-MM-DD). Only include opportunities created on or after this date.'),
+            'date_to' => $schema->string()->description('Optional end date (YYYY-MM-DD). Only include opportunities created on or before this date.'),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        $groupBy = (string) ($request['group_by'] ?? 'stage');
+        $dateFrom = isset($request['date_from']) && is_string($request['date_from']) ? $request['date_from'] : null;
+        $dateTo = isset($request['date_to']) && is_string($request['date_to']) ? $request['date_to'] : null;
+
+        try {
+            $result = resolve(AggregateOpportunities::class)->execute(
+                user: $user,
+                groupBy: $groupBy,
+                dateFrom: $dateFrom,
+                dateTo: $dateTo,
+            );
+        } catch (HttpException $e) {
+            return (string) json_encode(['error' => $e->getMessage()]);
+        }
+
+        return (string) json_encode($result, JSON_PRETTY_PRINT);
+    }
+}

--- a/packages/Chat/src/Tools/BaseReadListTool.php
+++ b/packages/Chat/src/Tools/BaseReadListTool.php
@@ -18,8 +18,6 @@ abstract class BaseReadListTool implements Tool
 {
     use NormalizesToolInput;
 
-    public function __construct(protected RecordReferenceResolver $recordReferenceResolver) {}
-
     /** @return class-string */
     abstract protected function actionClass(): string;
 
@@ -96,7 +94,7 @@ abstract class BaseReadListTool implements Tool
                 : null;
 
             $ref = $id !== null
-                ? $this->recordReferenceResolver->resolve($citationType, $id)
+                ? resolve(RecordReferenceResolver::class)->resolve($citationType, $id)
                 : null;
 
             $item['url'] = $ref['url'] ?? null;

--- a/packages/Chat/src/Tools/BaseReadListTool.php
+++ b/packages/Chat/src/Tools/BaseReadListTool.php
@@ -10,12 +10,15 @@ use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Support\RecordReferenceResolver;
 use Relaticle\Chat\Tools\Concerns\NormalizesToolInput;
 use Spatie\QueryBuilder\Exceptions\InvalidQuery;
 
 abstract class BaseReadListTool implements Tool
 {
     use NormalizesToolInput;
+
+    public function __construct(protected RecordReferenceResolver $recordReferenceResolver) {}
 
     /** @return class-string */
     abstract protected function actionClass(): string;
@@ -24,6 +27,8 @@ abstract class BaseReadListTool implements Tool
     abstract protected function resourceClass(): string;
 
     abstract protected function searchFilterName(): string;
+
+    abstract protected function citationType(): string;
 
     abstract public function description(): string;
 
@@ -74,7 +79,32 @@ abstract class BaseReadListTool implements Tool
         $resourceClass = $this->resourceClass();
         $collection = $resourceClass::collection($results);
 
-        return $collection->toJson(JSON_PRETTY_PRINT);
+        $items = json_decode($collection->toJson(), true);
+
+        if (! is_array($items)) {
+            return $collection->toJson(JSON_PRETTY_PRINT);
+        }
+
+        $citationType = $this->citationType();
+        $items = array_map(function (mixed $item) use ($citationType): mixed {
+            if (! is_array($item)) {
+                return $item;
+            }
+
+            $id = isset($item['id']) && (is_string($item['id']) || is_int($item['id']))
+                ? (string) $item['id']
+                : null;
+
+            $ref = $id !== null
+                ? $this->recordReferenceResolver->resolve($citationType, $id)
+                : null;
+
+            $item['url'] = $ref['url'] ?? null;
+
+            return $item;
+        }, $items);
+
+        return (string) json_encode($items, JSON_PRETTY_PRINT);
     }
 
     private function buildHttpRequest(Request $request): HttpRequest

--- a/packages/Chat/src/Tools/BaseReadShowTool.php
+++ b/packages/Chat/src/Tools/BaseReadShowTool.php
@@ -10,9 +10,12 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Support\RecordReferenceResolver;
 
 abstract class BaseReadShowTool implements Tool
 {
+    public function __construct(protected RecordReferenceResolver $recordReferenceResolver) {}
+
     /** @return class-string<Model> */
     abstract protected function modelClass(): string;
 
@@ -20,6 +23,8 @@ abstract class BaseReadShowTool implements Tool
     abstract protected function resourceClass(): string;
 
     abstract protected function entityLabel(): string;
+
+    abstract protected function citationType(): string;
 
     abstract public function description(): string;
 
@@ -65,8 +70,11 @@ abstract class BaseReadShowTool implements Tool
 
         $payload = new $resourceClass($model)->resolve();
 
+        $id = (string) $model->getKey();
+        $ref = $this->recordReferenceResolver->resolve($this->citationType(), $id);
+
         return (string) json_encode(
-            array_merge($payload, $this->extraPayload($model)),
+            array_merge($payload, $this->extraPayload($model), ['url' => $ref['url'] ?? null]),
             JSON_PRETTY_PRINT,
         );
     }

--- a/packages/Chat/src/Tools/BaseReadShowTool.php
+++ b/packages/Chat/src/Tools/BaseReadShowTool.php
@@ -14,8 +14,6 @@ use Relaticle\Chat\Support\RecordReferenceResolver;
 
 abstract class BaseReadShowTool implements Tool
 {
-    public function __construct(protected RecordReferenceResolver $recordReferenceResolver) {}
-
     /** @return class-string<Model> */
     abstract protected function modelClass(): string;
 
@@ -71,7 +69,7 @@ abstract class BaseReadShowTool implements Tool
         $payload = new $resourceClass($model)->resolve();
 
         $id = (string) $model->getKey();
-        $ref = $this->recordReferenceResolver->resolve($this->citationType(), $id);
+        $ref = resolve(RecordReferenceResolver::class)->resolve($this->citationType(), $id);
 
         return (string) json_encode(
             array_merge($payload, $this->extraPayload($model), ['url' => $ref['url'] ?? null]),

--- a/packages/Chat/src/Tools/BaseWriteCreateTool.php
+++ b/packages/Chat/src/Tools/BaseWriteCreateTool.php
@@ -21,8 +21,6 @@ abstract class BaseWriteCreateTool implements Tool
 {
     use WithConversationContext;
 
-    private const int MAX_BATCH_SIZE = 25;
-
     /** @return class-string */
     abstract protected function actionClass(): string;
 
@@ -75,7 +73,7 @@ abstract class BaseWriteCreateTool implements Tool
                 ->required()
                 ->description(
                     "The {$this->entityType()} records to create. Pass ONE item for a single record,"
-                    .' or up to '.self::MAX_BATCH_SIZE.' items to create them all in ONE proposal'
+                    .' or up to '.config('chat.max_batch_size').' items to create them all in ONE proposal'
                     .' (never loop one call per record).',
                 ),
             'plan' => $schema->object([
@@ -97,8 +95,10 @@ abstract class BaseWriteCreateTool implements Tool
             return (string) json_encode(['error' => 'Provide `records` — a non-empty array of records to create.']);
         }
 
-        if (count($records) > self::MAX_BATCH_SIZE) {
-            return (string) json_encode(['error' => 'Too many records — at most '.self::MAX_BATCH_SIZE.' per proposal.']);
+        $maxBatchSize = (int) config('chat.max_batch_size');
+
+        if (count($records) > $maxBatchSize) {
+            return (string) json_encode(['error' => "Too many records — at most {$maxBatchSize} per proposal."]);
         }
 
         $validator = resolve(CustomFieldsRequestValidator::class);

--- a/packages/Chat/src/Tools/BaseWriteDeleteTool.php
+++ b/packages/Chat/src/Tools/BaseWriteDeleteTool.php
@@ -57,6 +57,12 @@ abstract class BaseWriteDeleteTool implements Tool
             return (string) json_encode(['error' => 'Provide `ids` (a non-empty array) of records to delete.']);
         }
 
+        $maxBatchSize = (int) config('chat.max_batch_size');
+
+        if (count($requestedIds) > $maxBatchSize) {
+            return (string) json_encode(['error' => "Too many records — at most {$maxBatchSize} per proposal."]);
+        }
+
         /** @var Collection<int, Model> $models */
         $models = $this->modelClass()::query()
             ->whereBelongsTo($user->currentTeam)

--- a/packages/Chat/src/Tools/Company/GetCompanyTool.php
+++ b/packages/Chat/src/Tools/Company/GetCompanyTool.php
@@ -31,6 +31,11 @@ final class GetCompanyTool extends BaseReadShowTool
         return 'Company';
     }
 
+    protected function citationType(): string
+    {
+        return 'company';
+    }
+
     protected function eagerLoad(): array
     {
         return [...parent::eagerLoad(), 'accountOwner'];

--- a/packages/Chat/src/Tools/Company/ListCompaniesTool.php
+++ b/packages/Chat/src/Tools/Company/ListCompaniesTool.php
@@ -6,6 +6,8 @@ namespace Relaticle\Chat\Tools\Company;
 
 use App\Actions\Company\ListCompanies;
 use App\Http\Resources\V1\CompanyResource;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Tools\BaseReadListTool;
 
 final class ListCompaniesTool extends BaseReadListTool
@@ -28,6 +30,24 @@ final class ListCompaniesTool extends BaseReadListTool
     protected function searchFilterName(): string
     {
         return 'name';
+    }
+
+    /** @return array<string, mixed> */
+    protected function additionalSchema(JsonSchema $schema): array
+    {
+        return [
+            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    protected function additionalFilters(Request $request): array
+    {
+        return array_filter([
+            'created_after' => $request['created_after'] ?? null,
+            'created_before' => $request['created_before'] ?? null,
+        ]);
     }
 
     protected function citationType(): string

--- a/packages/Chat/src/Tools/Company/ListCompaniesTool.php
+++ b/packages/Chat/src/Tools/Company/ListCompaniesTool.php
@@ -29,4 +29,9 @@ final class ListCompaniesTool extends BaseReadListTool
     {
         return 'name';
     }
+
+    protected function citationType(): string
+    {
+        return 'company';
+    }
 }

--- a/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
+++ b/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
@@ -14,11 +14,12 @@ use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Services\PendingActionService;
 use Relaticle\Chat\Tools\Concerns\WithConversationContext;
-use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\Chat\Tools\CustomField\Concerns\ResolvesOwnedCustomField;
 use Relaticle\CustomFields\Services\TenantContextService;
 
 final class AddCustomFieldOptionsTool implements Tool
 {
+    use ResolvesOwnedCustomField;
     use WithConversationContext;
 
     public function name(): string
@@ -34,8 +35,11 @@ final class AddCustomFieldOptionsTool implements Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'id' => $schema->string()
-                ->description('The custom field ID to add options to.')
+            'entity_type' => $schema->string()
+                ->description('The CRM entity the field belongs to: company, people, opportunity, task, or note.')
+                ->required(),
+            'code' => $schema->string()
+                ->description('The machine code of the choice-type custom field to add options to, as shown in the custom_fields field list for that entity (e.g. "industry").')
                 ->required(),
             'options' => $schema->array()
                 ->items($schema->object([
@@ -57,10 +61,11 @@ final class AddCustomFieldOptionsTool implements Tool
             ]);
         }
 
-        $id = (string) ($request['id'] ?? '');
+        $entityType = (string) ($request['entity_type'] ?? '');
+        $code = (string) ($request['code'] ?? '');
 
-        if ($id === '') {
-            return (string) json_encode(['error' => 'Field ID is required.']);
+        if ($entityType === '' || $code === '') {
+            return (string) json_encode(['error' => 'Both entity_type and code are required to identify the field.']);
         }
 
         $options = is_array($request['options'] ?? null) ? $request['options'] : [];
@@ -70,20 +75,10 @@ final class AddCustomFieldOptionsTool implements Tool
         }
 
         $teamId = $user->currentTeam->getKey();
-        $previousTenantId = TenantContextService::getCurrentTenantId();
-        TenantContextService::setTenantId($teamId);
-
-        try {
-            $field = CustomField::query()
-                ->withoutGlobalScope(CustomFieldsActivableScope::class)
-                ->where('tenant_id', $teamId)
-                ->find($id);
-        } finally {
-            TenantContextService::setTenantId($previousTenantId);
-        }
+        $field = $this->resolveOwnedCustomField($teamId, $entityType, $code);
 
         if (! $field instanceof CustomField) {
-            return (string) json_encode(['error' => "Custom field with ID [{$id}] not found."]);
+            return (string) json_encode(['error' => "No custom field with code \"{$code}\" found on {$entityType}."]);
         }
 
         if (! in_array($field->type, CreateCustomField::CHOICE_TYPES, true)) {

--- a/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
+++ b/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
@@ -105,7 +105,7 @@ final class AddCustomFieldOptionsTool implements Tool
 
         if (($existingCount + count($options)) > $maxOptions) {
             return (string) json_encode([
-                'error' => "Adding {$maxOptions} more options would exceed the {$maxOptions} options limit for this field (currently has {$existingCount}).",
+                'error' => 'Adding '.count($options)." more options would exceed the {$maxOptions} options limit for this field (currently has {$existingCount}).",
             ]);
         }
 

--- a/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
+++ b/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools\CustomField;
+
+use App\Actions\CustomFields\AddCustomFieldOptions;
+use App\Actions\CustomFields\CreateCustomField;
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\Concerns\WithConversationContext;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+final class AddCustomFieldOptionsTool implements Tool
+{
+    use WithConversationContext;
+
+    public function name(): string
+    {
+        return 'AddCustomFieldOptionsTool';
+    }
+
+    public function description(): string
+    {
+        return 'Propose adding new options to an existing choice-type custom field (select, multi-select, radio, checkbox-list, toggle-buttons). Admin-only. Returns a proposal for user approval.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'id' => $schema->string()
+                ->description('The custom field ID to add options to.')
+                ->required(),
+            'options' => $schema->array()
+                ->items($schema->object([
+                    'name' => $schema->string()->description('The option label.')->required(),
+                ]))
+                ->description('The new options to append to the field.')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        if (! $user->ownsTeam($user->currentTeam)) {
+            return (string) json_encode([
+                'error' => 'Only team owners can manage custom field options.',
+            ]);
+        }
+
+        $id = (string) ($request['id'] ?? '');
+
+        if ($id === '') {
+            return (string) json_encode(['error' => 'Field ID is required.']);
+        }
+
+        $options = is_array($request['options'] ?? null) ? $request['options'] : [];
+
+        if ($options === []) {
+            return (string) json_encode(['error' => 'At least one option must be provided.']);
+        }
+
+        $teamId = $user->currentTeam->getKey();
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            $field = CustomField::query()
+                ->withoutGlobalScope(CustomFieldsActivableScope::class)
+                ->where('tenant_id', $teamId)
+                ->find($id);
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+
+        if (! $field instanceof CustomField) {
+            return (string) json_encode(['error' => "Custom field with ID [{$id}] not found."]);
+        }
+
+        if (! in_array($field->type, CreateCustomField::CHOICE_TYPES, true)) {
+            return (string) json_encode([
+                'error' => "Field type \"{$field->type}\" does not support options. Only select, multi-select, radio, checkbox-list, and toggle-buttons fields can have options added.",
+            ]);
+        }
+
+        $maxOptions = (int) config('chat.max_field_options', 50);
+
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            $existingCount = $field->options()->withoutGlobalScopes()->count();
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+
+        if (($existingCount + count($options)) > $maxOptions) {
+            return (string) json_encode([
+                'error' => "Adding {$maxOptions} more options would exceed the {$maxOptions} options limit for this field (currently has {$existingCount}).",
+            ]);
+        }
+
+        $optionNames = array_map(
+            static fn (mixed $o): string => is_array($o) ? (string) ($o['name'] ?? '') : (string) $o,
+            $options,
+        );
+
+        $actionData = [
+            '_record_id' => $field->getKey(),
+            'options' => $options,
+        ];
+
+        $displayData = [
+            'title' => 'Add Custom Field Options',
+            'summary' => "Add options to \"{$field->name}\": ".implode(', ', $optionNames),
+            'fields' => [
+                ['label' => 'Field', 'value' => $field->name],
+                ['label' => 'New Options', 'value' => implode(', ', $optionNames)],
+            ],
+        ];
+
+        $pending = resolve(PendingActionService::class)->createProposal(
+            user: $user,
+            conversationId: $this->resolveConversationId(),
+            actionClass: AddCustomFieldOptions::class,
+            operation: PendingActionOperation::Create,
+            entityType: 'custom_field',
+            actionData: $actionData,
+            displayData: $displayData,
+        );
+
+        return (string) json_encode([
+            'type' => 'pending_action',
+            'pending_action_id' => $pending->id,
+            'action' => 'AddCustomFieldOptions',
+            'entity_type' => 'custom_field',
+            'operation' => 'create',
+            'data' => $pending->action_data,
+            'display' => $pending->display_data,
+            'meta' => ['agent_should_stop' => true],
+        ], JSON_PRETTY_PRINT);
+    }
+}

--- a/packages/Chat/src/Tools/CustomField/Concerns/ResolvesOwnedCustomField.php
+++ b/packages/Chat/src/Tools/CustomField/Concerns/ResolvesOwnedCustomField.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools\CustomField\Concerns;
+
+use App\Models\CustomField;
+use Relaticle\CustomFields\Models\CustomField as BaseCustomField;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+trait ResolvesOwnedCustomField
+{
+    /**
+     * Resolve a custom field definition owned by the team, identified by its
+     * entity type and machine code. Deactivated fields are included so they can
+     * still be managed. Returns null when no matching field exists.
+     */
+    private function resolveOwnedCustomField(int|string $teamId, string $entityType, string $code): ?BaseCustomField
+    {
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            return CustomField::query()
+                ->withoutGlobalScope(CustomFieldsActivableScope::class)
+                ->where('tenant_id', $teamId)
+                ->where('entity_type', $entityType)
+                ->where('code', $code)
+                ->first();
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+    }
+}

--- a/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
+++ b/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools\CustomField;
+
+use App\Actions\CustomFields\CreateCustomField;
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\Concerns\WithConversationContext;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+
+final class CreateCustomFieldTool implements Tool
+{
+    use WithConversationContext;
+
+    public function name(): string
+    {
+        return 'CreateCustomFieldTool';
+    }
+
+    public function description(): string
+    {
+        return 'Propose creating a new custom field definition on a CRM entity. Admin-only — returns an error for non-owners. Returns a proposal for user approval.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        $allowedTypes = implode(', ', CreateCustomField::ALLOWED_TYPES);
+
+        return [
+            'entity_type' => $schema->string()
+                ->description('The CRM entity to add the field to: company, people, opportunity, task, or note.')
+                ->required(),
+            'name' => $schema->string()
+                ->description('The display name for the field (e.g. "Industry", "Priority").')
+                ->required(),
+            'type' => $schema->string()
+                ->description("The field type. Allowed: {$allowedTypes}. NOT allowed: file-upload, record, rich-editor, markdown-editor, currency.")
+                ->required(),
+            'code' => $schema->string()
+                ->description('Optional machine-readable code (snake_case). Auto-generated from name if omitted.'),
+            'options' => $schema->array()
+                ->items($schema->object([
+                    'name' => $schema->string()->description('The option label.')->required(),
+                ]))
+                ->description('Required for choice types (select, multi-select, radio, checkbox-list, toggle-buttons). Must not be provided for other types.'),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        if (! $user->ownsTeam($user->currentTeam)) {
+            return (string) json_encode([
+                'error' => 'Only team owners can create custom field definitions. I can guide you to the Custom Fields settings page if you want to ask your team owner to do this.',
+            ]);
+        }
+
+        $type = (string) ($request['type'] ?? '');
+
+        if (! in_array($type, CreateCustomField::ALLOWED_TYPES, true)) {
+            return (string) json_encode([
+                'error' => "Field type \"{$type}\" is not supported via chat. Allowed types: ".implode(', ', CreateCustomField::ALLOWED_TYPES).'.',
+            ]);
+        }
+
+        $isChoiceType = in_array($type, CreateCustomField::CHOICE_TYPES, true);
+
+        $options = is_array($request['options'] ?? null) ? $request['options'] : [];
+
+        if ($isChoiceType && $options === []) {
+            return (string) json_encode([
+                'error' => "Field type \"{$type}\" requires at least one option. Please provide an options array with at least one {\"name\": \"...\"} entry.",
+            ]);
+        }
+
+        if (! $isChoiceType && $options !== []) {
+            return (string) json_encode([
+                'error' => "Field type \"{$type}\" does not support options.",
+            ]);
+        }
+
+        $entityType = (string) ($request['entity_type'] ?? '');
+
+        if (! in_array($entityType, CreateCustomField::VALID_ENTITY_TYPES, true)) {
+            return (string) json_encode([
+                'error' => 'Invalid entity type "'.htmlspecialchars($entityType, ENT_QUOTES, 'UTF-8').'". Must be one of: '.implode(', ', CreateCustomField::VALID_ENTITY_TYPES).'.',
+            ]);
+        }
+
+        $maxFields = (int) config('chat.max_custom_fields_per_entity', 50);
+        $teamId = $user->currentTeam->getKey();
+        $existingCount = CustomField::query()
+            ->withoutGlobalScope(CustomFieldsActivableScope::class)
+            ->where('tenant_id', $teamId)
+            ->where('entity_type', $entityType)
+            ->count();
+
+        if ($existingCount >= $maxFields) {
+            return (string) json_encode([
+                'error' => "Cannot create more than {$maxFields} custom fields for entity type \"{$entityType}\".",
+            ]);
+        }
+
+        if ($isChoiceType) {
+            $maxOptions = (int) config('chat.max_field_options', 50);
+            if (count($options) > $maxOptions) {
+                return (string) json_encode([
+                    'error' => "Too many options — at most {$maxOptions} per field.",
+                ]);
+            }
+        }
+
+        $name = (string) ($request['name'] ?? '');
+        $code = (string) ($request['code'] ?? '');
+
+        $actionData = array_filter([
+            'entity_type' => $entityType,
+            'name' => $name,
+            'type' => $type,
+            'code' => $code !== '' ? $code : null,
+            'options' => $options !== [] ? $options : null,
+        ], fn (mixed $v): bool => $v !== null);
+
+        $optionsSummary = $options !== []
+            ? ' with options: '.implode(', ', array_map(static fn (mixed $o): string => is_array($o) ? (string) ($o['name'] ?? '') : (string) $o, $options))
+            : '';
+
+        $displayFields = [
+            ['label' => 'Entity', 'value' => $entityType],
+            ['label' => 'Name', 'value' => $name],
+            ['label' => 'Type', 'value' => $type],
+        ];
+
+        if ($code !== '') {
+            $displayFields[] = ['label' => 'Code', 'value' => $code];
+        }
+
+        if ($options !== []) {
+            $displayFields[] = [
+                'label' => 'Options',
+                'value' => implode(', ', array_map(static fn (mixed $o): string => is_array($o) ? (string) ($o['name'] ?? '') : (string) $o, $options)),
+            ];
+        }
+
+        $displayData = [
+            'title' => 'Create Custom Field',
+            'summary' => "Create \"{$name}\" ({$type}) on {$entityType}{$optionsSummary}",
+            'fields' => $displayFields,
+        ];
+
+        $pending = resolve(PendingActionService::class)->createProposal(
+            user: $user,
+            conversationId: $this->resolveConversationId(),
+            actionClass: CreateCustomField::class,
+            operation: PendingActionOperation::Create,
+            entityType: 'custom_field',
+            actionData: $actionData,
+            displayData: $displayData,
+        );
+
+        return (string) json_encode([
+            'type' => 'pending_action',
+            'pending_action_id' => $pending->id,
+            'action' => 'CreateCustomField',
+            'entity_type' => 'custom_field',
+            'operation' => 'create',
+            'data' => $pending->action_data,
+            'display' => $pending->display_data,
+            'meta' => ['agent_should_stop' => true],
+        ], JSON_PRETTY_PRINT);
+    }
+}

--- a/packages/Chat/src/Tools/CustomField/ListCustomFieldsTool.php
+++ b/packages/Chat/src/Tools/CustomField/ListCustomFieldsTool.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools\CustomField;
+
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\Eloquent\Builder;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+final class ListCustomFieldsTool implements Tool
+{
+    public function description(): string
+    {
+        return 'List the custom field definitions configured for this workspace, optionally filtered to one'
+            .' entity type. Returns each field\'s entity_type, name, code, type, active status, whether it is'
+            .' system-defined, and its options (for choice-type fields). Use this to answer "what custom fields'
+            .' do I have" and to find a field\'s entity_type + code before proposing an update or adding options.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'entity_type' => $schema->string()
+                ->description('Optional filter by entity: company, people, opportunity, task, or note.'),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $teamId = $user->currentTeam->getKey();
+
+        $entityType = isset($request['entity_type']) && is_string($request['entity_type']) && $request['entity_type'] !== ''
+            ? $request['entity_type']
+            : null;
+
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            $fields = CustomField::query()
+                ->withoutGlobalScope(CustomFieldsActivableScope::class)
+                ->where('tenant_id', $teamId)
+                ->when($entityType !== null, fn (Builder $query) => $query->where('entity_type', $entityType))
+                ->with(['options:id,custom_field_id,name'])
+                ->orderBy('entity_type')
+                ->orderBy('sort_order')
+                ->get();
+
+            $data = [];
+            foreach ($fields as $field) {
+                $data[] = [
+                    'entity_type' => $field->entity_type,
+                    'name' => $field->name,
+                    'code' => $field->code,
+                    'type' => $field->type,
+                    'active' => (bool) $field->active,
+                    'system_defined' => $field->isSystemDefined(),
+                    'options' => $field->options->pluck('name')->values()->all(),
+                ];
+            }
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+
+        return (string) json_encode([
+            'custom_fields' => $data,
+            'note' => 'System-defined fields cannot be modified from chat. To update or add options to a field, use its entity_type + code.',
+        ], JSON_PRETTY_PRINT);
+    }
+}

--- a/packages/Chat/src/Tools/CustomField/UpdateCustomFieldTool.php
+++ b/packages/Chat/src/Tools/CustomField/UpdateCustomFieldTool.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools\CustomField;
+
+use App\Actions\CustomFields\UpdateCustomField;
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\Concerns\WithConversationContext;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+final class UpdateCustomFieldTool implements Tool
+{
+    use WithConversationContext;
+
+    public function name(): string
+    {
+        return 'UpdateCustomFieldTool';
+    }
+
+    public function description(): string
+    {
+        return 'Propose renaming a custom field or toggling its active status. Admin-only. Cannot modify system-defined fields. Returns a proposal for user approval.';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'id' => $schema->string()
+                ->description('The custom field ID to update.')
+                ->required(),
+            'name' => $schema->string()
+                ->description('The new display name for the field.'),
+            'active' => $schema->boolean()
+                ->description('Set to false to deactivate the field, or true to reactivate it.'),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        if (! $user->ownsTeam($user->currentTeam)) {
+            return (string) json_encode([
+                'error' => 'Only team owners can update custom field definitions.',
+            ]);
+        }
+
+        $id = (string) ($request['id'] ?? '');
+
+        if ($id === '') {
+            return (string) json_encode(['error' => 'Field ID is required.']);
+        }
+
+        $teamId = $user->currentTeam->getKey();
+        $previousTenantId = TenantContextService::getCurrentTenantId();
+        TenantContextService::setTenantId($teamId);
+
+        try {
+            $field = CustomField::query()
+                ->withoutGlobalScope(CustomFieldsActivableScope::class)
+                ->where('tenant_id', $teamId)
+                ->find($id);
+        } finally {
+            TenantContextService::setTenantId($previousTenantId);
+        }
+
+        if (! $field instanceof CustomField) {
+            return (string) json_encode(['error' => "Custom field with ID [{$id}] not found."]);
+        }
+
+        if ($field->isSystemDefined()) {
+            return (string) json_encode(['error' => 'System-defined custom fields cannot be modified.']);
+        }
+
+        $newName = ($request['name'] ?? null) !== null ? (string) $request['name'] : null;
+        $newActive = ($request['active'] ?? null) !== null ? (bool) $request['active'] : null;
+
+        if ($newName === null && $newActive === null) {
+            return (string) json_encode(['error' => 'Provide at least one of: name, active.']);
+        }
+
+        $actionData = [
+            '_record_id' => $field->getKey(),
+            '_model_class' => CustomField::class,
+        ];
+
+        $displayFields = [];
+
+        if ($newName !== null) {
+            $actionData['name'] = $newName;
+            $displayFields[] = ['label' => 'Name', 'old' => $field->name, 'new' => $newName];
+        }
+
+        if ($newActive !== null) {
+            $actionData['active'] = $newActive;
+            $displayFields[] = [
+                'label' => 'Active',
+                'old' => $field->active ? 'Yes' : 'No',
+                'new' => $newActive ? 'Yes' : 'No',
+            ];
+        }
+
+        $displayData = [
+            'title' => 'Update Custom Field',
+            'summary' => "Update custom field \"{$field->name}\"",
+            'fields' => $displayFields,
+        ];
+
+        $pending = resolve(PendingActionService::class)->createProposal(
+            user: $user,
+            conversationId: $this->resolveConversationId(),
+            actionClass: UpdateCustomField::class,
+            operation: PendingActionOperation::Update,
+            entityType: 'custom_field',
+            actionData: $actionData,
+            displayData: $displayData,
+        );
+
+        return (string) json_encode([
+            'type' => 'pending_action',
+            'pending_action_id' => $pending->id,
+            'action' => 'UpdateCustomField',
+            'entity_type' => 'custom_field',
+            'operation' => 'update',
+            'data' => array_diff_key($pending->action_data, array_flip(['_record_id', '_model_class'])),
+            'display' => $pending->display_data,
+            'meta' => ['agent_should_stop' => true],
+        ], JSON_PRETTY_PRINT);
+    }
+}

--- a/packages/Chat/src/Tools/CustomField/UpdateCustomFieldTool.php
+++ b/packages/Chat/src/Tools/CustomField/UpdateCustomFieldTool.php
@@ -13,11 +13,11 @@ use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Services\PendingActionService;
 use Relaticle\Chat\Tools\Concerns\WithConversationContext;
-use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
-use Relaticle\CustomFields\Services\TenantContextService;
+use Relaticle\Chat\Tools\CustomField\Concerns\ResolvesOwnedCustomField;
 
 final class UpdateCustomFieldTool implements Tool
 {
+    use ResolvesOwnedCustomField;
     use WithConversationContext;
 
     public function name(): string
@@ -33,8 +33,11 @@ final class UpdateCustomFieldTool implements Tool
     public function schema(JsonSchema $schema): array
     {
         return [
-            'id' => $schema->string()
-                ->description('The custom field ID to update.')
+            'entity_type' => $schema->string()
+                ->description('The CRM entity the field belongs to: company, people, opportunity, task, or note.')
+                ->required(),
+            'code' => $schema->string()
+                ->description('The machine code of the custom field to update, as shown in the custom_fields field list for that entity (e.g. "industry").')
                 ->required(),
             'name' => $schema->string()
                 ->description('The new display name for the field.'),
@@ -54,27 +57,18 @@ final class UpdateCustomFieldTool implements Tool
             ]);
         }
 
-        $id = (string) ($request['id'] ?? '');
+        $entityType = (string) ($request['entity_type'] ?? '');
+        $code = (string) ($request['code'] ?? '');
 
-        if ($id === '') {
-            return (string) json_encode(['error' => 'Field ID is required.']);
+        if ($entityType === '' || $code === '') {
+            return (string) json_encode(['error' => 'Both entity_type and code are required to identify the field.']);
         }
 
         $teamId = $user->currentTeam->getKey();
-        $previousTenantId = TenantContextService::getCurrentTenantId();
-        TenantContextService::setTenantId($teamId);
-
-        try {
-            $field = CustomField::query()
-                ->withoutGlobalScope(CustomFieldsActivableScope::class)
-                ->where('tenant_id', $teamId)
-                ->find($id);
-        } finally {
-            TenantContextService::setTenantId($previousTenantId);
-        }
+        $field = $this->resolveOwnedCustomField($teamId, $entityType, $code);
 
         if (! $field instanceof CustomField) {
-            return (string) json_encode(['error' => "Custom field with ID [{$id}] not found."]);
+            return (string) json_encode(['error' => "No custom field with code \"{$code}\" found on {$entityType}."]);
         }
 
         if ($field->isSystemDefined()) {

--- a/packages/Chat/src/Tools/GuideToPageTool.php
+++ b/packages/Chat/src/Tools/GuideToPageTool.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools;
+
+use App\Models\User;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Support\DestinationResolver;
+
+final readonly class GuideToPageTool implements Tool
+{
+    public function __construct(private DestinationResolver $destinations) {}
+
+    public function description(): string
+    {
+        return 'Get a direct link to the workspace page where the user can perform an action this assistant '
+            .'cannot do itself: creating, editing, or deleting custom field definitions; bulk-importing records '
+            .'from a file; or managing team members. Call this instead of telling the user something is impossible.';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'destination' => $schema->string()
+                ->required()
+                ->description(
+                    'Where to send the user. One of: '
+                    .'"custom_fields" (create/edit/delete custom field definitions); '
+                    .'"import_companies", "import_people", "import_opportunities", "import_tasks", "import_notes" '
+                    .'(bulk-import many records of that type from a file); '
+                    .'"team_members" (invite or manage team members).',
+                ),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $team = $user->currentTeam;
+
+        $destination = (string) ($request['destination'] ?? '');
+
+        $url = $team === null ? null : $this->destinations->resolve($destination, $team);
+
+        if ($url === null) {
+            return (string) json_encode([
+                'error' => "No page is available for destination [{$destination}].",
+            ]);
+        }
+
+        return (string) json_encode([
+            'type' => 'navigation',
+            'destination' => $destination,
+            'url' => $url,
+        ], JSON_PRETTY_PRINT);
+    }
+}

--- a/packages/Chat/src/Tools/Note/GetNoteTool.php
+++ b/packages/Chat/src/Tools/Note/GetNoteTool.php
@@ -29,4 +29,9 @@ final class GetNoteTool extends BaseReadShowTool
     {
         return 'Note';
     }
+
+    protected function citationType(): string
+    {
+        return 'note';
+    }
 }

--- a/packages/Chat/src/Tools/Note/ListNotesTool.php
+++ b/packages/Chat/src/Tools/Note/ListNotesTool.php
@@ -29,4 +29,9 @@ final class ListNotesTool extends BaseReadListTool
     {
         return 'title';
     }
+
+    protected function citationType(): string
+    {
+        return 'note';
+    }
 }

--- a/packages/Chat/src/Tools/Opportunity/GetOpportunityTool.php
+++ b/packages/Chat/src/Tools/Opportunity/GetOpportunityTool.php
@@ -29,4 +29,9 @@ final class GetOpportunityTool extends BaseReadShowTool
     {
         return 'Opportunity';
     }
+
+    protected function citationType(): string
+    {
+        return 'opportunity';
+    }
 }

--- a/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
+++ b/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
@@ -49,4 +49,9 @@ final class ListOpportunitiesTool extends BaseReadListTool
             'contact_id' => $request['contact_id'] ?? null,
         ]);
     }
+
+    protected function citationType(): string
+    {
+        return 'opportunity';
+    }
 }

--- a/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
+++ b/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
@@ -40,6 +40,7 @@ final class ListOpportunitiesTool extends BaseReadListTool
             'contact_id' => $schema->string()->description('Filter by contact/person ID.'),
             'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
             'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
+            'stale_days' => $schema->integer()->description('Return only opportunities with no activity in the last N days (default 30). Use this to find deals that have gone quiet.'),
         ];
     }
 
@@ -51,6 +52,7 @@ final class ListOpportunitiesTool extends BaseReadListTool
             'contact_id' => $request['contact_id'] ?? null,
             'created_after' => $request['created_after'] ?? null,
             'created_before' => $request['created_before'] ?? null,
+            'stale_days' => isset($request['stale_days']) ? (string) $request['stale_days'] : null,
         ]);
     }
 

--- a/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
+++ b/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
@@ -38,6 +38,8 @@ final class ListOpportunitiesTool extends BaseReadListTool
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
             'contact_id' => $schema->string()->description('Filter by contact/person ID.'),
+            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
         ];
     }
 
@@ -47,6 +49,8 @@ final class ListOpportunitiesTool extends BaseReadListTool
         return array_filter([
             'company_id' => $request['company_id'] ?? null,
             'contact_id' => $request['contact_id'] ?? null,
+            'created_after' => $request['created_after'] ?? null,
+            'created_before' => $request['created_before'] ?? null,
         ]);
     }
 

--- a/packages/Chat/src/Tools/People/GetPersonTool.php
+++ b/packages/Chat/src/Tools/People/GetPersonTool.php
@@ -29,4 +29,9 @@ final class GetPersonTool extends BaseReadShowTool
     {
         return 'Person';
     }
+
+    protected function citationType(): string
+    {
+        return 'people';
+    }
 }

--- a/packages/Chat/src/Tools/People/ListPeopleTool.php
+++ b/packages/Chat/src/Tools/People/ListPeopleTool.php
@@ -47,4 +47,9 @@ final class ListPeopleTool extends BaseReadListTool
             'company_id' => $request['company_id'] ?? null,
         ]);
     }
+
+    protected function citationType(): string
+    {
+        return 'people';
+    }
 }

--- a/packages/Chat/src/Tools/People/ListPeopleTool.php
+++ b/packages/Chat/src/Tools/People/ListPeopleTool.php
@@ -37,6 +37,8 @@ final class ListPeopleTool extends BaseReadListTool
     {
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
+            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
         ];
     }
 
@@ -45,6 +47,8 @@ final class ListPeopleTool extends BaseReadListTool
     {
         return array_filter([
             'company_id' => $request['company_id'] ?? null,
+            'created_after' => $request['created_after'] ?? null,
+            'created_before' => $request['created_before'] ?? null,
         ]);
     }
 

--- a/packages/Chat/src/Tools/People/UpdatePersonTool.php
+++ b/packages/Chat/src/Tools/People/UpdatePersonTool.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Relaticle\Chat\Tools\People;
 
 use App\Actions\People\UpdatePeople;
+use App\Models\Company;
 use App\Models\People;
+use App\Models\Team;
+use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Ai\Tools\Request;
@@ -56,9 +59,27 @@ final class UpdatePersonTool extends BaseWriteUpdateTool
 
     protected function buildDisplayData(Request $request, Model $model): array
     {
+        /** @var User $user */
+        $user = auth()->user();
+        $team = $user->currentTeam;
+
         $fields = [];
+
         if (($request['name'] ?? null) !== null) {
-            $fields[] = ['label' => 'Name', 'old' => $model->getAttribute('name'), 'new' => $request['name']];
+            $fields[] = [
+                'label' => 'Name',
+                'old' => $model->getAttribute('name'),
+                'new' => $request['name'],
+            ];
+        }
+
+        $newCompanyId = $this->stringOrNull($request, 'company_id');
+        if ($newCompanyId !== null) {
+            $fields[] = [
+                'label' => 'Company',
+                'old' => $this->nameForId($model->getAttribute('company_id'), Company::class, 'name', $team),
+                'new' => $this->nameForId($newCompanyId, Company::class, 'name', $team),
+            ];
         }
 
         return [
@@ -66,5 +87,29 @@ final class UpdatePersonTool extends BaseWriteUpdateTool
             'summary' => "Update person \"{$model->getAttribute('name')}\"",
             'fields' => $fields,
         ];
+    }
+
+    private function stringOrNull(Request $request, string $key): ?string
+    {
+        $value = $request[$key] ?? null;
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    private function nameForId(?string $id, string $modelClass, string $nameAttribute, ?Team $team): string
+    {
+        if ($id === null || $id === '') {
+            return '';
+        }
+
+        $query = $modelClass::query()->whereKey($id);
+        if ($team instanceof Team) {
+            $query->where('team_id', $team->getKey());
+        }
+
+        return (string) ($query->value($nameAttribute) ?? '');
     }
 }

--- a/packages/Chat/src/Tools/Task/GetTaskTool.php
+++ b/packages/Chat/src/Tools/Task/GetTaskTool.php
@@ -35,4 +35,9 @@ final class GetTaskTool extends BaseReadShowTool
     {
         return ['assignees', 'customFieldValues.customField.options'];
     }
+
+    protected function citationType(): string
+    {
+        return 'task';
+    }
 }

--- a/packages/Chat/src/Tools/Task/ListTasksTool.php
+++ b/packages/Chat/src/Tools/Task/ListTasksTool.php
@@ -29,4 +29,9 @@ final class ListTasksTool extends BaseReadListTool
     {
         return 'title';
     }
+
+    protected function citationType(): string
+    {
+        return 'task';
+    }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
         -
             identifier: argument.type
             message: '#(Closure\(App\\Models\\CustomField|Relaticle\\CustomFields\\Models\\CustomField)(Option|Value|Section)?#'
+            reportUnmatched: false
 
         # Base ValidateSignature has untyped variadic ...$args that PHPStan infers as array|null
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,6 @@ parameters:
         -
             identifier: argument.type
             message: '#(Closure\(App\\Models\\CustomField|Relaticle\\CustomFields\\Models\\CustomField)(Option|Value|Section)?#'
-            reportUnmatched: false
 
         # Base ValidateSignature has untyped variadic ...$args that PHPStan infers as array|null
         -

--- a/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
+++ b/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
@@ -80,7 +80,8 @@ it('proposes adding options and creates them on approval', function (): void {
     $tool = makeAddOptionsTool($this->convId);
 
     $result = $tool->handle(new Request([
-        'id' => $this->selectField->getKey(),
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
         'options' => [['name' => 'Inactive'], ['name' => 'Pending']],
     ]));
 
@@ -121,7 +122,8 @@ it('returns error when non-owner tries to add options', function (): void {
 
     $tool = makeAddOptionsTool($this->convId);
     $result = $tool->handle(new Request([
-        'id' => $this->selectField->getKey(),
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
         'options' => [['name' => 'Inactive']],
     ]));
 
@@ -135,7 +137,8 @@ it('returns error when adding options to a non-choice type field', function (): 
     $tool = makeAddOptionsTool($this->convId);
 
     $result = $tool->handle(new Request([
-        'id' => $this->textField->getKey(),
+        'entity_type' => 'company',
+        'code' => $this->textField->code,
         'options' => [['name' => 'Some Option']],
     ]));
 
@@ -151,7 +154,8 @@ it('returns error when adding options would exceed the cap', function (): void {
     $tool = makeAddOptionsTool($this->convId);
 
     $result = $tool->handle(new Request([
-        'id' => $this->selectField->getKey(),
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
         'options' => [['name' => 'Too Many'], ['name' => 'Options Here']],
     ]));
 

--- a/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
+++ b/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CustomFields\AddCustomFieldOptions;
+use App\Models\CustomField;
+use App\Models\CustomFieldOption;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\CustomField\AddCustomFieldOptionsTool;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+mutates(AddCustomFieldOptionsTool::class, AddCustomFieldOptions::class);
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->owner->currentTeam;
+
+    Auth::guard('web')->setUser($this->owner);
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+    TenantContextService::setTenantId($this->team->getKey());
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    $this->selectField = CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Status',
+        'type' => 'select',
+        'system_defined' => false,
+        'active' => true,
+    ]);
+
+    $this->selectField->options()->create([
+        $tenantKey => $this->team->getKey(),
+        'name' => 'Active',
+        'sort_order' => 0,
+    ]);
+
+    $this->textField = CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Description',
+        'type' => 'text',
+        'system_defined' => false,
+        'active' => true,
+    ]);
+
+    $this->convId = '019df900-7777-7000-8000-000000000001';
+    DB::table('agent_conversations')->insert([
+        'id' => $this->convId,
+        'user_id' => (string) $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'title' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+afterEach(function (): void {
+    TenantContextService::setTenantId(null);
+});
+
+function makeAddOptionsTool(string $convId): AddCustomFieldOptionsTool
+{
+    $tool = resolve(AddCustomFieldOptionsTool::class);
+    $tool->setConversationId($convId);
+
+    return $tool;
+}
+
+it('proposes adding options and creates them on approval', function (): void {
+    $tool = makeAddOptionsTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'id' => $this->selectField->getKey(),
+        'options' => [['name' => 'Inactive'], ['name' => 'Pending']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['type'])->toBe('pending_action')
+        ->and($decoded['operation'])->toBe('create')
+        ->and($decoded['entity_type'])->toBe('custom_field')
+        ->and($decoded['meta']['agent_should_stop'])->toBeTrue();
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    expect($pending->action_class)->toBe(AddCustomFieldOptions::class)
+        ->and($pending->operation)->toBe(PendingActionOperation::Create)
+        ->and($pending->status)->toBe(PendingActionStatus::Pending);
+
+    $service = resolve(PendingActionService::class);
+    $service->approve($pending, $this->owner);
+
+    TenantContextService::setTenantId($this->team->getKey());
+    $optionNames = CustomFieldOption::query()
+        ->where('custom_field_id', $this->selectField->getKey())
+        ->pluck('name')
+        ->sort()
+        ->values()
+        ->toArray();
+
+    expect($optionNames)->toBe(['Active', 'Inactive', 'Pending']);
+});
+
+it('returns error when non-owner tries to add options', function (): void {
+    $nonOwner = User::factory()->create();
+    $nonOwner->teams()->attach($this->team, ['role' => 'editor']);
+    $nonOwner->switchTeam($this->team);
+
+    Auth::guard('web')->setUser($nonOwner);
+    $this->actingAs($nonOwner);
+
+    $tool = makeAddOptionsTool($this->convId);
+    $result = $tool->handle(new Request([
+        'id' => $this->selectField->getKey(),
+        'options' => [['name' => 'Inactive']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('returns error when adding options to a non-choice type field', function (): void {
+    $tool = makeAddOptionsTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'id' => $this->textField->getKey(),
+        'options' => [['name' => 'Some Option']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('returns error when adding options would exceed the cap', function (): void {
+    config(['chat.max_field_options' => 2]);
+
+    $tool = makeAddOptionsTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'id' => $this->selectField->getKey(),
+        'options' => [['name' => 'Too Many'], ['name' => 'Options Here']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});

--- a/tests/Feature/Chat/AggregateCrmToolTest.php
+++ b/tests/Feature/Chat/AggregateCrmToolTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Opportunity\AggregateOpportunities;
+use App\Actions\Opportunity\CreateOpportunity;
+use App\Features\OnboardSeed;
+use App\Models\Company;
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Ai\Tools\Request;
+use Laravel\Pennant\Feature;
+use Relaticle\Chat\Tools\AggregateCrmTool;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+mutates(AggregateCrmTool::class, AggregateOpportunities::class);
+
+beforeEach(function (): void {
+    Feature::define(OnboardSeed::class, false);
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->user->currentTeam;
+    Auth::guard('web')->setUser($this->user);
+    TenantContextService::setTenantId($this->team->getKey());
+});
+
+afterEach(function (): void {
+    TenantContextService::setTenantId(null);
+});
+
+it('groups opportunities by stage with correct count and total_amount', function (): void {
+    $createOpportunity = resolve(CreateOpportunity::class);
+
+    // Resolve stage field and its first two options
+    $stageField = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'opportunity')
+        ->where('code', 'stage')
+        ->with('options')
+        ->firstOrFail();
+
+    $stageOptions = $stageField->options;
+    $stage1Option = $stageOptions->first();
+    $stage2Option = $stageOptions->skip(1)->first();
+
+    // Create 2 opportunities in stage 1 (amounts: 1000 + 2500 = 3500)
+    // Pass option ID (ULID) directly — CreateOpportunity stores the raw string_value
+    $createOpportunity->execute($this->user, [
+        'name' => 'Deal Alpha',
+        'custom_fields' => [
+            'stage' => (string) $stage1Option->getKey(),
+            'amount' => 1000,
+        ],
+    ]);
+    $createOpportunity->execute($this->user, [
+        'name' => 'Deal Beta',
+        'custom_fields' => [
+            'stage' => (string) $stage1Option->getKey(),
+            'amount' => 2500,
+        ],
+    ]);
+
+    // Create 1 opportunity in stage 2 (amount: 500)
+    $createOpportunity->execute($this->user, [
+        'name' => 'Deal Gamma',
+        'custom_fields' => [
+            'stage' => (string) $stage2Option->getKey(),
+            'amount' => 500,
+        ],
+    ]);
+
+    $tool = resolve(AggregateCrmTool::class);
+    $response = $tool->handle(new Request(['group_by' => 'stage']));
+
+    $data = json_decode($response, true);
+    expect($data)->toBeArray()
+        ->and($data['group_by'])->toBe('stage')
+        ->and($data['total_count'])->toBe(3)
+        ->and((float) $data['total_amount'])->toBe(4000.0);
+
+    // Find stage 1 and stage 2 rows
+    $rowsByLabel = collect($data['rows'])->keyBy('label');
+
+    expect($rowsByLabel->has($stage1Option->name))->toBeTrue()
+        ->and($rowsByLabel->has($stage2Option->name))->toBeTrue();
+
+    $stage1Row = $rowsByLabel->get($stage1Option->name);
+    $stage2Row = $rowsByLabel->get($stage2Option->name);
+
+    expect($stage1Row['count'])->toBe(2)
+        ->and((float) $stage1Row['total_amount'])->toBe(3500.0)
+        ->and($stage2Row['count'])->toBe(1)
+        ->and((float) $stage2Row['total_amount'])->toBe(500.0);
+});
+
+it('groups opportunities by company with correct aggregation', function (): void {
+    $createOpportunity = resolve(CreateOpportunity::class);
+
+    $company = Company::factory()->for($this->team)->create(['name' => 'Acme Corp']);
+
+    $createOpportunity->execute($this->user, [
+        'name' => 'Deal 1',
+        'company_id' => (string) $company->getKey(),
+        'custom_fields' => ['amount' => 3000],
+    ]);
+    $createOpportunity->execute($this->user, [
+        'name' => 'Deal 2',
+        'company_id' => (string) $company->getKey(),
+        'custom_fields' => ['amount' => 2000],
+    ]);
+    $createOpportunity->execute($this->user, [
+        'name' => 'No company deal',
+        'custom_fields' => ['amount' => 100],
+    ]);
+
+    $tool = resolve(AggregateCrmTool::class);
+    $response = $tool->handle(new Request(['group_by' => 'company']));
+
+    $data = json_decode($response, true);
+    expect($data)->toBeArray()
+        ->and($data['group_by'])->toBe('company')
+        ->and($data['total_count'])->toBe(3)
+        ->and((float) $data['total_amount'])->toBe(5100.0);
+
+    $rowsByLabel = collect($data['rows'])->keyBy('label');
+    expect($rowsByLabel->has('Acme Corp'))->toBeTrue();
+
+    $acmeRow = $rowsByLabel->get('Acme Corp');
+    expect($acmeRow['count'])->toBe(2)
+        ->and((float) $acmeRow['total_amount'])->toBe(5000.0);
+});
+
+it('applies date_from filter correctly', function (): void {
+    $createOpportunity = resolve(CreateOpportunity::class);
+
+    $this->travelTo(now()->subDays(10));
+    $createOpportunity->execute($this->user, [
+        'name' => 'Old Deal',
+        'custom_fields' => ['amount' => 999],
+    ]);
+
+    $this->travelBack();
+    $createOpportunity->execute($this->user, [
+        'name' => 'New Deal',
+        'custom_fields' => ['amount' => 1000],
+    ]);
+
+    $tool = resolve(AggregateCrmTool::class);
+    $response = $tool->handle(new Request([
+        'group_by' => 'company',
+        'date_from' => now()->subDays(1)->toDateString(),
+    ]));
+
+    $data = json_decode($response, true);
+    expect($data['total_count'])->toBe(1)
+        ->and((float) $data['total_amount'])->toBe(1000.0);
+});
+
+it('returns an error for invalid group_by value', function (): void {
+    $tool = resolve(AggregateCrmTool::class);
+    $response = $tool->handle(new Request(['group_by' => 'invalid']));
+
+    $data = json_decode($response, true);
+    expect($data)->toBeArray()
+        ->and($data)->toHaveKey('error');
+});
+
+it('returns grand total of zero when no opportunities exist', function (): void {
+    $tool = resolve(AggregateCrmTool::class);
+    $response = $tool->handle(new Request(['group_by' => 'stage']));
+
+    $data = json_decode($response, true);
+    expect($data['total_count'])->toBe(0)
+        ->and((float) $data['total_amount'])->toBe(0.0);
+});
+
+it('respects tenant scope and does not leak cross-tenant data', function (): void {
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    $otherTeam = $otherUser->currentTeam;
+
+    TenantContextService::setTenantId($otherTeam->getKey());
+    Auth::guard('web')->setUser($otherUser);
+    resolve(CreateOpportunity::class)->execute($otherUser, [
+        'name' => 'Other Team Deal',
+        'custom_fields' => ['amount' => 99999],
+    ]);
+
+    TenantContextService::setTenantId($this->team->getKey());
+    Auth::guard('web')->setUser($this->user);
+
+    $tool = resolve(AggregateCrmTool::class);
+    $response = $tool->handle(new Request(['group_by' => 'company']));
+
+    $data = json_decode($response, true);
+    expect($data['total_count'])->toBe(0)
+        ->and((float) $data['total_amount'])->toBe(0.0);
+});

--- a/tests/Feature/Chat/AggregateCrmToolTest.php
+++ b/tests/Feature/Chat/AggregateCrmToolTest.php
@@ -7,6 +7,7 @@ use App\Actions\Opportunity\CreateOpportunity;
 use App\Features\OnboardSeed;
 use App\Models\Company;
 use App\Models\CustomField;
+use App\Models\Opportunity;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Ai\Tools\Request;
@@ -155,6 +156,21 @@ it('applies date_from filter correctly', function (): void {
     $data = json_decode($response, true);
     expect($data['total_count'])->toBe(1)
         ->and((float) $data['total_amount'])->toBe(1000.0);
+});
+
+it('reports accurate grand totals when company groups exceed the row cap', function (): void {
+    Company::factory()->count(101)->for($this->team)->create()->each(function (Company $company): void {
+        Opportunity::factory()->for($this->team)->create(['company_id' => $company->getKey()]);
+    });
+
+    $tool = resolve(AggregateCrmTool::class);
+    $response = $tool->handle(new Request(['group_by' => 'company']));
+
+    $data = json_decode($response, true);
+
+    expect($data['total_count'])->toBe(101)
+        ->and($data['rows'])->toHaveCount(100)
+        ->and($data['truncated'])->toBeTrue();
 });
 
 it('returns an error for invalid group_by value', function (): void {

--- a/tests/Feature/Chat/BatchSizeLimitTest.php
+++ b/tests/Feature/Chat/BatchSizeLimitTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Tools\BaseWriteCreateTool;
+use Relaticle\Chat\Tools\BaseWriteDeleteTool;
+use Relaticle\Chat\Tools\Company\CreateCompanyTool;
+use Relaticle\Chat\Tools\Task\DeleteTaskTool;
+
+mutates(BaseWriteCreateTool::class);
+mutates(BaseWriteDeleteTool::class);
+
+beforeEach(function (): void {
+    Bus::fake();
+
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->user->switchTeam($this->user->ownedTeams()->first());
+    $this->actingAs($this->user);
+
+    config(['chat.max_batch_size' => 3]);
+});
+
+it('rejects a create request that exceeds the batch cap and creates no PendingAction', function (): void {
+    $records = array_map(
+        static fn (int $i): array => ['name' => "Company {$i}"],
+        range(1, 4),
+    );
+
+    $json = app(CreateCompanyTool::class)->handle(new Request(['records' => $records]));
+    $payload = json_decode($json, true);
+
+    expect($payload)->toHaveKey('error')
+        ->and($payload['error'])->toContain('3')
+        ->and(PendingAction::query()->where('user_id', $this->user->getKey())->count())->toBe(0);
+});
+
+it('accepts a create request exactly at the batch cap', function (): void {
+    $records = array_map(
+        static fn (int $i): array => ['name' => "Company {$i}"],
+        range(1, 3),
+    );
+
+    $json = app(CreateCompanyTool::class)->handle(new Request(['records' => $records]));
+    $payload = json_decode($json, true);
+
+    expect($payload)->toHaveKey('type')
+        ->and($payload['type'])->toBe('pending_action')
+        ->and(PendingAction::query()->where('user_id', $this->user->getKey())->count())->toBe(1);
+});
+
+it('rejects a delete request that exceeds the batch cap and creates no PendingAction', function (): void {
+    $tasks = Task::factory()->count(4)->for($this->user->currentTeam)->create();
+    $ids = $tasks->pluck('id')->map(fn (mixed $id): string => (string) $id)->all();
+
+    $json = app(DeleteTaskTool::class)->handle(new Request(['ids' => $ids]));
+    $payload = json_decode($json, true);
+
+    expect($payload)->toHaveKey('error')
+        ->and($payload['error'])->toContain('3')
+        ->and(PendingAction::query()->where('user_id', $this->user->getKey())->count())->toBe(0);
+});
+
+it('accepts a delete request exactly at the batch cap', function (): void {
+    $tasks = Task::factory()->count(3)->for($this->user->currentTeam)->create();
+    $ids = $tasks->pluck('id')->map(fn (mixed $id): string => (string) $id)->all();
+
+    $json = app(DeleteTaskTool::class)->handle(new Request(['ids' => $ids]));
+    $payload = json_decode($json, true);
+
+    expect($payload)->toHaveKey('type')
+        ->and($payload['type'])->toBe('pending_action')
+        ->and(PendingAction::query()->where('user_id', $this->user->getKey())->count())->toBe(1);
+});

--- a/tests/Feature/Chat/CreateCustomFieldToolTest.php
+++ b/tests/Feature/Chat/CreateCustomFieldToolTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CustomFields\CreateCustomField;
+use App\Models\CustomField;
+use App\Models\CustomFieldOption;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\CustomField\CreateCustomFieldTool;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+mutates(CreateCustomFieldTool::class, CreateCustomField::class);
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->owner->currentTeam;
+
+    Auth::guard('web')->setUser($this->owner);
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+    TenantContextService::setTenantId($this->team->getKey());
+
+    $this->convId = '019df900-5555-7000-8000-000000000001';
+    DB::table('agent_conversations')->insert([
+        'id' => $this->convId,
+        'user_id' => (string) $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'title' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+afterEach(function (): void {
+    TenantContextService::setTenantId(null);
+});
+
+function makeCreateFieldTool(string $convId): CreateCustomFieldTool
+{
+    $tool = resolve(CreateCustomFieldTool::class);
+    $tool->setConversationId($convId);
+
+    return $tool;
+}
+
+it('creates a pending proposal for a select field with options', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Priority',
+        'type' => 'select',
+        'options' => [['name' => 'High'], ['name' => 'Low']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['type'])->toBe('pending_action')
+        ->and($decoded['operation'])->toBe('create')
+        ->and($decoded['entity_type'])->toBe('custom_field')
+        ->and($decoded['meta']['agent_should_stop'])->toBeTrue();
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    expect($pending->action_class)->toBe(CreateCustomField::class)
+        ->and($pending->operation)->toBe(PendingActionOperation::Create)
+        ->and($pending->entity_type)->toBe('custom_field')
+        ->and($pending->action_data['name'])->toBe('Priority')
+        ->and($pending->action_data['type'])->toBe('select')
+        ->and($pending->action_data['entity_type'])->toBe('company')
+        ->and($pending->action_data['options'])->toHaveCount(2)
+        ->and($pending->status)->toBe(PendingActionStatus::Pending);
+});
+
+it('executes the approved proposal and creates the field + options in the database', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+
+    $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Priority',
+        'type' => 'select',
+        'options' => [['name' => 'High'], ['name' => 'Low']],
+    ]));
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    $service = resolve(PendingActionService::class);
+    $service->approve($pending, $this->owner);
+
+    $field = CustomField::query()->withoutGlobalScope(CustomFieldsActivableScope::class)
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'company')
+        ->where('name', 'Priority')
+        ->first();
+
+    expect($field)->not->toBeNull()
+        ->and($field->type)->toBe('select')
+        ->and($field->active)->toBeTrue()
+        ->and($field->system_defined)->toBeFalse();
+
+    TenantContextService::setTenantId($this->team->getKey());
+    $optionNames = CustomFieldOption::query()
+        ->where('custom_field_id', $field->getKey())
+        ->pluck('name')
+        ->sort()
+        ->values()
+        ->toArray();
+
+    expect($optionNames)->toBe(['High', 'Low']);
+});
+
+it('returns error and creates no proposal when a non-owner invokes the tool', function (): void {
+    $nonOwner = User::factory()->create();
+    $nonOwner->teams()->attach($this->team, ['role' => 'editor']);
+    $nonOwner->switchTeam($this->team);
+
+    Auth::guard('web')->setUser($nonOwner);
+    $this->actingAs($nonOwner);
+
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Priority',
+        'type' => 'select',
+        'options' => [['name' => 'High']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('returns error for a non-allowlisted field type', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Attachment',
+        'type' => 'file-upload',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects when over the max_custom_fields_per_entity cap', function (): void {
+    config(['chat.max_custom_fields_per_entity' => 2]);
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+
+    CustomField::factory()->count(2)->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+    ]);
+
+    $tool = makeCreateFieldTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'One More',
+        'type' => 'text',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('requires options for choice types', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Status',
+        'type' => 'select',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('creates a text field without options successfully', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Website',
+        'type' => 'text',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['type'])->toBe('pending_action')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(1);
+});

--- a/tests/Feature/Chat/DestinationResolverTest.php
+++ b/tests/Feature/Chat/DestinationResolverTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Relaticle\Chat\Support\DestinationResolver;
+
+mutates(DestinationResolver::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->user->switchTeam($this->user->ownedTeams()->first());
+    $this->actingAs($this->user);
+});
+
+it('resolves the custom fields destination to an app-panel url', function (): void {
+    $url = app(DestinationResolver::class)->resolve('custom_fields', $this->user->currentTeam);
+
+    expect($url)->toBeString()
+        ->and($url)->toContain((string) $this->user->currentTeam->slug)
+        ->and($url)->toContain('custom-fields');
+});
+
+it('resolves every declared destination to a non-null url', function (): void {
+    $resolver = app(DestinationResolver::class);
+
+    foreach (DestinationResolver::DESTINATIONS as $destination) {
+        expect($resolver->resolve($destination, $this->user->currentTeam))
+            ->toBeString("destination [{$destination}] should resolve to a url");
+    }
+});
+
+it('returns null for an unknown destination', function (): void {
+    expect(app(DestinationResolver::class)->resolve('does_not_exist', $this->user->currentTeam))
+        ->toBeNull();
+});

--- a/tests/Feature/Chat/GuideToPageToolTest.php
+++ b/tests/Feature/Chat/GuideToPageToolTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Support\DestinationResolver;
+use Relaticle\Chat\Tools\GuideToPageTool;
+
+mutates(GuideToPageTool::class);
+mutates(DestinationResolver::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->user->switchTeam($this->user->ownedTeams()->first());
+    $this->actingAs($this->user);
+});
+
+it('returns a navigation payload with a url for a known destination', function (): void {
+    $json = app(GuideToPageTool::class)->handle(new Request(['destination' => 'custom_fields']));
+    $payload = json_decode($json, true);
+
+    expect($payload['type'])->toBe('navigation')
+        ->and($payload['destination'])->toBe('custom_fields')
+        ->and($payload['url'])->toBeString()
+        ->and($payload['url'])->toContain('custom-fields');
+});
+
+it('returns an error payload for an unknown destination', function (): void {
+    $json = app(GuideToPageTool::class)->handle(new Request(['destination' => 'nope']));
+    $payload = json_decode($json, true);
+
+    expect($payload)->toHaveKey('error')
+        ->and($payload)->not->toHaveKey('url');
+});
+
+it('does not create a pending action because it is not a write', function (): void {
+    app(GuideToPageTool::class)->handle(new Request(['destination' => 'team_members']));
+
+    expect(PendingAction::query()->count())->toBe(0);
+});

--- a/tests/Feature/Chat/ListCustomFieldsToolTest.php
+++ b/tests/Feature/Chat/ListCustomFieldsToolTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\CustomField;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Tools\CustomField\ListCustomFieldsTool;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+mutates(ListCustomFieldsTool::class);
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->owner->currentTeam;
+
+    Auth::guard('web')->setUser($this->owner);
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+    TenantContextService::setTenantId($this->team->getKey());
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+
+    $this->select = CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Account Tier',
+        'type' => 'select',
+        'system_defined' => false,
+        'active' => true,
+    ]);
+    $this->select->options()->create([
+        $tenantKey => $this->team->getKey(),
+        'name' => 'Gold',
+        'sort_order' => 0,
+    ]);
+
+    $this->inactive = CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'opportunity',
+        'name' => 'Legacy',
+        'type' => 'text',
+        'system_defined' => false,
+        'active' => false,
+    ]);
+});
+
+afterEach(function (): void {
+    TenantContextService::setTenantId(null);
+});
+
+it('lists custom field definitions with code, type, active status and options', function (): void {
+    $result = resolve(ListCustomFieldsTool::class)->handle(new Request([]));
+    $decoded = json_decode($result, true);
+
+    $fields = collect($decoded['custom_fields']);
+
+    $account = $fields->firstWhere('code', $this->select->code);
+    expect($account)->not->toBeNull()
+        ->and($account['entity_type'])->toBe('company')
+        ->and($account['name'])->toBe('Account Tier')
+        ->and($account['type'])->toBe('select')
+        ->and($account['active'])->toBeTrue()
+        ->and($account['options'])->toContain('Gold');
+
+    $legacy = $fields->firstWhere('code', $this->inactive->code);
+    expect($legacy)->not->toBeNull()
+        ->and($legacy['active'])->toBeFalse();
+});
+
+it('filters by entity_type', function (): void {
+    $result = resolve(ListCustomFieldsTool::class)->handle(new Request(['entity_type' => 'company']));
+    $decoded = json_decode($result, true);
+
+    $entities = collect($decoded['custom_fields'])->pluck('entity_type')->unique()->values()->all();
+
+    expect($entities)->toBe(['company']);
+});
+
+it('does not leak custom fields from another team', function (): void {
+    $otherOwner = User::factory()->withPersonalTeam()->create();
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $otherOwner->currentTeam->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Secret Field',
+        'type' => 'text',
+        'system_defined' => false,
+        'active' => true,
+    ]);
+
+    $result = resolve(ListCustomFieldsTool::class)->handle(new Request([]));
+    $codes = collect(json_decode($result, true)['custom_fields'])->pluck('name')->all();
+
+    expect($codes)->not->toContain('Secret Field');
+});

--- a/tests/Feature/Chat/ListDateFilterTest.php
+++ b/tests/Feature/Chat/ListDateFilterTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Company\ListCompanies;
+use App\Actions\Opportunity\ListOpportunities;
+use App\Actions\People\ListPeople;
+use App\Features\OnboardSeed;
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Ai\Tools\Request;
+use Laravel\Pennant\Feature;
+use Relaticle\Chat\Tools\Company\ListCompaniesTool;
+use Relaticle\Chat\Tools\Opportunity\ListOpportunitiesTool;
+use Relaticle\Chat\Tools\People\ListPeopleTool;
+
+mutates(ListOpportunities::class, ListCompanies::class, ListPeople::class);
+
+beforeEach(function (): void {
+    Feature::define(OnboardSeed::class, false);
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->user->currentTeam;
+    Auth::guard('web')->setUser($this->user);
+});
+
+it('filters opportunities by created_after', function (): void {
+    $this->travelTo(now()->subDays(10));
+    Opportunity::factory()->for($this->team)->create(['name' => 'Old Deal']);
+
+    $this->travelBack();
+    Opportunity::factory()->for($this->team)->create(['name' => 'New Deal']);
+
+    $tool = new ListOpportunitiesTool;
+    $response = $tool->handle(new Request([
+        'created_after' => now()->subDays(1)->toDateString(),
+    ]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('New Deal');
+});
+
+it('filters opportunities by created_before', function (): void {
+    $this->travelTo(now()->subDays(10));
+    Opportunity::factory()->for($this->team)->create(['name' => 'Old Deal']);
+
+    $this->travelBack();
+    Opportunity::factory()->for($this->team)->create(['name' => 'New Deal']);
+
+    $tool = new ListOpportunitiesTool;
+    $response = $tool->handle(new Request([
+        'created_before' => now()->subDays(5)->toDateString(),
+    ]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('Old Deal');
+});
+
+it('filters opportunities by both created_after and created_before', function (): void {
+    $now = now();
+
+    $this->travelTo($now->copy()->subDays(20));
+    Opportunity::factory()->for($this->team)->create(['name' => 'Very Old']);
+
+    $this->travelTo($now->copy()->subDays(7));
+    Opportunity::factory()->for($this->team)->create(['name' => 'Mid Deal']);
+
+    $this->travelTo($now);
+    Opportunity::factory()->for($this->team)->create(['name' => 'Fresh Deal']);
+
+    $tool = new ListOpportunitiesTool;
+    $response = $tool->handle(new Request([
+        'created_after' => $now->copy()->subDays(14)->toDateString(),
+        'created_before' => $now->copy()->subDays(3)->toDateString(),
+    ]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('Mid Deal');
+});
+
+it('filters companies by created_after', function (): void {
+    $this->travelTo(now()->subDays(10));
+    Company::factory()->for($this->team)->create(['name' => 'Old Co']);
+
+    $this->travelBack();
+    Company::factory()->for($this->team)->create(['name' => 'New Co']);
+
+    $tool = new ListCompaniesTool;
+    $response = $tool->handle(new Request([
+        'created_after' => now()->subDays(1)->toDateString(),
+    ]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('New Co');
+});
+
+it('filters people by created_after', function (): void {
+    $this->travelTo(now()->subDays(10));
+    People::factory()->for($this->team)->create(['name' => 'Old Person']);
+
+    $this->travelBack();
+    People::factory()->for($this->team)->create(['name' => 'New Person']);
+
+    $tool = new ListPeopleTool;
+    $response = $tool->handle(new Request([
+        'created_after' => now()->subDays(1)->toDateString(),
+    ]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('New Person');
+});

--- a/tests/Feature/Chat/MentionsTest.php
+++ b/tests/Feature/Chat/MentionsTest.php
@@ -62,6 +62,22 @@ it('returns matching companies for current team only', function (): void {
         ->and($companies->first()['name'])->toBe('Acme Inc');
 });
 
+it('includes a resolved record url for each result', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Acme Inc']);
+
+    $data = collect(
+        $this->getJson(route('chat.mentions', ['q' => 'Acme']))
+            ->assertOk()
+            ->json('data')
+    );
+
+    $match = $data->firstWhere('type', 'company');
+
+    expect($match)->not->toBeNull()
+        ->and($match['url'])->toBeString()
+        ->and($match['url'])->toContain((string) $company->id);
+});
+
 it('applies rate limiting', function (): void {
     for ($i = 0; $i < 60; $i++) {
         $response = $this->getJson(route('chat.mentions', ['q' => 'test']));

--- a/tests/Feature/Chat/MessageDocumentRenderingTest.php
+++ b/tests/Feature/Chat/MessageDocumentRenderingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Company;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -56,4 +57,67 @@ it('returns the document column on each message from ListConversationMessages', 
     expect($messages[0]['document']['type'])->toBe('doc');
     expect($messages[0]['document']['content'][0]['type'])->toBe('paragraph');
     expect($messages[0]['document']['content'][0]['content'][0]['text'])->toBe('Hello world');
+});
+
+it('attaches a server-resolved url to each mention', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $team = $user->currentTeam;
+    $this->actingAs($user);
+
+    $company = Company::factory()->for($team)->create(['name' => 'Acme Corp']);
+
+    $conversationId = (string) Str::uuid7();
+    AgentConversation::query()->insert([
+        'id' => $conversationId,
+        'user_id' => $user->getKey(),
+        'team_id' => $team->getKey(),
+        'title' => 'Test',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messageId = (string) Str::ulid();
+    DB::table('agent_conversation_messages')->insert([
+        'id' => $messageId,
+        'conversation_id' => $conversationId,
+        'user_id' => $user->getKey(),
+        'agent' => 'crm',
+        'role' => 'user',
+        'content' => '@Acme Corp tell me about this',
+        'document' => json_encode([
+            'type' => 'doc',
+            'content' => [[
+                'type' => 'paragraph',
+                'content' => [[
+                    'type' => 'mention',
+                    'attrs' => ['id' => (string) $company->id, 'type' => 'company', 'label' => 'Acme Corp', 'url' => null],
+                ]],
+            ]],
+        ]),
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '{}',
+        'meta' => '{}',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    DB::table('agent_conversation_message_mentions')->insert([
+        'id' => (string) Str::ulid(),
+        'message_id' => $messageId,
+        'type' => 'company',
+        'record_id' => (string) $company->id,
+        'label' => 'Acme Corp',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $messages = app(ListConversationMessages::class)->execute($user, $conversationId);
+
+    expect($messages[0]['mentions'])->toHaveCount(1)
+        ->and($messages[0]['mentions'][0]['type'])->toBe('company')
+        ->and($messages[0]['mentions'][0]['id'])->toBe((string) $company->id)
+        ->and($messages[0]['mentions'][0]['url'])->toBeString()
+        ->and($messages[0]['mentions'][0]['url'])->toContain((string) $company->id);
 });

--- a/tests/Feature/Chat/ReadToolCitationUrlTest.php
+++ b/tests/Feature/Chat/ReadToolCitationUrlTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Company;
+use App\Models\Note;
+use App\Models\Opportunity;
+use App\Models\People;
+use App\Models\Task;
+use App\Models\User;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Tools\Company\GetCompanyTool;
+use Relaticle\Chat\Tools\Company\ListCompaniesTool;
+use Relaticle\Chat\Tools\Note\GetNoteTool;
+use Relaticle\Chat\Tools\Note\ListNotesTool;
+use Relaticle\Chat\Tools\Opportunity\GetOpportunityTool;
+use Relaticle\Chat\Tools\Opportunity\ListOpportunitiesTool;
+use Relaticle\Chat\Tools\People\GetPersonTool;
+use Relaticle\Chat\Tools\People\ListPeopleTool;
+use Relaticle\Chat\Tools\Task\GetTaskTool;
+use Relaticle\Chat\Tools\Task\ListTasksTool;
+
+mutates(GetCompanyTool::class);
+mutates(ListCompaniesTool::class);
+mutates(GetPersonTool::class);
+mutates(ListPeopleTool::class);
+mutates(GetOpportunityTool::class);
+mutates(ListOpportunitiesTool::class);
+mutates(GetTaskTool::class);
+mutates(ListTasksTool::class);
+mutates(GetNoteTool::class);
+mutates(ListNotesTool::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->user->switchTeam($this->user->ownedTeams()->first());
+    $this->actingAs($this->user);
+    // Deliberately no Filament::setTenant() — mirrors job context
+});
+
+// --- GetCompanyTool ---
+
+it('GetCompanyTool output contains a non-null url with /companies/', function (): void {
+    $company = Company::factory()->for($this->user->currentTeam)->create(['name' => 'Acme']);
+
+    $payload = json_decode(app(GetCompanyTool::class)->handle(new Request(['id' => (string) $company->getKey()])), true);
+
+    expect($payload)->toHaveKey('url')
+        ->and($payload['url'])->toBeString()
+        ->and($payload['url'])->toContain('/companies/');
+});
+
+// --- ListCompaniesTool ---
+
+it('ListCompaniesTool output items each have a url containing /companies/', function (): void {
+    Company::factory()->count(2)->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(ListCompaniesTool::class)->handle(new Request([])), true);
+
+    expect($payload)->toBeArray()->not->toBeEmpty();
+
+    foreach ($payload as $item) {
+        expect($item)->toHaveKey('url')
+            ->and($item['url'])->toBeString()
+            ->and($item['url'])->toContain('/companies/');
+    }
+});
+
+// --- GetPersonTool ---
+
+it('GetPersonTool output contains a url with /people/', function (): void {
+    $person = People::factory()->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(GetPersonTool::class)->handle(new Request(['id' => (string) $person->getKey()])), true);
+
+    expect($payload)->toHaveKey('url')
+        ->and($payload['url'])->toContain('/people/');
+});
+
+// --- ListPeopleTool ---
+
+it('ListPeopleTool output items each have a url with /people/', function (): void {
+    People::factory()->count(2)->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(ListPeopleTool::class)->handle(new Request([])), true);
+
+    expect($payload)->toBeArray()->not->toBeEmpty();
+
+    foreach ($payload as $item) {
+        expect($item)->toHaveKey('url')
+            ->and($item['url'])->toContain('/people/');
+    }
+});
+
+// --- GetOpportunityTool ---
+
+it('GetOpportunityTool output contains a url with /opportunities/', function (): void {
+    $opportunity = Opportunity::factory()->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(GetOpportunityTool::class)->handle(new Request(['id' => (string) $opportunity->getKey()])), true);
+
+    expect($payload)->toHaveKey('url')
+        ->and($payload['url'])->toContain('/opportunities/');
+});
+
+// --- ListOpportunitiesTool ---
+
+it('ListOpportunitiesTool output items each have a url with /opportunities/', function (): void {
+    Opportunity::factory()->count(2)->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(ListOpportunitiesTool::class)->handle(new Request([])), true);
+
+    expect($payload)->toBeArray()->not->toBeEmpty();
+
+    foreach ($payload as $item) {
+        expect($item)->toHaveKey('url')
+            ->and($item['url'])->toContain('/opportunities/');
+    }
+});
+
+// --- GetTaskTool ---
+
+it('GetTaskTool output contains a url (task index)', function (): void {
+    $task = Task::factory()->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(GetTaskTool::class)->handle(new Request(['id' => (string) $task->getKey()])), true);
+
+    expect($payload)->toHaveKey('url')
+        ->and($payload['url'])->toBeString()
+        ->and($payload['url'])->toContain('/tasks');
+});
+
+// --- ListTasksTool ---
+
+it('ListTasksTool output items each have a url (task index)', function (): void {
+    Task::factory()->count(2)->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(ListTasksTool::class)->handle(new Request([])), true);
+
+    expect($payload)->toBeArray()->not->toBeEmpty();
+
+    foreach ($payload as $item) {
+        expect($item)->toHaveKey('url')
+            ->and($item['url'])->toBeString()
+            ->and($item['url'])->toContain('/tasks');
+    }
+});
+
+// --- GetNoteTool ---
+
+it('GetNoteTool output contains a url (note index)', function (): void {
+    $note = Note::factory()->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(GetNoteTool::class)->handle(new Request(['id' => (string) $note->getKey()])), true);
+
+    expect($payload)->toHaveKey('url')
+        ->and($payload['url'])->toBeString()
+        ->and($payload['url'])->toContain('/notes');
+});
+
+// --- ListNotesTool ---
+
+it('ListNotesTool output items each have a url (note index)', function (): void {
+    Note::factory()->count(2)->for($this->user->currentTeam)->create();
+
+    $payload = json_decode(app(ListNotesTool::class)->handle(new Request([])), true);
+
+    expect($payload)->toBeArray()->not->toBeEmpty();
+
+    foreach ($payload as $item) {
+        expect($item)->toHaveKey('url')
+            ->and($item['url'])->toBeString()
+            ->and($item['url'])->toContain('/notes');
+    }
+});

--- a/tests/Feature/Chat/RecordReferenceResolverJobContextTest.php
+++ b/tests/Feature/Chat/RecordReferenceResolverJobContextTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
+use App\Models\User;
+use Relaticle\Chat\Support\RecordReferenceResolver;
+
+mutates(RecordReferenceResolver::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->user->switchTeam($this->user->ownedTeams()->first());
+    $this->actingAs($this->user);
+    // Deliberately do NOT call Filament::setTenant() — this mirrors the queued job context
+});
+
+it('resolves a company URL without Filament tenant bound, using auth user currentTeam', function (): void {
+    $company = Company::factory()->for($this->user->currentTeam)->create(['name' => 'Acme Corp']);
+
+    $resolver = resolve(RecordReferenceResolver::class);
+    $ref = $resolver->resolve('company', (string) $company->getKey());
+
+    expect($ref)->not->toBeNull()
+        ->and($ref['url'])->toBeString()
+        ->and($ref['url'])->toContain('/companies/')
+        ->and($ref['label'])->toBe('Acme Corp');
+});
+
+it('resolves a people URL without Filament tenant bound', function (): void {
+    $person = People::factory()->for($this->user->currentTeam)->create(['name' => 'Jane Smith']);
+
+    $ref = resolve(RecordReferenceResolver::class)->resolve('people', (string) $person->getKey());
+
+    expect($ref)->not->toBeNull()
+        ->and($ref['url'])->toContain('/people/');
+});
+
+it('resolves an opportunity URL without Filament tenant bound', function (): void {
+    $opportunity = Opportunity::factory()->for($this->user->currentTeam)->create(['name' => 'Big Deal']);
+
+    $ref = resolve(RecordReferenceResolver::class)->resolve('opportunity', (string) $opportunity->getKey());
+
+    expect($ref)->not->toBeNull()
+        ->and($ref['url'])->toContain('/opportunities/');
+});
+
+it('resolves task to an index URL without Filament tenant bound', function (): void {
+    $ref = resolve(RecordReferenceResolver::class)->resolve('task', 'any-id');
+
+    expect($ref)->not->toBeNull()
+        ->and($ref['url'])->toBeString()
+        ->and($ref['url'])->toContain('/tasks');
+});
+
+it('resolves note to an index URL without Filament tenant bound', function (): void {
+    $ref = resolve(RecordReferenceResolver::class)->resolve('note', 'any-id');
+
+    expect($ref)->not->toBeNull()
+        ->and($ref['url'])->toBeString()
+        ->and($ref['url'])->toContain('/notes');
+});
+
+it('returns null when the user has no current team', function (): void {
+    // Remove from session so currentTeam is null
+    auth()->logout();
+
+    $resolver = resolve(RecordReferenceResolver::class);
+    $ref = $resolver->resolve('company', 'some-id');
+
+    expect($ref)->toBeNull();
+});

--- a/tests/Feature/Chat/StaleOpportunitiesToolTest.php
+++ b/tests/Feature/Chat/StaleOpportunitiesToolTest.php
@@ -70,3 +70,35 @@ it('includes opportunities created long ago with no recent activity when stale_d
     expect($items)->toHaveCount(1)
         ->and($items[0]['attributes']['name'])->toBe('Never Active');
 });
+
+it('still treats an opportunity as stale when a different team has a recent activity_log entry for the same subject_id', function (): void {
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    $otherTeam = $otherUser->currentTeam;
+
+    // Stale opportunity created 40 days ago on the current team
+    $this->travelTo(now()->subDays(40));
+    $staleOpp = Opportunity::factory()->for($this->team)->create(['name' => 'Cross-Team Stale Deal']);
+    $this->travelBack();
+
+    // Insert a recent activity_log row referencing the same subject_id but for a different team
+    DB::table('activity_log')->insert([
+        'log_name' => 'crm',
+        'description' => 'updated',
+        'subject_type' => 'opportunity',
+        'subject_id' => (string) $staleOpp->getKey(),
+        'team_id' => $otherTeam->getKey(),
+        'event' => 'updated',
+        'properties' => '[]',
+        'created_at' => now()->subDays(1)->toDateTimeString(),
+        'updated_at' => now()->subDays(1)->toDateTimeString(),
+    ]);
+
+    $tool = new ListOpportunitiesTool;
+    $response = $tool->handle(new Request(['stale_days' => 30]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('Cross-Team Stale Deal');
+});

--- a/tests/Feature/Chat/StaleOpportunitiesToolTest.php
+++ b/tests/Feature/Chat/StaleOpportunitiesToolTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\OnboardSeed;
+use App\Models\Opportunity;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Tools\Request;
+use Laravel\Pennant\Feature;
+use Relaticle\Chat\Tools\Opportunity\ListOpportunitiesTool;
+
+mutates(ListOpportunitiesTool::class);
+
+beforeEach(function (): void {
+    Feature::define(OnboardSeed::class, false);
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->user->currentTeam;
+    Auth::guard('web')->setUser($this->user);
+});
+
+it('returns only opportunities with no activity in the last 30 days when stale_days is set', function (): void {
+    // Create the stale opportunity 40 days in the past — this also backdates its creation activity log entry
+    $this->travelTo(now()->subDays(40));
+    $staleOpp = Opportunity::factory()->for($this->team)->create(['name' => 'Stale Deal']);
+
+    // Create the active opportunity now, then add a recent manual activity entry
+    $this->travelBack();
+    $activeOpp = Opportunity::factory()->for($this->team)->create(['name' => 'Active Deal']);
+
+    $tool = new ListOpportunitiesTool;
+    $response = $tool->handle(new Request(['stale_days' => 30]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('Stale Deal');
+});
+
+it('includes opportunities created long ago with no recent activity when stale_days is set', function (): void {
+    // Both opportunities created 40 days ago (backdate)
+    $this->travelTo(now()->subDays(40));
+    $neverActive = Opportunity::factory()->for($this->team)->create(['name' => 'Never Active']);
+
+    // Active one also created in the past but gets a recent activity entry
+    $activeOpp = Opportunity::factory()->for($this->team)->create(['name' => 'Active Deal']);
+
+    // Travel back and add a recent activity for the active opportunity
+    $this->travelBack();
+    DB::table('activity_log')->insert([
+        'log_name' => 'crm',
+        'description' => 'updated',
+        'subject_type' => 'opportunity',
+        'subject_id' => (string) $activeOpp->getKey(),
+        'team_id' => $this->team->getKey(),
+        'event' => 'updated',
+        'properties' => '[]',
+        'created_at' => now()->subDays(2)->toDateTimeString(),
+        'updated_at' => now()->subDays(2)->toDateTimeString(),
+    ]);
+
+    $tool = new ListOpportunitiesTool;
+    $response = $tool->handle(new Request(['stale_days' => 30]));
+
+    $data = json_decode($response, true);
+    $items = is_array($data) && isset($data['data']) ? $data['data'] : $data;
+
+    expect($items)->toHaveCount(1)
+        ->and($items[0]['attributes']['name'])->toBe('Never Active');
+});

--- a/tests/Feature/Chat/UpdateCustomFieldToolTest.php
+++ b/tests/Feature/Chat/UpdateCustomFieldToolTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CustomFields\UpdateCustomField;
+use App\Models\CustomField;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\CustomField\UpdateCustomFieldTool;
+use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+mutates(UpdateCustomFieldTool::class, UpdateCustomField::class);
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->owner->currentTeam;
+
+    Auth::guard('web')->setUser($this->owner);
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+    TenantContextService::setTenantId($this->team->getKey());
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    $this->field = CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Industry',
+        'type' => 'text',
+        'system_defined' => false,
+        'active' => true,
+    ]);
+
+    $this->convId = '019df900-6666-7000-8000-000000000001';
+    DB::table('agent_conversations')->insert([
+        'id' => $this->convId,
+        'user_id' => (string) $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'title' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+afterEach(function (): void {
+    TenantContextService::setTenantId(null);
+});
+
+function makeUpdateFieldTool(string $convId): UpdateCustomFieldTool
+{
+    $tool = resolve(UpdateCustomFieldTool::class);
+    $tool->setConversationId($convId);
+
+    return $tool;
+}
+
+it('proposes renaming a custom field and updates name on approval', function (): void {
+    $tool = makeUpdateFieldTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'id' => $this->field->getKey(),
+        'name' => 'Sector',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['type'])->toBe('pending_action')
+        ->and($decoded['operation'])->toBe('update')
+        ->and($decoded['entity_type'])->toBe('custom_field')
+        ->and($decoded['meta']['agent_should_stop'])->toBeTrue();
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    expect($pending->action_class)->toBe(UpdateCustomField::class)
+        ->and($pending->operation)->toBe(PendingActionOperation::Update)
+        ->and($pending->status)->toBe(PendingActionStatus::Pending);
+
+    $service = resolve(PendingActionService::class);
+    $service->approve($pending, $this->owner);
+
+    $this->field->refresh();
+
+    expect($this->field->name)->toBe('Sector');
+});
+
+it('returns error and creates no proposal for non-owner', function (): void {
+    $nonOwner = User::factory()->create();
+    $nonOwner->teams()->attach($this->team, ['role' => 'editor']);
+    $nonOwner->switchTeam($this->team);
+
+    Auth::guard('web')->setUser($nonOwner);
+    $this->actingAs($nonOwner);
+
+    $tool = makeUpdateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'id' => $this->field->getKey(),
+        'name' => 'Sector',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('returns error when trying to update a system_defined field', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    $systemField = CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+        'name' => 'System Field',
+        'type' => 'text',
+        'system_defined' => true,
+    ]);
+
+    $tool = makeUpdateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'id' => $systemField->getKey(),
+        'name' => 'Hacked',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('proposes toggling active status and applies it on approval', function (): void {
+    $tool = makeUpdateFieldTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'id' => $this->field->getKey(),
+        'active' => false,
+    ]));
+
+    $decoded = json_decode($result, true);
+    expect($decoded['type'])->toBe('pending_action');
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    $service = resolve(PendingActionService::class);
+    $service->approve($pending, $this->owner);
+
+    TenantContextService::setTenantId($this->team->getKey());
+    $refreshed = CustomField::query()
+        ->withoutGlobalScope(CustomFieldsActivableScope::class)
+        ->find($this->field->getKey());
+
+    expect($refreshed->active)->toBeFalse();
+});

--- a/tests/Feature/Chat/UpdateCustomFieldToolTest.php
+++ b/tests/Feature/Chat/UpdateCustomFieldToolTest.php
@@ -65,7 +65,8 @@ it('proposes renaming a custom field and updates name on approval', function ():
     $tool = makeUpdateFieldTool($this->convId);
 
     $result = $tool->handle(new Request([
-        'id' => $this->field->getKey(),
+        'entity_type' => 'company',
+        'code' => $this->field->code,
         'name' => 'Sector',
     ]));
 
@@ -100,7 +101,8 @@ it('returns error and creates no proposal for non-owner', function (): void {
 
     $tool = makeUpdateFieldTool($this->convId);
     $result = $tool->handle(new Request([
-        'id' => $this->field->getKey(),
+        'entity_type' => 'company',
+        'code' => $this->field->code,
         'name' => 'Sector',
     ]));
 
@@ -122,7 +124,8 @@ it('returns error when trying to update a system_defined field', function (): vo
 
     $tool = makeUpdateFieldTool($this->convId);
     $result = $tool->handle(new Request([
-        'id' => $systemField->getKey(),
+        'entity_type' => 'company',
+        'code' => $systemField->code,
         'name' => 'Hacked',
     ]));
 
@@ -136,7 +139,8 @@ it('proposes toggling active status and applies it on approval', function (): vo
     $tool = makeUpdateFieldTool($this->convId);
 
     $result = $tool->handle(new Request([
-        'id' => $this->field->getKey(),
+        'entity_type' => 'company',
+        'code' => $this->field->code,
         'active' => false,
     ]));
 

--- a/tests/Feature/Chat/UpdatePersonCompanyDiffTest.php
+++ b/tests/Feature/Chat/UpdatePersonCompanyDiffTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Company;
+use App\Models\People;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Tools\People\UpdatePersonTool;
+
+mutates(UpdatePersonTool::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->user->currentTeam;
+    Auth::guard('web')->setUser($this->user);
+
+    DB::table('agent_conversations')->insert([
+        'id' => '019df800-4444-7000-8000-000000000099',
+        'user_id' => (string) $this->user->getKey(),
+        'team_id' => $this->team->getKey(),
+        'title' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+it('proposal display_data contains a Company field when company_id is changed', function (): void {
+    $oldCompany = Company::factory()->for($this->team)->create(['name' => 'Old Corp']);
+    $newCompany = Company::factory()->for($this->team)->create(['name' => 'New Corp']);
+    $person = People::factory()->for($this->team)->for($oldCompany)->create(['name' => 'Jane Doe']);
+
+    $tool = resolve(UpdatePersonTool::class);
+    $tool->setConversationId('019df800-4444-7000-8000-000000000099');
+
+    $tool->handle(new Request([
+        'id' => (string) $person->getKey(),
+        'company_id' => (string) $newCompany->getKey(),
+    ]));
+
+    $pending = PendingAction::query()
+        ->where('team_id', $this->team->getKey())
+        ->latest()
+        ->firstOrFail();
+
+    $fields = $pending->display_data['fields'];
+    $labels = array_column($fields, 'label');
+
+    expect($labels)->toContain('Company');
+
+    $companyField = $fields[array_search('Company', $labels)];
+
+    expect($companyField['old'])->toBe('Old Corp')
+        ->and($companyField['new'])->toBe('New Corp');
+});
+
+it('proposal display_data does not include Company field when company_id is not changed', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Same Corp']);
+    $person = People::factory()->for($this->team)->for($company)->create(['name' => 'Bob Smith']);
+
+    $tool = resolve(UpdatePersonTool::class);
+    $tool->setConversationId('019df800-4444-7000-8000-000000000099');
+
+    $tool->handle(new Request([
+        'id' => (string) $person->getKey(),
+        'name' => 'Robert Smith',
+    ]));
+
+    $pending = PendingAction::query()
+        ->where('team_id', $this->team->getKey())
+        ->latest()
+        ->firstOrFail();
+
+    $labels = array_column($pending->display_data['fields'], 'label');
+
+    expect($labels)->not->toContain('Company')
+        ->and($labels)->toContain('Name');
+});
+
+it('shows empty old company when person had no company and a new one is assigned', function (): void {
+    $newCompany = Company::factory()->for($this->team)->create(['name' => 'First Corp']);
+    $person = People::factory()->for($this->team)->create([
+        'name' => 'No Company Person',
+        'company_id' => null,
+    ]);
+
+    $tool = resolve(UpdatePersonTool::class);
+    $tool->setConversationId('019df800-4444-7000-8000-000000000099');
+
+    $tool->handle(new Request([
+        'id' => (string) $person->getKey(),
+        'company_id' => (string) $newCompany->getKey(),
+    ]));
+
+    $pending = PendingAction::query()
+        ->where('team_id', $this->team->getKey())
+        ->latest()
+        ->firstOrFail();
+
+    $fields = $pending->display_data['fields'];
+    $companyField = $fields[array_search('Company', array_column($fields, 'label'))];
+
+    expect($companyField['old'])->toBe('')
+        ->and($companyField['new'])->toBe('First Corp');
+});


### PR DESCRIPTION
The AI assistant no longer dead-ends: when it cannot perform an action itself it escorts the user to the right page via a new `GuideToPageTool`/`DestinationResolver`, records it names in replies become clickable deep-links, and an "Ask about this" header action opens a record-scoped chat. It gains analytical reporting (`AggregateCrmTool` for pipeline by stage/company, created-date range list filters, and stale-opportunity detection) backed by the proven custom-field aggregation pattern. Admins can now create/update custom-field definitions and add select options through the existing approve/reject proposal flow (deletion stays escort-only), guarded server-side by a field-type allowlist, per-tenant field/option caps, and a centralized batch-size limit also enforced on bulk delete. Spans 53 files with ~50 new TDD tests; chat suite 535/535, arch 24/24, PHPStan clean, and every phase was verified live in a browser against the redis/Horizon/Reverb stack.

## Test plan
- `php artisan test --compact tests/Feature/Chat` (535/535) and `php -d memory_limit=2G vendor/bin/pest tests/Arch` (24/24)
- `vendor/bin/phpstan analyse` (0 errors)
- Browser-verified end-to-end: create-custom-field via chat, pipeline-by-stage, citations, bulk->import escort, and delete-escort