### PR TITLE
Make AI thread summary text copyable

### DIFF
--- a/resources/views/filament/actions/ai-summary.blade.php
+++ b/resources/views/filament/actions/ai-summary.blade.php
@@ -6,16 +6,48 @@
             </p>
         </div>
     @else
-        <div class="rounded-lg bg-gray-50 dark:bg-gray-800 p-4">
-            <p class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
-                {{ $summary->summary }}
-            </p>
-        </div>
+        <div
+            x-data="{
+                copied: false,
+                copy() {
+                    window.navigator.clipboard.writeText(this.$refs.summary.innerText.trim()).then(() => {
+                        this.copied = true;
+                        setTimeout(() => this.copied = false, 2000);
+                    });
+                },
+            }"
+            class="space-y-4"
+        >
+            <div class="rounded-lg bg-gray-50 dark:bg-gray-800 p-4">
+                <p x-ref="summary" class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">
+                    {{ $summary->summary }}
+                </p>
+            </div>
 
-        <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-            <div class="flex items-center gap-2">
-                <x-heroicon-o-clock class="h-4 w-4" />
-                <span>{{ __('Generated') }} {{ $summary->created_at->diffForHumans() }}</span>
+            <div class="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                <div class="flex items-center gap-2">
+                    <x-heroicon-o-clock class="h-4 w-4" />
+                    <span>{{ __('Generated') }} {{ $summary->created_at->diffForHumans() }}</span>
+                </div>
+
+                <button
+                    type="button"
+                    x-on:click="copy()"
+                    class="flex items-center gap-1.5 rounded-md px-2 py-1 font-medium text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                >
+                    <template x-if="! copied">
+                        <span class="flex items-center gap-1.5">
+                            <x-heroicon-o-clipboard-document class="h-4 w-4" />
+                            <span>{{ __('Copy') }}</span>
+                        </span>
+                    </template>
+                    <template x-if="copied">
+                        <span class="flex items-center gap-1.5 text-success-600 dark:text-success-400">
+                            <x-heroicon-o-check class="h-4 w-4" />
+                            <span>{{ __('Copied') }}</span>
+                        </span>
+                    </template>
+                </button>
             </div>
         </div>
     @endif


### PR DESCRIPTION
## What

Adds a **Copy** button to the AI email thread summary modal (`resources/views/filament/actions/ai-summary.blade.php`).

- New button sits in the modal footer, opposite the "Generated …" timestamp.
- Click copies the summary text via `navigator.clipboard`; button swaps to a green "Copied" check for 2s, then reverts (Alpine `x-data`).
- User-facing strings (`Copy`/`Copied`) wrapped in `__()` per i18n rules.

## Why

Users want to grab the AI-generated thread summary without manually selecting text in the modal.

## Verification

Verified in the local app (Filament panel) — button renders and is positioned correctly in light mode. Toggle is wired correctly; clipboard write succeeds on a real user click (secure context via Herd https).