### PR TITLE
fix(email): render full email body in detail view (sanitizer truncation)

### DIFF
--- a/app/Support/EmailHtmlSanitizer.php
+++ b/app/Support/EmailHtmlSanitizer.php
@@ -26,6 +26,11 @@ final readonly class EmailHtmlSanitizer
         // CSS values are not deep-sanitized, but the body is rendered in an
         // opaque-origin sandboxed iframe, so CSS cannot read cookies or run JS.
         $config = (new HtmlSanitizerConfig)
+            // Symfony defaults to truncating input at 20 KB, which silently
+            // clips real email bodies (newsletters routinely run 50–150 KB) to a
+            // fraction of their content. The body is already size-bounded at
+            // ingestion, so lift the cap and let the full message render.
+            ->withMaxInputLength(-1)
             ->allowSafeElements()
             ->allowElement('style')
             ->allowRelativeLinks()

--- a/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
+++ b/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
@@ -100,6 +100,22 @@ it('preserves inline styles and presentational attributes used by email layouts'
         ->assertMountedActionModalSeeHtml('align=&quot;center&quot;');
 });
 
+it('does not truncate email bodies larger than the sanitizer default input cap', function (): void {
+    // Symfony HtmlSanitizer truncates input at 20 KB by default; real email
+    // bodies routinely exceed that, so the tail of the message must survive.
+    $body = '<p>START-MARKER</p>'
+        .str_repeat('<p>filler paragraph to exceed the twenty kilobyte input cap</p>', 600)
+        .'<p>END-MARKER-9F3A</p>';
+
+    expect(strlen($body))->toBeGreaterThan(20_000);
+
+    $email = makeEmailWithBody($body);
+
+    mountEmailView($email)
+        ->assertMountedActionModalSeeHtml('START-MARKER')
+        ->assertMountedActionModalSeeHtml('END-MARKER-9F3A');
+});
+
 it('renders the email view iframe without a same-origin sandbox', function (): void {
     $email = makeEmailWithBody('<p>body</p>');
 


### PR DESCRIPTION
## Problem
Opening an email in the inbox detail view showed only the first portion of long messages. Rendering the raw `body_html` showed everything, but the sanitized output was clipped — so the loss happened inside sanitization, not rendering.

## Root cause
`App\Support\EmailHtmlSanitizer` builds a Symfony `HtmlSanitizerConfig` without setting `maxInputLength`, which defaults to **20 KB**. The sanitizer does `substr($input, 0, 20000)` before stripping, so a 73 KB email body was cut to 20 KB → ~15.7 KB rendered. Real newsletters routinely run 50–150 KB, so most long emails were truncated.

## Fix
Set `->withMaxInputLength(-1)` to disable the input cap. The body is already size-bounded at ingestion; the sanitizer's job here is XSS stripping, not input-size DoS protection. All other sanitization (scripts, inline event handlers, `javascript:` URLs) is unchanged.

## Verification
- Tinker on a real 73 KB body: sanitized output `15699` → `72710` bytes (full content; 467 bytes of unsafe markup still stripped).
- Added a regression test: an email body >20 KB asserts both the leading and trailing markers survive the rendered view.
- `6/6` tests pass in `EmailBodySanitizationTest`; Pint / PHPStan / Rector clean.