### PR TITLE
Add plus icon to blocklist repeater add button

### DIFF
--- a/app/Livewire/App/Email/UserEmailPrivacySettings.php
+++ b/app/Livewire/App/Email/UserEmailPrivacySettings.php
@@ -89,6 +89,7 @@ final class UserEmailPrivacySettings extends BaseLivewireComponent
                             ])
                             ->columns(2)
                             ->addActionLabel(__('email/privacy-settings.blocklist.add_entry'))
+                            ->addAction(fn (Action $action): Action => $action->icon('heroicon-m-plus'))
                             ->reorderable(false),
                         Actions::make([
                             Action::make('saveBlocklist')


### PR DESCRIPTION
## What
Adds a plus (`heroicon-m-plus`) icon to the "Add entry" button of the **Blocklist** repeater on the user email privacy settings page (`UserEmailPrivacySettings`).

## Why
The add-entry button was icon-less, reading as a bare text button. The plus icon makes the add affordance clearer and matches common Filament repeater conventions.

## Change
`UserEmailPrivacySettings.php` — `->addAction(fn (Action $action): Action => $action->icon('heroicon-m-plus'))` on the `blocklist` repeater.

## Verification
- Pint + PHPStan clean.
- Browser DOM confirms the rendered add button now contains the plus icon (`heroicon-m-plus`) before the "Add entry" label.