### PR TITLE
fix(email): render quoted original message in a sandboxed iframe

### DIFF
--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Filament\Concerns;
 
 use App\Models\User;
+use App\Support\EmailHtmlSanitizer;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
@@ -456,6 +457,7 @@ trait HasEmailComposeActions
                 ->content(function (Get $get): HtmlString {
                     $isForward = $get('mode') === 'forward';
                     $label = $isForward ? 'Forwarded message' : 'Original message';
+                    $safeQuotedHtml = EmailHtmlSanitizer::sanitize($get('quoted_body_html')) ?? '';
 
                     return new HtmlString(
                         '<div x-data="{ open: false }" class="mt-1">'
@@ -467,8 +469,8 @@ trait HasEmailComposeActions
                         .'</span>'
                         .'<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>'
                         .'</div>'
-                        .'<div x-show="open" x-collapse class="mt-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-3 text-sm text-gray-500 dark:text-gray-400 prose dark:prose-invert max-w-none">'
-                        .($get('quoted_body_html') ?? '')
+                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white">'
+                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0" style="height:20rem"></iframe>'
                         .'</div>'
                         .'</div>'
                     );

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Filament\Pages;
 
 use App\Models\User;
+use App\Support\EmailHtmlSanitizer;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
@@ -829,6 +830,7 @@ final class EmailInboxPage extends Page
                 ->content(function (Get $get): HtmlString {
                     $isForward = $get('mode') === 'forward';
                     $label = $isForward ? 'Forwarded message' : 'Original message';
+                    $safeQuotedHtml = EmailHtmlSanitizer::sanitize($get('quoted_body_html')) ?? '';
 
                     return new HtmlString(
                         '<div x-data="{ open: false }" class="mt-1">'
@@ -840,8 +842,8 @@ final class EmailInboxPage extends Page
                         .'</span>'
                         .'<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>'
                         .'</div>'
-                        .'<div x-show="open" x-collapse class="mt-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 px-4 py-3 text-sm text-gray-500 dark:text-gray-400 prose dark:prose-invert max-w-none">'
-                        .($get('quoted_body_html') ?? '')
+                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white">'
+                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0" style="height:20rem"></iframe>'
                         .'</div>'
                         .'</div>'
                     );

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -12,6 +12,7 @@ use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
+use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailBody;
@@ -128,6 +129,24 @@ it('forward persists a queued Email with FORWARD creation_source', function (): 
 
     expect($forward->status)->toBe(EmailStatus::QUEUED)
         ->and($forward->in_reply_to)->toBeNull();
+});
+
+it('renders the quoted original message in a sandboxed iframe with sanitized content', function (): void {
+    $this->inboundEmail->body->update([
+        'body_html' => '<style>body{background:#fff}</style><p>Quoted body</p><script>alert(1)</script>',
+    ]);
+
+    livewire(EmailInboxPage::class)
+        ->mountAction(
+            'replyForwardEmail',
+            arguments: ['emailId' => $this->inboundEmail->id, 'mode' => 'reply'],
+        )
+        ->assertActionMounted('replyForwardEmail')
+        // Quoted body is isolated in a sandboxed iframe, mirroring the email body view,
+        // instead of being dumped inline where the email's own styles leak into the panel.
+        ->assertSee('sandbox="allow-popups allow-popups-to-escape-sandbox"', escape: false)
+        // The untrusted script tag is stripped by the sanitizer before display.
+        ->assertDontSee('alert(1)', escape: false);
 });
 
 it('reply_all persists a queued Email with REPLY_ALL creation_source', function (): void {


### PR DESCRIPTION
## Problem

On the email inbox detail page, the email **body** renders cleanly because it goes through `EmailHtmlSanitizer` and is displayed inside a sandboxed `<iframe>` (isolated styles). The reply/forward **"Original message"** preview did not — it dumped the raw `quoted_body_html` straight into a `prose` `<div>`.

Two consequences:
- **Broken styling:** the quoted email's own `<style>` rules, inline styles, and white background leaked into the dark themed panel, so the section rendered as a broken white block instead of matching the body view.
- **XSS:** `quoted_body_html` is the raw `$email->body->body_html` (untrusted, unsanitized) being injected into the panel DOM.

## Fix

Render the quoted body the same way as the email body — pass it through `EmailHtmlSanitizer::sanitize()` and display it in a sandboxed iframe (`sandbox`, `referrerpolicy="no-referrer"`). This isolates the email's CSS and closes the XSS hole.

The reply form schema is duplicated across two render sites (the page does not use the compose trait), so both were updated identically:
- `packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php`
- `packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php`

## Verification

- Reproduced + confirmed the fix in the live app (DOM): the section now renders a sandboxed iframe with sanitized content, identical to the body view.
- New test in `ReplyForwardEmailTest` mounts the reply action and asserts the sandboxed iframe is rendered and the script payload is stripped (fails against the old code).
- `pint` / `rector` / `phpstan` (0 errors) / type-coverage (100%) / tests (4/4) all green.