### PR TITLE
fix: correct stale Laravel version and test count; update dependencies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 Multi-tenant SaaS CRM with paying customers. Tenant isolation is the highest-priority concern — a single cross-tenant data leak is a critical security incident. The app uses Filament panels with a per-request `TeamScope` global scope applied via middleware, not in model boot. `Model::unguard()` is enabled globally.
 
-Stack: PHP 8.4, Laravel 12, Filament 5, Livewire 4, Pest 4, Tailwind CSS 4.
+Stack: PHP 8.4, Laravel 13, Filament 5, Livewire 4, Pest 4, Tailwind CSS 4.
 
 CI enforces: PHPStan level 7, Pint formatting, Rector, 99.9% type coverage, full test suite. CI does **not** enforce: code coverage percentage, mutation testing, or required reviewer count.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/deploy.yml?style=for-the-badge&label=tests" alt="Tests"></a>
   <a href="https://relaticle.com/docs/mcp"><img src="https://img.shields.io/badge/MCP_Tools-30-8A2BE2?style=for-the-badge" alt="30 MCP Tools"></a>
-  <a href="https://laravel.com/docs/12.x"><img src="https://img.shields.io/badge/Laravel-12.x-FF2D20?style=for-the-badge&logo=laravel" alt="Laravel 12"></a>
+  <a href="https://laravel.com/docs/13.x"><img src="https://img.shields.io/badge/Laravel-13.x-FF2D20?style=for-the-badge&logo=laravel" alt="Laravel 13"></a>
   <a href="https://php.net"><img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4"></a>
   <a href="https://github.com/Relaticle/relaticle/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=for-the-badge" alt="License"></a>
 </p>
@@ -41,7 +41,7 @@ Relaticle is a self-hosted CRM with a production-grade MCP server. Connect any A
 - **Agent-Native Infrastructure** - MCP server with 30 tools, REST API with full CRUD, schema discovery for AI agents
 - **Customizable Data Model** - 22 field types including entity relationships, conditional visibility, and per-field encryption. No migrations needed.
 - **Multi-Team Isolation** - 5-layer authorization with team-scoped data and workspaces
-- **Modern Tech Stack** - Laravel 12, Filament 5, PHP 8.4, 1,100+ automated tests
+- **Modern Tech Stack** - Laravel 13, Filament 5, PHP 8.4, 2,000+ automated tests
 - **Privacy-First** - Self-hosted, AGPL-3.0, your data stays on your server
 
 # Requirements

--- a/composer.lock
+++ b/composer.lock
@@ -239,16 +239,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.385.2",
+            "version": "3.385.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "cc71d2d80d6effff8bf806a96c7f0f97ce4d7693"
+                "reference": "1952d9ce58aca5a5d444f74ed1034f7ba9125002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/cc71d2d80d6effff8bf806a96c7f0f97ce4d7693",
-                "reference": "cc71d2d80d6effff8bf806a96c7f0f97ce4d7693",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1952d9ce58aca5a5d444f74ed1034f7ba9125002",
+                "reference": "1952d9ce58aca5a5d444f74ed1034f7ba9125002",
                 "shasum": ""
             },
             "require": {
@@ -330,9 +330,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.385.2"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.385.3"
             },
-            "time": "2026-06-18T18:08:43+00:00"
+            "time": "2026-06-19T18:07:45+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -2524,16 +2524,16 @@
         },
         {
             "name": "giggsey/libphonenumber-for-php-lite",
-            "version": "9.0.32",
+            "version": "9.0.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php-lite.git",
-                "reference": "8e3b2cfd8fb77b3922dad43f9a70d516c28570d2"
+                "reference": "38c09da75cebfd6f197b61e57b3a655db04163e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/8e3b2cfd8fb77b3922dad43f9a70d516c28570d2",
-                "reference": "8e3b2cfd8fb77b3922dad43f9a70d516c28570d2",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php-lite/zipball/38c09da75cebfd6f197b61e57b3a655db04163e6",
+                "reference": "38c09da75cebfd6f197b61e57b3a655db04163e6",
                 "shasum": ""
             },
             "require": {
@@ -2598,7 +2598,7 @@
                 "issues": "https://github.com/giggsey/libphonenumber-for-php-lite/issues",
                 "source": "https://github.com/giggsey/libphonenumber-for-php-lite"
             },
-            "time": "2026-06-05T07:33:50+00:00"
+            "time": "2026-06-22T10:35:37+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -12336,16 +12336,16 @@
         },
         {
             "name": "spatie/temporary-directory",
-            "version": "2.3.1",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/temporary-directory.git",
-                "reference": "662e481d6ec07ef29fd05010433428851a42cd07"
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/662e481d6ec07ef29fd05010433428851a42cd07",
-                "reference": "662e481d6ec07ef29fd05010433428851a42cd07",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/32cbb9645b28839cf4f476708e99a2c70e6802c9",
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9",
                 "shasum": ""
             },
             "require": {
@@ -12381,7 +12381,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/temporary-directory/issues",
-                "source": "https://github.com/spatie/temporary-directory/tree/2.3.1"
+                "source": "https://github.com/spatie/temporary-directory/tree/2.4.0"
             },
             "funding": [
                 {
@@ -12393,7 +12393,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-12T07:42:22+00:00"
+            "time": "2026-06-22T07:55:44+00:00"
         },
         {
             "name": "spomky-labs/cbor-php",
@@ -16868,16 +16868,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v3.1.1",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
+                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
-                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
+                "reference": "2f3ebed5a4f663968a0590dbb7654a8b32cb63cb",
                 "shasum": ""
             },
             "require": {
@@ -16887,7 +16887,7 @@
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.23.1"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -16937,7 +16937,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.1"
+                "source": "https://github.com/amphp/amp/tree/v3.1.2"
             },
             "funding": [
                 {
@@ -16945,7 +16945,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-27T21:42:00+00:00"
+            "time": "2026-06-21T13:59:44+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -21568,16 +21568,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.4.6",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "9b9e5c76618e4d359f65b54ca2eabcad3d1761ee"
+                "reference": "34a9124ece04df818e6b4be4ecd0a4e23f4c0c64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9b9e5c76618e4d359f65b54ca2eabcad3d1761ee",
-                "reference": "9b9e5c76618e4d359f65b54ca2eabcad3d1761ee",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/34a9124ece04df818e6b4be4ecd0a4e23f4c0c64",
+                "reference": "34a9124ece04df818e6b4be4ecd0a4e23f4c0c64",
                 "shasum": ""
             },
             "require": {
@@ -21616,7 +21616,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.4.6"
+                "source": "https://github.com/rectorphp/rector/tree/2.5.1"
             },
             "funding": [
                 {
@@ -21624,7 +21624,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-17T11:56:28+00:00"
+            "time": "2026-06-21T10:28:27+00:00"
         },
         {
             "name": "revolt/event-loop",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "taipei",
+    "name": "mumbai",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -1078,9 +1078,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
             "dev": true,
             "funding": [
                 {
@@ -1098,10 +1098,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
+                "baseline-browser-mapping": "^2.10.38",
+                "caniuse-lite": "^1.0.30001799",
+                "electron-to-chromium": "^1.5.376",
+                "node-releases": "^2.0.48",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -1885,9 +1885,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.13",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-            "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+            "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "funding": [
                 {
                     "type": "github",

--- a/packages/Documentation/resources/markdown/developer-guide.md
+++ b/packages/Documentation/resources/markdown/developer-guide.md
@@ -20,7 +20,7 @@ Visit `http://localhost:8000` to access the application.
 
 | Component | Technology                            |
 |-----------|---------------------------------------|
-| Backend | PHP 8.4, Laravel 12                   |
+| Backend | PHP 8.4, Laravel 13                   |
 | Admin UI | Filament 5                            |
 | Frontend | Livewire 4, Alpine.js, Tailwind CSS 4 |
 | Database | PostgreSQL                             |
@@ -172,7 +172,7 @@ PRs must pass all checks before merge.
 
 ## Resources
 
-- [Laravel Docs](https://laravel.com/docs/12.x)
+- [Laravel Docs](https://laravel.com/docs/13.x)
 - [Filament Docs](https://filamentphp.com/docs)
 - [Livewire Docs](https://livewire.laravel.com/)
 - [Pest Docs](https://pestphp.com/)

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -1,6 +1,6 @@
 @php
     $faqs = [
-        ['Is Relaticle production-ready?', 'Yes. Relaticle has 1,100+ automated tests, 5-layer authorization, 56+ MCP-specific tests, and is used in production. The codebase is continuously tested with PHPStan static analysis and Pest mutation testing.'],
+        ['Is Relaticle production-ready?', 'Yes. Relaticle has 2,000+ automated tests, 5-layer authorization, 56+ MCP-specific tests, and is used in production. The codebase is continuously tested with PHPStan static analysis and Pest mutation testing.'],
         ['What can the built-in AI chat do?', 'Ask anything about your CRM and the chat works on your data: list and search records, draft follow-ups, summarize a deal, create a task, update or delete a record. @-mention any record (people, companies, deals, tasks, notes) to scope a question. Voice input, persistent searchable history, and dashboard insight cards are included.'],
         ['Can the AI chat delete or change my CRM data without my approval?', 'No. Destructive operations (delete, update existing records) show an approval card with Approve and Reject buttons — nothing happens until you click. Approved destructive actions can be undone for 5 seconds via a toast. Read-only and create operations don\'t require approval.'],
         ['Does the built-in chat send my data to OpenAI or Anthropic?', 'Inference runs through whichever AI provider your team configures (Anthropic Claude, Google Gemini, or any OpenAI-compatible endpoint). Conversation history is stored only in your Relaticle database — Relaticle never trains on your data. Self-hosted teams supply their own provider keys, so the destination is yours to choose.'],
@@ -46,7 +46,7 @@
                     '22 custom field types with conditional visibility and encryption',
                     'Self-hosted with full data ownership',
                     'Multi-team isolation with 5-layer authorization',
-                    '1,100+ automated tests',
+                    '2,000+ automated tests',
                     'CSV import and export',
                 ])
                 ->license('https://www.gnu.org/licenses/agpl-3.0.html')

--- a/resources/views/home/partials/community.blade.php
+++ b/resources/views/home/partials/community.blade.php
@@ -43,7 +43,7 @@
         <div class="max-w-3xl mx-auto">
             <div class="rounded-xl border border-gray-200/80 dark:border-white/[0.06] bg-gray-50/50 dark:bg-white/[0.015] overflow-hidden">
                 <div class="grid grid-cols-2 md:grid-cols-4 divide-x divide-gray-200/60 dark:divide-white/[0.04]">
-                    @foreach([['AGPL-3.0', 'Open Source'], ['1,100+', 'Automated Tests'], ['30', 'MCP Tools'], ['Free', 'Forever']] as $index => [$value, $label])
+                    @foreach([['AGPL-3.0', 'Open Source'], ['2,000+', 'Automated Tests'], ['30', 'MCP Tools'], ['Free', 'Forever']] as $index => [$value, $label])
                         <div class="px-6 py-5 text-center @if($index >= 2) border-t border-gray-200/60 dark:border-white/[0.04] md:border-t-0 @endif">
                             <div class="text-lg font-semibold text-gray-900 dark:text-white tracking-tight">{{ $value }}</div>
                             <div class="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5 uppercase tracking-wider font-medium">{{ $label }}</div>

--- a/resources/views/home/partials/features.blade.php
+++ b/resources/views/home/partials/features.blade.php
@@ -299,7 +299,7 @@
                         Start for free
                     </x-marketing.button>
                     <div class="mt-3 flex items-center gap-3 text-[10px] text-gray-500 dark:text-gray-500">
-                        <span>No credit card</span><span>&middot;</span><span>1,100+ tests</span><span>&middot;</span><span>AGPL-3.0</span>
+                        <span>No credit card</span><span>&middot;</span><span>2,000+ tests</span><span>&middot;</span><span>AGPL-3.0</span>
                     </div>
                 </div>
             </div>

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -173,7 +173,7 @@
             <div class="mt-16 max-w-4xl mx-auto">
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
                     @foreach([
-                        ['ri-shield-check-line', '1,100+', 'Automated Tests'],
+                        ['ri-shield-check-line', '2,000+', 'Automated Tests'],
                         ['ri-robot-2-line', '30', 'MCP Tools'],
                         ['ri-stack-line', '22', 'Field Types'],
                         ['ri-lock-line', '5-Layer', 'Authorization'],


### PR DESCRIPTION
Corrects the stale Laravel version (12 → 13 — `composer.json` requires `^13`, v13.16 installed) across the README badge, the public docs site, the GitHub Copilot context, and the marketing pages. Refreshes the automated-test-count claim from "1,100+" to "2,000+" (actual runner inventory is 2,312). Bumps composer dependencies (rector 2.4.6→2.5.1, aws-sdk-php, libphonenumber-for-php-lite, spatie/temporary-directory, amphp/amp) and npm dependencies (browserslist, nanoid) within existing constraints — `composer audit` and `npm audit` report no advisories/vulnerabilities. Note: despite the branch name, this PR contains no compose/Reverb or BYO-key changes (those remain under discussion).

**Verification:** `npm run build` green, Pint clean; full non-browser suite green — 2,279 passed, 2 skipped, 0 failed (2,281 tests, 6,537 assertions). Browser suite (31) not run here (needs the served app + Playwright).