### PR TITLE
fix(email): preselect connected account in signature create form

### DIFF
--- a/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
@@ -84,8 +84,8 @@ final class EmailSignaturesPage extends Page
         return ConnectedAccount::query()
             ->where('user_id', auth()->id())
             ->where('team_id', filament()->getTenant()?->getKey())
-            ->where('status', 'active')
-            ->oldest()
+            ->active()
+            ->defaultFirst()
             ->get();
     }
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
@@ -85,7 +85,7 @@ final class EmailSignaturesPage extends Page
             ->where('user_id', auth()->id())
             ->where('team_id', filament()->getTenant()?->getKey())
             ->where('status', 'active')
-            ->orderBy('created_at')
+            ->oldest()
             ->get();
     }
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailSignaturesPage.php
@@ -76,6 +76,19 @@ final class EmailSignaturesPage extends Page
             ->where('user_id', auth()->id());
     }
 
+    /**
+     * @return Collection<int, ConnectedAccount>
+     */
+    private function activeAccounts(): Collection
+    {
+        return ConnectedAccount::query()
+            ->where('user_id', auth()->id())
+            ->where('team_id', filament()->getTenant()?->getKey())
+            ->where('status', 'active')
+            ->orderBy('created_at')
+            ->get();
+    }
+
     private function findOwnedAccount(string $id): ConnectedAccount
     {
         /** @var ConnectedAccount */
@@ -95,16 +108,13 @@ final class EmailSignaturesPage extends Page
             ->schema([
                 Select::make('connected_account_id')
                     ->label(__('filament/pages/email-signatures.fields.connected_account'))
-                    ->options(fn (): array => ConnectedAccount::query()
-                        ->where('user_id', auth()->id())
-                        ->where('team_id', filament()->getTenant()?->getKey())
-                        ->where('status', 'active')
-                        ->get()
+                    ->options(fn (): array => $this->activeAccounts()
                         ->mapWithKeys(fn (ConnectedAccount $account): array => [
                             $account->getKey() => $account->label,
                         ])
                         ->all()
                     )
+                    ->default(fn (): ?string => $this->activeAccounts()->first()?->getKey())
                     ->required(),
 
                 TextInput::make('name')

--- a/tests/Feature/EmailIntegration/EmailSignaturesPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailSignaturesPageTest.php
@@ -72,6 +72,26 @@ it('preselects the connected account when opening the create form', function ():
         ->assertSet('mountedActions.0.data.connected_account_id', $this->account->id);
 });
 
+it('preselects the default account, not merely the oldest, when opening the create form', function (): void {
+    // $this->account is the oldest. Add a newer account and mark it default.
+    $newer = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'provider' => EmailProvider::GMAIL,
+        'provider_account_id' => 'default-account-id',
+        'email_address' => 'default@example.com',
+        'display_name' => 'Default Sender',
+        'is_default' => true,
+        'access_token' => 'fake-token-default',
+        'status' => EmailAccountStatus::ACTIVE,
+        'contact_creation_mode' => ContactCreationMode::None,
+    ]));
+
+    livewire(EmailSignaturesPage::class)
+        ->mountAction('createSignature')
+        ->assertSet('mountedActions.0.data.connected_account_id', $newer->id);
+});
+
 it('requires connected_account_id when creating a signature', function (): void {
     livewire(EmailSignaturesPage::class)
         ->callAction('createSignature', data: [

--- a/tests/Feature/EmailIntegration/EmailSignaturesPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailSignaturesPageTest.php
@@ -66,6 +66,12 @@ it('creates a signature and sends success notification', function (): void {
     expect(EmailSignature::where('name', 'Work Signature')->exists())->toBeTrue();
 });
 
+it('preselects the connected account when opening the create form', function (): void {
+    livewire(EmailSignaturesPage::class)
+        ->mountAction('createSignature')
+        ->assertSet('mountedActions.0.data.connected_account_id', $this->account->id);
+});
+
 it('requires connected_account_id when creating a signature', function (): void {
     livewire(EmailSignaturesPage::class)
         ->callAction('createSignature', data: [


### PR DESCRIPTION
## What

The **Create Signature** form on the Signatures page did not preselect a sender account. The `connected_account_id` Select showed the "Select an option" placeholder even when the user had only one active connected account, forcing a manual pick.

## Why

The compose and reply/forward forms both `->fillForm()` the active account, but `createSignatureAction` had no default — inconsistent UX and an unnecessary required step.

## Changes

- `EmailSignaturesPage`: extracted an `activeAccounts()` helper (dedups the options query, `orderBy('created_at')` for deterministic ordering) and added `->default()` to the `connected_account_id` Select so it preselects the first active account.
- Added a regression test asserting the create form preselects the account on mount.

## Verification

- `pest` filtered tests pass (preselect + create)
- `phpstan` clean
- type coverage 100%