### PR TITLE
feat(email): default connected account per user/team

### DIFF
--- a/database/factories/ConnectedAccountFactory.php
+++ b/database/factories/ConnectedAccountFactory.php
@@ -29,6 +29,7 @@ final class ConnectedAccountFactory extends Factory
             'email_address' => $this->faker->unique()->safeEmail(),
             'display_name' => $this->faker->name(),
             'access_token' => 'fake-token',
+            'is_default' => false,
             'status' => EmailAccountStatus::ACTIVE,
             'contact_creation_mode' => ContactCreationMode::None,
             'auto_create_companies' => false,
@@ -39,6 +40,13 @@ final class ConnectedAccountFactory extends Factory
     {
         return $this->state(fn (): array => [
             'provider' => EmailProvider::AZURE,
+        ]);
+    }
+
+    public function default(): static
+    {
+        return $this->state(fn (): array => [
+            'is_default' => true,
         ]);
     }
 

--- a/database/migrations/2026_06_22_000001_add_is_default_to_connected_accounts_table.php
+++ b/database/migrations/2026_06_22_000001_add_is_default_to_connected_accounts_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->boolean('is_default')->default(false)->after('display_name');
+        });
+
+        // Guarantee at most one default account per user within a team. Scoped to
+        // live rows so a soft-deleted default never blocks promoting a new one.
+        DB::statement(
+            'CREATE UNIQUE INDEX connected_accounts_one_default_per_user_team '.
+            'ON connected_accounts (user_id, team_id) '.
+            'WHERE is_default = true AND deleted_at IS NULL'
+        );
+
+        // Backfill: make the oldest live account the default for each user/team
+        // that has connections but no default yet.
+        DB::statement(<<<'SQL'
+            UPDATE connected_accounts AS ca
+            SET is_default = true
+            FROM (
+                SELECT DISTINCT ON (user_id, team_id) id
+                FROM connected_accounts
+                WHERE deleted_at IS NULL
+                ORDER BY user_id, team_id, created_at, id
+            ) AS oldest
+            WHERE ca.id = oldest.id
+              AND NOT EXISTS (
+                  SELECT 1 FROM connected_accounts d
+                  WHERE d.user_id = ca.user_id
+                    AND d.team_id = ca.team_id
+                    AND d.is_default = true
+                    AND d.deleted_at IS NULL
+              )
+        SQL);
+    }
+};

--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -10,6 +10,7 @@ return [
         'manage' => 'Manage',
         're_auth' => 'Re-authenticate',
         'edit_settings' => 'Settings',
+        'set_default' => 'Set as default',
         'disconnect' => 'Disconnect',
         'sync_calendar' => [
             'enable_label' => 'Sync calendar',
@@ -61,5 +62,10 @@ return [
             'title' => 'Account disconnected.',
             'body' => 'The account and its signatures have been removed.',
         ],
+        'default_set' => [
+            'title' => 'Default account updated.',
+            'body' => ':email is now your default sending account.',
+        ],
     ],
+    'default_badge' => 'Default',
 ];

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -12,6 +12,11 @@
                         <x-filament::badge :color="$account->status->getColor()">
                             {{ $account->status->getLabel() }}
                         </x-filament::badge>
+                        @if ($account->is_default)
+                            <x-filament::badge color="warning" icon="heroicon-s-star">
+                                {{ __('filament/pages/email-accounts.default_badge') }}
+                            </x-filament::badge>
+                        @endif
                     </div>
                     <div class="flex items-center gap-3">
                         @if ($account->last_synced_at)

--- a/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
@@ -45,6 +45,20 @@ final readonly class ConnectAccountAction
                 $account->restore();
             }
 
+            // The first account a user connects becomes their default. This also
+            // re-promotes a fresh connection when a previous default was removed,
+            // so the user is never left without one.
+            $hasDefault = ConnectedAccount::query()
+                ->where('user_id', $data->userId)
+                ->where('team_id', $data->teamId)
+                ->where('is_default', true)
+                ->whereKeyNot($account->getKey())
+                ->exists();
+
+            if (! $hasDefault && ! $account->is_default) {
+                $account->update(['is_default' => true]);
+            }
+
             return $account;
         });
     }

--- a/packages/EmailIntegration/src/Actions/DisconnectConnectedAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/DisconnectConnectedAccountAction.php
@@ -4,17 +4,35 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 final readonly class DisconnectConnectedAccountAction
 {
     public function execute(ConnectedAccount $account): void
     {
-        // Account is soft-deleted, so the DB-level cascade on email_signatures never
-        // fires. Remove dependent signatures explicitly to avoid orphaned rows whose
-        // connectedAccount relation resolves to null on the signatures page.
-        $account->signatures()->delete();
+        DB::transaction(function () use ($account): void {
+            // Account is soft-deleted, so the DB-level cascade on email_signatures never
+            // fires. Remove dependent signatures explicitly to avoid orphaned rows whose
+            // connectedAccount relation resolves to null on the signatures page.
+            $account->signatures()->delete();
 
-        $account->delete();
+            $wasDefault = $account->is_default;
+
+            $account->delete();
+
+            // Never leave the user without a default: hand it to their oldest
+            // remaining live account, if any.
+            if ($wasDefault) {
+                $successor = ConnectedAccount::query()
+                    ->where('user_id', $account->user_id)
+                    ->where('team_id', $account->team_id)
+                    ->whereKeyNot($account->getKey())
+                    ->oldest()
+                    ->first();
+
+                $successor?->update(['is_default' => true]);
+            }
+        });
     }
 }

--- a/packages/EmailIntegration/src/Actions/SetDefaultConnectedAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/SetDefaultConnectedAccountAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use Illuminate\Support\Facades\DB;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+final readonly class SetDefaultConnectedAccountAction
+{
+    /**
+     * Promote the given account to the user's default within its team. Only one
+     * account is default at a time, so the previous default is demoted first
+     * (the partial unique index forbids two live defaults for a user/team).
+     */
+    public function execute(ConnectedAccount $account): void
+    {
+        if ($account->is_default) {
+            return;
+        }
+
+        DB::transaction(function () use ($account): void {
+            ConnectedAccount::query()
+                ->where('user_id', $account->user_id)
+                ->where('team_id', $account->team_id)
+                ->where('is_default', true)
+                ->whereKeyNot($account->getKey())
+                ->update(['is_default' => false]);
+
+            $account->update(['is_default' => true]);
+        });
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -70,6 +70,7 @@ trait HasEmailComposeActions
                     ->where('user_id', $this->getAuthenticatedUser()->getKey())
                     ->where('team_id', filament()->getTenant()?->getKey())
                     ->where('status', 'active')
+                    ->defaultFirst()
                     ->first();
 
                 if ($account === null) {
@@ -143,6 +144,7 @@ trait HasEmailComposeActions
                     ->where('user_id', $user->getKey())
                     ->where('team_id', filament()->getTenant()?->getKey())
                     ->where('status', 'active')
+                    ->defaultFirst()
                     ->first();
 
                 $toParticipants = match ($mode) {
@@ -586,6 +588,7 @@ trait HasEmailComposeActions
                 ->where('user_id', $this->getAuthenticatedUser()->getKey())
                 ->where('team_id', filament()->getTenant()?->getKey())
                 ->where('status', 'active')
+                ->defaultFirst()
                 ->value('id');
         }
 
@@ -608,6 +611,7 @@ trait HasEmailComposeActions
             ->where('user_id', $this->getAuthenticatedUser()->getKey())
             ->where('team_id', filament()->getTenant()?->getKey())
             ->where('status', 'active')
+            ->defaultFirst()
             ->get()
             ->mapWithKeys(fn (ConnectedAccount $account): array => [$account->getKey() => $account->label])
             ->all();

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
 use Relaticle\EmailIntegration\Actions\DisconnectConnectedAccountAction;
+use Relaticle\EmailIntegration\Actions\SetDefaultConnectedAccountAction;
 use Relaticle\EmailIntegration\Actions\UpdateConnectedAccountSettingsAction;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
@@ -62,7 +63,7 @@ final class EmailAccountsPage extends Page
      */
     private function getAccounts(): Collection
     {
-        return $this->ownedAccountsQuery()->get();
+        return $this->ownedAccountsQuery()->defaultFirst()->get();
     }
 
     public function connectGmailAction(): Action
@@ -246,6 +247,31 @@ final class EmailAccountsPage extends Page
         return ConnectedAccount::query()->ownedBy($user, $team);
     }
 
+    public function setDefaultAction(): Action
+    {
+        return Action::make('setDefault')
+            ->label(__('filament/pages/email-accounts.actions.set_default'))
+            ->icon('heroicon-o-star')
+            ->color('warning')
+            ->size(Size::Small)
+            ->visible(fn (array $arguments): bool => $this->findAccount($arguments)?->is_default === false)
+            ->action(function (array $arguments): void {
+                $account = $this->findOwnedAccountOrFail($arguments);
+
+                resolve(SetDefaultConnectedAccountAction::class)->execute($account);
+
+                $this->connectedAccounts = $this->getAccounts();
+
+                Notification::make()
+                    ->success()
+                    ->title(__('filament/pages/email-accounts.notifications.default_set.title'))
+                    ->body(__('filament/pages/email-accounts.notifications.default_set.body', [
+                        'email' => $account->email_address,
+                    ]))
+                    ->send();
+            });
+    }
+
     public function disconnectAction(): Action
     {
         return Action::make('disconnect')
@@ -280,6 +306,7 @@ final class EmailAccountsPage extends Page
         // Invoke each action with the arguments (not ->arguments()) so account_id is encoded
         // into the mountAction() click handler, which reads getInvokedArguments().
         return ActionGroup::make([
+            ($this->setDefaultAction())($arguments),
             ($this->reAuthAction())($arguments)
                 ->visible(in_array($account->status, [
                     EmailAccountStatus::REAUTH_REQUIRED,

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -33,6 +33,7 @@ use Relaticle\EmailIntegration\Observers\ConnectedAccountObserver;
  * @property string $provider_account_id
  * @property string $email_address
  * @property string|null $display_name
+ * @property bool $is_default
  * @property string $access_token
  * @property string|null $refresh_token
  * @property Carbon|null $token_expires_at
@@ -61,6 +62,7 @@ final class ConnectedAccount extends Model
         'provider_account_id',
         'email_address',
         'display_name',
+        'is_default',
         'access_token',
         'refresh_token',
         'token_expires_at',
@@ -85,6 +87,7 @@ final class ConnectedAccount extends Model
         'token_expires_at' => 'datetime',
         'last_synced_at' => 'datetime',
         'last_calendar_synced_at' => 'datetime',
+        'is_default' => 'boolean',
         'sync_inbox' => 'boolean',
         'sync_sent' => 'boolean',
         'contact_creation_mode' => ContactCreationMode::class,
@@ -122,6 +125,19 @@ final class ConnectedAccount extends Model
     protected function active(Builder $query): Builder
     {
         return $query->where('status', EmailAccountStatus::ACTIVE);
+    }
+
+    /**
+     * Scope ordering the user's default account ahead of the rest, so callers that
+     * pick a single sending account (compose, reply) land on the default first.
+     *
+     * @param  Builder<ConnectedAccount>  $query
+     * @return Builder<ConnectedAccount>
+     */
+    #[Scope]
+    protected function defaultFirst(Builder $query): Builder
+    {
+        return $query->orderByDesc('is_default')->oldest();
     }
 
     // Relations

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
@@ -114,6 +115,71 @@ it('only loads the authenticated user\'s accounts in the current team on mount',
 
     expect($ids)->toContain($this->account->id)
         ->not->toContain($otherAccount->id);
+});
+
+it('promotes an account to default and demotes the previous default on setDefault', function (): void {
+    $current = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->default()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    livewire(EmailAccountsPage::class)
+        ->callAction('setDefault', arguments: ['account_id' => $this->account->id])
+        ->assertNotified();
+
+    expect($this->account->fresh()->is_default)->toBeTrue()
+        ->and($current->fresh()->is_default)->toBeFalse();
+});
+
+it('hides setDefault for the account that is already default', function (): void {
+    $default = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->default()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    livewire(EmailAccountsPage::class)
+        ->assertActionHidden(TestAction::make('setDefault')->arguments(['account_id' => $default->id]))
+        ->assertActionVisible(TestAction::make('setDefault')->arguments(['account_id' => $this->account->id]));
+});
+
+it('does not expose setDefault for another user\'s account', function (): void {
+    $otherUser = User::factory()->create(['current_team_id' => $this->team->id]);
+    $otherAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $otherUser->id,
+    ]));
+
+    livewire(EmailAccountsPage::class)
+        ->assertActionHidden(TestAction::make('setDefault')->arguments(['account_id' => $otherAccount->id]));
+
+    expect($otherAccount->fresh()->is_default)->toBeFalse();
+});
+
+it('promotes the remaining account to default when the default is disconnected', function (): void {
+    $default = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->default()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    livewire(EmailAccountsPage::class)
+        ->callAction('disconnect', arguments: ['account_id' => $default->id]);
+
+    $this->assertSoftDeleted(ConnectedAccount::class, ['id' => $default->id]);
+    expect($this->account->fresh()->is_default)->toBeTrue();
+});
+
+it('lists the default account first', function (): void {
+    $default = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->default()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    $ids = livewire(EmailAccountsPage::class)
+        ->get('connectedAccounts')
+        ->pluck('id')
+        ->all();
+
+    expect($ids[0])->toBe($default->id);
 });
 
 it('renders Connect Gmail and hides Connect Outlook for now', function (): void {

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -54,3 +54,39 @@ it('stores an azure connected account and flips calendar capability when Graph c
 
     Bus::assertDispatched(InitialCalendarSyncJob::class, fn (InitialCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
 });
+
+it('makes the first connected account the default and leaves later connections non-default', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+
+    $connect = function (string $email) use ($user): ConnectedAccount {
+        $social = new SocialiteUser;
+        $social->id = "gmail-{$email}";
+        $social->email = $email;
+        $social->name = 'Demo';
+        $social->token = 'access-token';
+        $social->refreshToken = 'refresh-token';
+        $social->expiresIn = 3600;
+        $social->approvedScopes = [
+            'https://www.googleapis.com/auth/gmail.readonly',
+            'https://www.googleapis.com/auth/gmail.send',
+        ];
+
+        Socialite::fake('google', $social);
+
+        $this->get(route('email-accounts.callback', ['provider' => 'gmail']))->assertRedirect();
+
+        return ConnectedAccount::query()
+            ->where('user_id', $user->getKey())
+            ->where('email_address', $email)
+            ->firstOrFail();
+    };
+
+    $first = $connect('first@example.com');
+    $second = $connect('second@example.com');
+
+    expect($first->refresh()->is_default)->toBeTrue()
+        ->and($second->refresh()->is_default)->toBeFalse();
+});


### PR DESCRIPTION
## What

Adds a **default connected email account** scoped per user + team. First account a user connects becomes their default; only one default is allowed at a time, and the user can change it.

## Why

Users can connect multiple email accounts (Gmail/Microsoft) but there was no notion of a default — compose/reply just grabbed an arbitrary active account. This makes the default explicit and user-controlled.

## Changes

- **DB**: `is_default` boolean on `connected_accounts` + partial unique index (`WHERE is_default = true AND deleted_at IS NULL`) guaranteeing one live default per user/team. Backfill promotes the oldest live account where none is set.
- **Model/factory**: `is_default` fillable + bool cast; `defaultFirst` scope; factory `default()` state.
- **Actions**:
  - `SetDefaultConnectedAccountAction` (new) — promote one, demote the prior, transactional.
  - `ConnectAccountAction` — first connect (or when no default exists) auto-sets default; reconnect never resets it.
  - `DisconnectConnectedAccountAction` — removing the default promotes the oldest remaining account, so a user is never left without one.
- **UI** (`EmailAccountsPage` + blade + lang): "Set as default" action (visible only on non-default accounts), gold-star **Default** badge, default-first listing.
- **Compose**: default account preselected in compose/reply "From" + signature lookups.

## Tests

6 new feature tests covering first-connect default, set-default promote/demote, ownership boundary, disconnect-promotes-successor, and default-first ordering. Pint / PHPStan (changed files) / 100% type coverage all green. Browser-verified the badge, the action visibility, and the default flip.