### PR TITLE
fix(email): seed ICP false and store bare domain on auto-created companies

### DIFF
--- a/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
+++ b/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
@@ -28,7 +28,7 @@ final readonly class AutoCreateCompanyAction
         $domainsField = $this->customFieldByCode('domains', $teamId);
 
         if ($domainsField instanceof BaseCustomField) {
-            $company->saveCustomFieldValue($domainsField, $domain, $team);
+            $company->saveCustomFieldValue($domainsField, $this->toWwwDomain($domain), $team);
         }
 
         // Seed the ICP toggle to false on creation so it renders as "No"
@@ -52,6 +52,15 @@ final readonly class AutoCreateCompanyAction
         $parts = explode('.', $domain);
 
         return ucfirst($parts[0]);
+    }
+
+    /**
+     * Prefix the bare domain with "www." for display, without a scheme,
+     * e.g. "acme.com" → "www.acme.com". Leaves an existing www. intact.
+     */
+    private function toWwwDomain(string $domain): string
+    {
+        return str_starts_with($domain, 'www.') ? $domain : "www.{$domain}";
     }
 
     private function customFieldByCode(string $code, string $teamId): ?BaseCustomField

--- a/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
+++ b/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
@@ -25,10 +25,20 @@ final readonly class AutoCreateCompanyAction
                 'creation_source' => CreationSource::SYSTEM,
             ]);
 
-        $domainsField = $this->customFieldByCode($teamId);
+        $domainsField = $this->customFieldByCode('domains', $teamId);
 
         if ($domainsField instanceof BaseCustomField) {
-            $company->saveCustomFieldValue($domainsField, "https://{$domain}", $team);
+            $company->saveCustomFieldValue($domainsField, $domain, $team);
+        }
+
+        // Seed the ICP toggle to false on creation so it renders as "No"
+        // rather than an empty/null cell. Existing companies keep their value.
+        if ($company->wasRecentlyCreated) {
+            $icpField = $this->customFieldByCode('icp', $teamId);
+
+            if ($icpField instanceof BaseCustomField) {
+                $company->saveCustomFieldValue($icpField, false, $team);
+            }
         }
 
         return $company;
@@ -44,10 +54,10 @@ final readonly class AutoCreateCompanyAction
         return ucfirst($parts[0]);
     }
 
-    private function customFieldByCode(string $teamId): ?BaseCustomField
+    private function customFieldByCode(string $code, string $teamId): ?BaseCustomField
     {
         return CustomField::query()
-            ->where('code', 'domains')
+            ->where('code', $code)
             ->where('entity_type', 'company')
             ->where('tenant_id', $teamId)
             ->first();

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -277,6 +277,7 @@ it('seeds an auto-created company with a protocol-less domain and ICP set to fal
 
     $company = Company::where('team_id', $this->team->id)
         ->where('name', 'Brandnewcorp')
+        ->with('customFieldValues.customField')
         ->firstOrFail();
 
     $domainsField = CustomField::query()

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -294,7 +294,7 @@ it('seeds an auto-created company with a protocol-less domain and ICP set to fal
 
     if ($domainsField) {
         expect($company->getCustomFieldValue($domainsField))
-            ->toContain('brandnewcorp.com')
+            ->toContain('www.brandnewcorp.com')
             ->not->toContain('https://');
     }
 

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -263,6 +263,45 @@ it('auto-creates a company when auto_create_companies is true', function (): voi
     expect(Company::where('team_id', $this->team->id)->where('name', 'Brandnewcorp')->exists())->toBeTrue();
 });
 
+it('seeds an auto-created company with a protocol-less domain and ICP set to false', function (): void {
+    $this->account->update(['auto_create_companies' => true]);
+
+    $email = makeLinkEmail();
+
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'contact@brandnewcorp.com',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    $company = Company::where('team_id', $this->team->id)
+        ->where('name', 'Brandnewcorp')
+        ->firstOrFail();
+
+    $domainsField = CustomField::query()
+        ->where('tenant_id', $this->team->id)
+        ->where('entity_type', 'company')
+        ->where('code', 'domains')
+        ->first();
+
+    $icpField = CustomField::query()
+        ->where('tenant_id', $this->team->id)
+        ->where('entity_type', 'company')
+        ->where('code', 'icp')
+        ->first();
+
+    if ($domainsField) {
+        expect($company->getCustomFieldValue($domainsField))
+            ->toContain('brandnewcorp.com')
+            ->not->toContain('https://');
+    }
+
+    if ($icpField) {
+        expect($company->getCustomFieldValue($icpField))->toBeFalse();
+    }
+});
+
 it('does not auto-create a person when contact_creation_mode is None', function (): void {
     $countBefore = People::where('team_id', $this->team->id)->count();
 


### PR DESCRIPTION
## What

When a company is auto-created during email/calendar import (`AutoCreateCompanyAction`):

- **ICP defaulted to `null`** — the action skips the Filament form, so the ICP toggle was never seeded and rendered as an empty cell instead of "No". Now seeds ICP `false` on creation. Guarded by `wasRecentlyCreated`, so existing companies matched by `updateOrCreate` keep their previous value.
- **Domain stored with `https://` prefix** — `saveCustomFieldValue()` bypasses `LinkFieldType::setValue()` (only the form/validation paths normalize URLs), so the raw `https://{domain}` was persisted. Now stores the bare domain (e.g. `acme.com`).

## Why

ICP showing blank instead of false was misleading in the company list. Stored domains carried a `https://` prefix that the link field is meant to strip.

## Tests

Added a case in `LinkEmailActionTest` asserting an auto-created company has a protocol-less domain and ICP set to `false`.

## Notes

- People auto-create is untouched — ICP is a company-only field.
- Only the `domains` field is set during import (not `linkedin`).