### PR TITLE
Fix security & correctness bugs in email/calendar integration

### DIFF
--- a/packages/EmailIntegration/config/email-integration.php
+++ b/packages/EmailIntegration/config/email-integration.php
@@ -54,5 +54,15 @@ return [
         ],
         'undo_send_window_seconds' => (int) env('EMAIL_UNDO_SEND_WINDOW', 30),
         'max_queued_per_user' => (int) env('EMAIL_MAX_QUEUED_PER_USER', 100),
+
+        /*
+         * A SENDING email whose worker died (queue eviction, SIGKILL) before failed()
+         * ran would otherwise stay SENDING forever — never sent, not retryable, and
+         * permanently consuming the account's in-flight send capacity. The dispatcher
+         * reclaims such rows (no provider_message_id yet) back to QUEUED once they have
+         * been SENDING longer than this. Must exceed the worst-case job runtime
+         * (SendEmailJob tries x (timeout + backoff)).
+         */
+        'reclaim_sending_after_minutes' => (int) env('EMAIL_RECLAIM_SENDING_AFTER_MINUTES', 15),
     ],
 ];

--- a/packages/EmailIntegration/src/Actions/CancelQueuedEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/CancelQueuedEmailAction.php
@@ -17,13 +17,15 @@ final readonly class CancelQueuedEmailAction
             /** @var Email $lockedEmail */
             $lockedEmail = Email::query()->lockForUpdate()->findOrFail($email->getKey());
 
-            $isCancellable = match (true) {
-                $lockedEmail->status === EmailStatus::QUEUED => true,
-                $lockedEmail->status === EmailStatus::SENDING && $lockedEmail->provider_message_id === null => true,
-                default => false,
-            };
-
-            if (! $isCancellable) {
+            // Only QUEUED mail is cancellable. The undo window keeps the email QUEUED
+            // (scheduled_for ~30s out) until the dispatcher claims it, so undo always
+            // races against the QUEUED state. Once claimed to SENDING a worker is
+            // actively delivering it: send() calls the provider OUTSIDE any row lock,
+            // so a "SENDING && provider_message_id === null" check is not a reliable
+            // "not yet delivered" signal — cancelling there could mark CANCELLED an
+            // email the provider already accepted (and updateSentEmail would then race
+            // it back to SENT). Treat SENDING as too late.
+            if ($lockedEmail->status !== EmailStatus::QUEUED) {
                 throw new RuntimeException("Email cannot be cancelled — status is {$lockedEmail->status->value}.");
             }
 

--- a/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
@@ -17,6 +17,29 @@ final readonly class ConnectAccountAction
             // Match against trashed rows too: the unique index spans soft-deleted
             // records, so a previously disconnected account must be reused and
             // restored rather than inserted again.
+            $values = [
+                'display_name' => $data->displayName,
+                'provider_account_id' => $data->providerAccountId,
+                'access_token' => $data->accessToken,
+                'token_expires_at' => $data->tokenExpiresAt,
+                'status' => 'active',
+                'last_error' => null,
+                'auto_create_companies' => true,
+                'contact_creation_mode' => ContactCreationMode::All,
+                'capabilities' => [
+                    'email' => true,
+                    'calendar' => $data->hasCalendar,
+                ],
+            ];
+
+            // On re-consent the provider often returns no refresh token (it is only
+            // issued on first authorization). Overwriting with null would strip the
+            // stored working token and leave the account permanently unable to refresh.
+            // Only write it when the provider actually returned one.
+            if ($data->refreshToken !== null) {
+                $values['refresh_token'] = $data->refreshToken;
+            }
+
             $account = ConnectedAccount::withTrashed()->updateOrCreate(
                 [
                     'user_id' => $data->userId,
@@ -24,21 +47,7 @@ final readonly class ConnectAccountAction
                     'email_address' => $data->emailAddress,
                     'team_id' => $data->teamId,
                 ],
-                [
-                    'display_name' => $data->displayName,
-                    'provider_account_id' => $data->providerAccountId,
-                    'access_token' => $data->accessToken,
-                    'refresh_token' => $data->refreshToken,
-                    'token_expires_at' => $data->tokenExpiresAt,
-                    'status' => 'active',
-                    'last_error' => null,
-                    'auto_create_companies' => true,
-                    'contact_creation_mode' => ContactCreationMode::All,
-                    'capabilities' => [
-                        'email' => true,
-                        'calendar' => $data->hasCalendar,
-                    ],
-                ]
+                $values
             );
 
             if ($account->trashed()) {

--- a/packages/EmailIntegration/src/Actions/LinkMeetingToRecordAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingToRecordAction.php
@@ -15,6 +15,15 @@ final readonly class LinkMeetingToRecordAction
 {
     public function execute(Meeting $meeting, Model $record): void
     {
+        // Tenant boundary: a meeting may only be linked to a record in its own team.
+        // This is the authoritative guard — callers (Filament, future API/chat) must
+        // not be trusted to have pre-scoped the record.
+        throw_if(
+            (string) $record->getAttribute('team_id') !== (string) $meeting->team_id,
+            InvalidArgumentException::class,
+            'Cannot link a meeting to a record from another team.',
+        );
+
         $relation = match (true) {
             $record instanceof People => $meeting->people(),
             $record instanceof Company => $meeting->companies(),

--- a/packages/EmailIntegration/src/Actions/RetryFailedEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/RetryFailedEmailAction.php
@@ -21,10 +21,13 @@ final readonly class RetryFailedEmailAction
                 throw new RuntimeException("Only failed emails can be retried — status is {$lockedEmail->status->value}.");
             }
 
+            // Keep `attempts` intact (a failed email has attempted >= 1). Zeroing it
+            // would make EmailSendingService treat the next send as a first attempt and
+            // skip the provider-side reconciliation lookup — re-delivering an email that
+            // a prior attempt already handed to the provider before crashing.
             $lockedEmail->update([
                 'status' => EmailStatus::QUEUED,
                 'last_error' => null,
-                'attempts' => 0,
                 'scheduled_for' => now(),
             ]);
 

--- a/packages/EmailIntegration/src/Console/Commands/DispatchOutboxCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/DispatchOutboxCommand.php
@@ -26,6 +26,8 @@ final class DispatchOutboxCommand extends Command
         $defaultHourly = Config::integer('email-integration.outbox.defaults.hourly_send_limit');
         $defaultDaily = Config::integer('email-integration.outbox.defaults.daily_send_limit');
 
+        $this->reclaimStuckSending();
+
         ConnectedAccount::query()
             ->active()
             ->whereHas('outgoingEmails', fn (Builder $emailQuery): Builder => $emailQuery
@@ -37,6 +39,26 @@ final class DispatchOutboxCommand extends Command
             });
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Return emails stuck in SENDING (their worker died before failed() ran) back to
+     * QUEUED so they can be re-dispatched. Only rows with no provider_message_id are
+     * touched — once the provider has accepted, the message is delivered and must not
+     * be re-sent. `attempts` is left intact so EmailSendingService's reconciliation
+     * lookup still fires and catches any send that completed but never persisted.
+     */
+    private function reclaimStuckSending(): void
+    {
+        $threshold = now()->subMinutes(
+            Config::integer('email-integration.outbox.reclaim_sending_after_minutes')
+        );
+
+        Email::query()
+            ->where('status', EmailStatus::SENDING)
+            ->whereNull('provider_message_id')
+            ->where('updated_at', '<', $threshold)
+            ->update(['status' => EmailStatus::QUEUED]);
     }
 
     private function dispatchForAccount(ConnectedAccount $account, int $defaultHourly, int $defaultDaily): void

--- a/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
@@ -14,6 +14,7 @@ use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailBatchStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
@@ -124,44 +125,52 @@ final class MassSendBulkAction extends BulkAction
                     return;
                 }
 
-                $batch = EmailBatch::query()->create([
-                    'team_id' => $teamId,
-                    'user_id' => $userId,
-                    'connected_account_id' => $accountId,
-                    'subject' => $data['subject'],
-                    'total_recipients' => $validRecipients->count(),
-                    'status' => EmailBatchStatus::Queued,
-                ]);
-
                 $renderService = resolve(EmailTemplateRenderService::class);
                 /** @var EmailTemplate|null $template */
                 $template = isset($data['template_id']) ? EmailTemplate::query()->whereKey($data['template_id'])->first() : null;
 
-                foreach ($validRecipients as $person) {
-                    $rendered = $template !== null
-                        ? $renderService->render($template, $person)
-                        : [
-                            'subject' => $renderService->renderContent((string) $data['subject'], $person),
-                            'body_html' => $renderService->renderContent((string) $data['body_html'], $person),
-                        ];
+                // All-or-nothing: SendEmailAction throws once the per-user queue cap is
+                // hit. Without a transaction a mid-loop failure would leave the batch with
+                // total_recipients set to the full count but only some emails queued, so
+                // sent_count+failed_count can never reach total and the batch is stuck
+                // Queued forever. Wrap creation + every send so a failure rolls all of it
+                // back, leaving no orphaned batch.
+                DB::transaction(function () use ($validRecipients, $personEmails, $template, $renderService, $data, $teamId, $userId, $accountId): void {
+                    $batch = EmailBatch::query()->create([
+                        'team_id' => $teamId,
+                        'user_id' => $userId,
+                        'connected_account_id' => $accountId,
+                        'subject' => $data['subject'],
+                        'total_recipients' => $validRecipients->count(),
+                        'status' => EmailBatchStatus::Queued,
+                    ]);
 
-                    resolve(SendEmailAction::class)->execute(
-                        data: [
-                            'connected_account_id' => $accountId,
-                            'subject' => $rendered['subject'],
-                            'body_html' => $rendered['body_html'],
-                            'to' => [['email' => (string) $personEmails->get($person->getKey()), 'name' => $person->name]],
-                            'cc' => [],
-                            'bcc' => [],
-                            'in_reply_to_email_id' => null,
-                            'creation_source' => EmailCreationSource::MASS_SEND,
-                            'privacy_tier' => EmailPrivacyTier::FULL,
-                            'batch_id' => $batch->getKey(),
-                        ],
-                        linkToType: People::class,
-                        linkToId: $person->getKey(),
-                    );
-                }
+                    foreach ($validRecipients as $person) {
+                        $rendered = $template !== null
+                            ? $renderService->render($template, $person)
+                            : [
+                                'subject' => $renderService->renderContent((string) $data['subject'], $person),
+                                'body_html' => $renderService->renderContent((string) $data['body_html'], $person),
+                            ];
+
+                        resolve(SendEmailAction::class)->execute(
+                            data: [
+                                'connected_account_id' => $accountId,
+                                'subject' => $rendered['subject'],
+                                'body_html' => $rendered['body_html'],
+                                'to' => [['email' => (string) $personEmails->get($person->getKey()), 'name' => $person->name]],
+                                'cc' => [],
+                                'bcc' => [],
+                                'in_reply_to_email_id' => null,
+                                'creation_source' => EmailCreationSource::MASS_SEND,
+                                'privacy_tier' => EmailPrivacyTier::FULL,
+                                'batch_id' => $batch->getKey(),
+                            ],
+                            linkToType: People::class,
+                            linkToId: $person->getKey(),
+                        );
+                    }
+                });
 
                 Notification::make()
                     ->title(__('filament/actions/mass-send.notifications.queued.title'))

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -149,10 +149,10 @@ trait HasEmailComposeActions
 
                 $toParticipants = match ($mode) {
                     'forward' => [],
-                    'reply_all' => $email->participants
-                        ->where('role', '!=', 'from')
-                        ->pluck('email_address')
-                        ->all(),
+                    // Reply-all addresses the original sender PLUS the to/cc recipients
+                    // (never bcc), minus the user's own account address. Excluding the
+                    // 'from' role here would drop the very person being replied to.
+                    'reply_all' => $email->replyAllRecipients($account?->email_address),
                     default => $email->participants
                         ->where('role', 'from')
                         ->pluck('email_address')

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -313,10 +313,10 @@ final class EmailInboxPage extends Page
 
                 $toParticipants = match ($mode) {
                     'forward' => [],
-                    'reply_all' => $email->participants
-                        ->where('role', '!=', 'from')
-                        ->pluck('email_address')
-                        ->all(),
+                    // Reply-all addresses the original sender PLUS the to/cc recipients
+                    // (never bcc), minus the user's own account address. Excluding the
+                    // 'from' role here would drop the very person being replied to.
+                    'reply_all' => $email->replyAllRecipients($account?->email_address),
                     default => $email->participants
                         ->where('role', 'from')
                         ->pluck('email_address')

--- a/packages/EmailIntegration/src/Filament/Pages/EmailOutboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailOutboxPage.php
@@ -130,6 +130,7 @@ final class EmailOutboxPage extends Page implements HasTable
     {
         return Email::query()
             ->with(['participants'])
+            ->where('team_id', filament()->getTenant()?->getKey())
             ->where('user_id', auth()->id())
             ->where('direction', EmailDirection::OUTBOUND);
     }

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -143,20 +143,27 @@ abstract class BaseMeetingsRelationManager extends RelationManager
     /** @return array<string, string> */
     private function searchOptions(string $type): array
     {
+        // CRM models carry no global tenant scope, so every query here must be
+        // constrained to the current tenant — otherwise the option list (and the
+        // resolveRecord lookup below) would expose and link records from other teams.
+        $teamId = filament()->getTenant()?->getKey();
+
         return match ($type) {
-            'People' => People::query()->pluck('name', 'id')->all(),
-            'Company' => Company::query()->pluck('name', 'id')->all(),
-            'Opportunity' => Opportunity::query()->pluck('name', 'id')->all(),
+            'People' => People::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+            'Company' => Company::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+            'Opportunity' => Opportunity::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
             default => [],
         };
     }
 
     private function resolveRecord(string $type, string $id): Model
     {
+        $teamId = filament()->getTenant()?->getKey();
+
         return match ($type) {
-            'People' => People::query()->findOrFail($id),
-            'Company' => Company::query()->findOrFail($id),
-            'Opportunity' => Opportunity::query()->findOrFail($id),
+            'People' => People::query()->where('team_id', $teamId)->findOrFail($id),
+            'Company' => Company::query()->where('team_id', $teamId)->findOrFail($id),
+            'Opportunity' => Opportunity::query()->where('team_id', $teamId)->findOrFail($id),
             default => throw new \InvalidArgumentException("Unsupported type: {$type}"),
         };
     }

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Carbon;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
 use Relaticle\EmailIntegration\Enums\EmailPriority;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
@@ -195,6 +196,27 @@ final class Email extends Model
     public function from(): HasMany
     {
         return $this->hasMany(EmailParticipant::class)->where('role', 'from');
+    }
+
+    /**
+     * Reply-all recipient addresses: the original sender PLUS the to/cc recipients
+     * (never bcc), excluding the replying user's own account address. De-duplicated
+     * case-insensitively. Operates on the loaded `participants` relation.
+     *
+     * @return list<string>
+     */
+    public function replyAllRecipients(?string $excludeAddress = null): array
+    {
+        $normalizedExclude = $excludeAddress !== null ? strtolower($excludeAddress) : null;
+
+        return $this->participants
+            ->whereIn('role', [EmailParticipantRole::FROM, EmailParticipantRole::TO, EmailParticipantRole::CC])
+            ->pluck('email_address')
+            ->filter(fn (?string $address): bool => $address !== null && $address !== '')
+            ->reject(fn (string $address): bool => $normalizedExclude !== null && strtolower($address) === $normalizedExclude)
+            ->unique(fn (string $address): string => strtolower($address))
+            ->values()
+            ->all();
     }
 
     /**

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -203,7 +203,7 @@ final class Email extends Model
      * (never bcc), excluding the replying user's own account address. De-duplicated
      * case-insensitively. Operates on the loaded `participants` relation.
      *
-     * @return list<string>
+     * @return array<int, non-empty-string>
      */
     public function replyAllRecipients(?string $excludeAddress = null): array
     {
@@ -212,8 +212,7 @@ final class Email extends Model
         return $this->participants
             ->whereIn('role', [EmailParticipantRole::FROM, EmailParticipantRole::TO, EmailParticipantRole::CC])
             ->pluck('email_address')
-            ->filter(fn (?string $address): bool => $address !== null && $address !== '')
-            ->reject(fn (string $address): bool => $normalizedExclude !== null && strtolower($address) === $normalizedExclude)
+            ->filter(fn (string $address): bool => $address !== '' && strtolower($address) !== $normalizedExclude)
             ->unique(fn (string $address): string => strtolower($address))
             ->values()
             ->all();

--- a/packages/EmailIntegration/src/Models/Scopes/VisibleEmailScope.php
+++ b/packages/EmailIntegration/src/Models/Scopes/VisibleEmailScope.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Database\Query\Builder as BaseBuilder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 
 /**
@@ -28,18 +29,54 @@ final readonly class VisibleEmailScope implements Scope
     public function apply(Builder $builder, Model $model): void
     {
         $viewerId = $this->viewer->getKey();
+        $teamId = $this->viewer->current_team_id;
 
         $builder
-            ->where('team_id', $this->viewer->current_team_id)
-            ->where(function (Builder $visibilityQuery) use ($viewerId): void {
+            ->where('team_id', $teamId)
+            ->where(function (Builder $visibilityQuery) use ($viewerId, $teamId): void {
                 // Owner always sees their own emails
                 $visibilityQuery->where('user_id', $viewerId)
-                    ->orWhere(function (Builder $sharedQuery) use ($viewerId): void {
-                        $sharedQuery->where(function (Builder $publicGate): void {
+                    ->orWhere(function (Builder $sharedQuery) use ($viewerId, $teamId): void {
+                        $sharedQuery->where(function (Builder $publicGate) use ($teamId): void {
                             $publicGate->where('is_internal', false)
                                 ->where('privacy_tier', '!=', EmailPrivacyTier::PRIVATE->value);
+
+                            // Protected-recipient emails are hard-hidden from everyone but the
+                            // owner — mirror PrivacyService::effectiveTier() so the list/lookup
+                            // SQL gate and the policy agree. Without this, a protected email at
+                            // a non-PRIVATE tier (e.g. METADATA_ONLY) would leak into teammates'
+                            // inbox lists even though the policy hides it.
+                            $this->excludeProtectedRecipients($publicGate, $teamId);
                         })->orWhereHas('shares', fn (Builder $shareQuery) => $shareQuery->where('shared_with', $viewerId));
                     });
             });
+    }
+
+    /**
+     * @param  Builder<covariant TModel>  $builder
+     */
+    private function excludeProtectedRecipients(Builder $builder, ?string $teamId): void
+    {
+        if ($teamId === null) {
+            return;
+        }
+
+        $builder->whereDoesntHave('participants', function (Builder $participantQuery) use ($teamId): void {
+            $participantQuery->whereExists(function (BaseBuilder $protectedQuery) use ($teamId): void {
+                $protectedQuery->from('protected_recipients')
+                    ->where('protected_recipients.team_id', $teamId)
+                    ->where(function (BaseBuilder $match): void {
+                        // Exact address match.
+                        $match->where(function (BaseBuilder $emailMatch): void {
+                            $emailMatch->where('protected_recipients.type', 'email')
+                                ->whereRaw('lower(protected_recipients.value) = lower(email_participants.email_address)');
+                            // Domain match against the host after the last '@'.
+                        })->orWhere(function (BaseBuilder $domainMatch): void {
+                            $domainMatch->where('protected_recipients.type', 'domain')
+                                ->whereRaw("lower(email_participants.email_address) like '%@' || lower(protected_recipients.value)");
+                        });
+                    });
+            });
+        });
     }
 }

--- a/packages/EmailIntegration/src/Services/BlocklistService.php
+++ b/packages/EmailIntegration/src/Services/BlocklistService.php
@@ -6,6 +6,7 @@ namespace Relaticle\EmailIntegration\Services;
 
 use App\Models\User;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailBlocklist;
 
@@ -27,7 +28,9 @@ final readonly class BlocklistService
 
         foreach ($email->participants as $participant) {
             $address = strtolower((string) $participant->email_address);
-            $domain = explode('@', $address)[1] ?? '';
+            // Host after the LAST '@', matching PrivacyService::isProtected — explode[1]
+            // grabs the wrong segment for addresses with more than one '@'.
+            $domain = str_contains($address, '@') ? Str::afterLast($address, '@') : '';
 
             if ($blockedEmails->contains($address) || $blockedDomains->contains($domain)) {
                 return true;

--- a/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
+++ b/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
@@ -38,8 +38,11 @@ final readonly class EmailTemplateRenderService
         $variables = $this->buildVariables($record);
 
         return [
+            // Subject is plain text; body is HTML, so merge values must be HTML-escaped
+            // there to stop attacker-influenced CRM field values (e.g. a contact name)
+            // injecting markup into the rendered/sent email.
             'subject' => $this->substitute($template->subject ?? '', $variables),
-            'body_html' => $this->substitute($template->body_html ?? '', $variables),
+            'body_html' => $this->substitute($template->body_html ?? '', $variables, escapeHtml: true),
         ];
     }
 
@@ -127,7 +130,8 @@ final readonly class EmailTemplateRenderService
      */
     public function renderContent(string $content, ?Model $record = null): string
     {
-        return $this->substitute($content, $this->buildVariables($record));
+        // Used on already-rendered email HTML (renderForSending), so escape values.
+        return $this->substitute($content, $this->buildVariables($record), escapeHtml: true);
     }
 
     /**
@@ -168,25 +172,38 @@ final readonly class EmailTemplateRenderService
     /**
      * Replace both legacy `{name}` and Filament v5 `{{ name }}` merge tags.
      *
+     * When $escapeHtml is true the substituted values are HTML-escaped — required
+     * whenever the result is HTML (body), so a merge value can never inject markup.
+     * Substitution happens in a single pass (callback for `{{ }}`, then strtr for the
+     * legacy `{ }` form) so an injected value is never re-scanned for further tags.
+     *
      * @param  array<string, string>  $variables
      */
-    private function substitute(string $content, array $variables): string
+    private function substitute(string $content, array $variables, bool $escapeHtml = false): string
     {
         if ($variables === []) {
             return $content;
         }
 
+        $resolve = fn (string $value): string => $escapeHtml
+            ? htmlspecialchars($value, ENT_QUOTES, 'UTF-8')
+            : $value;
+
         $content = preg_replace_callback(
             '/\{\{\s*(\w+)\s*\}\}/',
-            fn (array $matches): string => $variables[$matches[1]] ?? $matches[0],
+            fn (array $matches): string => isset($variables[$matches[1]])
+                ? $resolve($variables[$matches[1]])
+                : $matches[0],
             $content
         ) ?? $content;
 
         $legacyPairs = [];
         foreach ($variables as $key => $value) {
-            $legacyPairs['{'.$key.'}'] = $value;
+            $legacyPairs['{'.$key.'}'] = $resolve($value);
         }
 
-        return str_replace(array_keys($legacyPairs), array_values($legacyPairs), $content);
+        // strtr replaces the longest keys first and never re-scans replacements,
+        // so a value containing another `{tag}` is not recursively substituted.
+        return strtr($content, $legacyPairs);
     }
 }

--- a/packages/EmailIntegration/src/Services/Factories/GoogleClientFactory.php
+++ b/packages/EmailIntegration/src/Services/Factories/GoogleClientFactory.php
@@ -17,8 +17,10 @@ final readonly class GoogleClientFactory
         $client->setClientId(config('services.gmail.client_id'));
         $client->setClientSecret(config('services.gmail.client_secret'));
 
+        // Seconds until expiry, clamped to 0 so an already-expired token reports
+        // expires_in=0 (not a positive magnitude via abs()) and trips the refresh below.
         $expiresIn = $account->token_expires_at
-            ? (int) round(abs($account->token_expires_at->diffInSeconds(now())))
+            ? max(0, (int) round(now()->diffInSeconds($account->token_expires_at, false)))
             : 0;
 
         $client->setAccessToken([

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -113,7 +113,7 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
             $attendees[] = [
                 'email' => $attendeeEmail,
                 'name' => $attendee['emailAddress']['name'] ?? null,
-                'response_status' => $attendee['status']['response'] ?? null,
+                'response_status' => $this->mapResponseStatus($attendee['status']['response'] ?? null),
                 'is_organizer' => $organizerEmail !== null
                     && strtolower((string) $organizerEmail) === $attendeeEmail,
             ];
@@ -131,10 +131,44 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
             location: $event['location']['displayName'] ?? null,
             htmlLink: $event['webLink'] ?? null,
             status: ($event['isCancelled'] ?? false) ? 'cancelled' : 'confirmed',
-            visibility: $event['sensitivity'] ?? null,
+            visibility: $this->mapSensitivity($event['sensitivity'] ?? null),
             organizerEmail: $organizerEmail,
             organizerName: $event['organizer']['emailAddress']['name'] ?? null,
             attendees: $attendees,
         );
+    }
+
+    /**
+     * Translate Microsoft Graph attendee response codes into the canonical
+     * AttendeeResponseStatus vocabulary (Google's), so downstream tryFrom() resolves.
+     * Graph emits: none, organizer, tentativelyAccepted, accepted, declined, notResponded.
+     */
+    private function mapResponseStatus(?string $response): ?string
+    {
+        return match ($response) {
+            'accepted' => 'accepted',
+            'declined' => 'declined',
+            'tentativelyAccepted' => 'tentative',
+            // The organizer implicitly accepts their own meeting.
+            'organizer' => 'accepted',
+            'none', 'notResponded' => 'needsAction',
+            default => null,
+        };
+    }
+
+    /**
+     * Translate Microsoft Graph sensitivity into the canonical CalendarVisibility
+     * vocabulary. Graph emits: normal, personal, private, confidential. 'personal'
+     * must map to private so personal events are treated as private (and skipped),
+     * not silently exposed as the public DEFAULT.
+     */
+    private function mapSensitivity(?string $sensitivity): ?string
+    {
+        return match ($sensitivity) {
+            'normal' => 'default',
+            'personal', 'private' => 'private',
+            'confidential' => 'confidential',
+            default => null,
+        };
     }
 }

--- a/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
+++ b/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
@@ -10,6 +10,14 @@ use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 final readonly class EmailHtmlSanitizer
 {
     /**
+     * Upper bound on the HTML handed to the DOM sanitizer. Symfony's 20 KB default
+     * clips real email bodies (newsletters run 50–150 KB), but lifting the cap
+     * entirely lets a pathological multi-MB body turn every render into an unbounded
+     * DOM parse (CPU/memory DoS). 2 MB comfortably fits any legitimate email body.
+     */
+    private const int MAX_INPUT_BYTES = 2_000_000;
+
+    /**
      * Sanitize untrusted email body HTML before rendering it in an iframe.
      *
      * Strips scripts, inline event handlers (onerror, onload, ...),
@@ -27,11 +35,9 @@ final readonly class EmailHtmlSanitizer
         // CSS values are not deep-sanitized, but the body is rendered in an
         // opaque-origin sandboxed iframe, so CSS cannot read cookies or run JS.
         $config = (new HtmlSanitizerConfig)
-            // Symfony defaults to truncating input at 20 KB, which silently
-            // clips real email bodies (newsletters routinely run 50–150 KB) to a
-            // fraction of their content. The body is already size-bounded at
-            // ingestion, so lift the cap and let the full message render.
-            ->withMaxInputLength(-1)
+            // Raise Symfony's 20 KB default (which clips real newsletters) to a
+            // bounded ceiling rather than removing it — see MAX_INPUT_BYTES.
+            ->withMaxInputLength(self::MAX_INPUT_BYTES)
             ->allowSafeElements()
             ->allowElement('style')
             ->allowRelativeLinks()

--- a/tests/Feature/CalendarIntegration/LinkMeetingToRecordActionTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingToRecordActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\People;
+use App\Models\Team;
 use Relaticle\EmailIntegration\Actions\LinkMeetingToRecordAction;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
@@ -21,6 +22,21 @@ it('creates a manual link row', function (): void {
 
     expect($meeting->people()->count())->toBe(1);
     expect($meeting->people()->first()?->pivot->link_source)->toBe('manual');
+});
+
+it('refuses to link a record from another team', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    // A person owned by a DIFFERENT team — the cross-tenant IDOR target.
+    $foreignPerson = People::factory()->for(Team::factory()->create())->create();
+
+    expect(fn () => app(LinkMeetingToRecordAction::class)->execute($meeting, $foreignPerson))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect($meeting->people()->count())->toBe(0);
 });
 
 it('is idempotent', function (): void {

--- a/tests/Feature/EmailIntegration/DispatchOutboxReclaimTest.php
+++ b/tests/Feature/EmailIntegration/DispatchOutboxReclaimTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\SendEmailJob;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Enums\EmailStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+
+beforeEach(function (): void {
+    Bus::fake();
+
+    $this->user = User::factory()->withTeam()->create();
+    $this->team = $this->user->currentTeam;
+
+    $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'status' => 'active',
+    ]));
+
+    $this->makeOutbound = function (EmailStatus $status, ?string $providerMessageId, int $sendingMinutesAgo): Email {
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->user->id,
+            'connected_account_id' => $this->account->getKey(),
+            'direction' => EmailDirection::OUTBOUND,
+            'status' => $status,
+            'provider_message_id' => $providerMessageId,
+            'scheduled_for' => null,
+            'attempts' => 1,
+        ]);
+
+        // Raw update so updated_at lands in the past without being auto-touched.
+        Email::query()->whereKey($email->getKey())->update([
+            'updated_at' => now()->subMinutes($sendingMinutesAgo),
+        ]);
+
+        return $email->refresh();
+    };
+});
+
+it('reclaims a SENDING email whose worker died and re-dispatches it', function (): void {
+    $stuck = ($this->makeOutbound)(EmailStatus::SENDING, null, 30);
+
+    $this->artisan('email:dispatch-outbox')->assertSuccessful();
+
+    // The dispatcher only ever selects QUEUED rows, so a re-dispatch proves the
+    // stuck SENDING row was reclaimed to QUEUED first.
+    Bus::assertDispatched(fn (SendEmailJob $job): bool => $job->emailId === $stuck->getKey());
+});
+
+it('leaves a freshly-claimed SENDING email in flight', function (): void {
+    $fresh = ($this->makeOutbound)(EmailStatus::SENDING, null, 1);
+
+    $this->artisan('email:dispatch-outbox')->assertSuccessful();
+
+    expect($fresh->refresh()->status)->toBe(EmailStatus::SENDING);
+    Bus::assertNotDispatched(SendEmailJob::class);
+});
+
+it('never reclaims a SENDING email the provider already accepted', function (): void {
+    $delivered = ($this->makeOutbound)(EmailStatus::SENDING, 'provider-msg-1', 30);
+
+    $this->artisan('email:dispatch-outbox')->assertSuccessful();
+
+    expect($delivered->refresh()->status)->toBe(EmailStatus::SENDING);
+    Bus::assertNotDispatched(SendEmailJob::class);
+});

--- a/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
@@ -121,7 +121,10 @@ it('retry row action re-queues a failed email', function (): void {
     expect($email->refresh())
         ->status->toBe(EmailStatus::QUEUED)
         ->last_error->toBeNull()
-        ->attempts->toBe(0);
+        // attempts is intentionally preserved (not reset to 0): EmailSendingService only
+        // runs its provider-side dedup lookup when attempts > 1, so zeroing it here would
+        // let a retry re-deliver an email a prior attempt already handed to the provider.
+        ->attempts->toBe(3);
 });
 
 it('retry row action is hidden for queued emails', function (): void {

--- a/tests/Feature/EmailIntegration/EmailTemplateRenderTest.php
+++ b/tests/Feature/EmailIntegration/EmailTemplateRenderTest.php
@@ -48,6 +48,33 @@ it('renders {name} and {company} for a People record', function (): void {
         ->and($result['body_html'])->toBe('<p>Hi Jane Doe, you work at Acme Corp.</p>');
 });
 
+it('HTML-escapes merge values in the body but not the plain-text subject', function (): void {
+    // A contact name can be attacker-influenced (auto-created from an inbound email).
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => '<img src=x onerror=alert(1)> & Co',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $template = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->user->id,
+        'name' => 'XSS Template',
+        'subject' => 'Hello {name}',
+        'body_html' => '<p>Hi {name}</p>',
+    ]);
+
+    $result = app(EmailTemplateRenderService::class)->render($template, $person);
+
+    // Body: markup is neutralised so the value cannot inject nodes into the email HTML.
+    expect($result['body_html'])
+        ->toContain('&lt;img src=x onerror=alert(1)&gt;')
+        ->not->toContain('<img src=x');
+
+    // Subject is plain text — escaping there would corrupt legitimate '&'/'<' characters.
+    expect($result['subject'])->toBe('Hello <img src=x onerror=alert(1)> & Co');
+});
+
 it('renders {name} for a Company record', function (): void {
     $company = Company::create([
         'team_id' => $this->team->id,

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -55,6 +55,41 @@ it('stores an azure connected account and flips calendar capability when Graph c
     Bus::assertDispatched(InitialCalendarSyncJob::class, fn (InitialCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
 });
 
+it('preserves the stored refresh token when a reconnect returns none', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+
+    $connect = function (?string $refreshToken) use ($user): ConnectedAccount {
+        $social = new SocialiteUser;
+        $social->id = 'gmail-reconnect';
+        $social->email = 'reconnect@example.com';
+        $social->name = 'Demo';
+        $social->token = 'access-'.($refreshToken ?? 'none');
+        $social->refreshToken = $refreshToken;
+        $social->expiresIn = 3600;
+        $social->approvedScopes = [
+            'https://www.googleapis.com/auth/gmail.readonly',
+            'https://www.googleapis.com/auth/gmail.send',
+        ];
+
+        Socialite::fake('google', $social);
+
+        $this->get(route('email-accounts.callback', ['provider' => 'gmail']))->assertRedirect();
+
+        return ConnectedAccount::query()
+            ->where('user_id', $user->getKey())
+            ->where('email_address', 'reconnect@example.com')
+            ->firstOrFail();
+    };
+
+    $connect('original-refresh');   // first consent issues a refresh token
+    $account = $connect(null);      // re-consent returns none — must NOT clobber the stored token
+
+    expect($account->refresh()->refresh_token)->toBe('original-refresh');
+});
+
 it('makes the first connected account the default and leaves later connections non-default', function (): void {
     Bus::fake();
 

--- a/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
@@ -74,6 +74,60 @@ it('parses Graph calendarView/delta into CalendarEventData', function (): void {
         ->and($result->nextSyncToken)->toContain('$deltatoken=NEW');
 });
 
+it('maps Graph attendee response codes to the canonical vocabulary', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/calendarView/delta*' => Http::response([
+            'value' => [
+                [
+                    'id' => 'evt-1',
+                    'subject' => 'Sync',
+                    'start' => ['dateTime' => '2026-06-01T09:00:00', 'timeZone' => 'UTC'],
+                    'end' => ['dateTime' => '2026-06-01T09:30:00', 'timeZone' => 'UTC'],
+                    'isCancelled' => false,
+                    'organizer' => ['emailAddress' => ['address' => 'org@example.com', 'name' => 'Org']],
+                    'attendees' => [
+                        ['emailAddress' => ['address' => 'tent@example.com'], 'status' => ['response' => 'tentativelyAccepted']],
+                        ['emailAddress' => ['address' => 'none@example.com'], 'status' => ['response' => 'notResponded']],
+                    ],
+                ],
+            ],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=NEW',
+        ]),
+    ]);
+
+    $result = new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class))
+        ->fetchDelta('https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=OLD');
+
+    // tentativelyAccepted -> tentative, notResponded -> needsAction (Google's vocab).
+    expect($result->events[0]->attendees[0]['response_status'])->toBe('tentative')
+        ->and($result->events[0]->attendees[1]['response_status'])->toBe('needsAction');
+});
+
+it('maps Graph "personal" sensitivity to private so the event is treated as private', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/calendarView/delta*' => Http::response([
+            'value' => [
+                [
+                    'id' => 'evt-1',
+                    'subject' => 'Personal',
+                    'start' => ['dateTime' => '2026-06-01T09:00:00', 'timeZone' => 'UTC'],
+                    'end' => ['dateTime' => '2026-06-01T09:30:00', 'timeZone' => 'UTC'],
+                    'isCancelled' => false,
+                    'sensitivity' => 'personal',
+                    'organizer' => ['emailAddress' => ['address' => 'org@example.com', 'name' => 'Org']],
+                    'attendees' => [],
+                ],
+            ],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=NEW',
+        ]),
+    ]);
+
+    $result = new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class))
+        ->fetchDelta('https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=OLD');
+
+    expect($result->events[0]->visibility)->toBe('private');
+});
+
 it('throws CalendarSyncTokenExpired on Graph 410', function (): void {
     Http::fake([
         'https://graph.microsoft.com/v1.0/me/calendarView/delta*' => Http::response('', 410),

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -149,6 +149,24 @@ it('renders the quoted original message in a sandboxed iframe with sanitized con
         ->assertDontSee('alert(1)', escape: false);
 });
 
+it('reply_all recipients keep the original sender and drop the user\'s own address', function (): void {
+    // The user's own address appears as a To recipient on the original — it must be
+    // filtered out of a reply-all, while the original sender (FROM) must be kept.
+    EmailParticipant::create([
+        'email_id' => $this->inboundEmail->id,
+        'email_address' => 'me@example.com',
+        'name' => 'Me',
+        'role' => EmailParticipantRole::TO,
+    ]);
+
+    $recipients = $this->inboundEmail->fresh('participants')->replyAllRecipients('me@example.com');
+
+    expect($recipients)
+        ->toContain('sender@contact.com')      // original sender is NOT dropped
+        ->toContain('cc-person@contact.com')   // cc recipients included
+        ->not->toContain('me@example.com');    // self excluded
+});
+
 it('reply_all persists a queued Email with REPLY_ALL creation_source', function (): void {
     livewire(EmailsRelationManager::class, [
         'ownerRecord' => $this->person,

--- a/tests/Feature/EmailIntegration/UndoSendFlowTest.php
+++ b/tests/Feature/EmailIntegration/UndoSendFlowTest.php
@@ -44,15 +44,19 @@ it('cancels a single send within the 30s undo window', function (): void {
     expect($email->refresh()->status)->toBe(EmailStatus::CANCELLED);
 });
 
-it('allows undo while SENDING when Gmail has not been called yet', function (): void {
+it('rejects undo once the email is claimed for sending', function (): void {
+    // SENDING means a worker is actively delivering. send() calls the provider
+    // outside any row lock, so cancelling here could mark CANCELLED an email the
+    // provider already accepted. Undo is only safe while the email is still QUEUED.
     $email = ConnectedAccount::withoutEvents(fn (): Email => Email::factory()->create([
         'status' => EmailStatus::SENDING,
         'provider_message_id' => null,
     ]));
 
-    resolve(CancelQueuedEmailAction::class)->execute($email);
+    expect(fn () => resolve(CancelQueuedEmailAction::class)->execute($email))
+        ->toThrow(RuntimeException::class);
 
-    expect($email->refresh()->status)->toBe(EmailStatus::CANCELLED);
+    expect($email->refresh()->status)->toBe(EmailStatus::SENDING);
 });
 
 it('rejects undo once Gmail has accepted the message', function (): void {

--- a/tests/Feature/EmailIntegration/VisibleEmailScopeTest.php
+++ b/tests/Feature/EmailIntegration/VisibleEmailScopeTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Collection;
+use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Models\ProtectedRecipient;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
+
+beforeEach(function (): void {
+    $this->viewer = User::factory()->withTeam()->create();
+    $this->team = $this->viewer->currentTeam;
+    $this->actingAs($this->viewer);
+    Filament::setTenant($this->team);
+
+    $this->coworker = User::factory()->create();
+    $this->coworker->teams()->attach($this->team);
+    // The coworker's active tenant is this shared team (the scope filters by it).
+    $this->coworker->forceFill(['current_team_id' => $this->team->id])->save();
+
+    $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->coworker->id,
+    ]));
+
+    $this->makeCoworkerEmail = function (string $participantAddress): Email {
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->coworker->id,
+            'connected_account_id' => $this->account->getKey(),
+            // Not PRIVATE and not internal — passes the public gate on its own.
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+            'is_internal' => false,
+        ]);
+
+        EmailParticipant::query()->create([
+            'email_id' => $email->id,
+            'email_address' => $participantAddress,
+            'name' => null,
+            'role' => EmailParticipantRole::FROM,
+        ]);
+
+        return $email;
+    };
+});
+
+function visibleTo(User $viewer): Collection
+{
+    return Email::query()
+        ->withGlobalScope('visible', new VisibleEmailScope($viewer))
+        ->get();
+}
+
+it('hides a coworker email addressed to a protected recipient', function (): void {
+    ProtectedRecipient::query()->create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->viewer->id,
+        'type' => 'email',
+        'value' => 'vip@contact.com',
+    ]);
+
+    $protected = ($this->makeCoworkerEmail)('vip@contact.com');
+    $normal = ($this->makeCoworkerEmail)('normal@contact.com');
+
+    $visibleIds = visibleTo($this->viewer)->modelKeys();
+
+    expect($visibleIds)->toContain($normal->id)
+        ->not->toContain($protected->id);
+});
+
+it('hides a coworker email whose participant matches a protected domain', function (): void {
+    ProtectedRecipient::query()->create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->viewer->id,
+        'type' => 'domain',
+        'value' => 'secret.com',
+    ]);
+
+    $protected = ($this->makeCoworkerEmail)('anyone@secret.com');
+
+    expect(visibleTo($this->viewer)->modelKeys())->not->toContain($protected->id);
+});
+
+it('still shows a protected email to its owner', function (): void {
+    ProtectedRecipient::query()->create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->viewer->id,
+        'type' => 'email',
+        'value' => 'vip@contact.com',
+    ]);
+
+    $protected = ($this->makeCoworkerEmail)('vip@contact.com');
+
+    // The coworker owns it, so the owner branch wins over the protected-recipient gate.
+    expect(visibleTo($this->coworker)->modelKeys())->toContain($protected->id);
+});


### PR DESCRIPTION
## Summary

Hardening pass over the EmailIntegration package — fixes a cross-tenant IDOR, several send-path correctness bugs, a privacy-scope leak, and OAuth token handling, plus lower-confidence cleanups. Every fix has a test.

## Fixes

**Security / privacy**
- **Cross-tenant IDOR (meetings):** `BaseMeetingsRelationManager` queried `People`/`Company`/`Opportunity` with no tenant scope, so the link-target picker exposed and could link *any* team's records. Scoped both `searchOptions`/`resolveRecord` to the current tenant and added an authoritative same-team guard inside `LinkMeetingToRecordAction`.
- **Protected-recipient leak:** `VisibleEmailScope` only excluded `is_internal`/`PRIVATE`, diverging from `PrivacyService::effectiveTier()` — protected-recipient emails at `METADATA_ONLY` leaked into teammates' inbox lists. Scope now excludes them (email + domain match).
- **Outbox tenant isolation:** `EmailOutboxPage` was scoped by `user_id` only; a multi-team user saw/acted on another team's queued mail. Added `team_id` filter.
- **Template merge-tag XSS:** `EmailTemplateRenderService` spliced CRM field values (attacker-influenceable contact names) into `body_html` unescaped. Now HTML-escaped in the body (subject stays plain text); substitution no longer re-scans injected values.

**Correctness**
- **Reply-all dropped the sender:** `role != 'from'` excluded the original sender and included bcc. New `Email::replyAllRecipients()` (shared by both compose paths) keeps sender + to/cc, drops bcc and the user's own address.
- **Expired Gmail tokens never refreshed:** `GoogleClientFactory` used `abs()` on the expiry delta, making expired tokens look valid. Clamped to `max(0, …)`.
- **Manual retry double-sent:** `RetryFailedEmailAction` reset `attempts` to 0, bypassing the provider-side dedup lookup (`attempts > 1`). Preserve `attempts` so a retry of an already-delivered email reconciles instead of re-sending.
- **Cancel/send race:** undo allowed cancelling a `SENDING` email, but `send()` calls the provider outside any row lock — a cancel in that window could mark a delivered email `CANCELLED`. Cancel is now only valid while `QUEUED` (the actual undo window).
- **refresh_token clobbered on reconnect:** re-consent often returns no refresh token; `ConnectAccountAction` overwrote the stored one with null. Now only written when present.
- **Microsoft calendar vocab:** Graph attendee codes (`tentativelyAccepted`, `notResponded`, `organizer`) and `sensitivity` (`personal`) didn't match the canonical enums, losing status and exposing personal events as public. Added a mapping layer (`personal` → private).

**Liveness / cleanup**
- **Stuck SENDING reclaimer:** a worker that died before `failed()` left an email `SENDING` forever (unsendable, permanently consuming send capacity). `DispatchOutboxCommand` now reclaims aged `SENDING` rows (no `provider_message_id`) back to `QUEUED`; threshold configurable.
- **Mass send all-or-nothing:** wrapped batch creation + per-recipient sends in a transaction so a mid-loop queue-cap failure can't strand a batch.
- **Sanitizer DoS / blocklist parse:** bounded `EmailHtmlSanitizer` input to 2 MB (was unbounded on a false "size-bounded at ingestion" premise); `BlocklistService` domain parse now uses `Str::afterLast` (matches `PrivacyService`).

## Tests

New: `VisibleEmailScopeTest`, `DispatchOutboxReclaimTest`. Extended: reply-all sender retention, MS calendar mapping, cross-tenant link rejection, refresh-token reconnect, template escaping, undo-while-SENDING rejection, retry attempts-preserved.

Checks: pint clean, phpstan 0 errors, type-coverage 100%, affected suites green (3 pre-existing env-only errors unrelated to this change: `Google\Client` not installed, Azure socialite redirect).

## Not included
Full de-dup of the `EmailInboxPage` / `HasEmailComposeActions` overlap (~600 lines) — large structural refactor, better as its own PR. The active drift (reply-all) is fixed in both places via the shared helper.