### PR TITLE
fix(email): success icon for approve access request modals

### DIFF
--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -322,6 +322,8 @@ abstract class BaseRecordEmailsPage extends Page
     {
         return Action::make('approveAccessRequest')
             ->requiresConfirmation()
+            ->modalIcon('heroicon-o-check-circle')
+            ->modalIconColor('success')
             ->modalHeading(__('filament/pages/record-emails.actions.approve_access_request.modal_heading'))
             ->modalDescription(fn (array $arguments): string => sprintf(
                 'Grant %s access to this email?',

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccessRequestsPage.php
@@ -224,6 +224,8 @@ final class EmailAccessRequestsPage extends Page
             ->color('success')
             ->size(Size::ExtraSmall)
             ->requiresConfirmation()
+            ->modalIcon('heroicon-o-check-circle')
+            ->modalIconColor('success')
             ->modalHeading(__('filament/pages/email-access-requests.actions.approve.modal_heading'))
             ->modalDescription(fn (array $arguments): string => __('filament/pages/email-access-requests.actions.approve.modal_description', [
                 'name' => $this->requesterNameForOwnedRequest($arguments['requestId'] ?? null),

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -548,6 +548,8 @@ final class EmailInboxPage extends Page
     {
         return Action::make('approveAccessRequest')
             ->requiresConfirmation()
+            ->modalIcon('heroicon-o-check-circle')
+            ->modalIconColor('success')
             ->modalHeading(__('filament/pages/email-inbox.approve_access_request.modal_heading'))
             ->modalDescription(fn (array $arguments): string => sprintf(
                 'Grant %s access to this email?',


### PR DESCRIPTION
## What

Confirmation modals for the **approve email access request** action showed the default warning/alert icon, which reads as a destructive/caution prompt and doesn't match a positive approve action.

Set the modal icon to `heroicon-o-check-circle` with `success` color on all three approve modals:

- `EmailAccessRequestsPage::approveAccessRequest`
- `BaseRecordEmailsPage::approveAccessRequest`
- `EmailInboxPage::approveAccessRequest`

## Why

Modal icon should reflect the action's nature. Destructive actions (deny, cancel, disconnect, delete, unlink) keep the default warning alert — it suits them. Only the approve path was mismatched.