### PR TITLE
fix(email): pin initial-sync StoreEmailJob batch to emails-sync queue

### DIFF
--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -68,6 +68,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
 
         Bus::batch($jobs)
             ->name("Initial sync: {$account->email_address}")
+            ->onQueue('emails-sync')
             ->allowFailures()
             ->dispatch();
     }

--- a/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
+++ b/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use App\Jobs\ClassifyEmailJob;
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
@@ -12,6 +14,8 @@ use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
 use Relaticle\EmailIntegration\Jobs\StoreMeetingJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 
 mutates(
     ClassifyEmailJob::class,
@@ -51,4 +55,27 @@ it('routes inbound email sync and classify jobs to emails-sync queue', function 
         ->and((new InitialCalendarSyncJob($account))->queue)->toBe('emails-sync')
         ->and((new StoreMeetingJob($account, $event))->queue)->toBe('emails-sync')
         ->and((new ClassifyEmailJob('email-id'))->queue)->toBe('emails-sync');
+});
+
+it('dispatches the initial-sync StoreEmailJob batch onto the emails-sync queue', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn([
+        'cursor' => 'cursor-1',
+        'message_ids' => collect(['M1', 'M2']),
+    ]);
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    // Bus::batch() ignores each job's constructor onQueue() — without an explicit
+    // ->onQueue() on the batch the StoreEmailJobs leak onto the default queue.
+    Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->queue() === 'emails-sync'
+        && $batch->jobs->count() === 2
+    );
 });


### PR DESCRIPTION
## What

`InitialEmailSyncJob` dispatches its `StoreEmailJob`s via `Bus::batch()`. `Bus::batch()` **ignores each job's constructor `onQueue()`**, so the batched store jobs silently fell back to the `default` queue instead of `emails-sync`.

This forced operators to run a separate `queue:work` (default) worker just to store initial-sync emails, while the dedicated `emails-sync` supervisor (and Horizon) processed nothing for that path. The incremental path was unaffected — it uses a plain `dispatch()` which honors the constructor queue.

## Change

- Pin the batch to the correct queue: `Bus::batch($jobs)->onQueue('emails-sync')`.
- Add a **runtime** regression test asserting the dispatched batch lands on `emails-sync`. The pre-existing test only checked the job's constructor property (`$job->queue`), which passed even with the bug — false confidence, since the batch overrides queue at dispatch time. Verified the new test fails without the fix and passes with it.

## Verification

- `pint`, `rector --dry-run`: clean
- `phpstan` (changed production file): 0 errors
- type-coverage: 100%
- `SyncQueueRoutingTest`: 2/2 pass