### PR TITLE
Split user email privacy into its own page; gate workspace privacy to admins

### DIFF
--- a/app/Livewire/App/Email/UserEmailPrivacySettings.php
+++ b/app/Livewire/App/Email/UserEmailPrivacySettings.php
@@ -53,7 +53,10 @@ final class UserEmailPrivacySettings extends BaseLivewireComponent
                                     ->mapWithKeys(fn (EmailPrivacyTier $tier): array => [$tier->value => $tier->getLabel()])
                                     ->all()
                             )
-                            ->placeholder(__('email/privacy-settings.sharing_preference.use_workspace_default')),
+                            ->placeholder(__('email/privacy-settings.sharing_preference.use_workspace_default'))
+                            ->helperText(fn (): string => __('email/privacy-settings.sharing_preference.workspace_default_hint', [
+                                'tier' => ($this->authUser()->currentTeam->default_email_sharing_tier ?? EmailPrivacyTier::METADATA_ONLY)->getLabel(),
+                            ])),
                         Actions::make([
                             Action::make('saveTier')
                                 ->label(__('email/privacy-settings.actions.save'))

--- a/lang/en/email/privacy-settings.php
+++ b/lang/en/email/privacy-settings.php
@@ -8,6 +8,7 @@ return [
         'description' => 'Overrides the workspace default for emails you sync. Set to blank to use the workspace default.',
         'tier_label' => 'Default sharing tier',
         'use_workspace_default' => 'Use workspace default',
+        'workspace_default_hint' => 'Workspace default: :tier',
     ],
     'blocklist' => [
         'heading' => 'Blocked Addresses & Domains',

--- a/lang/en/filament/pages/email-privacy-settings.php
+++ b/lang/en/filament/pages/email-privacy-settings.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 return [
-    'title' => 'Privacy',
-    'navigation_label' => 'Privacy',
+    'title' => 'Workspace Privacy',
+    'navigation_label' => 'Workspace Privacy',
     'actions' => [
         'save' => 'Save',
     ],

--- a/lang/en/filament/pages/user-email-privacy.php
+++ b/lang/en/filament/pages/user-email-privacy.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'My Email Privacy',
+    'navigation_label' => 'My Email Privacy',
+];

--- a/packages/EmailIntegration/resources/views/filament/pages/email-privacy-settings.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-privacy-settings.blade.php
@@ -4,8 +4,4 @@
     <div class="mt-6">
         {{ $this->saveAction }}
     </div>
-
-    <div class="mt-6">
-        @livewire(\App\Livewire\App\Email\UserEmailPrivacySettings::class)
-    </div>
 </x-filament-panels::page>

--- a/packages/EmailIntegration/resources/views/filament/pages/user-email-privacy.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/user-email-privacy.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    @livewire(\App\Livewire\App\Email\UserEmailPrivacySettings::class)
+</x-filament-panels::page>

--- a/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Pages;
 
+use App\Enums\TeamRole;
+use App\Features\EmailIntegration;
+use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Placeholder;
@@ -15,16 +18,41 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Actions\UpdateTeamEmailPrivacySettingsAction;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Clusters\EmailSettings;
-use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\ProtectedRecipient;
 
 final class EmailPrivacySettingsPage extends Page implements HasSchemas
 {
-    use HasEmailFeatureFlag;
     use InteractsWithSchemas;
+
+    /**
+     * Workspace-wide privacy settings may only be viewed and changed by the team
+     * owner or an admin. Mirrors the write guard in
+     * {@see UpdateTeamEmailPrivacySettingsAction}; other roles use the
+     * per-user "My Email Privacy" page instead.
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public static function canAccess(array $parameters = []): bool
+    {
+        if (! Feature::active(EmailIntegration::class) || ! parent::canAccess()) {
+            return false;
+        }
+
+        $user = auth()->user();
+
+        if (! $user instanceof User) {
+            return false;
+        }
+
+        $team = $user->currentTeam;
+
+        return $team instanceof Team
+            && ($user->ownsTeam($team) || $user->hasTeamRole($team, TeamRole::Admin->value));
+    }
 
     protected string $view = 'email-integration::filament.pages.email-privacy-settings';
 

--- a/packages/EmailIntegration/src/Filament/Pages/UserEmailPrivacyPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/UserEmailPrivacyPage.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Pages;
+
+use Filament\Pages\Page;
+use Relaticle\EmailIntegration\Filament\Clusters\EmailSettings;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
+
+final class UserEmailPrivacyPage extends Page
+{
+    use HasEmailFeatureFlag;
+
+    protected string $view = 'email-integration::filament.pages.user-email-privacy';
+
+    protected static ?string $cluster = EmailSettings::class;
+
+    protected static ?string $slug = 'my-privacy';
+
+    protected static ?string $title = null;
+
+    protected static ?int $navigationSort = 5;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-user';
+
+    public function getTitle(): string
+    {
+        return __('filament/pages/user-email-privacy.title');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('filament/pages/user-email-privacy.navigation_label');
+    }
+}

--- a/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
@@ -136,3 +136,25 @@ it('allows an admin member to change team privacy settings', function (): void {
 
     expect($this->team->fresh()->default_email_sharing_tier)->toBe(EmailPrivacyTier::FULL);
 });
+
+it('grants the team owner access to the workspace privacy page', function (): void {
+    expect(EmailPrivacySettingsPage::canAccess())->toBeTrue();
+});
+
+it('grants an admin member access to the workspace privacy page', function (): void {
+    $admin = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($admin, ['role' => 'admin']);
+    $this->actingAs($admin);
+    Filament::setTenant($this->team);
+
+    expect(EmailPrivacySettingsPage::canAccess())->toBeTrue();
+});
+
+it('denies a non-admin member access to the workspace privacy page', function (): void {
+    $member = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($member, ['role' => 'editor']);
+    $this->actingAs($member);
+    Filament::setTenant($this->team);
+
+    expect(EmailPrivacySettingsPage::canAccess())->toBeFalse();
+});

--- a/tests/Feature/EmailIntegration/UserEmailPrivacyPageTest.php
+++ b/tests/Feature/EmailIntegration/UserEmailPrivacyPageTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\App\Email\UserEmailPrivacySettings;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Actions\UpdateUserEmailPrivacySettingsAction;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Pages\UserEmailPrivacyPage;
+
+mutates(UserEmailPrivacyPage::class, UserEmailPrivacySettings::class, UpdateUserEmailPrivacySettingsAction::class);
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withTeam()->create();
+    $this->team = $this->owner->currentTeam;
+});
+
+it('grants any team member access to the my-privacy page regardless of role', function (): void {
+    $member = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($member, ['role' => 'editor']);
+    $this->actingAs($member);
+    Filament::setTenant($this->team);
+
+    expect(UserEmailPrivacyPage::canAccess())->toBeTrue();
+});
+
+it('persists the user default sharing tier when a member saves their preference', function (): void {
+    $member = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($member, ['role' => 'editor']);
+    $this->actingAs($member);
+    Filament::setTenant($this->team);
+
+    livewire(UserEmailPrivacySettings::class)
+        ->set('data.default_email_sharing_tier', EmailPrivacyTier::FULL->value)
+        ->call('save')
+        ->assertNotified('Email privacy settings saved.');
+
+    expect($member->fresh()->default_email_sharing_tier)->toBe(EmailPrivacyTier::FULL);
+});


### PR DESCRIPTION
## What

Splits the Email Privacy Configuration into two distinct pages within the existing **Email Settings** cluster, instead of stacking workspace and personal settings on one page.

- **New page** `UserEmailPrivacyPage` (slug `my-privacy`, "My Email Privacy") — renders the existing `UserEmailPrivacySettings` Livewire component. Available to every team member.
- **Workspace page** `EmailPrivacySettingsPage` (slug `privacy`, renamed to "Workspace Privacy") — keeps the workspace default tier, auto-hide-internal notice, and protected recipients. The embedded user-settings block was removed from its blade.

## Access control

`EmailPrivacySettingsPage::canAccess()` now requires the feature flag **and** that the actor owns the team or holds `TeamRole::Admin`. This mirrors the write guard already in `UpdateTeamEmailPrivacySettingsAction`, so non-admins:

- do not see the **Workspace Privacy** cluster tab, and
- get **403** on the direct URL.

The per-user "My Email Privacy" page stays open to all members.

## UX

Since non-admins can no longer view the workspace page, the user page's sharing-preference select now shows a read-only hint of the current workspace default (e.g. *"Workspace default: Metadata only (participants + timestamps)"*) so "Use workspace default" is meaningful.

## Tests

- Owner and Admin member can access the workspace page; Editor/member is denied.
- Any member can access the my-privacy page; saving still persists tier + blocklist.
- Existing workspace save/mount tests unchanged and passing.

Verified in-browser (real app, email feature on): owner sees both tabs, non-admin sees only My Email Privacy and gets 403 on `/privacy`, and the workspace-default hint renders.

## Notes

- No data-model, migration, or action-signature changes.
- i18n keys added/renamed; no hardcoded user-facing strings.