### PR TITLE
fix(email): track email read state per viewer

### DIFF
--- a/database/factories/EmailReadFactory.php
+++ b/database/factories/EmailReadFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailRead;
+
+/**
+ * @extends Factory<EmailRead>
+ */
+final class EmailReadFactory extends Factory
+{
+    protected $model = EmailRead::class;
+
+    public function definition(): array
+    {
+        return [
+            'email_id' => Email::factory(),
+            'user_id' => User::factory(),
+            'read_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_03_21_050430_create_emails_table.php
+++ b/database/migrations/2026_03_21_050430_create_emails_table.php
@@ -42,7 +42,6 @@ return new class extends Migration
             // Computed flags — set during sync
             $table->boolean('has_attachments')->default(false);
             $table->boolean('is_internal')->default(false);      // true when all participants are workspace members
-            $table->timestamp('read_at')->nullable();
 
             $table->string('creation_source', 50)->default('sync'); // EmailCreationSource: sync | compose | forward | bcc_inbound
             $table->foreignUlid('batch_id')->nullable()->constrained('email_batches')->nullOnDelete();

--- a/database/migrations/2026_03_21_050530_create_email_reads_table.php
+++ b/database/migrations/2026_03_21_050530_create_email_reads_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Per-viewer read state. A row's existence means "this user has read this
+        // email"; read_at records when. Read state is per (email, user) so the
+        // owner's provider-synced state and each teammate's in-app reads stay
+        // independent — the single emails.read_at column could not express that.
+        Schema::create('email_reads', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('email_id')->constrained('emails')->cascadeOnDelete();
+            $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('read_at');
+            $table->timestamps();
+
+            $table->unique(['email_id', 'user_id']);
+            $table->index(['user_id', 'email_id']);
+        });
+    }
+};

--- a/packages/EmailIntegration/src/Actions/MarkEmailAsReadAction.php
+++ b/packages/EmailIntegration/src/Actions/MarkEmailAsReadAction.php
@@ -6,15 +6,32 @@ namespace Relaticle\EmailIntegration\Actions;
 
 use App\Models\User;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailRead;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 
 final readonly class MarkEmailAsReadAction
 {
+    /**
+     * Record that $user has read the email. Read state is per-viewer: the owner's
+     * provider-synced state and each teammate's in-app reads are tracked separately,
+     * so marking read decrements only the acting user's unread count.
+     */
     public function execute(string $emailId, User $user): void
     {
-        Email::query()
+        // Only let a user mark an email they can actually see — guards against
+        // forging read rows for private/out-of-team emails via a crafted id.
+        $isVisible = Email::query()
+            ->withGlobalScope('visible', new VisibleEmailScope($user))
             ->whereKey($emailId)
-            ->where('user_id', $user->getKey())
-            ->whereNull('read_at')
-            ->update(['read_at' => now()]);
+            ->exists();
+
+        if (! $isVisible) {
+            return;
+        }
+
+        EmailRead::query()->firstOrCreate(
+            ['email_id' => $emailId, 'user_id' => $user->getKey()],
+            ['read_at' => now()],
+        );
     }
 }

--- a/packages/EmailIntegration/src/Actions/StoreEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreEmailAction.php
@@ -12,6 +12,7 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Models\EmailRead;
 use Throwable;
 
 final readonly class StoreEmailAction
@@ -39,8 +40,17 @@ final readonly class StoreEmailAction
                 'direction' => $data->direction,
                 'folder' => $data->folder,
                 'has_attachments' => $data->hasAttachments,
-                'read_at' => $data->isRead ? $data->sentAt : null,
             ]);
+
+            // Read state is per-viewer; the provider's "already read" flag reflects
+            // the owner's mailbox, so seed only the owner's read row.
+            if ($data->isRead) {
+                EmailRead::query()->create([
+                    'email_id' => $email->getKey(),
+                    'user_id' => $connectedAccount->user_id,
+                    'read_at' => $data->sentAt,
+                ]);
+            }
 
             $email->body()->create([
                 'body_text' => $data->bodyText,

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -26,7 +26,6 @@ use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
-use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
@@ -98,6 +97,7 @@ abstract class BaseRecordEmailsPage extends Page
             ->emails()
             // participants + shares are read per row by the privacy policy; eager-load to avoid N+1.
             ->with(['from', 'labels', 'participants', 'shares'])
+            ->withReadStateFor($user->getKey())
             ->withGlobalScope('visible', new VisibleEmailScope($user));
 
         if ($this->folder === EmailFolder::Sent) {
@@ -144,8 +144,7 @@ abstract class BaseRecordEmailsPage extends Page
         return $record
             ->emails()
             ->withGlobalScope('visible', new VisibleEmailScope($this->authUser()))
-            ->where('direction', EmailDirection::INBOUND)
-            ->whereNull('read_at')
+            ->unreadFor($this->authUser()->getKey())
             ->count();
     }
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -35,7 +35,6 @@ use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
-use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
@@ -125,6 +124,7 @@ final class EmailInboxPage extends Page
 
         $query = Email::query()
             ->with(['from', 'labels'])
+            ->withReadStateFor($user->getKey())
             ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user));
 
@@ -168,8 +168,7 @@ final class EmailInboxPage extends Page
         return Email::query()
             ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user))
-            ->where('direction', EmailDirection::INBOUND)
-            ->whereNull('read_at')
+            ->unreadFor($user->getKey())
             ->count();
     }
 

--- a/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
@@ -15,6 +15,7 @@ use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailRead;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Throwable;
 
@@ -60,26 +61,40 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
             dispatch(new StoreEmailJob($account, $messageId));
         }
 
-        // Mark emails as read when UNREAD label was removed in Gmail
+        // Read state is per-viewer; the provider delta reflects the OWNER's mailbox,
+        // so toggle only the owner's read rows (teammates' read state is untouched).
+        $ownerId = $account->user_id;
+
+        // Mark emails as read when the UNREAD label was removed in Gmail.
         $readIds = $delta->readMessageIds->all();
 
         if ($readIds !== []) {
-            Email::query()
+            $readEmailIds = Email::query()
                 ->where('connected_account_id', $account->getKey())
                 ->whereIn('provider_message_id', $readIds)
-                ->whereNull('read_at')
-                ->update(['read_at' => now()]);
+                ->pluck('id');
+
+            foreach ($readEmailIds as $emailId) {
+                EmailRead::query()->firstOrCreate(
+                    ['email_id' => $emailId, 'user_id' => $ownerId],
+                    ['read_at' => now()],
+                );
+            }
         }
 
         // Mark emails unread again when the provider flipped them back to unread.
         $unreadIds = $delta->unreadMessageIds?->all() ?? [];
 
         if ($unreadIds !== []) {
-            Email::query()
+            $unreadEmailIds = Email::query()
                 ->where('connected_account_id', $account->getKey())
                 ->whereIn('provider_message_id', $unreadIds)
-                ->whereNotNull('read_at')
-                ->update(['read_at' => null]);
+                ->pluck('id');
+
+            EmailRead::query()
+                ->whereIn('email_id', $unreadEmailIds)
+                ->where('user_id', $ownerId)
+                ->delete();
         }
 
         $account->update([

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -51,7 +51,6 @@ use Relaticle\EmailIntegration\Observers\EmailObserver;
  * @property EmailPrivacyTier $privacy_tier
  * @property bool $has_attachments
  * @property bool $is_internal
- * @property Carbon|null $read_at
  * @property EmailCreationSource $creation_source
  * @property string|null $batch_id
  * @property Carbon|null $scheduled_for
@@ -90,7 +89,6 @@ final class Email extends Model
         'privacy_tier',
         'has_attachments',
         'is_internal',
-        'read_at',
         'creation_source',
         'batch_id',
         'scheduled_for',
@@ -109,7 +107,6 @@ final class Email extends Model
 
     protected $casts = [
         'sent_at' => 'datetime',
-        'read_at' => 'datetime',
         'direction' => EmailDirection::class,
         'folder' => EmailFolder::class,
         'status' => EmailStatus::class,
@@ -154,6 +151,32 @@ final class Email extends Model
     protected function inbox(Builder $query): Builder
     {
         return $query->where('direction', EmailDirection::INBOUND);
+    }
+
+    /**
+     * Expose a per-viewer `is_read` boolean so list rows can render unread state
+     * for the authenticated user (not the owner's global state).
+     *
+     * @param  Builder<Email>  $query
+     * @return Builder<Email>
+     */
+    #[Scope]
+    protected function withReadStateFor(Builder $query, string $userId): Builder
+    {
+        return $query->withExists(['reads as is_read' => fn (Builder $readQuery): Builder => $readQuery->where('user_id', $userId)]);
+    }
+
+    /**
+     * Inbound emails the given user has not yet read.
+     *
+     * @param  Builder<Email>  $query
+     * @return Builder<Email>
+     */
+    #[Scope]
+    protected function unreadFor(Builder $query, string $userId): Builder
+    {
+        return $query->where('direction', EmailDirection::INBOUND)
+            ->whereDoesntHave('reads', fn (Builder $readQuery): Builder => $readQuery->where('user_id', $userId));
     }
 
     // Relations
@@ -232,6 +255,14 @@ final class Email extends Model
     public function shares(): HasMany
     {
         return $this->hasMany(EmailShare::class);
+    }
+
+    /**
+     * @return HasMany<EmailRead, $this>
+     */
+    public function reads(): HasMany
+    {
+        return $this->hasMany(EmailRead::class);
     }
 
     /**

--- a/packages/EmailIntegration/src/Models/EmailRead.php
+++ b/packages/EmailIntegration/src/Models/EmailRead.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Models;
+
+use App\Models\User;
+use Database\Factories\EmailReadFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $email_id
+ * @property string $user_id
+ * @property Carbon $read_at
+ */
+final class EmailRead extends Model
+{
+    /**
+     * @use HasFactory<EmailReadFactory>
+     */
+    use HasFactory, HasUlids;
+
+    protected static function newFactory(): EmailReadFactory
+    {
+        return EmailReadFactory::new();
+    }
+
+    protected $fillable = [
+        'email_id',
+        'user_id',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'read_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Email, $this>
+     */
+    public function email(): BelongsTo
+    {
+        return $this->belongsTo(Email::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/resources/views/components/emails/list-row.blade.php
+++ b/resources/views/components/emails/list-row.blade.php
@@ -4,7 +4,8 @@
     use Relaticle\EmailIntegration\Enums\EmailDirection;
 
     $isSelected  = $selectedEmailId === $email->id;
-    $isUnread    = $email->read_at === null && $email->direction === EmailDirection::INBOUND;
+    // `is_read` is a per-viewer flag set by the withReadStateFor() query scope.
+    $isUnread    = ! $email->is_read && $email->direction === EmailDirection::INBOUND;
     $from        = $email->from->first();
     $senderName  = $from?->name ?: $from?->email_address ?: '?';
     $authUser    = auth()->user();

--- a/tests/Feature/EmailIntegration/EmailUnreadCountPerViewerTest.php
+++ b/tests/Feature/EmailIntegration/EmailUnreadCountPerViewerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withTeam()->create();
+    $this->viewer = User::factory()->create(['current_team_id' => $this->owner->currentTeam->id]);
+    $this->team = $this->owner->currentTeam;
+
+    $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+    ]));
+
+    // Two inbound, fully-shared emails — visible AND unread to every teammate.
+    $this->newer = Email::factory()->inbound()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->account->getKey(),
+        'sent_at' => now(),
+    ]);
+
+    $this->older = Email::factory()->inbound()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->account->getKey(),
+        'sent_at' => now()->subHour(),
+    ]);
+});
+
+it('lets a teammate clear their own unread count on a shared email', function (): void {
+    $this->actingAs($this->viewer);
+    Filament::setTenant($this->team);
+
+    // Mounting auto-selects + reads the newest email for the viewer, leaving one unread.
+    $page = livewire(EmailInboxPage::class);
+    expect($page->instance()->inboxUnreadCount())->toBe(1);
+    // The unread row renders the per-viewer unread indicator dot.
+    $page->assertSeeHtml('h-1.5 w-1.5 rounded-full bg-primary-500');
+
+    $page->call('selectEmail', $this->older->getKey());
+
+    expect($page->instance()->inboxUnreadCount())->toBe(0);
+    $page->assertDontSeeHtml('h-1.5 w-1.5 rounded-full bg-primary-500');
+});
+
+it('keeps each viewer unread state independent of the owner', function (): void {
+    // Viewer reads BOTH emails.
+    $this->actingAs($this->viewer);
+    Filament::setTenant($this->team);
+
+    $viewerPage = livewire(EmailInboxPage::class);
+    $viewerPage->call('selectEmail', $this->older->getKey());
+    expect($viewerPage->instance()->inboxUnreadCount())->toBe(0);
+
+    // Owner has not touched the older email — mounting only auto-reads the newest,
+    // so one stays unread for the owner regardless of what the viewer did.
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+
+    $ownerPage = livewire(EmailInboxPage::class);
+    expect($ownerPage->instance()->inboxUnreadCount())->toBe(1);
+});

--- a/tests/Feature/EmailIntegration/IncrementalEmailSyncJobMicrosoftTest.php
+++ b/tests/Feature/EmailIntegration/IncrementalEmailSyncJobMicrosoftTest.php
@@ -9,10 +9,52 @@ use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailRead;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 
 mutates(IncrementalEmailSyncJob::class);
+
+/**
+ * @param  array<string, mixed>  $deltaOverrides
+ */
+function runIncrementalSync(ConnectedAccount $account, array $deltaOverrides): void
+{
+    Queue::fake();
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchDelta')->andReturn(new MailDeltaResult(
+        messageIds: $deltaOverrides['messageIds'] ?? collect([]),
+        readMessageIds: $deltaOverrides['readMessageIds'] ?? collect([]),
+        newCursor: 'next-cursor',
+        unreadMessageIds: $deltaOverrides['unreadMessageIds'] ?? null,
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    (new IncrementalEmailSyncJob($account))->handle($factory);
+}
+
+function syncableAccount(): ConnectedAccount
+{
+    $user = User::factory()->withTeam()->create();
+
+    return ConnectedAccount::factory()
+        ->azure()
+        ->for($user)
+        ->create([
+            'team_id' => $user->currentTeam->getKey(),
+            'access_token' => 'a',
+            'refresh_token' => 'r',
+            'token_expires_at' => now()->addHour(),
+            'sync_cursor' => 'old-cursor',
+            'status' => EmailAccountStatus::ACTIVE,
+            'capabilities' => ['email' => true, 'calendar' => false],
+        ]);
+}
 
 it('advances the cursor and dispatches StoreEmailJob for new Microsoft messages', function (): void {
     Queue::fake();
@@ -47,4 +89,49 @@ it('advances the cursor and dispatches StoreEmailJob for new Microsoft messages'
     Queue::assertPushed(StoreEmailJob::class, 2);
 
     expect($account->refresh()->sync_cursor)->toBe('new-cursor');
+});
+
+it('records the owner read state when the provider marks a message read', function (): void {
+    Queue::fake();
+
+    $account = syncableAccount();
+
+    $email = Email::factory()->create([
+        'team_id' => $account->team_id,
+        'user_id' => $account->user_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_message_id' => 'MSG-READ',
+    ]);
+
+    runIncrementalSync($account, ['readMessageIds' => collect(['MSG-READ'])]);
+
+    $this->assertDatabaseHas('email_reads', [
+        'email_id' => $email->getKey(),
+        'user_id' => $account->user_id,
+    ]);
+});
+
+it('removes the owner read state when the provider marks a message unread', function (): void {
+    Queue::fake();
+
+    $account = syncableAccount();
+
+    $email = Email::factory()->create([
+        'team_id' => $account->team_id,
+        'user_id' => $account->user_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_message_id' => 'MSG-UNREAD',
+    ]);
+
+    EmailRead::factory()->create([
+        'email_id' => $email->getKey(),
+        'user_id' => $account->user_id,
+    ]);
+
+    runIncrementalSync($account, ['unreadMessageIds' => collect(['MSG-UNREAD'])]);
+
+    $this->assertDatabaseMissing('email_reads', [
+        'email_id' => $email->getKey(),
+        'user_id' => $account->user_id,
+    ]);
 });

--- a/tests/Feature/EmailIntegration/StoreEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailActionTest.php
@@ -87,8 +87,12 @@ it('persists the email record with correct fields', function (): void {
         ->and($email->snippet)->toBe('First 255 chars...')
         ->and($email->direction)->toBe(EmailDirection::INBOUND)
         ->and($email->folder)->toBe(EmailFolder::Inbox)
-        ->and($email->has_attachments)->toBeFalse()
-        ->and($email->read_at)->toBeNull();
+        ->and($email->has_attachments)->toBeFalse();
+
+    $this->assertDatabaseMissing('email_reads', [
+        'email_id' => $email->getKey(),
+        'user_id' => $this->user->id,
+    ]);
 });
 
 it('dispatches ClassifyEmailJob after storing the email', function (): void {
@@ -100,14 +104,15 @@ it('dispatches ClassifyEmailJob after storing the email', function (): void {
     );
 });
 
-it('sets read_at when isRead is true', function (): void {
+it("records the owner's read state when isRead is true", function (): void {
     $sentAt = now()->subHour();
     $data = makeFetchedEmailData(['sentAt' => $sentAt, 'isRead' => true]);
 
     $email = resolve(StoreEmailAction::class)->execute($this->account, $data);
 
-    expect($email->read_at)->not->toBeNull()
-        ->and($email->read_at->toDateTimeString())->toBe($sentAt->toDateTimeString());
+    $read = $email->reads()->where('user_id', $this->user->id)->sole();
+
+    expect($read->read_at->toDateTimeString())->toBe($sentAt->toDateTimeString());
 });
 
 it('stores body_text and body_html in email_bodies', function (): void {


### PR DESCRIPTION
## Problem

On the email index page, the unread badge counts every email a user can *see* (their own plus emails shared via privacy tiers), but read state lived in a single global `emails.read_at` column owned by the email's connector. When a teammate opened a *shared* email, `MarkEmailAsReadAction` was gated to `user_id = owner`, so the click was a no-op and the unread count never dropped for that teammate.

The count was computed per-viewer; the read state was global. The two could not be reconciled while read state was a single column.

## Fix

Move read state to a per-`(email, user)` table so each viewer's reads are independent — matching how shared-inbox CRMs (Front, Missive, HubSpot) handle it.

- **New `email_reads` table** — row existence = "this user read this email", `read_at` records when. `emails.read_at` removed (edited the original create-table migration since the branch is unmerged).
- **`EmailRead` model + factory**, `Email::reads()` relation, and two query scopes: `withReadStateFor($userId)` (exposes a per-viewer `is_read` flag) and `unreadFor($userId)`.
- **`MarkEmailAsReadAction`** now upserts a read row for the acting user (any visible email), guarded by `VisibleEmailScope` so reads can't be forged for emails the user can't see.
- **`EmailInboxPage` / `BaseRecordEmailsPage`** — unread count uses `unreadFor()`; list query adds `withReadStateFor()`.
- **`list-row.blade.php`** — unread dot/bold now keys off the per-viewer `is_read` flag instead of the global `read_at`.
- **Owner provider-sync paths** (`StoreEmailAction` initial read flag, `IncrementalEmailSyncJob` read/unread deltas) — write/delete only the **owner's** read row, since the Gmail/Graph read flag reflects the owner's mailbox. Teammate read state is never touched by sync.

## Tests

- New `EmailUnreadCountPerViewerTest`: a teammate reading a shared email clears their own count; the owner's count stays independent; the per-viewer unread indicator renders/clears correctly.
- Added `IncrementalEmailSyncJob` coverage for provider read → owner read row, and provider unread → owner read row removed.
- Updated `StoreEmailActionTest` read-state assertions to the per-viewer model.

Full EmailIntegration suite passes (pre-existing, unrelated `MicrosoftOAuthRedirectTest` failures aside). pint / rector / phpstan clean, type-coverage 100%.