### PR TITLE
fix(email): key auto-created people on email, not display name

### DIFF
--- a/app/Support/Database/AdvisoryLock.php
+++ b/app/Support/Database/AdvisoryLock.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Thin seam over Postgres advisory locks.
+ *
+ * Keeps the single driver-specific construct (`pg_advisory_xact_lock`) in one
+ * place so call sites read as portable, intent-revealing code instead of raw
+ * SQL. This is the only file that should reference the advisory-lock primitive.
+ */
+final class AdvisoryLock
+{
+    /**
+     * Run $callback while holding a transaction-scoped advisory lock keyed on $key.
+     *
+     * The lock is acquired inside a transaction and released automatically on
+     * commit/rollback, so a concurrent caller using the same key blocks until
+     * this one's writes are committed and visible — making a check-then-write
+     * sequence atomic across parallel processes (e.g. queue workers).
+     *
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public function transactional(string $key, Closure $callback): mixed
+    {
+        return DB::transaction(function () use ($key, $callback) {
+            // hashtextextended folds the arbitrary string key into the bigint the
+            // advisory-lock API requires; the lock is held until this tx commits.
+            DB::select('select pg_advisory_xact_lock(hashtextextended(?, 0))', [$key]);
+
+            return $callback();
+        });
+    }
+}

--- a/app/Support/Database/AdvisoryLock.php
+++ b/app/Support/Database/AdvisoryLock.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\DB;
  * place so call sites read as portable, intent-revealing code instead of raw
  * SQL. This is the only file that should reference the advisory-lock primitive.
  */
-final class AdvisoryLock
+final readonly class AdvisoryLock
 {
     /**
      * Run $callback while holding a transaction-scoped advisory lock keyed on $key.

--- a/packages/EmailIntegration/src/Actions/AutoCreatePersonAction.php
+++ b/packages/EmailIntegration/src/Actions/AutoCreatePersonAction.php
@@ -8,14 +8,23 @@ use App\Enums\CreationSource;
 use App\Models\CustomField;
 use App\Models\People;
 use App\Models\Team;
+use App\Support\Database\AdvisoryLock;
+use Illuminate\Contracts\Database\Query\Builder;
 use Relaticle\CustomFields\Models\CustomField as BaseCustomField;
 
 final readonly class AutoCreatePersonAction
 {
+    public function __construct(private AdvisoryLock $advisoryLock) {}
+
     /**
-     * Create a new Person record seeded with name + email custom field value.
-     * The person is created with CreationSource::SYSTEM so it is distinguishable
-     * from manually created records.
+     * Find-or-create a Person for the given email address.
+     *
+     * Identity is the email address, never the display name: two distinct people
+     * who happen to share a name must stay distinct, and the same address reuses
+     * the existing record rather than spawning a duplicate. The lock serialises
+     * concurrent queue workers racing the same address so the check-then-create
+     * stays atomic. New records use CreationSource::SYSTEM so they are
+     * distinguishable from manually created ones.
      */
     public function execute(
         string $name,
@@ -24,21 +33,49 @@ final readonly class AutoCreatePersonAction
         Team $team,
         ?string $companyId = null,
     ): People {
-        $person = People::query()
-            ->updateOrCreate([
+        $emailField = $this->customFieldByCode($teamId);
+
+        return $this->advisoryLock->transactional("auto-create-person:{$teamId}:{$emailAddress}", function () use ($name, $emailAddress, $teamId, $team, $companyId, $emailField): People {
+            $existing = $this->findByEmail($emailAddress, $teamId, $emailField);
+
+            if ($existing instanceof People) {
+                return $existing;
+            }
+
+            $person = People::query()->create([
                 'name' => $name ?: $emailAddress,
                 'team_id' => $teamId,
                 'company_id' => $companyId,
                 'creation_source' => CreationSource::SYSTEM,
             ]);
 
-        $emailField = $this->customFieldByCode($teamId);
+            if ($emailField instanceof BaseCustomField) {
+                $person->saveCustomFieldValue($emailField, [$emailAddress], $team);
+            }
 
-        if ($emailField instanceof BaseCustomField) {
-            $person->saveCustomFieldValue($emailField, [$emailAddress], $team);
+            return $person;
+        });
+    }
+
+    /**
+     * Match an existing Person carrying this address in the people "emails"
+     * custom field. Returns null when the field is unconfigured for the team —
+     * there is then no canonical place email identity is stored, so the caller
+     * falls through to creating a fresh record.
+     */
+    private function findByEmail(string $emailAddress, string $teamId, ?BaseCustomField $emailField): ?People
+    {
+        if (! $emailField instanceof BaseCustomField) {
+            return null;
         }
 
-        return $person;
+        return People::query()
+            ->where('team_id', $teamId)
+            ->whereHas('customFieldValues', fn (Builder $valueQuery): Builder => $valueQuery
+                ->where('custom_field_id', $emailField->getKey())
+                ->whereJsonContains('json_value', $emailAddress)
+            )
+            ->first();
     }
 
     private function customFieldByCode(string $teamId): ?BaseCustomField

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -8,6 +8,7 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Actions\AutoCreatePersonAction;
 use Relaticle\EmailIntegration\Actions\LinkEmailAction;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -17,6 +18,7 @@ use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 
 mutates(LinkEmailAction::class);
+mutates(AutoCreatePersonAction::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -332,6 +334,48 @@ it('auto-creates a person when contact_creation_mode is All', function (): void 
     app(LinkEmailAction::class)->execute($email);
 
     expect(People::where('team_id', $this->team->id)->where('name', 'New Contact')->exists())->toBeTrue();
+});
+
+it('creates distinct people for participants sharing a display name but different emails', function (): void {
+    $this->account->update(['contact_creation_mode' => ContactCreationMode::All]);
+
+    $email = makeLinkEmail();
+
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'john@a-corp.com',
+        'name' => 'John Smith',
+    ]);
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'john@b-corp.com',
+        'name' => 'John Smith',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(People::where('team_id', $this->team->id)->where('name', 'John Smith')->count())->toBe(2);
+});
+
+it('does not duplicate a person when the same address appears on multiple participants', function (): void {
+    $this->account->update(['contact_creation_mode' => ContactCreationMode::All]);
+
+    $email = makeLinkEmail();
+
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'dup@partner.com',
+        'name' => 'Dup Person',
+    ]);
+    EmailParticipant::factory()->cc()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'dup@partner.com',
+        'name' => 'Dup Person',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(People::where('team_id', $this->team->id)->where('name', 'Dup Person')->count())->toBe(1);
 });
 
 it('does not auto-create a person when Bidirectional and only one direction exists', function (): void {


### PR DESCRIPTION
## What

Auto-created `People` records (from email sync) are now keyed on the **email address**, not the From **display name**.

## Why

`AutoCreatePersonAction` used `updateOrCreate` keyed on `name` + team + company + source. Email identity lives in the people `emails` custom field (EAV), not a column — so keying on name was wrong in both directions:

- **Over-merge:** two distinct people sharing a display name (e.g. two "John Smith" at different domains, same/no company) collapsed into one record.
- **Under-dedupe:** the same person whose display name varied between emails ("John Smith" vs "John") spawned a second record.

## Change

- Replace name-keyed `updateOrCreate` with an email-based **find-then-create** (`findByEmail` matches the `emails` custom field; reuse on hit, else `create()`).
- Wrap the check-then-create in a transaction-scoped **advisory lock** keyed on `team:email`, so concurrent sync workers racing the same brand-new address cannot both insert a duplicate. The lock is released at commit (when the new row becomes visible).
- Isolate the only Postgres-specific construct (`pg_advisory_xact_lock`) behind a reusable `App\Support\Database\AdvisoryLock` seam — call sites stay clean, coupling lives in one file.

Display-name → person-name at create time was already correct and remains so (`$name ?: $emailAddress`).

## Tests

`LinkEmailActionTest` (20 passing), incl. two new cases:
- distinct people sharing a display name but different emails → **2** records
- the same address across multiple participants → **1** record

PHPStan clean, Pint clean, type coverage 100% on changed files.