### PR TITLE
Dedupe auto-created companies by domain under an advisory lock

### DIFF
--- a/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
+++ b/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
@@ -9,14 +9,46 @@ use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\Team;
 use Relaticle\CustomFields\Models\CustomField as BaseCustomField;
+use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
+use Relaticle\EmailIntegration\Support\UsesTransactionalLock;
 
 final readonly class AutoCreateCompanyAction
 {
+    use UsesTransactionalLock;
+
+    public function __construct(
+        private CompanyDomainMatcher $domainMatcher,
+    ) {}
+
+    /**
+     * Resolve a Company for the domain, creating one only when no existing company
+     * already owns it. Serialised per (team, domain) with a transaction-level
+     * advisory lock so two StoreEmailJob/calendar workers processing the first
+     * email from a brand-new domain in parallel can't both miss the match and
+     * create duplicate companies: the first holder creates, the rest re-check
+     * inside the lock and reuse it.
+     */
+    public function execute(string $domain, string $teamId, Team $team): Company
+    {
+        return $this->transactional("auto-create-company:{$teamId}:{$domain}", function () use ($domain, $teamId, $team): Company {
+            // Only create when the domain is not already in another company. The
+            // caller's unlocked match can be stale by the time we get the lock, so
+            // re-check here under mutual exclusion before creating.
+            $existing = $this->domainMatcher->firstMatching($domain, $teamId);
+
+            if ($existing instanceof Company) {
+                return $existing;
+            }
+
+            return $this->createCompany($domain, $teamId, $team);
+        });
+    }
+
     /**
      * Create a new Company record seeded with a name derived from the domain
      * and the domain stored in the domains custom field.
      */
-    public function execute(string $domain, string $teamId, Team $team): Company
+    private function createCompany(string $domain, string $teamId, Team $team): Company
     {
         $company = Company::query()
             ->updateOrCreate([

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -17,12 +17,14 @@ use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
+use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
 
 final readonly class LinkEmailAction
 {
     public function __construct(
         private AutoCreateCompanyAction $autoCreateCompany,
         private AutoCreatePersonAction $autoCreatePerson,
+        private CompanyDomainMatcher $domainMatcher,
     ) {}
 
     public function execute(Email $email): void
@@ -48,19 +50,14 @@ final readonly class LinkEmailAction
             $domain = $this->extractDomain($participant->email_address);
 
             if ($domain && $skippedDomains->doesntContain($domain)) {
-                $company = Company::query()->where('team_id', $teamId)
-                    ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
-                        ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('code', 'domains'))
-                        ->whereRaw('json_value::text ~* ?', [$this->domainMatchPattern($domain)])
-                    )
-                    ->first();
+                $company = $this->domainMatcher->firstMatching($domain, $teamId);
 
                 // 2. Auto-create Company when no existing record found.
                 if (! $company && $connectedAccount?->auto_create_companies) {
                     $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
                 }
 
-                if ($company) {
+                if ($company instanceof Company) {
                     $participant->update(['company_id' => $company->getKey()]);
                     $email->companies()->syncWithoutDetaching([$company->getKey()]);
 
@@ -179,17 +176,6 @@ final readonly class LinkEmailAction
         $parts = explode('@', $email);
 
         return count($parts) === 2 ? strtolower($parts[1]) : null;
-    }
-
-    /**
-     * Build a POSIX regex matching the domain as a complete host token inside the
-     * JSON-encoded domains array. Tolerates scheme/subdomain/path variants while
-     * avoiding substring collisions (e.g. "acme.co" vs "acme.com.au") and
-     * neutralising LIKE wildcards present in sender-controlled input.
-     */
-    private function domainMatchPattern(string $domain): string
-    {
-        return '(^|["/.])'.preg_quote($domain).'(["/:]|$)';
     }
 
     /**

--- a/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
@@ -18,12 +18,14 @@ use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
+use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
 
 final readonly class LinkMeetingAction
 {
     public function __construct(
         private AutoCreateCompanyAction $autoCreateCompany,
         private AutoCreatePersonAction $autoCreatePerson,
+        private CompanyDomainMatcher $domainMatcher,
     ) {}
 
     public function execute(Meeting $meeting): void
@@ -39,18 +41,13 @@ final readonly class LinkMeetingAction
             $domain = $this->extractDomain($attendee->email_address);
 
             if ($domain && $skippedDomains->doesntContain($domain)) {
-                $company = Company::query()->where('team_id', $teamId)
-                    ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
-                        ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('code', 'domains'))
-                        ->whereRaw('json_value::text ~* ?', [$this->domainMatchPattern($domain)])
-                    )
-                    ->first();
+                $company = $this->domainMatcher->firstMatching($domain, $teamId);
 
                 if (! $company && $account?->auto_create_companies) {
                     $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
                 }
 
-                if ($company) {
+                if ($company instanceof Company) {
                     $attendee->update(['company_id' => $company->getKey()]);
                     if ($this->autoAttach($meeting->companies(), $company->getKey())) {
                         $this->updateCompanyMetrics($company, $meeting);
@@ -193,16 +190,5 @@ final readonly class LinkMeetingAction
         $parts = explode('@', $email);
 
         return count($parts) === 2 ? strtolower($parts[1]) : null;
-    }
-
-    /**
-     * Build a POSIX regex matching the domain as a complete host token inside the
-     * JSON-encoded domains array. Tolerates scheme/subdomain/path variants while
-     * avoiding substring collisions (e.g. "acme.co" vs "acme.com.au") and
-     * neutralising LIKE wildcards present in attendee-controlled input.
-     */
-    private function domainMatchPattern(string $domain): string
-    {
-        return '(^|["/.])'.preg_quote($domain).'(["/:]|$)';
     }
 }

--- a/packages/EmailIntegration/src/Support/CompanyDomainMatcher.php
+++ b/packages/EmailIntegration/src/Support/CompanyDomainMatcher.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Support;
+
+use App\Models\Company;
+use Illuminate\Contracts\Database\Query\Builder;
+
+/**
+ * Single source of truth for resolving an email/attendee domain to an existing
+ * Company via the team's "domains" custom field. Shared by the email and meeting
+ * link actions (fast path) and the system auto-create action (locked re-check),
+ * so the matching semantics never drift between them.
+ */
+final class CompanyDomainMatcher
+{
+    /**
+     * Find the first Company in the team whose "domains" custom field contains
+     * the given domain as a complete host token. Returns null when no company
+     * owns the domain.
+     */
+    public function firstMatching(string $domain, string $teamId): ?Company
+    {
+        return Company::query()->where('team_id', $teamId)
+            ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
+                ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('code', 'domains'))
+                ->whereRaw('json_value::text ~* ?', [$this->matchPattern($domain)])
+            )
+            ->first();
+    }
+
+    /**
+     * Build a POSIX regex matching the domain as a complete host token inside the
+     * JSON-encoded domains array. Tolerates scheme/subdomain/path variants while
+     * avoiding substring collisions (e.g. "acme.co" vs "acme.com.au") and
+     * neutralising LIKE wildcards present in sender-controlled input.
+     */
+    public function matchPattern(string $domain): string
+    {
+        return '(^|["/.])'.preg_quote($domain).'(["/:]|$)';
+    }
+}

--- a/packages/EmailIntegration/src/Support/UsesTransactionalLock.php
+++ b/packages/EmailIntegration/src/Support/UsesTransactionalLock.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Support;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Serialises a critical section across processes with a Postgres transaction-level
+ * advisory lock. Preferred over Cache::lock here: it is Postgres-native (no cache
+ * driver/TTL to tune), and the lock is released automatically when the transaction
+ * commits or rolls back, so a crashing worker can never strand it.
+ */
+trait UsesTransactionalLock
+{
+    /**
+     * Run the callback inside a transaction holding an advisory lock keyed by an
+     * arbitrary string. Concurrent callers with the same key block until the
+     * holder's transaction ends.
+     *
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    protected function transactional(string $key, Closure $callback): mixed
+    {
+        return DB::transaction(function () use ($key, $callback) {
+            // hashtextextended folds the arbitrary string key into the bigint the
+            // advisory-lock API requires; the lock is held until this tx commits.
+            DB::select('select pg_advisory_xact_lock(hashtextextended(?, 0))', [$key]);
+
+            return $callback();
+        });
+    }
+}

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -8,6 +8,7 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Actions\AutoCreateCompanyAction;
 use Relaticle\EmailIntegration\Actions\LinkEmailAction;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -301,6 +302,39 @@ it('seeds an auto-created company with a protocol-less domain and ICP set to fal
     if ($icpField) {
         expect($company->getCustomFieldValue($icpField))->toBeFalse();
     }
+});
+
+it('does not create a duplicate company when the domain is already owned', function (): void {
+    $action = app(AutoCreateCompanyAction::class);
+
+    $first = $action->execute('brandnewcorp.com', $this->team->id, $this->team);
+    $second = $action->execute('brandnewcorp.com', $this->team->id, $this->team);
+
+    expect($second->getKey())->toBe($first->getKey());
+    expect(Company::where('team_id', $this->team->id)->where('name', 'Brandnewcorp')->count())->toBe(1);
+});
+
+it('reuses an existing company that already owns the domain instead of creating one', function (): void {
+    $domainsField = CustomField::query()
+        ->where('tenant_id', $this->team->id)
+        ->where('entity_type', 'company')
+        ->where('code', 'domains')
+        ->first();
+
+    if (! $domainsField) {
+        $this->markTestSkipped('No domains custom field seeded for this team.');
+    }
+
+    $existing = Company::factory()->create([
+        'team_id' => $this->team->id,
+        'name' => 'Acme Corp',
+    ]);
+    $existing->saveCustomFieldValue($domainsField, 'https://acme.com', $this->team);
+
+    $resolved = app(AutoCreateCompanyAction::class)->execute('acme.com', $this->team->id, $this->team);
+
+    expect($resolved->getKey())->toBe($existing->getKey());
+    expect(Company::where('team_id', $this->team->id)->where('name', 'Acme')->exists())->toBeFalse();
 });
 
 it('does not auto-create a person when contact_creation_mode is None', function (): void {


### PR DESCRIPTION
## Problem

Email/calendar sync matches an incoming sender domain to a `Company`, and auto-creates one when no match is found. The match and the create were separated by a gap: two `StoreEmailJob`/calendar workers processing the first message from a brand-new domain in parallel could **both** miss the match and **both** create a company → duplicate companies for the same domain.

## Changes

- **`CompanyDomainMatcher`** (new) — single source of truth for resolving a domain → `Company` via the team's `domains` custom field. The regex match + pattern were previously duplicated in `LinkEmailAction` and `LinkMeetingAction`; both now delegate to the matcher.
- **`AutoCreateCompanyAction`** — now creates a company **only if the domain is not already owned by another company**, and serialises the resolve-or-create per `(team, domain)` with a Postgres transaction-level advisory lock. First holder creates; the rest re-check inside the lock and reuse the existing company.
- **`UsesTransactionalLock`** (new trait) — `transactional(key, callback)` wrapping `DB::transaction` + `pg_advisory_xact_lock(hashtextextended(?, 0))`. Consistent with the person-creation path.

### Why an advisory lock over `Cache::lock`

The guarded resource is a Postgres row, so the lock belongs in the same database and transaction as the write: no TTL to outrun (a slow custom-field save can't expire the lock mid-create), no lock-timeout exceptions, no second system to fail over, and it's released automatically on commit/rollback. There's no unique constraint to lean on because the domain lives in `custom_field_values.json_value` (JSON), which can't be cleanly unique-indexed.

## Tests

Added two regression tests to `LinkEmailActionTest`:
- repeating auto-create for the same domain yields one company
- an existing company already owning the domain is reused, not duplicated

Pint, PHPStan, and Rector clean; affected email + calendar link tests pass.