### PR TITLE
fix(email): collapse page header padding in email inbox

### DIFF
--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -40,7 +40,7 @@
     };
 @endphp
 
-<div class="flex flex-col">
+<div class="flex flex-col [&_.fi-page-header-main-ctn]:!pb-0">
 
     {{-- ── Internal email banner ──────────────────────────────────────────── --}}
     @if ($record->is_internal && $isOwner)

--- a/resources/views/filament/pages/email-inbox.blade.php
+++ b/resources/views/filament/pages/email-inbox.blade.php
@@ -1,4 +1,4 @@
-<x-filament-panels::page class="!pb-0">
+<x-filament-panels::page class="[&_.fi-page-header-main-ctn]:!pb-0">
     <div class="flex overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm h-[80vh]">
 
         {{-- ── Left panel: folder tabs + search + email list ─────────── --}}


### PR DESCRIPTION
## What

Replaces the email inbox page wrapper class `!pb-0` with `[&_.fi-page-header-main-ctn]:!pb-0`, and applies the same selector to the `email-view` component root.

## Why

The blanket `!pb-0` killed all bottom padding on the page. Scoping the override to the Filament page-header container (`.fi-page-header-main-ctn`) removes only the header's bottom padding so the inbox sits flush under the header, while leaving normal page spacing intact.

## Changes

- `resources/views/filament/pages/email-inbox.blade.php` — page header padding override scoped to `.fi-page-header-main-ctn`.
- `resources/views/components/emails/email-view.blade.php` — same scoped selector on the component root.