### PR TITLE
Add 'Mark all emails as read' to inbox

### DIFF
--- a/lang/en/filament/pages/email-inbox.php
+++ b/lang/en/filament/pages/email-inbox.php
@@ -13,6 +13,10 @@ return [
             ],
         ],
     ],
+    'mark_all_read' => [
+        'label' => 'Mark all read',
+        'notification' => '{0}No unread emails to mark|{1}1 email marked as read|[2,*]:count emails marked as read',
+    ],
     'reply_forward' => [
         'modal_headings' => [
             'reply_all' => 'Reply All',

--- a/packages/EmailIntegration/src/Actions/MarkAllEmailsAsReadAction.php
+++ b/packages/EmailIntegration/src/Actions/MarkAllEmailsAsReadAction.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\User;
+use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailRead;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
+
+final readonly class MarkAllEmailsAsReadAction
+{
+    /**
+     * Mark every visible, still-unread inbound email in the given folder as read
+     * for $user. Read state is per-viewer, so this clears only the acting user's
+     * unread count. Returns the number of emails newly marked read.
+     *
+     * Unread is meaningful only for inbound mail, so Sent (and other outbound-only
+     * folders) resolve to zero matches and the action is a no-op there.
+     */
+    public function execute(User $user, EmailFolder $folder): int
+    {
+        $query = Email::query()
+            ->forTeam($user->current_team_id)
+            ->withGlobalScope('visible', new VisibleEmailScope($user))
+            ->unreadFor($user->getKey());
+
+        if ($folder === EmailFolder::Sent) {
+            $query->sent();
+        } elseif ($folder === EmailFolder::Inbox) {
+            $query->inbox();
+        }
+
+        $emailIds = $query->pluck('id');
+
+        if ($emailIds->isEmpty()) {
+            return 0;
+        }
+
+        $now = now();
+
+        // Every matched id is guaranteed absent from email_reads (unreadFor filters
+        // on that), so a single bulk insert is safe — no conflict handling needed.
+        EmailRead::query()->insert($emailIds->map(fn (string $emailId): array => [
+            'id' => (string) Str::ulid(),
+            'email_id' => $emailId,
+            'user_id' => $user->getKey(),
+            'read_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ])->all());
+
+        return $emailIds->count();
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -30,6 +30,7 @@ use Livewire\Attributes\Url;
 use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
+use Relaticle\EmailIntegration\Actions\MarkAllEmailsAsReadAction;
 use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
@@ -179,6 +180,18 @@ final class EmailInboxPage extends Page
         resolve(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
 
         unset($this->inboxUnreadCount);
+    }
+
+    public function markAllAsRead(): void
+    {
+        $count = resolve(MarkAllEmailsAsReadAction::class)->execute($this->authUser(), $this->folder);
+
+        unset($this->inboxUnreadCount, $this->emails);
+
+        Notification::make()
+            ->success()
+            ->title(trans_choice('filament/pages/email-inbox.mark_all_read.notification', $count, ['count' => $count]))
+            ->send();
     }
 
     public function setFolder(string $folder): void

--- a/resources/views/filament/pages/email-inbox.blade.php
+++ b/resources/views/filament/pages/email-inbox.blade.php
@@ -12,6 +12,24 @@
 
             <x-emails.search-bar :search="$search" />
 
+            @if ($this->inboxUnreadCount > 0)
+                <div class="flex shrink-0 items-center justify-between border-b border-gray-200 dark:border-gray-700 px-3 py-1.5">
+                    <span class="text-xs text-gray-400 dark:text-gray-500">
+                        {{ $this->inboxUnreadCount }} unread
+                    </span>
+                    <button
+                        wire:click="markAllAsRead"
+                        wire:loading.attr="disabled"
+                        wire:target="markAllAsRead"
+                        type="button"
+                        class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-primary-600 dark:text-primary-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:pointer-events-none disabled:opacity-50"
+                    >
+                        <x-ri-check-double-line class="h-3.5 w-3.5" />
+                        {{ __('filament/pages/email-inbox.mark_all_read.label') }}
+                    </button>
+                </div>
+            @endif
+
             <div class="flex-1 overflow-y-scroll divide-y divide-gray-100 dark:divide-gray-800">
                 @forelse ($this->emails as $email)
                     <x-emails.list-row :email="$email" :selected-email-id="$selectedEmailId" :folder="$folder" />

--- a/tests/Feature/EmailIntegration/EmailUnreadCountPerViewerTest.php
+++ b/tests/Feature/EmailIntegration/EmailUnreadCountPerViewerTest.php
@@ -7,6 +7,7 @@ use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailRead;
 
 beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
@@ -66,4 +67,50 @@ it('keeps each viewer unread state independent of the owner', function (): void 
 
     $ownerPage = livewire(EmailInboxPage::class);
     expect($ownerPage->instance()->inboxUnreadCount())->toBe(1);
+});
+
+it('marks every visible unread inbox email as read for the viewer', function (): void {
+    $this->actingAs($this->viewer);
+    Filament::setTenant($this->team);
+
+    $page = livewire(EmailInboxPage::class);
+    // Mounting auto-reads only the newest, leaving the older one unread.
+    expect($page->instance()->inboxUnreadCount())->toBe(1);
+
+    $page->call('markAllAsRead');
+
+    expect($page->instance()->inboxUnreadCount())->toBe(0);
+    expect(EmailRead::query()->where('user_id', $this->viewer->id)->whereIn('email_id', [$this->newer->id, $this->older->id])->count())->toBe(2);
+});
+
+it('does not mark emails the viewer cannot see', function (): void {
+    // A private email the owner never shared — invisible to the viewer.
+    $private = Email::factory()->inbound()->private()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->account->getKey(),
+        'sent_at' => now()->subDay(),
+    ]);
+
+    $this->actingAs($this->viewer);
+    Filament::setTenant($this->team);
+
+    livewire(EmailInboxPage::class)->call('markAllAsRead');
+
+    expect(EmailRead::query()->where('user_id', $this->viewer->id)->where('email_id', $private->id)->exists())->toBeFalse();
+});
+
+it('leaves an already-read row untouched when marking all as read', function (): void {
+    $this->actingAs($this->viewer);
+    Filament::setTenant($this->team);
+
+    $page = livewire(EmailInboxPage::class);
+    // Mount already read the newest email for the viewer.
+    $existing = EmailRead::query()->where('user_id', $this->viewer->id)->where('email_id', $this->newer->id)->sole();
+
+    $page->call('markAllAsRead');
+
+    $after = EmailRead::query()->where('user_id', $this->viewer->id)->where('email_id', $this->newer->id)->sole();
+    expect($after->id)->toBe($existing->id)
+        ->and($after->read_at->equalTo($existing->read_at))->toBeTrue();
 });


### PR DESCRIPTION
## What

Adds a **Mark all read** action to the email inbox left panel that clears every unread email in the current folder for the viewer in one click.

- New `MarkAllEmailsAsReadAction` — bulk-marks all visible, unread **inbound** emails in the given folder as read for the user. Per-viewer read state (one row per `email_id`/`user_id` in `email_reads`); single bulk `insert()` of the matched ids. Respects `VisibleEmailScope` so a user can never mark an email they cannot see. No-op on Sent/Drafts/Archive (no inbound mail). Returns the count marked.
- `EmailInboxPage::markAllAsRead()` — invokes the action for the current folder, busts the `inboxUnreadCount`/`emails` computed caches, and fires a count-aware success toast.
- Button rendered next to the unread count in the left panel, visible only when unread > 0 (`ri-check-double-line` icon).
- All user-facing strings localized via `__()` / `trans_choice` in `lang/en/filament/pages/email-inbox.php`.

## Why

Users had to open each email individually to clear unread state. With high-volume inboxes this is the expected one-click bulk action.

## Tests

3 new cases in `EmailUnreadCountPerViewerTest` (Livewire-driven against `EmailInboxPage`):

- marks every visible unread inbox email as read for the viewer
- does **not** mark emails the viewer cannot see (private/unshared)
- leaves an already-read row untouched (idempotent — no duplicate, original `read_at` kept)

Quality gates: pint, rector, phpstan (0 errors), type-coverage 100%.