### PR TITLE
Group email reply/forward into a native action group beside the date

### DIFF
--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -104,105 +104,148 @@ trait HasEmailComposeActions
             });
     }
 
+    /**
+     * Legacy single action mounted by name from the email-thread reply buttons
+     * (the `reply-email` browser event → {@see openReplyModal()}), where the mode
+     * and target email arrive as runtime arguments.
+     */
     public function replyForwardEmailAction(): Action
     {
         return Action::make('replyForwardEmail')
-            ->slideOver()
             ->link()
             ->hiddenLabel()
-            ->icon(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
-                'reply_all' => 'heroicon-o-arrow-uturn-right',
-                'reply' => 'heroicon-o-arrow-uturn-left',
-                'forward' => 'heroicon-o-arrow-right',
-                default => 'heroicon-o-arrow-uturn-right',
-            })
-            ->extraAttributes([
-                'class' => 'p-2',
-            ])
-            ->modalHeading(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
-                'reply_all' => 'Reply All',
-                'forward' => 'Forward',
-                default => 'Reply',
-            })
-            ->tooltip(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
-                'reply_all' => 'Reply All',
-                'forward' => 'Forward',
-                default => 'Reply',
-            })
+            ->extraAttributes(['class' => 'p-2'])
+            ->icon(fn (array $arguments): string => $this->replyForwardIcon($arguments['mode'] ?? 'reply'))
+            ->tooltip(fn (array $arguments): string => $this->replyForwardLabel($arguments['mode'] ?? 'reply'))
+            ->modalHeading(fn (array $arguments): string => $this->replyForwardLabel($arguments['mode'] ?? 'reply'))
+            ->slideOver()
             ->modalWidth(Width::SevenExtraLarge)
-            ->fillForm(function (array $arguments): array {
-                $email = $this->resolveComposableEmail($arguments['emailId'] ?? null);
-
-                if (! $email instanceof Email) {
-                    return [];
-                }
-
-                $user = $this->getAuthenticatedUser();
-                $mode = $arguments['mode'] ?? 'reply';
-
-                $account = ConnectedAccount::query()
-                    ->where('user_id', $user->getKey())
-                    ->where('team_id', filament()->getTenant()?->getKey())
-                    ->where('status', 'active')
-                    ->defaultFirst()
-                    ->first();
-
-                $toParticipants = match ($mode) {
-                    'forward' => [],
-                    // Reply-all addresses the original sender PLUS the to/cc recipients
-                    // (never bcc), minus the user's own account address. Excluding the
-                    // 'from' role here would drop the very person being replied to.
-                    'reply_all' => $email->replyAllRecipients($account?->email_address),
-                    default => $email->participants
-                        ->where('role', 'from')
-                        ->pluck('email_address')
-                        ->all(),
-                };
-
-                // Only quote the original body when the viewer is entitled to read it.
-                $quotedBody = $user->can('viewBody', $email) ? ($email->body->body_html ?? '') : '';
-
-                $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
-
-                return [
-                    'connected_account_id' => $account?->getKey(),
-                    'to' => $toParticipants,
-                    'subject' => $subjectPrefix.($email->subject ?? ''),
-                    'body_html' => '',
-                    'quoted_body_html' => $quotedBody,
-                    'mode' => $mode,
-                    'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
-                    'privacy_tier' => $this->defaultPrivacyTier()->value,
-                ];
-            })
+            ->fillForm(fn (array $arguments): array => $this->replyForwardFormData(
+                $arguments['emailId'] ?? null,
+                $arguments['mode'] ?? 'reply',
+            ))
             ->schema($this->replyFormSchema())
             ->action(function (array $data, array $arguments): void {
-                $mode = $arguments['mode'] ?? 'reply';
-
-                if (filled($data['quoted_body_html'] ?? '')) {
-                    $quotedSection = $mode === 'forward'
-                        ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
-                        : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
-
-                    $data['body_html'] = ($data['body_html'] ?? '').$quotedSection;
-                }
-
-                $source = match ($mode) {
-                    'reply_all' => EmailCreationSource::REPLY_ALL,
-                    'forward' => EmailCreationSource::FORWARD,
-                    default => EmailCreationSource::REPLY,
-                };
-
-                $record = $this->getCrmRecord();
-
-                $email = resolve(SendEmailAction::class)->execute(
-                    data: $this->buildSendData($data, $source),
-                    linkToType: $record::class,
-                    linkToId: $record->getKey(),
-                );
-
-                $this->sendQueuedNotification($email);
+                $this->submitReplyForward($data, $arguments['mode'] ?? 'reply');
             });
+    }
+
+    /**
+     * Build a reply/reply-all/forward action with its mode baked in, for use as a
+     * child of the native `<x-filament-actions::group>` dropdown. Grouped-action
+     * triggers cannot carry per-action arguments, so callers supply the target
+     * email id (the one currently open in the detail pane).
+     */
+    protected function replyForwardModeAction(string $name, string $mode, ?string $emailId): Action
+    {
+        return Action::make($name)
+            ->label($this->replyForwardLabel($mode))
+            ->icon($this->replyForwardIcon($mode))
+            ->modalHeading($this->replyForwardLabel($mode))
+            ->slideOver()
+            ->modalWidth(Width::SevenExtraLarge)
+            ->fillForm(fn (): array => $this->replyForwardFormData($emailId, $mode))
+            ->schema($this->replyFormSchema())
+            ->action(function (array $data) use ($mode): void {
+                $this->submitReplyForward($data, $mode);
+            });
+    }
+
+    private function replyForwardIcon(string $mode): string
+    {
+        return match ($mode) {
+            'reply_all' => 'heroicon-o-arrow-uturn-right',
+            'forward' => 'heroicon-o-arrow-right',
+            default => 'heroicon-o-arrow-uturn-left',
+        };
+    }
+
+    private function replyForwardLabel(string $mode): string
+    {
+        return match ($mode) {
+            'reply_all' => 'Reply All',
+            'forward' => 'Forward',
+            default => 'Reply',
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function replyForwardFormData(?string $emailId, string $mode): array
+    {
+        $email = $this->resolveComposableEmail($emailId);
+
+        if (! $email instanceof Email) {
+            return [];
+        }
+
+        $user = $this->getAuthenticatedUser();
+
+        $account = ConnectedAccount::query()
+            ->where('user_id', $user->getKey())
+            ->where('team_id', filament()->getTenant()?->getKey())
+            ->where('status', 'active')
+            ->defaultFirst()
+            ->first();
+
+        $toParticipants = match ($mode) {
+            'forward' => [],
+            // Reply-all addresses the original sender PLUS the to/cc recipients
+            // (never bcc), minus the user's own account address. Excluding the
+            // 'from' role here would drop the very person being replied to.
+            'reply_all' => $email->replyAllRecipients($account?->email_address),
+            default => $email->participants
+                ->where('role', 'from')
+                ->pluck('email_address')
+                ->all(),
+        };
+
+        // Only quote the original body when the viewer is entitled to read it.
+        $quotedBody = $user->can('viewBody', $email) ? ($email->body->body_html ?? '') : '';
+
+        $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
+
+        return [
+            'connected_account_id' => $account?->getKey(),
+            'to' => $toParticipants,
+            'subject' => $subjectPrefix.($email->subject ?? ''),
+            'body_html' => '',
+            'quoted_body_html' => $quotedBody,
+            'mode' => $mode,
+            'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
+            'privacy_tier' => $this->defaultPrivacyTier()->value,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function submitReplyForward(array $data, string $mode): void
+    {
+        if (filled($data['quoted_body_html'] ?? '')) {
+            $quotedSection = $mode === 'forward'
+                ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
+                : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
+
+            $data['body_html'] = ($data['body_html'] ?? '').$quotedSection;
+        }
+
+        $source = match ($mode) {
+            'reply_all' => EmailCreationSource::REPLY_ALL,
+            'forward' => EmailCreationSource::FORWARD,
+            default => EmailCreationSource::REPLY,
+        };
+
+        $record = $this->getCrmRecord();
+
+        $email = resolve(SendEmailAction::class)->execute(
+            data: $this->buildSendData($data, $source),
+            linkToType: $record::class,
+            linkToId: $record->getKey(),
+        );
+
+        $this->sendQueuedNotification($email);
     }
 
     private function sendQueuedNotification(Email $email): void

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -82,6 +82,21 @@ abstract class BaseRecordEmailsPage extends Page
         ];
     }
 
+    public function replyAction(): Action
+    {
+        return $this->replyForwardModeAction('reply', 'reply', $this->selectedEmailId);
+    }
+
+    public function replyAllAction(): Action
+    {
+        return $this->replyForwardModeAction('replyAll', 'reply_all', $this->selectedEmailId);
+    }
+
+    public function forwardAction(): Action
+    {
+        return $this->replyForwardModeAction('forward', 'forward', $this->selectedEmailId);
+    }
+
     /**
      * @return LengthAwarePaginator<int, Email&object{pivot: MorphPivot}>
      */

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -266,102 +266,160 @@ final class EmailInboxPage extends Page
             });
     }
 
+    /**
+     * Legacy single action mounted by name from the email-thread reply buttons
+     * (the `reply-email` browser event → {@see openReplyModal()}), where the mode
+     * and target email arrive as runtime arguments.
+     */
     protected function replyForwardEmailAction(): Action
     {
         return Action::make('replyForwardEmail')
-            ->slideOver()
             ->link()
             ->hiddenLabel()
-            ->icon(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
-                'reply_all' => 'heroicon-o-arrow-uturn-right',
-                'reply' => 'heroicon-o-arrow-uturn-left',
-                'forward' => 'heroicon-o-arrow-right',
-                default => 'heroicon-o-arrow-uturn-right',
-            })
-            ->tooltip(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
-                'reply_all' => 'Reply All',
-                'forward' => 'Forward',
-                default => 'Reply',
-            })
-            ->extraAttributes([
-                'class' => 'p-2',
-            ])
-            ->modalHeading(fn (array $arguments): string => match ($arguments['mode'] ?? 'reply') {
-                'reply_all' => __('filament/pages/email-inbox.reply_forward.modal_headings.reply_all'),
-                'forward' => __('filament/pages/email-inbox.reply_forward.modal_headings.forward'),
-                default => __('filament/pages/email-inbox.reply_forward.modal_headings.reply'),
-            })
+            ->extraAttributes(['class' => 'p-2'])
+            ->icon(fn (array $arguments): string => $this->replyForwardIcon($arguments['mode'] ?? 'reply'))
+            ->tooltip(fn (array $arguments): string => $this->replyForwardLabel($arguments['mode'] ?? 'reply'))
+            ->modalHeading(fn (array $arguments): string => $this->replyForwardLabel($arguments['mode'] ?? 'reply'))
+            ->slideOver()
             ->modalWidth(Width::SevenExtraLarge)
-            ->fillForm(function (array $arguments): array {
-                $email = $this->resolveTeamEmail($arguments['emailId'] ?? null, 'view');
-
-                if (! $email instanceof Email) {
-                    return [];
-                }
-
-                $email->loadMissing(['participants', 'body']);
-
-                $user = $this->authUser();
-                $mode = $arguments['mode'] ?? 'reply';
-
-                $account = ConnectedAccount::query()
-                    ->where('user_id', $user->getKey())
-                    ->where('team_id', filament()->getTenant()?->getKey())
-                    ->where('status', 'active')
-                    ->first();
-
-                $toParticipants = match ($mode) {
-                    'forward' => [],
-                    // Reply-all addresses the original sender PLUS the to/cc recipients
-                    // (never bcc), minus the user's own account address. Excluding the
-                    // 'from' role here would drop the very person being replied to.
-                    'reply_all' => $email->replyAllRecipients($account?->email_address),
-                    default => $email->participants
-                        ->where('role', 'from')
-                        ->pluck('email_address')
-                        ->all(),
-                };
-
-                // Only quote the original body when the viewer is entitled to read it.
-                $quotedBody = $user->can('viewBody', $email) ? $email->body?->body_html : null;
-
-                $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
-
-                return [
-                    'connected_account_id' => $account?->getKey(),
-                    'to' => $toParticipants,
-                    'subject' => $subjectPrefix.($email->subject ?? ''),
-                    'body_html' => '',
-                    'quoted_body_html' => $quotedBody,
-                    'mode' => $mode,
-                    'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
-                    'privacy_tier' => $this->defaultPrivacyTier()->value,
-                ];
-            })
+            ->fillForm(fn (array $arguments): array => $this->replyForwardFormData(
+                $arguments['emailId'] ?? null,
+                $arguments['mode'] ?? 'reply',
+            ))
             ->schema($this->replyFormSchema())
             ->action(function (array $data, array $arguments): void {
-                $mode = $arguments['mode'] ?? 'reply';
-
-                if (filled($data['quoted_body_html'] ?? '')) {
-                    $quotedSection = $mode === 'forward'
-                        ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
-                        : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
-
-                    $data['body_html'] = ($data['body_html'] ?? '').$quotedSection;
-                }
-
-                $source = match ($mode) {
-                    'reply_all' => EmailCreationSource::REPLY_ALL,
-                    'forward' => EmailCreationSource::FORWARD,
-                    default => EmailCreationSource::REPLY,
-                };
-
-                resolve(SendEmailAction::class)->execute(
-                    data: $this->buildSendData($data, $source),
-                );
-
-                Notification::make()->title(__('filament/pages/email-inbox.reply_forward.notifications.queued.title'))->success()->send();
+                $this->submitReplyForward($data, $arguments['mode'] ?? 'reply');
             });
+    }
+
+    public function replyAction(): Action
+    {
+        return $this->replyForwardModeAction('reply', 'reply');
+    }
+
+    public function replyAllAction(): Action
+    {
+        return $this->replyForwardModeAction('replyAll', 'reply_all');
+    }
+
+    public function forwardAction(): Action
+    {
+        return $this->replyForwardModeAction('forward', 'forward');
+    }
+
+    /**
+     * A single reply/reply-all/forward action with its mode baked in, for use as
+     * a child of the native `<x-filament-actions::group>` dropdown. Grouped-action
+     * triggers cannot carry per-action arguments, so the target email is the one
+     * currently open in the detail pane ({@see $selectedEmailId}).
+     */
+    private function replyForwardModeAction(string $name, string $mode): Action
+    {
+        return Action::make($name)
+            ->label($this->replyForwardLabel($mode))
+            ->icon($this->replyForwardIcon($mode))
+            ->modalHeading($this->replyForwardLabel($mode))
+            ->slideOver()
+            ->modalWidth(Width::SevenExtraLarge)
+            ->fillForm(fn (): array => $this->replyForwardFormData($this->selectedEmailId, $mode))
+            ->schema($this->replyFormSchema())
+            ->action(function (array $data) use ($mode): void {
+                $this->submitReplyForward($data, $mode);
+            });
+    }
+
+    private function replyForwardIcon(string $mode): string
+    {
+        return match ($mode) {
+            'reply_all' => 'heroicon-o-arrow-uturn-right',
+            'forward' => 'heroicon-o-arrow-right',
+            default => 'heroicon-o-arrow-uturn-left',
+        };
+    }
+
+    private function replyForwardLabel(string $mode): string
+    {
+        return match ($mode) {
+            'reply_all' => __('filament/pages/email-inbox.reply_forward.modal_headings.reply_all'),
+            'forward' => __('filament/pages/email-inbox.reply_forward.modal_headings.forward'),
+            default => __('filament/pages/email-inbox.reply_forward.modal_headings.reply'),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function replyForwardFormData(?string $emailId, string $mode): array
+    {
+        $email = $this->resolveTeamEmail($emailId, 'view');
+
+        if (! $email instanceof Email) {
+            return [];
+        }
+
+        $email->loadMissing(['participants', 'body']);
+
+        $user = $this->authUser();
+
+        $account = ConnectedAccount::query()
+            ->where('user_id', $user->getKey())
+            ->where('team_id', filament()->getTenant()?->getKey())
+            ->where('status', 'active')
+            ->first();
+
+        $toParticipants = match ($mode) {
+            'forward' => [],
+            // Reply-all addresses the original sender PLUS the to/cc recipients
+            // (never bcc), minus the user's own account address. Excluding the
+            // 'from' role here would drop the very person being replied to.
+            'reply_all' => $email->replyAllRecipients($account?->email_address),
+            default => $email->participants
+                ->where('role', 'from')
+                ->pluck('email_address')
+                ->all(),
+        };
+
+        // Only quote the original body when the viewer is entitled to read it.
+        $quotedBody = $user->can('viewBody', $email) ? $email->body?->body_html : null;
+
+        $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
+
+        return [
+            'connected_account_id' => $account?->getKey(),
+            'to' => $toParticipants,
+            'subject' => $subjectPrefix.($email->subject ?? ''),
+            'body_html' => '',
+            'quoted_body_html' => $quotedBody,
+            'mode' => $mode,
+            'in_reply_to_email_id' => $mode !== 'forward' ? $email->getKey() : null,
+            'privacy_tier' => $this->defaultPrivacyTier()->value,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function submitReplyForward(array $data, string $mode): void
+    {
+        if (filled($data['quoted_body_html'] ?? '')) {
+            $quotedSection = $mode === 'forward'
+                ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
+                : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
+
+            $data['body_html'] = ($data['body_html'] ?? '').$quotedSection;
+        }
+
+        $source = match ($mode) {
+            'reply_all' => EmailCreationSource::REPLY_ALL,
+            'forward' => EmailCreationSource::FORWARD,
+            default => EmailCreationSource::REPLY,
+        };
+
+        resolve(SendEmailAction::class)->execute(
+            data: $this->buildSendData($data, $source),
+        );
+
+        Notification::make()->title(__('filament/pages/email-inbox.reply_forward.notifications.queued.title'))->success()->send();
     }
 
     protected function manageSharingAction(): Action

--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -125,12 +125,28 @@
         {{-- Right column: date · badges · action icons --}}
         <div class="flex shrink-0 flex-col items-end gap-2.5">
 
-            {{-- Date --}}
-            @if ($record->sent_at)
-                <time class="whitespace-nowrap text-xs text-gray-400 dark:text-gray-500">
-                    {{ $record->sent_at->format('M j, Y · g:i A') }}
-                </time>
-            @endif
+            {{-- Date + reply action group --}}
+            <div class="flex items-center gap-3">
+                @if ($record->sent_at)
+                    <time class="whitespace-nowrap text-xs text-gray-400 dark:text-gray-500">
+                        {{ $record->sent_at->format('M j, Y · g:i A') }}
+                    </time>
+                @endif
+
+                @if ($canViewBody)
+                    <x-filament-actions::group
+                        :actions="[
+                            $this->replyAction,
+                            $this->replyAllAction,
+                            $this->forwardAction,
+                        ]"
+                        icon="heroicon-o-ellipsis-vertical"
+                        color="gray"
+                        size="sm"
+                        dropdown-placement="bottom-end"
+                    />
+                @endif
+            </div>
 
             {{-- Direction + AI badges --}}
             <div class="flex flex-wrap items-center justify-end gap-1.5">
@@ -148,19 +164,6 @@
                     </span>
                 @endif
             </div>
-
-            {{-- Icon-only action group --}}
-            @if ($canViewBody)
-                <div
-                    x-data
-                    class="flex items-center divide-x divide-gray-200 dark:divide-gray-700 overflow-hidden rounded-lg ring-1 ring-gray-200 dark:ring-gray-700"
-                >
-                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'reply']) }}
-                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'reply_all']) }}
-                    {{ ($this->replyForwardEmailAction)(['emailId' => $record->id, 'mode' => 'forward']) }}
-
-                </div>
-            @endif
 
         </div>
     </div>

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -167,6 +167,35 @@ it('reply_all recipients keep the original sender and drop the user\'s own addre
         ->not->toContain('me@example.com');    // self excluded
 });
 
+it('header reply action group targets the selected email without trigger arguments', function (): void {
+    // The native <x-filament-actions::group> dropdown renders its child triggers
+    // without per-action arguments, so the `reply` action must resolve its target
+    // from the currently selected email rather than from mounted arguments.
+    livewire(EmailInboxPage::class)
+        ->set('selectedEmailId', $this->inboundEmail->id)
+        ->callAction(
+            'reply',
+            data: [
+                'connected_account_id' => $this->account->id,
+                'to' => ['sender@contact.com'],
+                'cc' => [],
+                'bcc' => [],
+                'subject' => 'Re: Original Subject',
+                'body_html' => '<p>Reply via group</p>',
+                'in_reply_to_email_id' => $this->inboundEmail->id,
+            ],
+        )
+        ->assertHasNoActionErrors();
+
+    $reply = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::REPLY)
+        ->firstOrFail();
+
+    expect($reply->status)->toBe(EmailStatus::QUEUED)
+        ->and($reply->in_reply_to)->toBe($this->inboundEmail->rfc_message_id);
+});
+
 it('reply_all persists a queued Email with REPLY_ALL creation_source', function (): void {
     livewire(EmailsRelationManager::class, [
         'ownerRecord' => $this->person,


### PR DESCRIPTION
## What

Replaces the three stacked reply/reply-all/forward icon buttons in the email detail header with a single **native Filament `ActionGroup` dropdown**, positioned inline beside the sent date. Trigger is a vertical three-dot (ellipsis) icon; the menu holds Reply / Reply All / Forward.

## Why

- The actions were a hand-rolled Alpine dropdown dispatching `reply-email`. Switching to `<x-filament-actions::group>` gives free modal integration, theming, and accessibility, and matches Filament conventions.
- Compacts the header — one trigger beside the date instead of a stacked segmented button row.

## Changes

- `components/emails/email-view.blade.php`: Alpine dropdown → `<x-filament-actions::group :actions="[$this->replyAction, $this->replyAllAction, $this->forwardAction]" icon="heroicon-o-ellipsis-vertical" ... />`.
- Added `reply` / `replyAll` / `forward` actions backed by a shared builder:
  - `HasEmailComposeActions` concern: extracted shared helpers (`replyForwardFormData`, `submitReplyForward`, `replyForwardIcon`, `replyForwardLabel`) + protected `replyForwardModeAction(name, mode, emailId)`; legacy `replyForwardEmailAction` (email-thread dispatch path) refactored to reuse them.
  - `EmailInboxPage` (own copies) and `BaseRecordEmailsPage` (delegates to the concern): the three public action methods.

## Notes

- Filament grouped-action triggers cannot carry per-action `->arguments()` (the rendered trigger dropped `emailId`, which would open a blank reply form). Fixed by resolving the target from the open email (`selectedEmailId`) instead of trigger args.
- The `selectedEmailId`-reading methods live on the two pages (not the shared concern) because `BaseEmailsRelationManager` also uses the concern, has no `selectedEmailId`, and renders a different view.

## Verification

- Pint, PHPStan (0 errors), type-coverage 100%.
- `ReplyForwardEmailTest` 6/6 — added a test asserting the group `reply` action targets the selected email with no trigger arguments.
- Browser: action-group trigger renders beside the date; dropdown opens Reply / Reply All / Forward.