### PR TITLE
refactor(email): consolidate sync config to single source

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -91,10 +91,4 @@ return [
         'tenant' => env('AZURE_TENANT_ID'),
         'proxy' => env('PROXY'),  // optionally
     ],
-
-    'email_sync' => [
-        'initial_days' => env('EMAIL_SYNC_INITIAL_DAYS', 90),
-        'interval' => env('EMAIL_SYNC_INTERVAL_MINUTES', 5),
-        'batch_size' => env('EMAIL_SYNC_BATCH_SIZE', 50),
-    ],
 ];

--- a/packages/EmailIntegration/config/email-integration.php
+++ b/packages/EmailIntegration/config/email-integration.php
@@ -39,7 +39,6 @@ return [
      */
     'sync' => [
         'initial_days' => (int) env('EMAIL_SYNC_INITIAL_DAYS', 90),
-        'interval_minutes' => env('EMAIL_SYNC_INTERVAL_MINUTES', 5),
         'batch_size' => (int) env('EMAIL_SYNC_BATCH_SIZE', 50),
     ],
 

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -62,7 +62,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
         }
 
         $jobs = collect($newIds)
-            ->chunk(config('services.email_sync.batch_size', 50))
+            ->chunk(Config::integer('email-integration.sync.batch_size', 50))
             ->flatMap(fn (Collection $chunk): array => $chunk->map(fn (string $id): StoreEmailJob => new StoreEmailJob($account, $id))->all())
             ->all();
 


### PR DESCRIPTION
## What

Email sync settings were duplicated across two config files, both reading the same `EMAIL_SYNC_*` env vars, and read inconsistently:

- `email-integration.sync.initial_days` → read by `InitialEmailSyncJob`
- `services.email_sync.batch_size` → read by the same job, from the *other* file
- `interval` / `interval_minutes` → never read (the schedule hardcodes `everyFiveMinutes()`)

This collapses sync config to a single source of truth in `email-integration.sync` (`initial_days` + `batch_size`), both consumed by the job. Deleted the duplicate `services.email_sync` block and the dead `interval` keys.

## Why

One canonical location, no split-brain config, no dead keys masquerading as tunable settings.

## Changes

- `config/services.php` — drop duplicate `email_sync` block
- `packages/EmailIntegration/config/email-integration.php` — drop dead `interval_minutes`
- `packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php` — read `batch_size` from `email-integration.sync`

## Verification

- `vendor/bin/pint` passed
- `SyncQueueRoutingTest` 2/2 passed
- Confirmed no remaining refs to `services.email_sync`, `interval_minutes`, or `EMAIL_SYNC_INTERVAL_MINUTES`