### PR TITLE
feat(email): per-account inbox filter with default-first landing

### DIFF
--- a/lang/en/filament/pages/email-inbox.php
+++ b/lang/en/filament/pages/email-inbox.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 return [
     'navigation_label' => 'Emails',
+    'account_filter' => [
+        'label' => 'Account',
+        'all' => 'All accounts',
+    ],
     'compose' => [
         'label' => 'Compose',
         'notifications' => [

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -24,6 +24,7 @@ use Filament\Support\Enums\Width;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\View\View;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
@@ -81,11 +82,52 @@ final class EmailInboxPage extends Page
     #[Url(as: 'email')]
     public ?string $selectedEmailId = null;
 
+    /**
+     * Active connected-account scope for the list: a ConnectedAccount id, or the
+     * literal `all` for the unified cross-account view.
+     */
+    #[Url(as: 'account')]
+    public string $accountId = '';
+
     public string $search = '';
 
     public function mount(): void
     {
         $this->folder = EmailFolder::tryFrom((string) request()->query('folder', EmailFolder::Inbox->value)) ?? EmailFolder::Inbox;
+        $this->accountId = $this->resolveInitialAccountId();
+        $this->ensureEmailSelected();
+    }
+
+    /**
+     * Land on the user's default account first (option 1). Honour a valid account
+     * already in the URL (or the `all` sentinel); otherwise fall back to the
+     * default account, then any account, then `all` when none are connected.
+     */
+    private function resolveInitialAccountId(): string
+    {
+        if ($this->accountId === 'all') {
+            return 'all';
+        }
+
+        $accounts = $this->userActiveAccounts();
+
+        if ($this->accountId !== '' && $accounts->has($this->accountId)) {
+            return $this->accountId;
+        }
+
+        return (string) ($accounts->keys()->first() ?? 'all');
+    }
+
+    public function updatedAccountId(): void
+    {
+        if ($this->accountId !== 'all' && ! $this->userActiveAccounts()->has($this->accountId)) {
+            $this->accountId = 'all';
+        }
+
+        $this->search = '';
+        $this->selectedEmailId = null;
+        $this->resetPage();
+        unset($this->emails, $this->inboxUnreadCount);
         $this->ensureEmailSelected();
     }
 
@@ -129,6 +171,10 @@ final class EmailInboxPage extends Page
             ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user));
 
+        if ($this->accountId !== '' && $this->accountId !== 'all') {
+            $query->where('connected_account_id', $this->accountId);
+        }
+
         if ($this->folder === EmailFolder::Sent) {
             $query->sent();
         } elseif ($this->folder === EmailFolder::Inbox) {
@@ -166,11 +212,16 @@ final class EmailInboxPage extends Page
     {
         $user = $this->authUser();
 
-        return Email::query()
+        $query = Email::query()
             ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user))
-            ->unreadFor($user->getKey())
-            ->count();
+            ->unreadFor($user->getKey());
+
+        if ($this->accountId !== '' && $this->accountId !== 'all') {
+            $query->where('connected_account_id', $this->accountId);
+        }
+
+        return $query->count();
     }
 
     public function selectEmail(string $id): void
@@ -1034,17 +1085,53 @@ final class EmailInboxPage extends Page
     }
 
     /**
+     * The user's active connected accounts for the current team, default first,
+     * keyed by id. Cached per request so the switcher and list filter share it.
+     *
+     * @return Collection<string, ConnectedAccount>
+     */
+    private function userActiveAccounts(): Collection
+    {
+        /** @var Collection<string, ConnectedAccount> */
+        return once(fn (): Collection => ConnectedAccount::query()
+            ->where('user_id', $this->authUser()->getKey())
+            ->where('team_id', filament()->getTenant()?->getKey())
+            ->where('status', 'active')
+            ->orderByDesc('is_default')
+            ->oldest()
+            ->get()
+            ->keyBy('id'));
+    }
+
+    /**
      * @return array<string, string>
      */
     private function activeAccountOptions(): array
     {
-        return ConnectedAccount::query()
-            ->where('user_id', $this->authUser()->getKey())
-            ->where('team_id', filament()->getTenant()?->getKey())
-            ->where('status', 'active')
-            ->get()
+        return $this->userActiveAccounts()
             ->mapWithKeys(fn (ConnectedAccount $account): array => [$account->getKey() => $account->label])
             ->all();
+    }
+
+    /**
+     * Switcher options: every active account plus an "All accounts" entry. Shown
+     * only when the user has more than one account ({@see $this->accountId}).
+     *
+     * @return array<string, string>
+     */
+    #[Computed]
+    public function accountFilterOptions(): array
+    {
+        return [
+            ...$this->activeAccountOptions(),
+            'all' => __('filament/pages/email-inbox.account_filter.all'),
+        ];
+    }
+
+    #[Computed]
+    public function showAccountSwitcher(): bool
+    {
+        return $this->userActiveAccounts()->count() > 1;
     }
 
     /**

--- a/resources/views/filament/pages/email-inbox.blade.php
+++ b/resources/views/filament/pages/email-inbox.blade.php
@@ -4,6 +4,21 @@
         {{-- ── Left panel: folder tabs + search + email list ─────────── --}}
         <div class="flex w-80 shrink-0 flex-col border-r border-gray-200 dark:border-gray-700">
 
+            @if ($this->showAccountSwitcher)
+                <div class="flex shrink-0 items-center gap-2 border-b border-gray-200 dark:border-gray-700 px-3 py-2">
+                    <x-ri-mail-line class="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                    <select
+                        wire:model.live="accountId"
+                        aria-label="{{ __('filament/pages/email-inbox.account_filter.label') }}"
+                        class="w-full cursor-pointer border-0 bg-transparent py-0 pl-0 pr-7 text-sm font-medium text-gray-700 dark:text-gray-200 focus:ring-0"
+                    >
+                        @foreach ($this->accountFilterOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @endif
+
             <div class="flex shrink-0 border-b border-gray-200 dark:border-gray-700">
                 <x-emails.folder-tab folder="all"   :active="$folder->value === 'all'"   icon="heroicon-o-squares-2x2"   label="All" />
                 <x-emails.folder-tab folder="inbox" :active="$folder->value === 'inbox'" icon="heroicon-o-inbox"          label="Inbox" :badge="$this->inboxUnreadCount" />

--- a/tests/Feature/EmailIntegration/EmailInboxAccountFilterTest.php
+++ b/tests/Feature/EmailIntegration/EmailInboxAccountFilterTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withTeam()->create();
+    $this->team = $this->owner->currentTeam;
+
+    $this->defaultAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'is_default' => true,
+    ]));
+
+    $this->secondaryAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'is_default' => false,
+    ]));
+
+    $this->defaultEmail = Email::factory()->inbound()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->defaultAccount->getKey(),
+        'sent_at' => now(),
+    ]);
+
+    $this->secondaryEmail = Email::factory()->inbound()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->secondaryAccount->getKey(),
+        'sent_at' => now()->subHour(),
+    ]);
+
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+});
+
+it('lands on the default account and shows only its emails', function (): void {
+    $page = livewire(EmailInboxPage::class);
+
+    expect($page->instance()->accountId)->toBe($this->defaultAccount->getKey());
+    expect($page->instance()->emails()->pluck('id')->all())
+        ->toBe([$this->defaultEmail->getKey()]);
+});
+
+it('shows every account when switched to "all"', function (): void {
+    $page = livewire(EmailInboxPage::class)->set('accountId', 'all');
+
+    expect($page->instance()->emails()->pluck('id')->all())
+        ->toEqualCanonicalizing([$this->defaultEmail->getKey(), $this->secondaryEmail->getKey()]);
+});
+
+it('scopes the list to a chosen secondary account', function (): void {
+    $page = livewire(EmailInboxPage::class)->set('accountId', $this->secondaryAccount->getKey());
+
+    expect($page->instance()->emails()->pluck('id')->all())
+        ->toBe([$this->secondaryEmail->getKey()]);
+});
+
+it('falls back to "all" when given an account the user does not own', function (): void {
+    $stranger = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'is_default' => false,
+    ]));
+
+    $page = livewire(EmailInboxPage::class)->set('accountId', $stranger->getKey());
+
+    expect($page->instance()->accountId)->toBe('all');
+});
+
+it('only renders the account switcher with more than one account', function (): void {
+    livewire(EmailInboxPage::class)
+        ->assertSeeHtml('wire:model.live="accountId"');
+
+    $this->secondaryAccount->delete();
+
+    livewire(EmailInboxPage::class)
+        ->assertDontSeeHtml('wire:model.live="accountId"');
+});


### PR DESCRIPTION
## What

The email inbox showed messages from **all** connected accounts at once, with no way to scope to one. This adds a per-account filter:

- Inbox now **lands on the user's default account** (`is_default` first) instead of a merged stream.
- A switcher (`<select>`) above the folder tabs lets the user jump between accounts instantly, with an **"All accounts"** option for the unified view.
- The switcher is **hidden when the user has only one account** — no UI noise for the common case.
- Both the email list and the unread-count badge respect the active account scope.

## Why

Compose and reply already force the user to pick a sending account, so a fully-merged inbox was inconsistent with the rest of the email UX. Scoping to one account (default-first) matches how most CRMs treat per-account email and removes the "which identity am I looking at" confusion.

## Implementation notes

- URL-persisted `accountId` Livewire prop (`?account=…`), sentinel `all` for the unified view.
- Reuses the existing `ConnectedAccount` `defaultFirst`/`active` ordering; new memoized `userActiveAccounts()` helper also backs the compose/reply account options (consolidated).
- Account selection is validated against the user's own active accounts on both initial resolve and switch — an arbitrary `?account=<id>` falls back to default/all, no cross-user leak.

## Verification

- New `EmailInboxAccountFilterTest.php` (5 cases): default-first landing, all-accounts view, secondary-account scope, stranger-account fallback, switcher visibility.
- pint, rector, phpstan clean; type-coverage 100%.
- Browser-verified default-first landing and account switching in both single- and multi-account states.