### PR TITLE
Align email inbox header rows and tidy action bar spacing

### DIFF
--- a/resources/views/components/emails/detail-action-bar.blade.php
+++ b/resources/views/components/emails/detail-action-bar.blade.php
@@ -8,7 +8,7 @@
 @endphp
 
 @if ($isOwner || $canSummarize || $canRequestAccess)
-    <div class="flex shrink-0 items-center justify-end gap-1 border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 px-4 py-2">
+    <div class="flex h-8 shrink-0 items-center justify-end gap-2 border-b border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 px-4">
 
         @if ($isOwner)
             {{ ($this->manageSharingAction)(['emailId' => $email->id]) }}

--- a/resources/views/filament/pages/email-inbox.blade.php
+++ b/resources/views/filament/pages/email-inbox.blade.php
@@ -10,7 +10,7 @@
                     <select
                         wire:model.live="accountId"
                         aria-label="{{ __('filament/pages/email-inbox.account_filter.label') }}"
-                        class="w-full cursor-pointer border-0 bg-transparent py-0 pl-0 pr-7 text-sm font-medium text-gray-700 dark:text-gray-200 focus:ring-0"
+                        class="w-full min-w-0 truncate cursor-pointer border-0 bg-transparent py-0 pl-0 pr-7 text-sm font-medium text-gray-700 dark:text-gray-200 focus:ring-0"
                     >
                         @foreach ($this->accountFilterOptions as $value => $label)
                             <option value="{{ $value }}">{{ $label }}</option>

--- a/resources/views/filament/pages/email-inbox.blade.php
+++ b/resources/views/filament/pages/email-inbox.blade.php
@@ -5,7 +5,7 @@
         <div class="flex w-80 shrink-0 flex-col border-r border-gray-200 dark:border-gray-700">
 
             @if ($this->showAccountSwitcher)
-                <div class="flex shrink-0 items-center gap-2 border-b border-gray-200 dark:border-gray-700 px-3 py-2">
+                <div class="flex h-8 shrink-0 items-center gap-2 border-b border-gray-200 dark:border-gray-700 px-3">
                     <x-ri-mail-line class="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
                     <select
                         wire:model.live="accountId"


### PR DESCRIPTION
## What

Small visual polish on the email inbox left panel and thread detail action bar.

- **Aligned header dividers**: the account-switcher row (left panel) and the thread action bar (right panel) now share a fixed `h-8` height, so their bottom borders land on the same horizontal line instead of being a few pixels off.
- **Compact height**: both rows dropped the `py-2` padding in favor of the fixed `h-8`, making the header strip slightly shorter.
- **Action bar spacing**: bumped the gap between the "Sharing" and "Summarize Thread" buttons from `gap-1` to `gap-2`.

## Why

The two header rows were rendered at different heights (the action bar's buttons are taller than the switcher's select), so their dividers looked misaligned. Equalizing the height fixes the visual seam between the two panels.

## Verification

Verified live in the browser (light mode): both dividers align on one line, no button clipping, switcher remains transparent.