### PR TITLE
fix(email): mark-all-read + centered loading spinner on record inbox

### DIFF
--- a/packages/EmailIntegration/src/Actions/MarkAllEmailsAsReadAction.php
+++ b/packages/EmailIntegration/src/Actions/MarkAllEmailsAsReadAction.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
 use App\Models\User;
 use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
@@ -20,11 +23,13 @@ final readonly class MarkAllEmailsAsReadAction
      *
      * Unread is meaningful only for inbound mail, so Sent (and other outbound-only
      * folders) resolve to zero matches and the action is a no-op there.
+     *
+     * When $record is given (a Company/People/Opportunity record page), only that
+     * record's emails are marked — not the user's whole team inbox.
      */
-    public function execute(User $user, EmailFolder $folder): int
+    public function execute(User $user, EmailFolder $folder, Company|Opportunity|People|null $record = null): int
     {
-        $query = Email::query()
-            ->forTeam($user->current_team_id)
+        $query = ($record?->emails() ?? Email::query()->forTeam($user->current_team_id))
             ->withGlobalScope('visible', new VisibleEmailScope($user))
             ->unreadFor($user->getKey());
 
@@ -34,7 +39,9 @@ final readonly class MarkAllEmailsAsReadAction
             $query->inbox();
         }
 
-        $emailIds = $query->pluck('id');
+        // Qualify the column — the record-scoped path joins through `emailables`,
+        // where a bare "id" is ambiguous.
+        $emailIds = $query->pluck('emails.id');
 
         if ($emailIds->isEmpty()) {
             return 0;

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -23,6 +23,7 @@ use Livewire\Attributes\Computed;
 use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
+use Relaticle\EmailIntegration\Actions\MarkAllEmailsAsReadAction;
 use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
@@ -181,6 +182,21 @@ abstract class BaseRecordEmailsPage extends Page
         unset($this->emails);
         $firstItem = $this->emails()->items()[0] ?? null;
         $this->selectedEmailId = $firstItem instanceof Email ? $firstItem->id : null;
+    }
+
+    public function markAllAsRead(): void
+    {
+        /** @var Company|Opportunity|People $record */
+        $record = $this->getRecord();
+
+        $count = resolve(MarkAllEmailsAsReadAction::class)->execute($this->authUser(), $this->folder, $record);
+
+        unset($this->inboxUnreadCount, $this->emails);
+
+        Notification::make()
+            ->success()
+            ->title(trans_choice('filament/pages/email-inbox.mark_all_read.notification', $count, ['count' => $count]))
+            ->send();
     }
 
     public function updatedSearch(): void

--- a/resources/views/filament/pages/record-emails.blade.php
+++ b/resources/views/filament/pages/record-emails.blade.php
@@ -12,6 +12,24 @@
 
             <x-emails.search-bar :search="$search" />
 
+            @if ($this->inboxUnreadCount > 0)
+                <div class="flex shrink-0 items-center justify-between border-b border-gray-200 dark:border-gray-700 px-3 py-1.5">
+                    <span class="text-xs text-gray-400 dark:text-gray-500">
+                        {{ $this->inboxUnreadCount }} unread
+                    </span>
+                    <button
+                        wire:click="markAllAsRead"
+                        wire:loading.attr="disabled"
+                        wire:target="markAllAsRead"
+                        type="button"
+                        class="inline-flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-primary-600 dark:text-primary-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:pointer-events-none disabled:opacity-50"
+                    >
+                        <x-ri-check-double-line class="h-3.5 w-3.5" />
+                        {{ __('filament/pages/email-inbox.mark_all_read.label') }}
+                    </button>
+                </div>
+            @endif
+
             <div class="flex-1 overflow-y-scroll divide-y divide-gray-100 dark:divide-gray-800">
                 @forelse($this->emails as $email)
                     <x-emails.list-row :email="$email" :selected-email-id="$selectedEmailId" :folder="$folder" />
@@ -47,17 +65,17 @@
         </div>
 
         {{-- ── Right panel: email detail ───────────────────────────────── --}}
-        <div class="relative flex flex-1 flex-col overflow-y-auto">
+        <div class="relative flex flex-1 flex-col min-h-0">
 
             {{-- Loading overlay while switching emails --}}
-            <div wire:loading wire:target="selectEmail" class="absolute inset-0 z-10 flex items-center justify-center bg-white/60 dark:bg-gray-900/60">
-                <svg class="h-8 w-8 animate-spin text-primary-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <div wire:loading wire:target="selectEmail,setFolder" class="absolute inset-0 z-10 bg-white/70 dark:bg-gray-900/70">
+                <svg class="absolute top-1/2 left-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 animate-spin text-primary-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
                 </svg>
             </div>
 
-            <div wire:loading.class="opacity-0" wire:target="selectEmail">
+            <div wire:loading.class="opacity-0" wire:target="selectEmail,setFolder" class="flex flex-1 flex-col overflow-y-auto min-h-0">
                 @if ($this->selectedEmail !== null)
                     <x-emails.detail-action-bar :email="$this->selectedEmail" />
 

--- a/tests/Feature/EmailIntegration/RecordEmailsMarkAllReadTest.php
+++ b/tests/Feature/EmailIntegration/RecordEmailsMarkAllReadTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\PeopleResource\Pages\PeopleEmailsPage;
+use App\Models\People;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailRead;
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withTeam()->create();
+    $this->team = $this->owner->currentTeam;
+
+    $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+    ]));
+
+    $this->person = People::factory()->create([
+        'team_id' => $this->team->id,
+        'creator_id' => $this->owner->id,
+    ]);
+
+    $this->newer = Email::factory()->inbound()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->account->getKey(),
+        'sent_at' => now(),
+    ]);
+
+    $this->older = Email::factory()->inbound()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->account->getKey(),
+        'sent_at' => now()->subHour(),
+    ]);
+
+    $this->person->emails()->attach([$this->newer->getKey(), $this->older->getKey()]);
+
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+});
+
+it('marks all of the record\'s unread emails as read', function (): void {
+    $page = livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()]);
+    // The record page selects the newest on mount but does not auto-read it,
+    // so both attached emails start unread.
+    expect($page->instance()->inboxUnreadCount())->toBe(2);
+
+    $page->call('markAllAsRead');
+
+    expect($page->instance()->inboxUnreadCount())->toBe(0);
+    expect(EmailRead::query()->where('user_id', $this->owner->id)
+        ->whereIn('email_id', [$this->newer->id, $this->older->id])->count())->toBe(2);
+});
+
+it('does not mark emails belonging to other records', function (): void {
+    // An unread email NOT attached to this person.
+    $unrelated = Email::factory()->inbound()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->account->getKey(),
+        'sent_at' => now()->subDay(),
+    ]);
+
+    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->call('markAllAsRead');
+
+    expect(EmailRead::query()->where('user_id', $this->owner->id)
+        ->where('email_id', $unrelated->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## What

Brings the **Company → Emails** and **People → Email** inbox page (`BaseRecordEmailsPage` / `record-emails.blade.php`) to parity with the main Mail inbox.

Two reported gaps:

1. **Missing "Mark all read".** The record inbox had no unread-count / mark-all-read bar that the main Mail inbox has.
2. **Loading spinner mispositioned.** The email-detail loading overlay rendered its spinner in the top-left corner instead of centered.

## Why

Both pages are meant to render the same split-pane inbox UI, but the record page had drifted from the main inbox.

- Mark-all-read was only implemented on `EmailInboxPage`.
- The record page's loading overlay used flex-centering on a parent that itself had `overflow-y-auto`, which pushed the spinner to the top-left. The main inbox uses a translate-centered spinner on a non-scroll parent.

## Changes

- `record-emails.blade.php` — add unread-count + "Mark all read" bar; rewrite the detail-pane loading overlay to match the main inbox (absolute translate-centered spinner; move `overflow-y-auto` off the positioning parent onto the content wrapper, add `min-h-0`).
- `BaseRecordEmailsPage` — add `markAllAsRead()`, scoped to the current record.
- `MarkAllEmailsAsReadAction` — optional `$record` param so the record page marks only that record's emails (not the whole team inbox); qualify `pluck('emails.id')` for the joined relation query.
- New `RecordEmailsMarkAllReadTest` — marks the record's unread emails; leaves other records' emails untouched.

## Verification

- New test 2/2 pass; existing `EmailUnreadCountPerViewerTest` 5/5 still pass (action signature change is backward-safe).
- pint / phpstan / rector clean on touched files.
- Browser: People → Email page now shows the "Mark all read" bar; clicking it clears the unread count and Inbox badge.