### PR TITLE
Default new email accounts to Bidirectional contact creation

### DIFF
--- a/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
@@ -25,7 +25,7 @@ final readonly class ConnectAccountAction
                 'status' => 'active',
                 'last_error' => null,
                 'auto_create_companies' => true,
-                'contact_creation_mode' => ContactCreationMode::All,
+                'contact_creation_mode' => ContactCreationMode::Bidirectional,
                 'capabilities' => [
                     'email' => true,
                     'calendar' => $data->hasCalendar,

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Bus;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use Relaticle\EmailIntegration\Controllers\CallbackController;
+use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -50,7 +51,8 @@ it('stores an azure connected account and flips calendar capability when Graph c
         ->firstOrFail();
 
     expect($account->hasCalendar())->toBeTrue()
-        ->and($account->capabilities['email'])->toBeTrue();
+        ->and($account->capabilities['email'])->toBeTrue()
+        ->and($account->contact_creation_mode)->toBe(ContactCreationMode::Bidirectional);
 
     Bus::assertDispatched(InitialCalendarSyncJob::class, fn (InitialCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
 });


### PR DESCRIPTION
## What

New connected accounts now default `contact_creation_mode` to **Bidirectional** instead of **All** in `ConnectAccountAction`.

## Why

Bidirectional only auto-creates a person when the account has exchanged mail/meetings in both directions — a safer default than `All`, which creates a person for every inbound/outbound address and floods the CRM with one-off contacts.

## Notes

- DB column default stays `none` (never used — the action always sets the field explicitly).
- Existing accounts unchanged; users can still pick any mode in account settings.
- Added an assertion to the azure connect test verifying the new default.