### PR TITLE
feat(email): default compose account to inbox-selected account

### DIFF
--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -293,11 +293,10 @@ final class EmailInboxPage extends Page
             ->tooltip('⌘ + e')
             ->visible(fn (): bool => $this->hasActiveConnectedAccount())
             ->fillForm(function (): array {
-                $account = ConnectedAccount::query()
-                    ->where('user_id', $this->authUser()->getKey())
-                    ->where('team_id', filament()->getTenant()?->getKey())
-                    ->where('status', 'active')
-                    ->first();
+                // Default to the account currently filtered in the inbox; fall back
+                // to the first active account when viewing "all" or none selected.
+                $accounts = $this->userActiveAccounts();
+                $account = $accounts->get($this->accountId) ?? $accounts->first();
 
                 if ($account === null) {
                     return [];

--- a/tests/Feature/EmailIntegration/EmailInboxComposeTest.php
+++ b/tests/Feature/EmailIntegration/EmailInboxComposeTest.php
@@ -53,6 +53,20 @@ it('keeps the default signature in the body when a template is selected', functi
         });
 });
 
+it('defaults the compose account to the inbox-selected account', function (): void {
+    $secondary = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'email_address' => 'second@example.com',
+        'display_name' => 'Second Sender',
+    ]));
+
+    livewire(EmailInboxPage::class)
+        ->set('accountId', $secondary->id)
+        ->mountAction('composeEmail')
+        ->assertSet('mountedActions.0.data.connected_account_id', $secondary->id);
+});
+
 it('removes the signature block when "no signature" is selected', function (): void {
     $signature = EmailSignature::withoutEvents(fn () => EmailSignature::factory()->create([
         'connected_account_id' => $this->account->id,


### PR DESCRIPTION
## What

The inbox compose form now defaults the **From** account (`connected_account_id`) to the account currently selected in the inbox filter, instead of always picking the user's first active account.

When the inbox shows "all" or no specific account, it falls back to the first active account as before.

## Why

Users filtering their inbox to a specific connected account expect a new email to be sent from that same account. Previously they had to manually re-select it on every compose, which was easy to miss and led to sending from the wrong address.

## Changes

- `EmailInboxPage::composeEmailAction()` — `fillForm` resolves the account via `userActiveAccounts()->get($this->accountId)` with a first-active fallback.
- Added a feature test asserting compose defaults to the inbox-selected account.

Reply/forward are unchanged — they correctly default to the account that received the email.