### PR TITLE
fix(email): add vertical gap between connected account cards

### DIFF
--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -1,6 +1,7 @@
 <x-filament-panels::page>
     <div class="space-y-6">
         <x-filament::section heading="Connected Email Accounts">
+            <div class="space-y-3">
             @forelse($this->connectedAccounts as $account)
                 <div class="flex items-center justify-between p-4 border border-gray-200 rounded-lg dark:border-gray-700">
                     <div class="flex items-center gap-3">
@@ -32,6 +33,7 @@
             @empty
                 <p class="text-sm text-gray-500 dark:text-gray-400">No email accounts connected yet.</p>
             @endforelse
+            </div>
         </x-filament::section>
 
         <x-filament::section heading="Connect an Account">


### PR DESCRIPTION
## What

Adds vertical spacing between the cards in the **Connected Email Accounts** section of the email accounts page. The cards previously rendered flush against each other with no gap.

## Why

The `@forelse` loop emitted each account card as a sibling `<div>` directly inside the section content, which has no built-in vertical rhythm — so two or more connected accounts stacked with no separation.

## How

Wrapped the loop in a `<div class="space-y-3">` container so adjacent cards get a consistent 0.75rem gap. Empty-state copy stays inside the wrapper. Pure markup change — no logic touched.