### PR TITLE
fix(email): honor sync_inbox/sync_sent toggles on sync

### DIFF
--- a/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
@@ -61,6 +61,15 @@ final class StoreEmailJob implements ShouldBeUnique, ShouldQueue
 
         $fetched = $mailFactory->make($this->connectedAccount)->fetchMessage($this->messageId);
 
+        // Honour the account's inbox/sent toggles. Gated here rather than in a
+        // provider service so it covers Gmail and Microsoft, and both the initial
+        // backfill and incremental syncs, in one place. Re-read from the DB on
+        // unserialize (SerializesModels), so a toggle change before this job runs
+        // takes effect.
+        if (! $this->connectedAccount->syncsDirection($fetched->direction)) {
+            return;
+        }
+
         $action->execute($this->connectedAccount, $fetched);
     }
 

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -204,6 +204,20 @@ final class ConnectedAccount extends Model
     }
 
     /**
+     * Whether emails of the given direction should be synced, per the user's
+     * inbox/sent toggles. The single source of truth for direction gating —
+     * consulted on the store path so it covers both providers and both the
+     * initial backfill and incremental syncs.
+     */
+    public function syncsDirection(EmailDirection $direction): bool
+    {
+        return match ($direction) {
+            EmailDirection::INBOUND => $this->sync_inbox,
+            EmailDirection::OUTBOUND => $this->sync_sent,
+        };
+    }
+
+    /**
      * @return Attribute<string, string>
      */
     protected function label(): Attribute

--- a/tests/Feature/EmailIntegration/EmailSyncDirectionFilterTest.php
+++ b/tests/Feature/EmailIntegration/EmailSyncDirectionFilterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Relaticle\EmailIntegration\Actions\StoreEmailAction;
+use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
+
+mutates(StoreEmailJob::class);
+
+/**
+ * Build a StoreEmailJob whose mailbox returns a message of the given direction,
+ * then run it against the account's inbox/sent toggles.
+ */
+function runStoreEmailJob(ConnectedAccount $account, EmailDirection $direction): void
+{
+    $fetched = new FetchedEmailData(
+        providerMessageId: 'msg-'.$direction->value,
+        rfcMessageId: '<msg@example.com>',
+        threadId: 'thread-1',
+        inReplyTo: null,
+        subject: 'Hello',
+        snippet: 'Hello',
+        sentAt: Carbon::now(),
+        direction: $direction,
+        folder: $direction === EmailDirection::OUTBOUND ? EmailFolder::Sent : EmailFolder::Inbox,
+        hasAttachments: false,
+        isRead: true,
+        bodyText: 'Hello',
+        bodyHtml: '<p>Hello</p>',
+        participants: [
+            ['email_address' => 'someone@example.com', 'name' => 'Someone', 'role' => 'from'],
+        ],
+        attachments: [],
+    );
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchMessage')->andReturn($fetched);
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new StoreEmailJob($account, $fetched->providerMessageId))->handle($factory, resolve(StoreEmailAction::class));
+}
+
+it('skips storing a sent email when sync_sent is off', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create(['sync_sent' => false, 'sync_inbox' => true]));
+
+    runStoreEmailJob($account, EmailDirection::OUTBOUND);
+
+    expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(0);
+});
+
+it('skips storing an inbox email when sync_inbox is off', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create(['sync_inbox' => false, 'sync_sent' => true]));
+
+    runStoreEmailJob($account, EmailDirection::INBOUND);
+
+    expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(0);
+});
+
+it('stores an email whose direction is enabled', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create(['sync_inbox' => true, 'sync_sent' => true]));
+
+    runStoreEmailJob($account, EmailDirection::INBOUND);
+
+    expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(1);
+});


### PR DESCRIPTION
## What

The **Sync inbox** / **Sync sent** toggles in the account settings modal persisted to the database but were never consulted during sync — every email was imported regardless of direction. The toggles were dead switches.

This wires them to the sync path:

- New `ConnectedAccount::syncsDirection(EmailDirection): bool` — reads `sync_inbox` / `sync_sent`.
- `StoreEmailJob` checks it after fetching a message and skips storing any direction the user has toggled off.

Gated at `StoreEmailJob` rather than a provider service because it's the single chokepoint **both** sync jobs funnel through — so the fix covers **Gmail + Microsoft** and **initial backfill + incremental** in one place. `SerializesModels` re-reads the account fresh at run time, so a toggle change takes effect on the next sync.

## Scope

- Defaults unchanged: `sync_inbox` / `sync_sent` both default `true` — new accounts sync everything, nothing silently dropped.
- Forward-only: toggling a direction off stops **future** import; already-synced mail stays until the account is disconnected. (Matches HubSpot/Attio/Pipedrive behavior.)

## Tests

`EmailSyncDirectionFilterTest` drives the real `StoreEmailJob`:
- `sync_sent = false` + a sent message → not stored
- `sync_inbox = false` + an inbox message → not stored
- direction enabled → stored

Verified live in the browser: flipping **Sync sent** off and saving persisted `sync_sent = false` to the DB.

Gates: pint, rector, phpstan, type-coverage (100%) all green.