### PR TITLE
Fix crash, privacy-leak, N+1, metric, and type-safety bugs in email/calendar integration

### DIFF
--- a/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
+++ b/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
@@ -149,7 +149,7 @@ final class ViewCompany extends ViewRecord
                         TextEntry::make('days_since_last_email')
                             ->label(__('filament/resources/company.pages.view.communication_intelligence.fields.days_since_last_email.label'))
                             ->getStateUsing(fn (Company $record): string => $record->last_email_at
-                                ? __('filament/resources/company.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => now()->diffInDays($record->last_email_at)])
+                                ? __('filament/resources/company.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => (int) now()->diffInDays($record->last_email_at, true)])
                                 : __('filament/resources/company.pages.view.communication_intelligence.fields.days_since_last_email.empty')
                             ),
 

--- a/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
@@ -123,7 +123,7 @@ final class ViewOpportunity extends ViewRecord
                     TextEntry::make('days_since_last_email')
                         ->label(__('filament/resources/opportunity.pages.view.communication_intelligence.fields.days_since_last_email.label'))
                         ->getStateUsing(fn (Opportunity $record): string => $record->last_email_at
-                            ? __('filament/resources/opportunity.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => now()->diffInDays($record->last_email_at)])
+                            ? __('filament/resources/opportunity.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => (int) now()->diffInDays($record->last_email_at, true)])
                             : __('filament/resources/opportunity.pages.view.communication_intelligence.fields.days_since_last_email.empty')
                         ),
 

--- a/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
+++ b/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
@@ -125,7 +125,7 @@ final class ViewPeople extends ViewRecord
                     TextEntry::make('days_since_last_email')
                         ->label(__('filament/resources/person.pages.view.communication_intelligence.fields.days_since_last_email.label'))
                         ->getStateUsing(fn (People $record): string => $record->last_email_at
-                            ? __('filament/resources/person.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => now()->diffInDays($record->last_email_at)])
+                            ? __('filament/resources/person.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => (int) now()->diffInDays($record->last_email_at, true)])
                             : __('filament/resources/person.pages.view.communication_intelligence.fields.days_since_last_email.empty')
                         ),
 

--- a/app/Http/Controllers/EmailAttachmentController.php
+++ b/app/Http/Controllers/EmailAttachmentController.php
@@ -36,6 +36,11 @@ final readonly class EmailAttachmentController
 
         abort_if(blank($attachment->provider_attachment_id), 404, 'Attachment is not available for download.');
 
+        // The provider download needs the parent message id; outbound/partially-synced
+        // rows can have a null provider_message_id, so guard for a clean 404 rather than
+        // passing null into the string-typed downloadAttachment() (TypeError → 500).
+        abort_if(blank($email->provider_message_id), 404, 'Attachment is not available for download.');
+
         $connectedAccount = $email->connectedAccount;
 
         abort_if($connectedAccount === null, 404, 'Email account is no longer connected.');

--- a/app/Models/Concerns/HasActivityTimeline.php
+++ b/app/Models/Concerns/HasActivityTimeline.php
@@ -36,6 +36,11 @@ trait HasActivityTimeline
                         'visible',
                         new VisibleEmailScope($viewer),
                     ));
+                } else {
+                    // No authenticated viewer — never expose email content unscoped.
+                    // VisibleEmailScope isn't a default scope on Email, so without this
+                    // the relation would load every email regardless of privacy.
+                    $source->using(fn (Builder|Relation $query) => $query->whereRaw('1 = 0'));
                 }
             })
             ->fromRelation('notes', fn (RelatedModelSource $source): RelatedModelSource => $source

--- a/packages/EmailIntegration/src/Actions/DeleteEmailTemplatesAction.php
+++ b/packages/EmailIntegration/src/Actions/DeleteEmailTemplatesAction.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Actions;
 
 use App\Models\User;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Collection;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 
 final readonly class DeleteEmailTemplatesAction

--- a/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
@@ -53,6 +53,8 @@ final readonly class StoreMeetingAction
                 'deleted_at' => null,
             ];
 
+            $isNewMeeting = ! ($meeting instanceof Meeting);
+
             if ($meeting instanceof Meeting) {
                 $meeting->fill($attributes)->save();
             } else {
@@ -72,6 +74,21 @@ final readonly class StoreMeetingAction
             }
 
             $this->linkMeeting->execute($meeting);
+
+            // Logged here (not in MeetingObserver::created) because the attendee_count is
+            // only correct after attendees are inserted above — the observer fires on the
+            // bare Meeting::create() before any attendee exists, recording 0.
+            if ($isNewMeeting) {
+                activity()
+                    ->performedOn($meeting)
+                    ->withProperties([
+                        'title' => $meeting->title,
+                        'starts_at' => $meeting->starts_at->toIso8601String(),
+                        'attendee_count' => count($payload->attendees),
+                    ])
+                    ->event('meeting.created')
+                    ->log('meeting.created');
+            }
 
             return $meeting;
         });

--- a/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
+++ b/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
@@ -16,8 +16,6 @@ use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
-use Relaticle\EmailIntegration\Models\Email;
-use Relaticle\EmailIntegration\Observers\EmailObserver;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Factories\CalendarServiceFactory;
@@ -43,7 +41,9 @@ final class EmailIntegrationServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'email-integration');
 
-        Email::observe(EmailObserver::class);
+        // Email is already observed via #[ObservedBy(EmailObserver::class)] on the model.
+        // Registering it again here fires every listener twice (double metric increments,
+        // double auto-create) for any create path where participants exist at create time.
 
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
             $schedule->call(function (): void {

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -166,7 +166,10 @@ final class EmailInboxPage extends Page
         $user = $this->authUser();
 
         $query = Email::query()
-            ->with(['from', 'labels'])
+            // participants + shares are needed by PrivacyService::effectiveTier() (which each
+            // row's can('viewSubject'/'viewBody') hits) — eager-load them to avoid 2 lazy
+            // queries per row, matching BaseRecordEmailsPage / BaseEmailsRelationManager.
+            ->with(['from', 'labels', 'participants', 'shares'])
             ->withReadStateFor($user->getKey())
             ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user));

--- a/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
@@ -115,7 +115,7 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
             ->onQueue('emails-sync')
             ->allowFailures()
             ->then(function () use ($accountId, $newCursor): void {
-                $account = ConnectedAccount::query()->find($accountId);
+                $account = ConnectedAccount::query()->whereKey($accountId)->first();
                 $account?->update([
                     'sync_cursor' => $newCursor,
                     'last_synced_at' => now(),

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -81,7 +81,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
             // re-attempted next sync (dedup makes the re-fetch cheap) instead of dropping
             // the unstored message.
             ->then(function () use ($accountId, $cursor): void {
-                ConnectedAccount::query()->find($accountId)?->update(['sync_cursor' => $cursor]);
+                ConnectedAccount::query()->whereKey($accountId)->first()?->update(['sync_cursor' => $cursor]);
             })
             ->dispatch();
     }

--- a/packages/EmailIntegration/src/Observers/MeetingObserver.php
+++ b/packages/EmailIntegration/src/Observers/MeetingObserver.php
@@ -8,18 +8,8 @@ use Relaticle\EmailIntegration\Models\Meeting;
 
 final class MeetingObserver
 {
-    public function created(Meeting $meeting): void
-    {
-        activity()
-            ->performedOn($meeting)
-            ->withProperties([
-                'title' => $meeting->title,
-                'starts_at' => $meeting->starts_at->toIso8601String(),
-                'attendee_count' => $meeting->attendees()->count(),
-            ])
-            ->event('meeting.created')
-            ->log('meeting.created');
-    }
+    // meeting.created is logged from StoreMeetingAction once attendees are inserted, so the
+    // attendee_count is accurate — the observer's created() fired too early (count was 0).
 
     public function deleted(Meeting $meeting): void
     {

--- a/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
+++ b/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
@@ -9,11 +9,16 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Agents\ThreadSummarizer;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailThread;
 use RuntimeException;
 
 final readonly class EmailThreadSummaryService
 {
+    public function __construct(
+        private PrivacyService $privacy,
+    ) {}
+
     /**
      * Get or generate an AI summary for an email thread.
      * Only includes email bodies the viewer has access to.
@@ -33,7 +38,7 @@ final readonly class EmailThreadSummaryService
     private function generateAndCache(EmailThread $thread, User $viewer): AiSummary
     {
         $emails = $thread->emails()
-            ->with(['from', 'participants', 'body', 'labels'])
+            ->with(['from', 'participants', 'body', 'labels', 'shares'])
             ->oldest('sent_at')
             ->get();
 
@@ -46,23 +51,33 @@ final readonly class EmailThreadSummaryService
         foreach ($emails as $index => $email) {
             $n = $index + 1;
             // `from` is eager-loaded above to avoid an N+1 across the thread's emails.
+            // A malformed/draft message can carry no `from` participant, so the collection
+            // may be empty — default rather than dereference a missing row.
             $firstFrom = $email->from->first();
-            $from = $firstFrom->name ?? $firstFrom->email_address ?? 'Unknown';
+            $from = $firstFrom instanceof EmailParticipant
+                ? ($firstFrom->name ?? $firstFrom->email_address ?? 'Unknown')
+                : 'Unknown';
             $date = $email->sent_at?->toDateTimeString() ?? '—';
             $dir = $email->direction->getLabel();
 
             $lines[] = "--- Email {$n} ({$dir}) ---";
             $lines[] = "From: {$from}  |  Date: {$date}";
 
-            $isOwner = $email->user_id === $viewer->getKey();
+            // Single source of truth for visibility: PrivacyService::effectiveTier() also
+            // honours per-email shares, internal-email and protected-recipient hiding, which
+            // a raw privacy_tier read would leak into the AI prompt + cached summary.
+            $tier = $this->privacy->effectiveTier($email, $viewer);
 
-            if ($isOwner || $email->privacy_tier === EmailPrivacyTier::FULL) {
+            if ($tier === EmailPrivacyTier::FULL) {
                 $body = data_get($email, 'body.body_text', $email->snippet ?? '(no body)');
                 $lines[] = 'Body: '.mb_substr((string) $body, 0, 500);
-            } elseif ($email->privacy_tier === EmailPrivacyTier::SUBJECT) {
+            } elseif ($tier === EmailPrivacyTier::SUBJECT) {
                 $lines[] = "Subject: {$email->subject}  (body hidden)";
-            } else {
+            } elseif ($tier === EmailPrivacyTier::METADATA_ONLY) {
                 $lines[] = '(metadata only)';
+            } else {
+                // null tier — fully hidden from this viewer
+                $lines[] = '(restricted)';
             }
 
             $aiLabels = $email->labels->where('source', 'ai')->pluck('label')->implode(', ');

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -249,14 +249,14 @@ final readonly class GmailService implements MailServiceInterface
             $data['to'] ?? []
         ));
 
-        if (filled($data['cc'])) {
+        if (filled($data['cc'] ?? null)) {
             $headers[] = 'Cc: '.implode(', ', array_map(
                 fn (array $recipient): string => $this->formatAddress($recipient['name'] ?? '', $recipient['email']),
                 $data['cc']
             ));
         }
 
-        if (filled($data['bcc'])) {
+        if (filled($data['bcc'] ?? null)) {
             $headers[] = 'Bcc: '.implode(', ', array_map(
                 fn (array $recipient): string => $this->formatAddress($recipient['name'] ?? '', $recipient['email']),
                 $data['bcc']

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -181,8 +181,10 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
             htmlLink: $event->getHtmlLink(),
             status: $status !== '' ? $status : 'confirmed',
             visibility: $event->getVisibility(),
-            organizerEmail: $organizer->getEmail(),
-            organizerName: $organizer->getDisplayName(),
+            // Google omits the organizer on some events (holidays, birthdays, imported .ics),
+            // so getOrganizer() can be null — the DTO types both fields as ?string.
+            organizerEmail: $organizer?->getEmail(),
+            organizerName: $organizer?->getDisplayName(),
             attendees: $attendees,
         );
     }

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -37,8 +37,11 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         $http = $this->clientFactory->make($this->account);
 
         $messageIds = [];
-        $readMessageIds = [];
-        $unreadMessageIds = [];
+        // id => isRead, last-write-wins. The same id can appear on several delta pages
+        // with isRead flipping; keying by id keeps the LATEST state so a message never
+        // lands in both the read and unread lists (which the sync job would then apply
+        // in an order-dependent way).
+        $readState = [];
         $nextUrl = $cursor;
         $deltaLink = $cursor;
 
@@ -56,11 +59,7 @@ final class MicrosoftGraphMailService implements MailServiceInterface
                 $messageIds[] = $id;
 
                 if (array_key_exists('isRead', $message)) {
-                    if ($message['isRead'] === true) {
-                        $readMessageIds[] = $id;
-                    } else {
-                        $unreadMessageIds[] = $id;
-                    }
+                    $readState[$id] = $message['isRead'] === true;
                 }
             }
 
@@ -68,11 +67,21 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             $deltaLink = $response['@odata.deltaLink'] ?? $deltaLink;
         } while ($nextUrl !== null);
 
+        $readMessageIds = [];
+        $unreadMessageIds = [];
+        foreach ($readState as $id => $isRead) {
+            if ($isRead) {
+                $readMessageIds[] = $id;
+            } else {
+                $unreadMessageIds[] = $id;
+            }
+        }
+
         return new MailDeltaResult(
             messageIds: collect($messageIds)->unique()->values(),
-            readMessageIds: collect($readMessageIds)->unique()->values(),
+            readMessageIds: collect($readMessageIds)->values(),
             newCursor: (string) $deltaLink,
-            unreadMessageIds: collect($unreadMessageIds)->unique()->values(),
+            unreadMessageIds: collect($unreadMessageIds)->values(),
         );
     }
 

--- a/tests/Feature/CalendarIntegration/MeetingObserverTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingObserverTest.php
@@ -14,7 +14,9 @@ beforeEach(function (): void {
     Queue::fake();
 });
 
-it('logs a meeting.created activity entry when a meeting is created', function (): void {
+it('does not log meeting.created on a bare model write', function (): void {
+    // meeting.created is logged from StoreMeetingAction (after attendees are inserted so the
+    // attendee_count is accurate), not from the observer — a raw model write must not emit it.
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
 
     $meeting = Meeting::factory()->for($account, 'connectedAccount')->create();
@@ -25,7 +27,7 @@ it('logs a meeting.created activity entry when a meeting is created', function (
         ->where('event', 'meeting.created')
         ->exists();
 
-    expect($exists)->toBeTrue();
+    expect($exists)->toBeFalse();
 });
 
 it('logs a meeting.cancelled activity entry when a meeting is deleted', function (): void {
@@ -44,15 +46,17 @@ it('logs a meeting.cancelled activity entry when a meeting is deleted', function
     expect($exists)->toBeTrue();
 });
 
-it('records title in properties when a meeting is created', function (): void {
+it('records title in properties when a meeting is cancelled', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
 
-    $meeting = Meeting::factory()->for($account, 'connectedAccount')->create(['title' => 'Q2 Kickoff']);
+    $meeting = Meeting::withoutEvents(fn () => Meeting::factory()->for($account, 'connectedAccount')->create(['title' => 'Q2 Kickoff']));
+
+    $meeting->delete();
 
     $activity = Activity::withoutGlobalScopes()
         ->where('subject_type', $meeting->getMorphClass())
         ->where('subject_id', $meeting->getKey())
-        ->where('event', 'meeting.created')
+        ->where('event', 'meeting.cancelled')
         ->firstOrFail();
 
     expect($activity->properties->get('title'))->toBe('Q2 Kickoff');

--- a/tests/Feature/CalendarIntegration/StoreMeetingActionUpsertTest.php
+++ b/tests/Feature/CalendarIntegration/StoreMeetingActionUpsertTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\ActivityLog\Activity;
 use Illuminate\Support\Carbon;
 use Relaticle\EmailIntegration\Actions\StoreMeetingAction;
 use Relaticle\EmailIntegration\Data\NormalizedAttendee;
@@ -46,6 +47,63 @@ it('creates a meeting with attendees', function (): void {
     expect($meeting->title)->toBe('Design review');
     expect($meeting->attendees()->count())->toBe(3);
     expect($meeting->attendees()->where('is_self', true)->first()?->email_address)->toBe('me@example.com');
+});
+
+it('logs a meeting.created activity entry with the accurate attendee_count', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
+
+    $payload = new NormalizedMeetingPayload(
+        providerEventId: 'evt-log',
+        providerRecurringEventId: null,
+        icalUid: 'uid-log',
+        title: 'Q2 Kickoff',
+        description: null,
+        location: null,
+        startsAt: Carbon::now()->addDays(2),
+        endsAt: Carbon::now()->addDays(2)->addHour(),
+        allDay: false,
+        organizerEmail: 'host@example.com',
+        organizerName: 'Host',
+        status: CalendarEventStatus::CONFIRMED,
+        visibility: CalendarVisibility::DEFAULT,
+        selfResponseStatus: AttendeeResponseStatus::ACCEPTED,
+        htmlLink: null,
+        attendees: [
+            new NormalizedAttendee('host@example.com', 'Host', AttendeeResponseStatus::ACCEPTED, true, false),
+            new NormalizedAttendee('me@example.com', 'Me', AttendeeResponseStatus::ACCEPTED, false, true),
+            new NormalizedAttendee('guest@acme.com', 'Guest', AttendeeResponseStatus::TENTATIVE, false, false),
+        ],
+    );
+
+    $meeting = (app(StoreMeetingAction::class))->execute($payload, $account);
+
+    $activity = Activity::withoutGlobalScopes()
+        ->where('subject_type', $meeting->getMorphClass())
+        ->where('subject_id', $meeting->getKey())
+        ->where('event', 'meeting.created')
+        ->firstOrFail();
+
+    expect($activity->properties->get('title'))->toBe('Q2 Kickoff');
+    // Logged from the action after attendees are inserted, so the count is correct
+    // (the previous observer-based log fired before attendees existed and recorded 0).
+    expect($activity->properties->get('attendee_count'))->toBe(3);
+});
+
+it('does not log meeting.created when updating an existing meeting', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
+    $payload = new NormalizedMeetingPayload(
+        providerEventId: 'evt-upd-log',
+        providerRecurringEventId: null, icalUid: null,
+        title: 'First', description: null, location: null,
+        startsAt: Carbon::now()->addDay(), endsAt: Carbon::now()->addDay()->addHour(),
+        allDay: false, organizerEmail: null, organizerName: null,
+        status: CalendarEventStatus::CONFIRMED, visibility: CalendarVisibility::DEFAULT,
+        selfResponseStatus: AttendeeResponseStatus::ACCEPTED, htmlLink: null, attendees: [],
+    );
+    (app(StoreMeetingAction::class))->execute($payload, $account);
+    (app(StoreMeetingAction::class))->execute($payload, $account);
+
+    expect(Activity::withoutGlobalScopes()->where('event', 'meeting.created')->count())->toBe(1);
 });
 
 it('updates an existing meeting idempotently', function (): void {


### PR DESCRIPTION
Review-driven bug fixes for the email + calendar integration package. Found via a recall-biased review of the PR; verified each against the code and adversarially re-reviewed the fixes.

## Correctness / crashes
- **Thread summary leaked hidden email bodies** — `EmailThreadSummaryService` masked content from the raw `privacy_tier` column, bypassing `PrivacyService::effectiveTier()` (which hard-hides `is_internal`/protected-recipient emails and honours per-email shares). Internal/protected `FULL`-tier bodies were fed into the AI prompt and cached, readable by any teammate with thread access. Now routed through `effectiveTier()` (single source of truth); eager-loads `shares`.
- **Null organizer crashed Google calendar sync** — `GoogleCalendarService::normalizeGoogleEvent` dereferenced `$event->getOrganizer()` (null for holidays/birthdays/imported events). Now null-safe.
- **Null `from` crashed thread summary** — `$email->from->first()` can be null for a malformed/draft message. Added an explicit guard.

## Metrics / data
- **Meeting activity always logged `attendee_count: 0`** — observer fired on `Meeting::create()` before attendees were inserted. Moved the `meeting.created` log into `StoreMeetingAction` (after insert) so the count is accurate; tests updated/relocated.
- **`days_since_last_email` showed negative fractions** — `now()->diffInDays($date)` returns a signed float in Carbon 3. Fixed to `(int) ...diffInDays($date, true)` across the Company/People/Opportunity view pages.
- **Microsoft read/unread state was page-order-dependent** — a message appearing on multiple delta pages with `isRead` flipped could land in both lists. Rewritten as a last-write-wins map so each id resolves to exactly one state.
- **Double `EmailObserver` registration** — model `#[ObservedBy]` + provider `Email::observe()` fired listeners twice. Removed the provider duplicate.

## Privacy / security
- **Timeline leaked emails on a null viewer** — `HasActivityTimeline` only applied `VisibleEmailScope` when a `User` was present; otherwise emails loaded unscoped. Now denies the email source when there is no authenticated viewer.
- **Attachment download 500 on null `provider_message_id`** — added a `404` guard before the provider call.

## Lint / static analysis
- **Gmail `filled($data['cc'])`** on an optional key → `filled($data['cc'] ?? null)`.
- **Inbox N+1** — eager-load `participants`/`shares` to match the sibling email surfaces.
- **phpstan (CI `test:types`)** — fixed 3 type errors blocking the PR: `find()` union `update()` in the sync jobs (`whereKey()->first()`), and `DeleteEmailTemplatesAction` typed to the Eloquent collection Filament passes.

## Verification
- pint, rector (`composer test:refactor`), and phpstan all clean on changed files.
- Email + Calendar + ActivityLog test suites pass (355+ tests); meeting tests updated to cover the relocated logging with an accurate `attendee_count` assertion.

Deliberately deferred (flagged, separate PR): the larger privacy-rule SQL-mirror consolidation, ViewPage/sanitizer/classifier duplication.