### PR TITLE
Refactor email inbox & access request pages

### DIFF
--- a/lang/en/filament/pages/email-access-requests.php
+++ b/lang/en/filament/pages/email-access-requests.php
@@ -4,6 +4,36 @@ declare(strict_types=1);
 
 return [
     'navigation_label' => 'Access Requests',
+    'tabs' => [
+        'aria' => 'Access request tabs',
+        'incoming' => 'Incoming',
+        'outgoing' => 'Sent',
+    ],
+    'filters' => [
+        'all' => 'All',
+        'pending' => 'Pending',
+        'approved' => 'Approved',
+        'denied' => 'Denied',
+    ],
+    'search' => [
+        'placeholder' => 'Search by name or subject…',
+    ],
+    'request' => [
+        'requested_incoming' => 'requested access',
+        'requested_outgoing' => 'you requested access',
+        'unknown_user' => 'Unknown user',
+        'no_subject' => '(No subject)',
+        'email_unavailable' => 'The associated email is no longer available.',
+    ],
+    'empty' => [
+        'filtered_heading' => 'No :status requests',
+        'filtered_description' => 'Try a different filter or clear the active one.',
+        'show_all' => 'Show all',
+        'incoming_heading' => 'No incoming requests',
+        'outgoing_heading' => 'No sent requests',
+        'incoming_description' => 'When someone asks for access to one of your private emails, it will show up here.',
+        'outgoing_description' => "You haven't asked for access to any emails yet.",
+    ],
     'actions' => [
         'open_email' => 'Open in inbox',
         'approve' => [

--- a/lang/en/filament/pages/email-inbox.php
+++ b/lang/en/filament/pages/email-inbox.php
@@ -8,6 +8,36 @@ return [
         'label' => 'Account',
         'all' => 'All accounts',
     ],
+    'folders' => [
+        'all' => 'All',
+        'inbox' => 'Inbox',
+        'sent' => 'Sent',
+    ],
+    'search' => [
+        'placeholder' => 'Search emails…',
+    ],
+    'unread_label' => ':count unread',
+    'pagination' => [
+        'previous' => 'Prev',
+        'next' => 'Next',
+        'range' => ':first–:last of :total',
+    ],
+    'list_empty' => [
+        'no_results' => 'No results for ":search"',
+        'all' => 'No emails',
+        'sent' => 'No sent emails',
+        'inbox' => 'No received emails',
+    ],
+    'detail_empty' => [
+        'heading' => 'Select an email to read',
+        'description' => 'Choose a message from the list on the left',
+    ],
+    'pending_access' => [
+        'heading' => '{1}1 pending access request|[2,*]:count pending access requests',
+        'unknown_user' => 'Unknown user',
+        'approve' => 'Approve',
+        'deny' => 'Deny',
+    ],
     'compose' => [
         'label' => 'Compose',
         'notifications' => [

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -220,7 +220,7 @@ final class EmailInboxPage extends Page
     #[Computed]
     public function pendingAccessRequests(): Collection
     {
-        $email = $this->selectedEmail;
+        $email = $this->selectedEmail();
 
         if ($email === null || $email->user_id !== $this->authUser()->getKey()) {
             return collect();

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -36,6 +36,7 @@ use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
+use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
@@ -208,6 +209,28 @@ final class EmailInboxPage extends Page
             ->withGlobalScope('visible', new VisibleEmailScope($this->authUser()))
             ->whereKey($this->selectedEmailId)
             ->first();
+    }
+
+    /**
+     * Pending access requests for the open email, but only when the viewer owns
+     * it — the detail pane shows an inline approve/deny strip for these.
+     *
+     * @return Collection<int, EmailAccessRequest>
+     */
+    #[Computed]
+    public function pendingAccessRequests(): Collection
+    {
+        $email = $this->selectedEmail;
+
+        if ($email === null || $email->user_id !== $this->authUser()->getKey()) {
+            return collect();
+        }
+
+        return EmailAccessRequest::query()
+            ->with('requester')
+            ->where('email_id', $email->getKey())
+            ->where('status', EmailAccessRequestStatus::PENDING)
+            ->get();
     }
 
     #[Computed]

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -222,7 +222,7 @@ final class EmailInboxPage extends Page
     {
         $email = $this->selectedEmail();
 
-        if ($email === null || $email->user_id !== $this->authUser()->getKey()) {
+        if (! $email instanceof Email || $email->user_id !== $this->authUser()->getKey()) {
             return collect();
         }
 

--- a/resources/views/components/emails/folder-tab.blade.php
+++ b/resources/views/components/emails/folder-tab.blade.php
@@ -11,10 +11,7 @@
     ])
 >
     <x-dynamic-component :component="$icon" class="h-4 w-4" wire:loading.remove wire:target="setFolder('{{ $folder }}')" />
-    <svg wire:loading wire:target="setFolder('{{ $folder }}')" class="h-4 w-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-    </svg>
+    <x-filament::loading-indicator class="h-4 w-4" wire:loading wire:target="setFolder('{{ $folder }}')" />
     {{ $label }}
     @if ($badge !== null && $badge > 0)
         <span class="inline-flex items-center justify-center min-w-[1.125rem] h-[1.125rem] rounded-full bg-primary-500 px-1 text-[10px] font-semibold leading-none text-white">

--- a/resources/views/components/emails/list-empty.blade.php
+++ b/resources/views/components/emails/list-empty.blade.php
@@ -3,17 +3,11 @@
 <div class="flex flex-col items-center justify-center gap-2 px-4 py-16 text-center">
     @if (filled($search))
         <x-heroicon-o-magnifying-glass class="h-8 w-8 text-gray-300 dark:text-gray-600" />
-        <p class="text-sm text-gray-400 dark:text-gray-500">No results for "{{ $search }}"</p>
+        <p class="text-sm text-gray-400 dark:text-gray-500">{{ __('filament/pages/email-inbox.list_empty.no_results', ['search' => $search]) }}</p>
     @else
         <x-heroicon-o-envelope class="h-8 w-8 text-gray-300 dark:text-gray-600" />
         <p class="text-sm text-gray-400 dark:text-gray-500">
-            @if ($folder->value === 'all')
-                No emails
-            @elseif ($folder->value === 'sent')
-                No sent emails
-            @else
-                No received emails
-            @endif
+            {{ __('filament/pages/email-inbox.list_empty.'.$folder->value) }}
         </p>
     @endif
 </div>

--- a/resources/views/components/emails/search-bar.blade.php
+++ b/resources/views/components/emails/search-bar.blade.php
@@ -4,15 +4,12 @@
     <div class="relative">
         <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
             <x-heroicon-o-magnifying-glass class="h-4 w-4 text-gray-400 dark:text-gray-500" wire:loading.remove wire:target="search" />
-            <svg wire:loading wire:target="search" class="h-4 w-4 animate-spin text-primary-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-            </svg>
+            <x-filament::loading-indicator class="h-4 w-4 text-primary-500" wire:loading wire:target="search" />
         </div>
         <input
             wire:model.live.debounce.300ms="search"
             type="text"
-            placeholder="Search emails…"
+            placeholder="{{ __('filament/pages/email-inbox.search.placeholder') }}"
             class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 py-2 pl-9 pr-3 text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:border-primary-500 dark:focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
         />
         @if (filled($search))

--- a/resources/views/filament/pages/email-access-requests.blade.php
+++ b/resources/views/filament/pages/email-access-requests.blade.php
@@ -1,7 +1,7 @@
 <x-filament-panels::page>
 
     {{-- ── Tab switcher ─────────────────────────────────────────────── --}}
-    <x-filament::tabs label="Access request tabs" class="ei-tabs-segmented">
+    <x-filament::tabs :label="__('filament/pages/email-access-requests.tabs.aria')" class="ei-tabs-segmented">
         <x-filament::tabs.item
             :active="$tab === 'incoming'"
             :icon="\Filament\Support\Icons\Heroicon::OutlinedInboxArrowDown"
@@ -9,7 +9,7 @@
             badge-color="primary"
             wire:click="setTab('incoming')"
         >
-            Incoming
+            {{ __('filament/pages/email-access-requests.tabs.incoming') }}
         </x-filament::tabs.item>
 
         <x-filament::tabs.item
@@ -17,7 +17,7 @@
             :icon="\Filament\Support\Icons\Heroicon::OutlinedPaperAirplane"
             wire:click="setTab('outgoing')"
         >
-            Sent
+            {{ __('filament/pages/email-access-requests.tabs.outgoing') }}
         </x-filament::tabs.item>
     </x-filament::tabs>
 
@@ -25,10 +25,10 @@
     @php
         $counts = $this->statusCounts;
         $filters = [
-            ['key' => null,        'label' => 'All',      'count' => $counts['total']],
-            ['key' => 'pending',   'label' => 'Pending',  'count' => $counts['pending']],
-            ['key' => 'approved',  'label' => 'Approved', 'count' => $counts['approved']],
-            ['key' => 'denied',    'label' => 'Denied',   'count' => $counts['denied']],
+            ['key' => null,        'label' => __('filament/pages/email-access-requests.filters.all'),      'count' => $counts['total']],
+            ['key' => 'pending',   'label' => __('filament/pages/email-access-requests.filters.pending'),  'count' => $counts['pending']],
+            ['key' => 'approved',  'label' => __('filament/pages/email-access-requests.filters.approved'), 'count' => $counts['approved']],
+            ['key' => 'denied',    'label' => __('filament/pages/email-access-requests.filters.denied'),   'count' => $counts['denied']],
         ];
     @endphp
 
@@ -61,15 +61,12 @@
             <div class="relative w-full sm:w-64">
                 <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-2.5">
                     <x-heroicon-o-magnifying-glass class="h-4 w-4 text-gray-400 dark:text-gray-500" wire:loading.remove wire:target="search" />
-                    <svg wire:loading wire:target="search" class="h-4 w-4 animate-spin text-primary-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-                    </svg>
+                    <x-filament::loading-indicator class="h-4 w-4 text-primary-500" wire:loading wire:target="search" />
                 </div>
                 <input
                     wire:model.live.debounce.300ms="search"
                     type="text"
-                    placeholder="Search by name or subject…"
+                    placeholder="{{ __('filament/pages/email-access-requests.search.placeholder') }}"
                     class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 py-1.5 pl-8 pr-8 text-xs text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:border-primary-500 dark:focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
                 />
                 @if (filled($search))
@@ -114,14 +111,8 @@
                 {{-- Avatar --}}
                 <div class="relative shrink-0">
                     @if ($person !== null)
-                        @php
-                            $photoPath = $person->profile_photo_path;
-                            $avatarUrl = filled($photoPath) && \Illuminate\Support\Facades\Storage::disk(config('jetstream.profile_photo_disk', 'public'))->exists($photoPath)
-                                ? \Illuminate\Support\Facades\Storage::disk(config('jetstream.profile_photo_disk', 'public'))->url($photoPath)
-                                : resolve(\App\Services\AvatarService::class)->generate($person->name);
-                        @endphp
                         <img
-                            src="{{ $avatarUrl }}"
+                            src="{{ $person->getFilamentAvatarUrl() }}"
                             alt="{{ $person->name }}"
                             class="h-8 w-8 rounded-full object-cover"
                         />
@@ -142,10 +133,12 @@
                 <div class="min-w-0 flex-1 space-y-1">
                     <div class="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
                         <span class="text-xs font-semibold text-gray-900 dark:text-gray-100">
-                            {{ $person?->name ?? 'Unknown user' }}
+                            {{ $person?->name ?? __('filament/pages/email-access-requests.request.unknown_user') }}
                         </span>
                         <span class="text-[11px] text-gray-500 dark:text-gray-400">
-                            {{ $tab === 'incoming' ? 'requested access' : 'you requested access' }}
+                            {{ $tab === 'incoming'
+                                ? __('filament/pages/email-access-requests.request.requested_incoming')
+                                : __('filament/pages/email-access-requests.request.requested_outgoing') }}
                         </span>
                         <span class="text-gray-300 dark:text-gray-600">·</span>
                         <span class="text-[11px] text-gray-400 dark:text-gray-500">
@@ -191,7 +184,7 @@
                         <x-heroicon-o-envelope class="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
                         <div class="min-w-0 flex-1">
                             <p class="truncate text-xs font-medium text-gray-800 dark:text-gray-200">
-                                {{ $email->subject ?? '(No subject)' }}
+                                {{ $email->subject ?? __('filament/pages/email-access-requests.request.no_subject') }}
                             </p>
                             @if (filled($email->snippet))
                                 <p class="line-clamp-1 text-[11px] text-gray-500 dark:text-gray-400">
@@ -203,7 +196,7 @@
                 </div>
             @else
                 <p class="text-[11px] italic text-gray-400 dark:text-gray-500">
-                    The associated email is no longer available.
+                    {{ __('filament/pages/email-access-requests.request.email_unavailable') }}
                 </p>
             @endif
         </div>
@@ -213,25 +206,27 @@
                 <x-heroicon-o-key class="h-8 w-8 text-gray-400 dark:text-gray-500" />
             </div>
             @if ($statusFilter !== null)
-                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">No {{ $statusFilter }} requests</p>
+                <p class="text-sm font-medium text-gray-600 dark:text-gray-400">{{ __('filament/pages/email-access-requests.empty.filtered_heading', ['status' => $statusFilter]) }}</p>
                 <p class="max-w-sm text-xs text-gray-400 dark:text-gray-500">
-                    Try a different filter or clear the active one.
+                    {{ __('filament/pages/email-access-requests.empty.filtered_description') }}
                 </p>
                 <button
                     wire:click="setStatusFilter(null)"
                     type="button"
                     class="mt-1 inline-flex items-center gap-1 rounded-lg bg-primary-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-primary-700 transition-colors"
                 >
-                    Show all
+                    {{ __('filament/pages/email-access-requests.empty.show_all') }}
                 </button>
             @else
                 <p class="text-sm font-medium text-gray-600 dark:text-gray-400">
-                    {{ $tab === 'incoming' ? 'No incoming requests' : 'No sent requests' }}
+                    {{ $tab === 'incoming'
+                        ? __('filament/pages/email-access-requests.empty.incoming_heading')
+                        : __('filament/pages/email-access-requests.empty.outgoing_heading') }}
                 </p>
                 <p class="max-w-sm text-xs text-gray-400 dark:text-gray-500">
                     {{ $tab === 'incoming'
-                        ? 'When someone asks for access to one of your private emails, it will show up here.'
-                        : "You haven't asked for access to any emails yet." }}
+                        ? __('filament/pages/email-access-requests.empty.incoming_description')
+                        : __('filament/pages/email-access-requests.empty.outgoing_description') }}
                 </p>
             @endif
         </div>

--- a/resources/views/filament/pages/email-inbox.blade.php
+++ b/resources/views/filament/pages/email-inbox.blade.php
@@ -20,9 +20,9 @@
             @endif
 
             <div class="flex shrink-0 border-b border-gray-200 dark:border-gray-700">
-                <x-emails.folder-tab folder="all"   :active="$folder->value === 'all'"   icon="heroicon-o-squares-2x2"   label="All" />
-                <x-emails.folder-tab folder="inbox" :active="$folder->value === 'inbox'" icon="heroicon-o-inbox"          label="Inbox" :badge="$this->inboxUnreadCount" />
-                <x-emails.folder-tab folder="sent"  :active="$folder->value === 'sent'"  icon="heroicon-o-paper-airplane" label="Sent" />
+                <x-emails.folder-tab folder="all"   :active="$folder->value === 'all'"   icon="heroicon-o-squares-2x2"   :label="__('filament/pages/email-inbox.folders.all')" />
+                <x-emails.folder-tab folder="inbox" :active="$folder->value === 'inbox'" icon="heroicon-o-inbox"          :label="__('filament/pages/email-inbox.folders.inbox')" :badge="$this->inboxUnreadCount" />
+                <x-emails.folder-tab folder="sent"  :active="$folder->value === 'sent'"  icon="heroicon-o-paper-airplane" :label="__('filament/pages/email-inbox.folders.sent')" />
             </div>
 
             <x-emails.search-bar :search="$search" />
@@ -30,7 +30,7 @@
             @if ($this->inboxUnreadCount > 0)
                 <div class="flex shrink-0 items-center justify-between border-b border-gray-200 dark:border-gray-700 px-3 py-1.5">
                     <span class="text-xs text-gray-400 dark:text-gray-500">
-                        {{ $this->inboxUnreadCount }} unread
+                        {{ __('filament/pages/email-inbox.unread_label', ['count' => $this->inboxUnreadCount]) }}
                     </span>
                     <button
                         wire:click="markAllAsRead"
@@ -61,10 +61,14 @@
                     class="flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:pointer-events-none disabled:opacity-40"
                 >
                     <x-heroicon-o-chevron-left class="h-3.5 w-3.5" />
-                    Prev
+                    {{ __('filament/pages/email-inbox.pagination.previous') }}
                 </button>
                 <span class="text-xs text-gray-400 dark:text-gray-500">
-                    {{ $this->emails->firstItem() ?? 0 }}–{{ $this->emails->lastItem() ?? 0 }} of {{ $this->emails->total() }}
+                    {{ __('filament/pages/email-inbox.pagination.range', [
+                        'first' => $this->emails->firstItem() ?? 0,
+                        'last' => $this->emails->lastItem() ?? 0,
+                        'total' => $this->emails->total(),
+                    ]) }}
                 </span>
                 <button
                     wire:click="nextPage"
@@ -72,7 +76,7 @@
                     @disabled($this->emails->onLastPage())
                     class="flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:pointer-events-none disabled:opacity-40"
                 >
-                    Next
+                    {{ __('filament/pages/email-inbox.pagination.next') }}
                     <x-heroicon-o-chevron-right class="h-3.5 w-3.5" />
                 </button>
             </div>
@@ -84,42 +88,27 @@
 
             {{-- Loading overlay while switching emails --}}
             <div wire:loading wire:target="selectEmail,setFolder" class="absolute inset-0 z-10 bg-white/70 dark:bg-gray-900/70">
-                <svg class="absolute top-1/2 left-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 animate-spin text-primary-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
-                </svg>
+                <x-filament::loading-indicator class="absolute top-1/2 left-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 text-primary-500" />
             </div>
 
             <div wire:loading.class="opacity-0" wire:target="selectEmail,setFolder" class="flex flex-1 flex-col overflow-y-auto min-h-0">
                 @if ($this->selectedEmail !== null)
                     <x-emails.detail-action-bar :email="$this->selectedEmail" />
 
-                    @php
-                        $authUser = auth()->user();
-                        $isEmailOwner = $this->selectedEmail->user_id === $authUser->getKey();
-                        $pendingRequests = $isEmailOwner
-                            ? \Relaticle\EmailIntegration\Models\EmailAccessRequest::query()
-                                ->with('requester')
-                                ->where('email_id', $this->selectedEmail->id)
-                                ->where('status', \Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus::PENDING)
-                                ->get()
-                            : collect();
-                    @endphp
-
-                    @if ($pendingRequests->isNotEmpty())
+                    @if ($this->pendingAccessRequests->isNotEmpty())
                         <div class="shrink-0 border-b border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 px-4 py-3">
                             <div class="flex items-center gap-2 mb-2">
                                 <x-heroicon-o-key class="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
                                 <span class="text-xs font-semibold text-amber-800 dark:text-amber-300">
-                                    {{ $pendingRequests->count() === 1 ? '1 pending access request' : $pendingRequests->count().' pending access requests' }}
+                                    {{ trans_choice('filament/pages/email-inbox.pending_access.heading', $this->pendingAccessRequests->count(), ['count' => $this->pendingAccessRequests->count()]) }}
                                 </span>
                             </div>
                             <div class="space-y-1.5">
-                                @foreach ($pendingRequests as $accessRequest)
+                                @foreach ($this->pendingAccessRequests as $accessRequest)
                                     <div class="flex items-center justify-between gap-3 rounded-lg bg-white dark:bg-gray-900 border border-amber-200 dark:border-amber-800 px-3 py-2">
                                         <div class="flex items-center gap-2 min-w-0">
                                             <span class="text-xs font-medium text-gray-900 dark:text-gray-100 truncate">
-                                                {{ $accessRequest->requester?->name ?? 'Unknown user' }}
+                                                {{ $accessRequest->requester?->name ?? __('filament/pages/email-inbox.pending_access.unknown_user') }}
                                             </span>
                                             <span class="shrink-0 inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-900/50 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300">
                                                 {{ \Relaticle\EmailIntegration\Enums\EmailPrivacyTier::from($accessRequest->tier_requested)->getLabel() }}
@@ -132,7 +121,7 @@
                                                 class="inline-flex items-center gap-1 rounded-md bg-success-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-success-700 transition-colors"
                                             >
                                                 <x-heroicon-o-check class="h-3 w-3" />
-                                                Approve
+                                                {{ __('filament/pages/email-inbox.pending_access.approve') }}
                                             </button>
                                             <button
                                                 wire:click="mountAction('denyAccessRequest', { requestId: '{{ $accessRequest->id }}' })"
@@ -140,7 +129,7 @@
                                                 class="inline-flex items-center gap-1 rounded-md bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 px-2.5 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                                             >
                                                 <x-heroicon-o-x-mark class="h-3 w-3" />
-                                                Deny
+                                                {{ __('filament/pages/email-inbox.pending_access.deny') }}
                                             </button>
                                         </div>
                                     </div>
@@ -155,8 +144,8 @@
                         <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800">
                             <x-heroicon-o-envelope-open class="h-8 w-8 text-gray-400 dark:text-gray-500" />
                         </div>
-                        <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Select an email to read</p>
-                        <p class="text-xs text-gray-400 dark:text-gray-500">Choose a message from the list on the left</p>
+                        <p class="text-sm font-medium text-gray-600 dark:text-gray-400">{{ __('filament/pages/email-inbox.detail_empty.heading') }}</p>
+                        <p class="text-xs text-gray-400 dark:text-gray-500">{{ __('filament/pages/email-inbox.detail_empty.description') }}</p>
                     </div>
                 @endif
             </div>


### PR DESCRIPTION
## What

Cleanup of the email **inbox** and **access requests** pages — no behavior change.

- **Move logic out of the view.** The inbox blade ran an inline `EmailAccessRequest::query()->...->get()` (plus ownership check) inside `@php`. Relocated verbatim into a `pendingAccessRequests()` `#[Computed]` on `EmailInboxPage`; the blade now just reads `$this->pendingAccessRequests`. Query and result are identical.
- **i18n.** Replaced hardcoded user-facing strings across both pages and the shared `x-emails.*` components with `__()` lang keys (folder labels, unread/pagination labels, empty states, filter pills, tab labels, pending-access strip). Added the missing keys to `lang/en/filament/pages/email-inbox.php` and `email-access-requests.php`.
- **Reuse over reinvention.** The access-request card reimplemented avatar resolution inline (Storage disk + `AvatarService` fallback). Swapped for the existing `User::getFilamentAvatarUrl()`, matching how Filament renders avatars everywhere else.

## Why

Query/logic in blades is invisible to the static-analysis stack (PHPStan skips compiled templates; the write-outside-action rule only flags writes) and only caught by human review. Moving it to the page and centralizing strings/avatars removes that blind spot and cuts duplication.

## Verification

`pint` + `phpstan` clean. Loading spinners were also unified to the native `x-filament::loading-indicator`.