### PR TITLE
fix(ci): route docker hub bootstrap pulls through mirror.gcr.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,11 +36,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Configure Docker Hub pull-through mirror
+        run: |
+          config='/etc/docker/daemon.json'
+          existing='{}'
+          if [ -f "$config" ]; then
+            existing=$(cat "$config")
+          fi
+          echo "$existing" | jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee "$config" > /dev/null
+          sudo systemctl restart docker
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -56,6 +60,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata
         id: meta
@@ -121,8 +131,15 @@ jobs:
           pattern: digests-*
           merge-multiple: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Configure Docker Hub pull-through mirror
+        run: |
+          config='/etc/docker/daemon.json'
+          existing='{}'
+          if [ -f "$config" ]; then
+            existing=$(cat "$config")
+          fi
+          echo "$existing" | jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee "$config" > /dev/null
+          sudo systemctl restart docker
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -136,6 +153,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata for GHCR
         id: meta-ghcr

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,11 +39,12 @@ jobs:
       - name: Configure Docker Hub pull-through mirror
         run: |
           config='/etc/docker/daemon.json'
+          sudo install -d -m 0755 /etc/docker
           existing='{}'
           if [ -f "$config" ]; then
-            existing=$(cat "$config")
+            existing=$(sudo cat "$config")
           fi
-          echo "$existing" | jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee "$config" > /dev/null
+          printf '%s' "$existing" | jq '. + {"registry-mirrors": ((."registry-mirrors" // []) + ["https://mirror.gcr.io"] | unique)}' | sudo tee "$config" > /dev/null
           sudo systemctl restart docker
 
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,11 +135,12 @@ jobs:
       - name: Configure Docker Hub pull-through mirror
         run: |
           config='/etc/docker/daemon.json'
+          sudo install -d -m 0755 /etc/docker
           existing='{}'
           if [ -f "$config" ]; then
-            existing=$(cat "$config")
+            existing=$(sudo cat "$config")
           fi
-          echo "$existing" | jq '. + {"registry-mirrors": ["https://mirror.gcr.io"]}' | sudo tee "$config" > /dev/null
+          printf '%s' "$existing" | jq '. + {"registry-mirrors": ((."registry-mirrors" // []) + ["https://mirror.gcr.io"] | unique)}' | sudo tee "$config" > /dev/null
           sudo systemctl restart docker
 
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
## Problem

The `Build and Push Docker Image` workflow failed on both matrix platforms at **Set up Docker Buildx** ([run](https://github.com/relaticle/relaticle/actions/runs/29279804622)):

```
#1 pulling image moby/buildkit:buildx-stable-1
#1 ERROR: Error response from daemon: received unexpected HTTP status: 500 Internal Server Error
```

The `docker-container` buildx driver boots by having the **host Docker daemon** pull `moby/buildkit` from Docker Hub (QEMU similarly pulls `tonistiigi/binfmt`). Docker Hub returned a server-side 500 on both runners simultaneously — a transient Hub incident. Because the bootstrap image had no local cache, the step failed hard (the QEMU pull hit the same 500 but recovered from cache).

Two structural fragilities left us exposed:
1. The build's bootstrap images are a hard dependency on Docker Hub — a single point of failure subject to both 5xx outages and anonymous **429** rate limits.
2. The `Log in to Docker Hub` step ran *after* buildx setup (and is skipped on PRs), so those pulls were anonymous.

## Fix

- **Host-level pull-through mirror (`mirror.gcr.io`)** configured before any pull, in both the `build` and `merge` jobs. The host daemon now fetches `moby/buildkit` / `tonistiigi/binfmt` from Google's cache of Docker Hub, surviving Hub outages and rate limits with zero maintenance. `registry-mirrors` only affects `docker.io` pulls, so GHCR is untouched. The step merges into any existing `/etc/docker/daemon.json` rather than overwriting it.
- **Logins moved ahead of QEMU/Buildx** so that if a pull does reach Docker Hub, it's authenticated (raises the anonymous rate-limit ceiling).

Note the mirror addresses the 500 (the actual failure); the login reorder is defense-in-depth against future 429s.

## Verification

- YAML validated; step order confirmed `mirror → auth → bootstrap` in both jobs.
- `jq` merge logic tested locally against empty and pre-populated `daemon.json` (existing keys preserved).
- This PR's own `pull_request` run exercises the previously-failing `Set up Docker Buildx` bootstrap on both platforms (build push is disabled on PRs, so no images are published).