### PR TITLE
fix: redirect Fortify email-verify route to Filament prompt

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -9,7 +9,9 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Actions\Fortify\UpdateUserPassword;
 use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Contracts\User\CreatesNewSocialUsers;
+use Filament\Facades\Filament;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
@@ -34,6 +36,14 @@ final class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
+
+        // Jetstream registers the Blade-based `auth.verify-email` prompt view for
+        // Fortify's `/email/verify` route, but this app renders all auth UI through
+        // Filament and never publishes that view. Send unverified users hitting the
+        // Fortify verification-notice route to Filament's real prompt instead.
+        Fortify::verifyEmailView(fn (): RedirectResponse => to_route(
+            Filament::getPanel('app')->getEmailVerificationPromptRouteName(),
+        ));
 
         RateLimiter::for('login', function (Request $request) {
             $throttleKey = Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());

--- a/tests/Feature/Auth/EmailVerificationPromptTest.php
+++ b/tests/Feature/Auth/EmailVerificationPromptTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Providers\FortifyServiceProvider;
+use Filament\Facades\Filament;
+
+mutates(FortifyServiceProvider::class);
+
+test('unverified user hitting the Fortify verification-notice route is sent to the Filament prompt', function () {
+    $user = User::factory()->unverified()->create();
+
+    $this->actingAs($user)
+        ->get('/email/verify')
+        ->assertRedirect(Filament::getPanel('app')->getEmailVerificationPromptUrl());
+});
+
+test('verified user hitting the Fortify verification-notice route is redirected away from the prompt', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/email/verify');
+
+    $response->assertRedirect();
+
+    expect($response->headers->get('Location'))
+        ->not->toBe(Filament::getPanel('app')->getEmailVerificationPromptUrl());
+});


### PR DESCRIPTION
## Problem

Production Sentry error `InvalidArgumentException: View [auth.verify-email] not found.` (500) at `/email/verify`. Jetstream's `viewPrefix('auth.')` binds Fortify's email-verification prompt to the `auth.verify-email` Blade view, but this app renders all auth UI through Filament and never published that view, so authenticated-but-unverified users hitting Fortify's `verification.notice` route crash.

## Fix

Override `Fortify::verifyEmailView()` in `FortifyServiceProvider` to redirect to Filament's real email-verification prompt, keeping the `verification.notice` route intact for the `verified` middleware. A regression test in `tests/Feature/Auth/EmailVerificationPromptTest.php` covers both the unverified (redirect to prompt) and verified (redirected away) paths.

## Verification

Reproduced the exact exception first, confirmed the redirect after; Pint, Rector, PHPStan, 100% type-coverage, and the Auth/EmailVerification/Teams/Smoke suites all pass.