### PR TITLE
fix: force activitylog:clean in scheduler so production runs stop failing

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -102,7 +102,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('import:cleanup')->hourly();
         $schedule->command('queue:prune-batches --hours=24')->daily();
         $schedule->command('invitations:cleanup')->daily();
-        $schedule->command('activitylog:clean')->daily();
+        $schedule->command('activitylog:clean --force')->daily();
         $schedule->command('chat:expire-pending-actions')->everyFiveMinutes();
         $schedule->command('chat:release-orphaned-reservations')->everyTenMinutes()->withoutOverlapping()->onOneServer();
         $schedule->command('chat:reset-credits')->dailyAt('00:05')->withoutOverlapping()->onOneServer();

--- a/tests/Feature/Commands/ActivityLogCleanScheduleTest.php
+++ b/tests/Feature/Commands/ActivityLogCleanScheduleTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+test('activitylog:clean is scheduled with --force so production runs are not cancelled', function (): void {
+    $this->artisan('schedule:list')
+        ->expectsOutputToContain('activitylog:clean --force')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Problem

Production reports this on a daily cadence:

> Scheduled command ['/usr/bin/php8.4' 'artisan' activitylog:clean] failed with exit code [1].

The pasted stack trace is only Laravel's generic scheduler wrapper — it does not show *why* the command exited 1.

## Root cause

`activitylog:clean` is spatie/laravel-activitylog's maintenance command. It uses Laravel's `ConfirmableTrait`:

```php
if (! $this->confirmToProceed()) {
    return 1;
}
```

`confirmToProceed()` triggers a confirmation prompt whenever `APP_ENV=production` and `--force` is absent. The scheduler shells out non-interactively (no TTY), the prompt auto-answers "no", the command prints `Command cancelled.` and returns **1**, and the scheduler surfaces the wrapper exception above.

This is **not** a DB error or a bug in the custom `CleanActivityLogAction` — the delete never runs. It fails at the confirmation gate. Consequence: the `activity_log` table has never actually been pruned in production.

## Reproduction (deterministic)

| Command | Exit code |
|---|---|
| `php artisan activitylog:clean` (local, non-prod) | 0 — why it's never seen locally |
| `APP_ENV=production php artisan activitylog:clean` | **1** — matches production |
| `APP_ENV=production php artisan activitylog:clean --force` | 0 — the fix |

Sibling sweep: `activitylog:clean` is the only scheduled command using `ConfirmableTrait` / branching on environment. `import:cleanup`, `invitations:cleanup`, `queue:prune-batches`, `chat:*`, `subscribers:sync-recency-tags`, `app:purge-scheduled-deletions` all exit 0 under `APP_ENV=production`.

## Fix

Add `--force` to the scheduled command — the standard pattern for confirmable commands (same as `migrate --force` in deploys).

## Test plan

- New regression test asserts the daily schedule carries `--force`; verified load-bearing (passes with the flag, fails without it).
- `vendor/bin/pint --dirty` — passed
- `vendor/bin/rector --dry-run` — clean
- `vendor/bin/phpstan analyse` — 0 errors
- `composer test:type-coverage` — 100.0%
- `php artisan test tests/Feature/Commands` — 23 passed, 1 pre-existing skip