### PR TITLE
feat: add cross-tenant Activity observability to SystemAdmin panel

### DIFF
--- a/app/Models/ActivityLog/Activity.php
+++ b/app/Models/ActivityLog/Activity.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Models\ActivityLog;
 
 use App\Models\ActivityLog\Scopes\TeamScope;
+use App\Models\Team;
 use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Spatie\Activitylog\Models\Activity as SpatieActivity;
 
 /**
@@ -13,6 +15,14 @@ use Spatie\Activitylog\Models\Activity as SpatieActivity;
  */
 final class Activity extends SpatieActivity
 {
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
     protected static function booted(): void
     {
         self::addGlobalScope(new TeamScope);

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -6,8 +6,14 @@ namespace Relaticle\SystemAdmin\Filament\Resources;
 
 use App\Models\ActivityLog\Activity;
 use App\Models\ActivityLog\Scopes\TeamScope;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
 use Filament\Resources\Resource;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Override;
@@ -57,6 +63,7 @@ final class ActivityResource extends Resource
     {
         return $table
             ->defaultSort('created_at', 'desc')
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with(['team', 'causer']))
             ->columns([
                 TextColumn::make('created_at')
                     ->dateTime()
@@ -84,6 +91,45 @@ final class ActivityResource extends Resource
                 TextColumn::make('description')
                     ->limit(60)
                     ->wrap(),
+            ])
+            ->filters([
+                SelectFilter::make('team_id')
+                    ->label('Team')
+                    ->options(fn (): array => Team::query()->orderBy('name')->pluck('name', 'id')->all())
+                    ->searchable(),
+                SelectFilter::make('subject_type')
+                    ->label('Subject')
+                    ->options([
+                        'company' => 'Company',
+                        'people' => 'People',
+                        'opportunity' => 'Opportunity',
+                        'task' => 'Task',
+                        'note' => 'Note',
+                    ]),
+                SelectFilter::make('event')
+                    ->options([
+                        'created' => 'Created',
+                        'updated' => 'Updated',
+                        'deleted' => 'Deleted',
+                    ]),
+                SelectFilter::make('causer')
+                    ->label('User')
+                    ->options(fn (): array => User::query()->orderBy('name')->pluck('name', 'id')->all())
+                    ->searchable()
+                    ->query(fn (Builder $query, array $data): Builder => filled($data['value'] ?? null)
+                        ? $query->where('causer_type', 'user')->where('causer_id', $data['value'])
+                        : $query),
+                Filter::make('created_at')
+                    ->schema([
+                        DatePicker::make('from')->label('From'),
+                        DatePicker::make('until')->label('Until'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when(filled($data['from'] ?? null), fn (Builder $q): Builder => $q->whereDate('created_at', '>=', $data['from']))
+                        ->when(filled($data['until'] ?? null), fn (Builder $q): Builder => $q->whereDate('created_at', '<=', $data['until']))),
+            ])
+            ->recordActions([
+                ViewAction::make(),
             ]);
     }
 

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources;
+
+use App\Models\ActivityLog\Activity;
+use App\Models\ActivityLog\Scopes\TeamScope;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Override;
+use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
+
+final class ActivityResource extends Resource
+{
+    protected static ?string $model = Activity::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clock';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Dashboards';
+
+    protected static ?int $navigationSort = 5;
+
+    protected static ?string $navigationLabel = 'Activity';
+
+    protected static ?string $modelLabel = 'Activity';
+
+    protected static ?string $pluralModelLabel = 'Activity';
+
+    protected static ?string $slug = 'activity';
+
+    #[Override]
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->withoutGlobalScope(TeamScope::class);
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit(mixed $record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete(mixed $record): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('team.name')
+                    ->label('Team')
+                    ->placeholder('—')
+                    ->sortable(),
+                TextColumn::make('causer.name')
+                    ->label('User')
+                    ->placeholder('System')
+                    ->sortable(),
+                TextColumn::make('subject_type')
+                    ->label('Subject')
+                    ->badge()
+                    ->color('gray')
+                    ->formatStateUsing(fn (?string $state): string => $state === null ? '—' : ucfirst($state)),
+                TextColumn::make('event')
+                    ->badge()
+                    ->color(fn (?string $state): string => match ($state) {
+                        'created' => 'success',
+                        'deleted' => 'danger',
+                        default => 'gray',
+                    }),
+                TextColumn::make('description')
+                    ->limit(60)
+                    ->wrap(),
+            ]);
+    }
+
+    #[Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListActivities::route('/'),
+        ];
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -78,8 +78,7 @@ final class ActivityResource extends Resource
                     ->sortable(),
                 TextColumn::make('causer.name')
                     ->label('User')
-                    ->placeholder('System')
-                    ->sortable(),
+                    ->placeholder('System'),
                 TextColumn::make('subject_type')
                     ->label('Subject')
                     ->badge()

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -10,7 +10,10 @@ use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
+use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
@@ -18,6 +21,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Override;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
+use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ViewActivity;
 
 final class ActivityResource extends Resource
 {
@@ -138,6 +142,101 @@ final class ActivityResource extends Resource
     {
         return [
             'index' => ListActivities::route('/'),
+            'view' => ViewActivity::route('/{record}'),
         ];
+    }
+
+    #[Override]
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make([
+                    TextEntry::make('created_at')->dateTime(),
+                    TextEntry::make('event')
+                        ->badge()
+                        ->color(fn (?string $state): string => match ($state) {
+                            'created' => 'success',
+                            'deleted' => 'danger',
+                            default => 'gray',
+                        }),
+                    TextEntry::make('team.name')->label('Team')->placeholder('—'),
+                    TextEntry::make('causer.name')->label('User')->placeholder('System'),
+                    TextEntry::make('subject_type')
+                        ->label('Subject')
+                        ->formatStateUsing(fn (?string $state, Activity $record): string => $state === null
+                            ? '—'
+                            : ucfirst($state).' #'.$record->subject_id),
+                    TextEntry::make('description')->columnSpanFull(),
+                ])->columns(2)->columnSpanFull(),
+                Section::make('Changes')
+                    ->schema([
+                        TextEntry::make('changes')
+                            ->hiddenLabel()
+                            ->listWithLineBreaks()
+                            ->bulleted()
+                            ->placeholder('No field changes recorded.')
+                            ->state(fn (Activity $record): array => self::buildChangeSummary($record))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+            ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function buildChangeSummary(Activity $record): array
+    {
+        /** @var array<string, mixed> $properties */
+        $properties = $record->properties?->toArray() ?? [];
+
+        if (isset($properties['custom_field_changes']) && is_array($properties['custom_field_changes'])) {
+            return collect($properties['custom_field_changes'])
+                ->map(function (array $change): string {
+                    $label = (string) ($change['label'] ?? $change['code'] ?? 'Field');
+                    $old = self::stringifyValue($change['old'] ?? null);
+                    $new = self::stringifyValue($change['new'] ?? null);
+
+                    return "{$label}: {$old} → {$new}";
+                })
+                ->values()
+                ->all();
+        }
+
+        if (isset($properties['attributes']) && is_array($properties['attributes'])) {
+            /** @var array<string, mixed> $new */
+            $new = $properties['attributes'];
+            /** @var array<string, mixed> $old */
+            $old = is_array($properties['old'] ?? null) ? $properties['old'] : [];
+
+            return collect($new)
+                ->map(fn (mixed $value, string $key): string => sprintf(
+                    '%s: %s → %s',
+                    $key,
+                    self::stringifyValue($old[$key] ?? null),
+                    self::stringifyValue($value),
+                ))
+                ->values()
+                ->all();
+        }
+
+        return collect($properties)
+            ->map(fn (mixed $value, string $key): string => "{$key}: ".self::stringifyValue($value))
+            ->values()
+            ->all();
+    }
+
+    private static function stringifyValue(mixed $value): string
+    {
+        if (is_array($value)) {
+            return (string) ($value['label'] ?? json_encode($value));
+        }
+
+        if ($value === null || $value === '') {
+            return '—';
+        }
+
+        return is_bool($value) ? ($value ? 'true' : 'false') : (string) $value;
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -129,8 +129,8 @@ final class ActivityResource extends Resource
                         DatePicker::make('until')->label('Until'),
                     ])
                     ->query(fn (Builder $query, array $data): Builder => $query
-                        ->when(filled($data['from'] ?? null), fn (Builder $q): Builder => $q->whereDate('created_at', '>=', $data['from']))
-                        ->when(filled($data['until'] ?? null), fn (Builder $q): Builder => $q->whereDate('created_at', '<=', $data['until']))),
+                        ->when(filled($data['from'] ?? null), fn (Builder $q): Builder => $q->whereDate('activity_log.created_at', '>=', $data['from']))
+                        ->when(filled($data['until'] ?? null), fn (Builder $q): Builder => $q->whereDate('activity_log.created_at', '<=', $data['until']))),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -221,6 +221,21 @@ final class ActivityResource extends Resource
                 ->all();
         }
 
+        if (isset($properties['old']) && is_array($properties['old']) && ! isset($properties['attributes'])) {
+            /** @var array<string, mixed> $old */
+            $old = $properties['old'];
+
+            return collect($old)
+                ->map(fn (mixed $value, string $key): string => sprintf(
+                    '%s: %s → %s',
+                    $key,
+                    self::stringifyValue($value),
+                    self::stringifyValue(null),
+                ))
+                ->values()
+                ->all();
+        }
+
         return collect($properties)
             ->map(fn (mixed $value, string $key): string => "{$key}: ".self::stringifyValue($value))
             ->values()

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
@@ -7,10 +7,18 @@ namespace Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages;
 use Filament\Pages\Concerns\ExposesTableToWidgets;
 use Filament\Resources\Pages\ListRecords;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityOverviewStatsWidget;
 
 final class ListActivities extends ListRecords
 {
     use ExposesTableToWidgets;
 
     protected static string $resource = ActivityResource::class;
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            ActivityOverviewStatsWidget::class,
+        ];
+    }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
@@ -8,6 +8,7 @@ use Filament\Pages\Concerns\ExposesTableToWidgets;
 use Filament\Resources\Pages\ListRecords;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource;
 use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityOverviewStatsWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityVolumeChartWidget;
 
 final class ListActivities extends ListRecords
 {
@@ -19,6 +20,7 @@ final class ListActivities extends ListRecords
     {
         return [
             ActivityOverviewStatsWidget::class,
+            ActivityVolumeChartWidget::class,
         ];
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages;
+
+use Filament\Pages\Concerns\ExposesTableToWidgets;
+use Filament\Resources\Pages\ListRecords;
+use Relaticle\SystemAdmin\Filament\Resources\ActivityResource;
+
+final class ListActivities extends ListRecords
+{
+    use ExposesTableToWidgets;
+
+    protected static string $resource = ActivityResource::class;
+}

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ListActivities.php
@@ -9,6 +9,8 @@ use Filament\Resources\Pages\ListRecords;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource;
 use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityOverviewStatsWidget;
 use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityVolumeChartWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\TopActiveTeamsChartWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\TopActiveUsersChartWidget;
 
 final class ListActivities extends ListRecords
 {
@@ -21,6 +23,8 @@ final class ListActivities extends ListRecords
         return [
             ActivityOverviewStatsWidget::class,
             ActivityVolumeChartWidget::class,
+            TopActiveTeamsChartWidget::class,
+            TopActiveUsersChartWidget::class,
         ];
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ViewActivity.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource/Pages/ViewActivity.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages;
+
+use Filament\Resources\Pages\ViewRecord;
+use Relaticle\SystemAdmin\Filament\Resources\ActivityResource;
+
+final class ViewActivity extends ViewRecord
+{
+    protected static string $resource = ActivityResource::class;
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/Activity/ActivityOverviewStatsWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/Activity/ActivityOverviewStatsWidget.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Widgets\Activity;
+
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\Concerns\InteractsWithActivityTable;
+
+final class ActivityOverviewStatsWidget extends StatsOverviewWidget
+{
+    use InteractsWithActivityTable;
+
+    protected static ?int $sort = 1;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected ?string $pollingInterval = null;
+
+    protected function getStats(): array
+    {
+        $total = $this->activityQuery()->count();
+        $teams = $this->activityQuery()->whereNotNull('team_id')->distinct()->count('team_id');
+        $users = $this->activityQuery()->where('causer_type', 'user')->distinct()->count('causer_id');
+        $deletions = $this->activityQuery()->where('event', 'deleted')->count();
+
+        return [
+            Stat::make('Total Activities', number_format($total)),
+            Stat::make('Active Teams', number_format($teams)),
+            Stat::make('Active Users', number_format($users)),
+            Stat::make('Deletions', number_format($deletions))
+                ->color($deletions > 0 ? 'danger' : 'gray'),
+        ];
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/Activity/ActivityVolumeChartWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/Activity/ActivityVolumeChartWidget.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Widgets\Activity;
+
+use Carbon\CarbonImmutable;
+use Filament\Widgets\ChartWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\Concerns\InteractsWithActivityTable;
+
+final class ActivityVolumeChartWidget extends ChartWidget
+{
+    use InteractsWithActivityTable;
+
+    protected static ?int $sort = 2;
+
+    protected ?string $pollingInterval = null;
+
+    protected ?string $maxHeight = '260px';
+
+    public function getHeading(): string
+    {
+        return 'Activity Over Time';
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+
+    protected function getData(): array
+    {
+        [$start, $end, $unit] = $this->resolveWindow();
+
+        /** @var array<string, int> $counts */
+        $counts = $this->activityQuery()
+            ->whereBetween('created_at', [$start, $end])
+            ->toBase()
+            ->selectRaw('date_trunc(?, created_at) as bucket, count(*) as cnt', [$unit])
+            ->groupByRaw('bucket')
+            ->orderByRaw('bucket')
+            ->get()
+            ->mapWithKeys(fn (object $row): array => [
+                CarbonImmutable::parse((string) $row->bucket)->toDateString() => (int) $row->cnt,
+            ])
+            ->all();
+
+        $labels = [];
+        $values = [];
+        $step = $unit === 'week' ? '1 week' : '1 day';
+
+        for ($cursor = $start; $cursor <= $end; $cursor = $cursor->add($step)) {
+            $key = $cursor->toDateString();
+            $labels[] = $cursor->format('M j');
+            $values[] = $counts[$key] ?? 0;
+        }
+
+        return [
+            'datasets' => [
+                ['label' => 'Activities', 'data' => $values],
+            ],
+            'labels' => $labels,
+        ];
+    }
+
+    /**
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable, 2: string}
+     */
+    private function resolveWindow(): array
+    {
+        /** @var array<string, mixed> $filter */
+        $filter = $this->tableFilters['created_at'] ?? [];
+
+        $end = filled($filter['until'] ?? null)
+            ? CarbonImmutable::parse((string) $filter['until'])->endOfDay()
+            : CarbonImmutable::now();
+
+        $start = filled($filter['from'] ?? null)
+            ? CarbonImmutable::parse((string) $filter['from'])->startOfDay()
+            : $end->subDays(30)->startOfDay();
+
+        $unit = $start->diffInDays($end) > 62 ? 'week' : 'day';
+
+        if ($unit === 'week') {
+            $start = $start->startOfWeek();
+        }
+
+        return [$start, $end, $unit];
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/Activity/ActivityVolumeChartWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/Activity/ActivityVolumeChartWidget.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\SystemAdmin\Filament\Widgets\Activity;
 
 use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use Filament\Widgets\ChartWidget;
 use Relaticle\SystemAdmin\Filament\Widgets\Activity\Concerns\InteractsWithActivityTable;
 
@@ -82,7 +83,7 @@ final class ActivityVolumeChartWidget extends ChartWidget
         $unit = $start->diffInDays($end) > 62 ? 'week' : 'day';
 
         if ($unit === 'week') {
-            $start = $start->startOfWeek();
+            $start = $start->startOfWeek(CarbonInterface::MONDAY);
         }
 
         return [$start, $end, $unit];

--- a/packages/SystemAdmin/src/Filament/Widgets/Activity/Concerns/InteractsWithActivityTable.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/Activity/Concerns/InteractsWithActivityTable.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Widgets\Activity\Concerns;
+
+use Filament\Widgets\Concerns\InteractsWithPageTable;
+use Illuminate\Database\Eloquent\Builder;
+use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
+
+trait InteractsWithActivityTable
+{
+    use InteractsWithPageTable;
+
+    protected function getTablePage(): string
+    {
+        return ListActivities::class;
+    }
+
+    /**
+     * The List page's filtered query, with ordering stripped for aggregation.
+     * TeamScope is already bypassed via ActivityResource::getEloquentQuery().
+     */
+    protected function activityQuery(): Builder
+    {
+        return $this->getPageTableQuery()->reorder();
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/Activity/TopActiveTeamsChartWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/Activity/TopActiveTeamsChartWidget.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Widgets\Activity;
+
+use Filament\Widgets\ChartWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\Concerns\InteractsWithActivityTable;
+
+final class TopActiveTeamsChartWidget extends ChartWidget
+{
+    use InteractsWithActivityTable;
+
+    protected static ?int $sort = 3;
+
+    protected ?string $pollingInterval = null;
+
+    protected ?string $maxHeight = '260px';
+
+    public function getHeading(): string
+    {
+        return 'Most Active Teams';
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+
+    protected function getData(): array
+    {
+        $rows = $this->activityQuery()
+            ->whereNotNull('team_id')
+            ->join('teams', 'teams.id', '=', 'activity_log.team_id')
+            ->toBase()
+            ->selectRaw('teams.name as name, count(*) as cnt')
+            ->groupByRaw('teams.name')
+            ->orderByRaw('cnt desc')
+            ->limit(10)
+            ->get();
+
+        return [
+            'datasets' => [
+                ['label' => 'Activities', 'data' => $rows->pluck('cnt')->map(fn (mixed $v): int => (int) $v)->all()],
+            ],
+            'labels' => $rows->pluck('name')->map(fn (mixed $v): string => (string) $v)->all(),
+        ];
+    }
+
+    protected function getOptions(): array
+    {
+        return ['indexAxis' => 'y'];
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/Activity/TopActiveUsersChartWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/Activity/TopActiveUsersChartWidget.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Widgets\Activity;
+
+use Filament\Widgets\ChartWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\Concerns\InteractsWithActivityTable;
+
+final class TopActiveUsersChartWidget extends ChartWidget
+{
+    use InteractsWithActivityTable;
+
+    protected static ?int $sort = 4;
+
+    protected ?string $pollingInterval = null;
+
+    protected ?string $maxHeight = '260px';
+
+    public function getHeading(): string
+    {
+        return 'Most Active Users';
+    }
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+
+    protected function getData(): array
+    {
+        $rows = $this->activityQuery()
+            ->where('causer_type', 'user')
+            ->join('users', 'users.id', '=', 'activity_log.causer_id')
+            ->toBase()
+            ->selectRaw('users.name as name, count(*) as cnt')
+            ->groupByRaw('users.name')
+            ->orderByRaw('cnt desc')
+            ->limit(10)
+            ->get();
+
+        return [
+            'datasets' => [
+                ['label' => 'Activities', 'data' => $rows->pluck('cnt')->map(fn (mixed $v): int => (int) $v)->all()],
+            ],
+            'labels' => $rows->pluck('name')->map(fn (mixed $v): string => (string) $v)->all(),
+        ];
+    }
+
+    protected function getOptions(): array
+    {
+        return ['indexAxis' => 'y'];
+    }
+}

--- a/packages/SystemAdmin/src/Policies/ActivityPolicy.php
+++ b/packages/SystemAdmin/src/Policies/ActivityPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Policies;
+
+final class ActivityPolicy
+{
+    public function viewAny(): bool
+    {
+        return true;
+    }
+
+    public function view(): bool
+    {
+        return true;
+    }
+
+    public function create(): bool
+    {
+        return false;
+    }
+
+    public function update(): bool
+    {
+        return false;
+    }
+
+    public function delete(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -116,7 +116,7 @@ it('renders the view page for a custom-field-changes activity', function (): voi
             'code' => 'priority',
             'label' => 'Priority',
             'type' => 'select',
-            'old' => ['value' => null, 'label' => '—'],
+            'old' => ['value' => 'low', 'label' => 'Low'],
             'new' => ['value' => 'high', 'label' => 'High'],
         ]]],
     ]);
@@ -126,5 +126,21 @@ it('renders the view page for a custom-field-changes activity', function (): voi
     ])
         ->assertOk()
         ->assertSee('Priority')
+        ->assertSee('Low')
         ->assertSee('High');
+});
+
+it('renders the view page for a deleted activity with an itemized old→new diff', function (): void {
+    $activity = seedActivity($this->teamA, $this->ownerA, [
+        'event' => 'deleted',
+        'description' => 'deleted',
+        'properties' => ['old' => ['name' => 'Acme Co']],
+    ]);
+
+    livewire(ViewActivity::class, [
+        'record' => $activity->getKey(),
+    ])
+        ->assertOk()
+        ->assertSee('Acme Co')
+        ->assertDontSee('{"name"');
 });

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -9,6 +9,7 @@ use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
+use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ViewActivity;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
 /**
@@ -90,4 +91,40 @@ it('filters activity by date range', function (): void {
         ->filterTable('created_at', ['from' => '2026-06-10', 'until' => '2026-06-20'])
         ->assertCanSeeTableRecords([$inRange])
         ->assertCanNotSeeTableRecords([$outOfRange]);
+});
+
+it('renders the view page with a standard attribute diff', function (): void {
+    $activity = seedActivity($this->teamA, $this->ownerA, [
+        'event' => 'updated',
+        'description' => 'updated',
+        'properties' => ['attributes' => ['name' => 'New Co'], 'old' => ['name' => 'Old Co']],
+    ]);
+
+    livewire(ViewActivity::class, [
+        'record' => $activity->getKey(),
+    ])
+        ->assertOk()
+        ->assertSee('Old Co')
+        ->assertSee('New Co');
+});
+
+it('renders the view page for a custom-field-changes activity', function (): void {
+    $activity = seedActivity($this->teamA, $this->ownerA, [
+        'event' => 'custom_field_changes',
+        'description' => 'custom_field_changes',
+        'properties' => ['custom_field_changes' => [[
+            'code' => 'priority',
+            'label' => 'Priority',
+            'type' => 'select',
+            'old' => ['value' => null, 'label' => '—'],
+            'new' => ['value' => 'high', 'label' => 'High'],
+        ]]],
+    ]);
+
+    livewire(ViewActivity::class, [
+        'record' => $activity->getKey(),
+    ])
+        ->assertOk()
+        ->assertSee('Priority')
+        ->assertSee('High');
 });

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -168,6 +168,14 @@ it('overview stats reflect the active filter', function (): void {
         ->toBe(1);
 });
 
+it('does not error when sorting by the polymorphic user column', function (): void {
+    seedActivity($this->teamA, $this->ownerA);
+
+    livewire(ListActivities::class)
+        ->sortTable('causer.name')
+        ->assertOk();
+});
+
 it('renders the activity volume chart', function (): void {
     seedActivity($this->teamA, $this->ownerA);
     seedActivity($this->teamA, $this->ownerA);

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -12,6 +12,8 @@ use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActiviti
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ViewActivity;
 use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityOverviewStatsWidget;
 use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityVolumeChartWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\TopActiveTeamsChartWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\TopActiveUsersChartWidget;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
 /**
@@ -172,4 +174,13 @@ it('renders the activity volume chart', function (): void {
 
     livewire(ActivityVolumeChartWidget::class)
         ->assertOk();
+});
+
+it('renders the top-active teams and users charts', function (): void {
+    seedActivity($this->teamA, $this->ownerA);
+    seedActivity($this->teamA, $this->ownerA);
+    seedActivity($this->teamB, $this->ownerB);
+
+    livewire(TopActiveTeamsChartWidget::class)->assertOk();
+    livewire(TopActiveUsersChartWidget::class)->assertOk();
 });

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -50,3 +50,44 @@ it('shows activity across all tenants on the list page', function (): void {
         ->assertOk()
         ->assertCanSeeTableRecords([$a, $b]);
 });
+
+it('filters activity by team', function (): void {
+    $a = seedActivity($this->teamA, $this->ownerA);
+    $b = seedActivity($this->teamB, $this->ownerB);
+
+    livewire(ListActivities::class)
+        ->filterTable('team_id', $this->teamA->id)
+        ->assertCanSeeTableRecords([$a])
+        ->assertCanNotSeeTableRecords([$b]);
+});
+
+it('filters activity by event', function (): void {
+    $created = seedActivity($this->teamA, $this->ownerA, ['event' => 'created', 'description' => 'created']);
+    $deleted = seedActivity($this->teamA, $this->ownerA, ['event' => 'deleted', 'description' => 'deleted']);
+
+    livewire(ListActivities::class)
+        ->filterTable('event', 'deleted')
+        ->assertCanSeeTableRecords([$deleted])
+        ->assertCanNotSeeTableRecords([$created]);
+});
+
+it('filters activity by causer', function (): void {
+    $otherUser = User::factory()->create();
+    $mine = seedActivity($this->teamA, $this->ownerA, ['description' => 'by owner A']);
+    $theirs = seedActivity($this->teamA, $otherUser, ['description' => 'by other user']);
+
+    livewire(ListActivities::class)
+        ->filterTable('causer', $this->ownerA->id)
+        ->assertCanSeeTableRecords([$mine])
+        ->assertCanNotSeeTableRecords([$theirs]);
+});
+
+it('filters activity by date range', function (): void {
+    $inRange = $this->travelTo('2026-06-15 12:00:00', fn (): Activity => seedActivity($this->teamA, $this->ownerA, ['description' => 'in range']));
+    $outOfRange = $this->travelTo('2026-06-01 12:00:00', fn (): Activity => seedActivity($this->teamA, $this->ownerA, ['description' => 'out of range']));
+
+    livewire(ListActivities::class)
+        ->filterTable('created_at', ['from' => '2026-06-10', 'until' => '2026-06-20'])
+        ->assertCanSeeTableRecords([$inRange])
+        ->assertCanNotSeeTableRecords([$outOfRange]);
+});

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ViewActivity;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityOverviewStatsWidget;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
 /**
@@ -143,4 +144,23 @@ it('renders the view page for a deleted activity with an itemized old→new diff
         ->assertOk()
         ->assertSee('Acme Co')
         ->assertDontSee('{"name"');
+});
+
+it('overview stats reflect the active filter', function (): void {
+    seedActivity($this->teamA, $this->ownerA);
+    seedActivity($this->teamA, $this->ownerA);
+    seedActivity($this->teamA, $this->ownerA, ['event' => 'deleted']);
+    seedActivity($this->teamB, $this->ownerB);
+
+    $component = livewire(ActivityOverviewStatsWidget::class, [
+        'tableFilters' => ['team_id' => ['value' => (string) $this->teamA->id]],
+    ])
+        ->assertOk()
+        ->assertSee('Total Activities');
+
+    // teamA has 3 activities (2 created + 1 deleted); teamB's 1 is excluded by the filter.
+    // If the filter were ignored, the total would be 4 (both teams combined) and this
+    // pattern — the "Total Activities" stat's value div containing exactly "3" — would not match.
+    expect(preg_match('/Total Activities.*?fi-wi-stats-overview-stat-value">\s*3\s*</s', $component->html()))
+        ->toBe(1);
 });

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -184,3 +184,14 @@ it('renders the top-active teams and users charts', function (): void {
     livewire(TopActiveTeamsChartWidget::class)->assertOk();
     livewire(TopActiveUsersChartWidget::class)->assertOk();
 });
+
+it('renders the top-active charts when the date filter is active', function (): void {
+    seedActivity($this->teamA, $this->ownerA);
+    seedActivity($this->teamA, $this->ownerA);
+    seedActivity($this->teamB, $this->ownerB);
+
+    $filters = ['created_at' => ['from' => now()->subDay()->toDateString(), 'until' => null]];
+
+    livewire(TopActiveTeamsChartWidget::class, ['tableFilters' => $filters])->assertOk();
+    livewire(TopActiveUsersChartWidget::class, ['tableFilters' => $filters])->assertOk();
+});

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\ActivityLog\Activity;
+use App\Models\ActivityLog\Scopes\TeamScope;
+use App\Models\Company;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+/**
+ * @param  array<string, mixed>  $attributes
+ */
+function seedActivity(Team $team, User $causer, array $attributes = []): Activity
+{
+    return Activity::withoutGlobalScope(TeamScope::class)->create(array_merge([
+        'log_name' => 'crm',
+        'description' => 'created',
+        'event' => 'created',
+        'subject_type' => 'company',
+        'subject_id' => Company::withoutEvents(fn (): Company => Company::factory()->create())->id,
+        'causer_type' => 'user',
+        'causer_id' => $causer->id,
+        'team_id' => $team->id,
+        'properties' => [],
+    ], $attributes));
+}
+
+mutates(Activity::class);
+
+beforeEach(function (): void {
+    $this->admin = SystemAdministrator::factory()->create();
+    $this->actingAs($this->admin, 'sysadmin');
+    Filament::setCurrentPanel('sysadmin');
+
+    $this->ownerA = User::factory()->withTeam()->create();
+    $this->teamA = $this->ownerA->currentTeam;
+    $this->ownerB = User::factory()->withTeam()->create();
+    $this->teamB = $this->ownerB->currentTeam;
+});
+
+it('shows activity across all tenants on the list page', function (): void {
+    $a = seedActivity($this->teamA, $this->ownerA, ['description' => 'created company A']);
+    $b = seedActivity($this->teamB, $this->ownerB, ['description' => 'created company B']);
+
+    livewire(ListActivities::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$a, $b]);
+});

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -11,6 +11,7 @@ use Filament\Facades\Filament;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ViewActivity;
 use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityOverviewStatsWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\Activity\ActivityVolumeChartWidget;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
 /**
@@ -163,4 +164,12 @@ it('overview stats reflect the active filter', function (): void {
     // pattern — the "Total Activities" stat's value div containing exactly "3" — would not match.
     expect(preg_match('/Total Activities.*?fi-wi-stats-overview-stat-value">\s*3\s*</s', $component->html()))
         ->toBe(1);
+});
+
+it('renders the activity volume chart', function (): void {
+    seedActivity($this->teamA, $this->ownerA);
+    seedActivity($this->teamA, $this->ownerA);
+
+    livewire(ActivityVolumeChartWidget::class)
+        ->assertOk();
 });


### PR DESCRIPTION
Adds a read-only, cross-tenant **Activity** resource to the internal SystemAdmin panel that surfaces the `activity_log` audit trail as both a forensic lookup and engagement analytics. It provides a filterable table (team, user, subject type, event, date range) and a detail view that renders per-field change diffs for create/update/delete and custom-field-change events, plus four filter-reactive header widgets — overview stats, an activity-over-time chart, and top-active teams/users — that recompute against the table's live filters via Filament's `ExposesTableToWidgets`/`InteractsWithPageTable`. Every read strips the tenant `TeamScope` so the tenant-less admin panel sees all teams, and the surface is read-only end-to-end (policy + resource deny writes). No migration, schedule, or dependency changes.

## Test plan
- 13 feature tests: cross-tenant visibility (TeamScope bypass), every filter incl. the polymorphic causer + date-range boundaries, the change-diff builder across all spatie property shapes (create/update/delete/custom-field/raw), each widget under an active filter, and a regression guard against sorting the polymorphic User column.
- Full SystemAdmin suite (73) + Arch (24) green; PHPStan 0 errors; type-coverage 100%.
- Browser-verified in light and dark: cross-tenant table, all four widgets reacting in lockstep to the Team filter, the date filter across joined charts, and the deleted/custom-field diffs rendering itemized (not raw JSON).