### PR TITLE
fix(email): send outbound attachments + P0 cleanups

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -43,7 +43,6 @@ use Spatie\MediaLibrary\InteractsWithMedia;
  * @property int $email_count
  * @property int $inbound_email_count
  * @property int $outbound_email_count
- * @property float|null $avg_response_time_hours
  * @property-read string $created_by
  */
 #[ObservedBy(CompanyObserver::class)]
@@ -145,7 +144,7 @@ final class Company extends Model implements HasCustomFields, HasMedia, HasTimel
                 'id', 'team_id', 'creator_id', 'creation_source', 'custom_fields',
                 'created_at', 'updated_at', 'deleted_at', 'account_owner_id',
                 'last_email_at', 'last_interaction_at', 'email_count', 'inbound_email_count',
-                'outbound_email_count', 'avg_response_time_hours',
+                'outbound_email_count',
             ])
             ->useLogName('crm')
             ->setDescriptionForEvent(fn (string $eventName): string => $eventName);

--- a/app/Models/People.php
+++ b/app/Models/People.php
@@ -39,7 +39,6 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property int $email_count
  * @property int $inbound_email_count
  * @property int $outbound_email_count
- * @property float|null $avg_response_time_hours
  */
 #[ObservedBy(PeopleObserver::class)]
 #[Fillable([
@@ -117,7 +116,7 @@ final class People extends Model implements HasCustomFields, HasTimeline
                 'id', 'team_id', 'creator_id', 'creation_source', 'custom_fields',
                 'created_at', 'updated_at', 'deleted_at',
                 'last_email_at', 'last_interaction_at', 'email_count', 'inbound_email_count',
-                'outbound_email_count', 'avg_response_time_hours',
+                'outbound_email_count',
             ])
             ->useLogName('crm')
             ->setDescriptionForEvent(fn (string $eventName): string => $eventName);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Sentry\Laravel\Integration;
@@ -123,6 +124,15 @@ return Application::configure(basePath: dirname(__DIR__))
         })
             ->everyFiveMinutes()
             ->name('email:incremental-sync')
+            ->withoutOverlapping();
+
+        $schedule->call(function (): void {
+            ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
+                ->whereJsonContains('capabilities->calendar', true)
+                ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalCalendarSyncJob($account)));
+        })
+            ->everyFiveMinutes()
+            ->name('calendar:incremental-sync')
             ->withoutOverlapping();
 
         $schedule->command('email:dispatch-outbox')

--- a/database/migrations/2026_03_21_055435_add_email_intelligence_to_people_and_companies.php
+++ b/database/migrations/2026_03_21_055435_add_email_intelligence_to_people_and_companies.php
@@ -17,7 +17,6 @@ return new class extends Migration
                 $table->unsignedInteger('email_count')->default(0)->after('last_interaction_at');
                 $table->unsignedInteger('inbound_email_count')->default(0)->after('email_count');
                 $table->unsignedInteger('outbound_email_count')->default(0)->after('inbound_email_count');
-                $table->float('avg_response_time_hours')->nullable()->after('outbound_email_count');
             });
         }
     }

--- a/packages/EmailIntegration/src/Actions/SendEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailAction.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -19,6 +20,7 @@ use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use RuntimeException;
@@ -41,6 +43,8 @@ final readonly class SendEmailAction
      *     batch_id?: ?string,
      *     scheduled_for?: ?DateTimeInterface,
      *     priority?: EmailPriority,
+     *     attachments?: array<int, string>,
+     *     attachment_file_names?: array<string, string>,
      * }  $data
      * @param  class-string|null  $linkToType
      */
@@ -60,7 +64,10 @@ final readonly class SendEmailAction
 
         $scheduledFor = $this->resolveScheduledFor($data, $priority);
 
-        return DB::transaction(function () use ($account, $data, $priority, $scheduledFor, $linkToType, $linkToId): Email {
+        /** @var array<int, string> $attachmentPaths */
+        $attachmentPaths = array_values($data['attachments'] ?? []);
+
+        return DB::transaction(function () use ($account, $data, $priority, $scheduledFor, $linkToType, $linkToId, $attachmentPaths): Email {
             // Scope the reply lookup to the sender's team. in_reply_to_email_id arrives
             // from a client-controlled hidden field and Email has no team global scope,
             // so an unscoped lookup would let a user thread their outbound mail onto
@@ -95,7 +102,7 @@ final readonly class SendEmailAction
                 'status' => EmailStatus::QUEUED,
                 'priority' => $priority,
                 'privacy_tier' => $data['privacy_tier'],
-                'has_attachments' => false,
+                'has_attachments' => $attachmentPaths !== [],
                 'is_internal' => false,
                 'creation_source' => $data['creation_source'],
                 'batch_id' => $data['batch_id'] ?? null,
@@ -126,6 +133,8 @@ final readonly class SendEmailAction
                 }
             }
 
+            $this->storeAttachments($email, $attachmentPaths, $data['attachment_file_names'] ?? []);
+
             if ($linkToType !== null && $linkToId !== null) {
                 DB::table('emailables')->insert([
                     'email_id' => $email->getKey(),
@@ -139,6 +148,32 @@ final readonly class SendEmailAction
 
             return $email;
         });
+    }
+
+    /**
+     * Persist compose-uploaded attachments so the send job can attach their bytes.
+     * Paths point at temporary files on the compose disk written by the FileUpload.
+     *
+     * @param  array<int, string>  $paths
+     * @param  array<string, string>  $originalNames  storage path => original client filename
+     */
+    private function storeAttachments(Email $email, array $paths, array $originalNames): void
+    {
+        $disk = Storage::disk(EmailAttachment::DISK);
+
+        foreach ($paths as $path) {
+            if (! $disk->exists($path)) {
+                continue;
+            }
+
+            EmailAttachment::query()->create([
+                'email_id' => $email->getKey(),
+                'filename' => $originalNames[$path] ?? basename($path),
+                'mime_type' => $disk->mimeType($path) ?: 'application/octet-stream',
+                'size' => $disk->size($path),
+                'storage_path' => $path,
+            ]);
+        }
     }
 
     /**

--- a/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
+++ b/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
@@ -5,17 +5,11 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration;
 
 use App\Features\EmailIntegration;
-use Illuminate\Console\Scheduling\Schedule;
-use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Console\Commands\BackfillEmailThreadsCommand;
 use Relaticle\EmailIntegration\Console\Commands\DispatchOutboxCommand;
-use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
-use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
-use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
-use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Factories\CalendarServiceFactory;
@@ -44,22 +38,9 @@ final class EmailIntegrationServiceProvider extends ServiceProvider
         // Email is already observed via #[ObservedBy(EmailObserver::class)] on the model.
         // Registering it again here fires every listener twice (double metric increments,
         // double auto-create) for any create path where participants exist at create time.
-
-        $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
-            $schedule->call(function (): void {
-                ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
-                    ->cursor()
-                    ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalEmailSyncJob($account)));
-            })->everyFiveMinutes()->name('email-incremental-sync');
-
-            $schedule->call(function (): void {
-                ConnectedAccount::query()
-                    ->where('status', EmailAccountStatus::ACTIVE)
-                    ->whereJsonContains('capabilities->calendar', true)
-                    ->cursor()
-                    ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalCalendarSyncJob($account)));
-            })->everyFiveMinutes()->name('calendar-incremental-sync');
-        });
+        //
+        // Incremental email + calendar sync are scheduled in bootstrap/app.php (all
+        // scheduled work lives there); do not re-register them here.
 
         Route::middleware('web')
             ->group(function (): void {

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -392,6 +392,7 @@ trait HasEmailComposeActions
                         ->disk('local')
                         ->directory('email-attachments')
                         ->maxSize(10240)
+                        ->storeFileNamesIn('attachment_file_names')
                         ->nullable(),
                 ]),
 
@@ -567,6 +568,8 @@ trait HasEmailComposeActions
             'batch_id' => null,
             'scheduled_for' => $scheduledFor,
             'priority' => EmailPriority::PRIORITY,
+            'attachments' => $data['attachments'] ?? [],
+            'attachment_file_names' => $data['attachment_file_names'] ?? [],
         ];
     }
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -884,6 +884,7 @@ final class EmailInboxPage extends Page
                         ->disk('local')
                         ->directory('email-attachments')
                         ->maxSize(10240)
+                        ->storeFileNamesIn('attachment_file_names')
                         ->nullable(),
                 ]),
 
@@ -1041,6 +1042,8 @@ final class EmailInboxPage extends Page
             'creation_source' => $source,
             'privacy_tier' => $this->resolvePrivacyTier($data['privacy_tier'] ?? null),
             'batch_id' => null,
+            'attachments' => $data['attachments'] ?? [],
+            'attachment_file_names' => $data['attachment_file_names'] ?? [],
         ];
     }
 

--- a/packages/EmailIntegration/src/Models/EmailAttachment.php
+++ b/packages/EmailIntegration/src/Models/EmailAttachment.php
@@ -19,6 +19,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 final class EmailAttachment extends Model
 {
     /**
+     * Filesystem disk that holds outbound attachment bytes between compose and send.
+     * Shared by the compose FileUpload, SendEmailAction (write) and EmailSendingService (read).
+     */
+    public const string DISK = 'local';
+
+    /**
      * @use HasFactory<EmailAttachmentFactory>
      */
     use HasFactory, HasUlids;

--- a/packages/EmailIntegration/src/Services/Contracts/MailServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/MailServiceInterface.php
@@ -33,6 +33,7 @@ interface MailServiceInterface
      *     in_reply_to?: string,
      *     thread_id?: string,
      *     rfc_message_id?: string,
+     *     attachments?: array<int, array{filename: string, mime_type: string, content: string}>,
      * } $data
      * @return array{provider_message_id: string, thread_id: string, rfc_message_id: string}
      */

--- a/packages/EmailIntegration/src/Services/EmailSendingService.php
+++ b/packages/EmailIntegration/src/Services/EmailSendingService.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services;
 
+use Illuminate\Support\Facades\Storage;
 use Relaticle\EmailIntegration\Actions\SyncEmailThreadAction;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
@@ -102,7 +104,38 @@ final readonly class EmailSendingService
             $payload['thread_id'] = (string) $email->thread_id;
         }
 
+        $attachments = $this->resolveAttachments($email);
+
+        if ($attachments !== []) {
+            $payload['attachments'] = $attachments;
+        }
+
         return $service->sendMessage($payload);
+    }
+
+    /**
+     * Read the stored bytes for each attachment so the provider can serialize them
+     * into the outgoing message.
+     *
+     * @return array<int, array{filename: string, mime_type: string, content: string}>
+     */
+    private function resolveAttachments(Email $email): array
+    {
+        if (! $email->has_attachments) {
+            return [];
+        }
+
+        $disk = Storage::disk(EmailAttachment::DISK);
+
+        return $email->attachments
+            ->filter(fn (EmailAttachment $attachment): bool => $attachment->storage_path !== null && $disk->exists($attachment->storage_path))
+            ->map(fn (EmailAttachment $attachment): array => [
+                'filename' => (string) $attachment->filename,
+                'mime_type' => (string) $attachment->mime_type,
+                'content' => (string) $disk->get((string) $attachment->storage_path),
+            ])
+            ->values()
+            ->all();
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -263,9 +263,13 @@ final readonly class GmailService implements MailServiceInterface
             ));
         }
 
+        $attachments = $data['attachments'] ?? [];
+
         $headers[] = 'Subject: =?UTF-8?B?'.base64_encode((string) $data['subject']).'?=';
         $headers[] = 'MIME-Version: 1.0';
-        $headers[] = 'Content-Type: multipart/alternative; boundary="boundary_relaticle"';
+        $headers[] = $attachments === []
+            ? 'Content-Type: multipart/alternative; boundary="boundary_relaticle"'
+            : 'Content-Type: multipart/mixed; boundary="mixed_relaticle"';
         $headers[] = 'Date: '.now()->toRfc2822String();
 
         // Stamp our own Message-ID so a retry can find an already-sent copy via
@@ -281,15 +285,45 @@ final readonly class GmailService implements MailServiceInterface
 
         $bodyText = $data['body_text'] ?? strip_tags($data['body_html'] ?? '');
 
-        $raw = implode("\r\n", $headers)."\r\n\r\n";
-        $raw .= "--boundary_relaticle\r\n";
-        $raw .= "Content-Type: text/plain; charset=UTF-8\r\n\r\n";
-        $raw .= $bodyText."\r\n\r\n";
-        $raw .= "--boundary_relaticle\r\n";
-        $raw .= "Content-Type: text/html; charset=UTF-8\r\n\r\n";
-        $raw .= ($data['body_html'] ?? '')."\r\n\r\n";
+        $alternative = "--boundary_relaticle\r\n"
+            ."Content-Type: text/plain; charset=UTF-8\r\n\r\n"
+            .$bodyText."\r\n\r\n"
+            ."--boundary_relaticle\r\n"
+            ."Content-Type: text/html; charset=UTF-8\r\n\r\n"
+            .($data['body_html'] ?? '')."\r\n\r\n"
+            .'--boundary_relaticle--';
 
-        return $raw.'--boundary_relaticle--';
+        if ($attachments === []) {
+            return implode("\r\n", $headers)."\r\n\r\n".$alternative;
+        }
+
+        // Attachments present: nest the alternative body inside a multipart/mixed
+        // envelope, then append each file as a base64 attachment part.
+        $raw = implode("\r\n", $headers)."\r\n\r\n";
+        $raw .= "--mixed_relaticle\r\n";
+        $raw .= "Content-Type: multipart/alternative; boundary=\"boundary_relaticle\"\r\n\r\n";
+        $raw .= $alternative."\r\n\r\n";
+
+        foreach ($attachments as $attachment) {
+            $filename = $this->sanitizeAttachmentFilename($attachment['filename']);
+
+            $raw .= "--mixed_relaticle\r\n";
+            $raw .= 'Content-Type: '.$attachment['mime_type'].'; name="'.$filename."\"\r\n";
+            $raw .= "Content-Transfer-Encoding: base64\r\n";
+            $raw .= 'Content-Disposition: attachment; filename="'.$filename."\"\r\n\r\n";
+            $raw .= chunk_split(base64_encode($attachment['content']))."\r\n";
+        }
+
+        return $raw.'--mixed_relaticle--';
+    }
+
+    /**
+     * Strip characters that could break out of the quoted filename and inject
+     * MIME headers.
+     */
+    private function sanitizeAttachmentFilename(string $filename): string
+    {
+        return str_replace(['"', '\\', "\r", "\n"], '', $filename);
     }
 
     private function formatAddress(string $name, string $email): string

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -176,6 +176,15 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             $message['internetMessageId'] = $data['rfc_message_id'];
         }
 
+        if (($data['attachments'] ?? []) !== []) {
+            $message['attachments'] = array_map(fn (array $attachment): array => [
+                '@odata.type' => '#microsoft.graph.fileAttachment',
+                'name' => $attachment['filename'],
+                'contentType' => $attachment['mime_type'],
+                'contentBytes' => base64_encode($attachment['content']),
+            ], $data['attachments']);
+        }
+
         $this->clientFactory->make($this->account)
             ->post('/me/sendMail', ['message' => $message, 'saveToSentItems' => true])
             ->throw();

--- a/tests/Feature/EmailIntegration/GmailMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/GmailMailServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use Google\Service\Gmail;
+use Google\Service\Gmail\Message;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\GmailService;
+
+mutates(GmailService::class);
+
+/**
+ * @param  Closure(Message): void  $capture
+ */
+function fakeGmail(Closure $capture): Gmail
+{
+    $messages = Mockery::mock();
+    $messages->shouldReceive('send')
+        ->once()
+        ->andReturnUsing(function (string $userId, Message $message) use ($capture): Message {
+            $capture($message);
+
+            return new Message(['id' => 'gmail-id', 'threadId' => 'gmail-thread']);
+        });
+
+    $gmail = Mockery::mock(Gmail::class);
+    $gmail->users_messages = $messages;
+
+    return $gmail;
+}
+
+function decodeRaw(Message $message): string
+{
+    return (string) base64_decode(strtr($message->getRaw(), '-_', '+/'));
+}
+
+it('wraps the body and attachment in a multipart/mixed MIME message', function (): void {
+    $account = ConnectedAccount::factory()->make([
+        'email_address' => 'sender@example.com',
+        'display_name' => 'Sender',
+    ]);
+
+    $captured = null;
+    $gmail = fakeGmail(function (Message $message) use (&$captured): void {
+        $captured = $message;
+    });
+
+    $result = (new GmailService($account, $gmail))->sendMessage([
+        'subject' => 'Quarterly report',
+        'body_html' => '<p>See attached.</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'attachments' => [[
+            'filename' => 'report.pdf',
+            'mime_type' => 'application/pdf',
+            'content' => 'RAW-PDF-BYTES',
+        ]],
+    ]);
+
+    $raw = decodeRaw($captured);
+
+    expect($result['provider_message_id'])->toBe('gmail-id')
+        ->and($raw)->toContain('Content-Type: multipart/mixed; boundary="mixed_relaticle"')
+        ->and($raw)->toContain('Content-Type: multipart/alternative; boundary="boundary_relaticle"')
+        ->and($raw)->toContain('Content-Disposition: attachment; filename="report.pdf"')
+        ->and($raw)->toContain(chunk_split(base64_encode('RAW-PDF-BYTES')));
+});
+
+it('sends a plain multipart/alternative message when there are no attachments', function (): void {
+    $account = ConnectedAccount::factory()->make([
+        'email_address' => 'sender@example.com',
+        'display_name' => 'Sender',
+    ]);
+
+    $captured = null;
+    $gmail = fakeGmail(function (Message $message) use (&$captured): void {
+        $captured = $message;
+    });
+
+    (new GmailService($account, $gmail))->sendMessage([
+        'subject' => 'No attachment',
+        'body_html' => '<p>Body</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+    ]);
+
+    $raw = decodeRaw($captured);
+
+    expect($raw)->toContain('Content-Type: multipart/alternative; boundary="boundary_relaticle"')
+        ->and($raw)->not->toContain('multipart/mixed');
+});
+
+it('strips quotes and newlines from attachment filenames to prevent header injection', function (): void {
+    $account = ConnectedAccount::factory()->make([
+        'email_address' => 'sender@example.com',
+        'display_name' => 'Sender',
+    ]);
+
+    $captured = null;
+    $gmail = fakeGmail(function (Message $message) use (&$captured): void {
+        $captured = $message;
+    });
+
+    (new GmailService($account, $gmail))->sendMessage([
+        'subject' => 'Injection attempt',
+        'body_html' => '<p>Body</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'attachments' => [[
+            'filename' => "evil\"\r\nBcc: attacker@example.com",
+            'mime_type' => 'text/plain',
+            'content' => 'x',
+        ]],
+    ]);
+
+    $raw = decodeRaw($captured);
+
+    expect($raw)->toContain('filename="evilBcc: attacker@example.com"')
+        ->and($raw)->not->toContain("\r\nBcc: attacker@example.com");
+});

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -143,3 +143,32 @@ it('POSTs to /me/sendMail and returns provider ids', function (): void {
 
     Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/sendMail'));
 });
+
+it('includes file attachments in the /me/sendMail payload', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/sendMail' => Http::response('', 202),
+    ]);
+
+    $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
+
+    $service->sendMessage([
+        'subject' => 'Hi',
+        'body_html' => '<p>Hi</p>',
+        'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'attachments' => [[
+            'filename' => 'report.pdf',
+            'mime_type' => 'application/pdf',
+            'content' => 'PDF-BYTES',
+        ]],
+    ]);
+
+    Http::assertSent(function (Request $r): bool {
+        $attachments = $r->data()['message']['attachments'] ?? [];
+
+        return $attachments !== []
+            && $attachments[0]['@odata.type'] === '#microsoft.graph.fileAttachment'
+            && $attachments[0]['name'] === 'report.pdf'
+            && $attachments[0]['contentType'] === 'application/pdf'
+            && $attachments[0]['contentBytes'] === base64_encode('PDF-BYTES');
+    });
+});

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -6,6 +6,8 @@ use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -238,4 +240,81 @@ it('throws when the user has hit the max queued limit', function (): void {
         'privacy_tier' => EmailPrivacyTier::FULL,
         'batch_id' => null,
     ]))->toThrow(RuntimeException::class, 'queued');
+});
+
+it('persists uploaded attachments and flags the email', function (): void {
+    Storage::fake('local');
+
+    $path = UploadedFile::fake()
+        ->createWithContent('quarterly-report.pdf', '%PDF-1.4 fake pdf bytes')
+        ->store('email-attachments', 'local');
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Here is the report',
+        'body_html' => '<p>See attached.</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+        'attachments' => [$path],
+        'attachment_file_names' => [$path => 'quarterly-report.pdf'],
+    ]);
+
+    $attachment = $email->attachments()->first();
+
+    expect($email->has_attachments)->toBeTrue()
+        ->and($email->attachments()->count())->toBe(1)
+        ->and($attachment->filename)->toBe('quarterly-report.pdf')
+        ->and($attachment->storage_path)->toBe($path)
+        ->and($attachment->size)->toBeGreaterThan(0)
+        ->and($attachment->mime_type)->not->toBeEmpty();
+});
+
+it('reads attachment bytes into the provider payload when sending', function (): void {
+    Storage::fake('local');
+
+    $path = UploadedFile::fake()
+        ->createWithContent('notes.txt', 'attachment body')
+        ->store('email-attachments', 'local');
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'With file',
+        'body_html' => '<p>hi</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+        'attachments' => [$path],
+        'attachment_file_names' => [$path => 'notes.txt'],
+    ]);
+
+    $captured = null;
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('sendMessage')->once()->andReturnUsing(function (array $payload) use (&$captured): array {
+        $captured = $payload;
+
+        return [
+            'provider_message_id' => 'pm',
+            'thread_id' => 'th',
+            'rfc_message_id' => $payload['rfc_message_id'] ?? '<x@example.com>',
+        ];
+    });
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    app(EmailSendingService::class)->send($email->refresh());
+
+    expect($captured['attachments'])->toHaveCount(1)
+        ->and($captured['attachments'][0]['filename'])->toBe('notes.txt')
+        ->and($captured['attachments'][0]['mime_type'])->not->toBeEmpty()
+        ->and($captured['attachments'][0]['content'])->toBe('attachment body');
 });


### PR DESCRIPTION
## Summary

P0 correctness fixes on the email/calendar integration, surfaced by the Attio comparison.

### 1. Outbound attachments were silently dropped (data loss)
The compose form exposes a `FileUpload('attachments')`, but `SendEmailAction` hardcoded `has_attachments => false` and never read or sent `$data['attachments']` — users could attach files that vanished on send. Now:
- persist `email_attachments` rows from the compose upload (original filename via `storeFileNamesIn`, mime type, size, storage path) and set `has_attachments`
- read the stored bytes at send time and serialize them into the outgoing message — **Gmail** `multipart/mixed`, **Microsoft Graph** `fileAttachment`
- sanitize attachment filenames to prevent MIME header injection
- disk name centralized on `EmailAttachment::DISK`

Both compose surfaces (`HasEmailComposeActions` and `EmailInboxPage`) are wired.

### 2. Duplicate sync scheduling
`email-incremental-sync` was registered in **both** `bootstrap/app.php` (guarded: `whereNotNull('sync_cursor')` + `withoutOverlapping`) and the service provider (unguarded). Removed the provider copy and moved `calendar-incremental-sync` into `bootstrap/app.php` so all scheduling lives in one place (per the `.ai/core` convention). `schedule:list` now shows each exactly once.

### 3. Dead column
Dropped `avg_response_time_hours` from `people`/`companies` — it was declared and added by an (unshipped) migration but never written or read anywhere. Removed from the migration and both models.

## Test plan
- `SendEmailActionTest`: attachments persisted + flagged; bytes read into the provider payload at send time
- `GmailMailServiceTest` (new): `multipart/mixed` with base64 attachment; unchanged `multipart/alternative` when no attachments; filename injection stripped
- `MicrosoftGraphMailServiceTest`: `fileAttachment` present in the `/me/sendMail` body
- Full `tests/Feature/EmailIntegration` + `tests/Feature/CalendarIntegration` green (364), Arch green (24)
- `pint` / `rector --dry-run` / `phpstan` clean; type coverage 100%
- Fresh `migrate:fresh` verified: column dropped, rollups intact

> Note: live provider send-with-attachment is covered by tests at the MIME/payload level; end-to-end verification against a real Gmail/Microsoft mailbox is pending OAuth credentials.