### PR TITLE
fix: deep-link View Task/Note actions to open the record modal

### DIFF
--- a/app/Actions/Task/NotifyTaskAssignees.php
+++ b/app/Actions/Task/NotifyTaskAssignees.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Actions\Task;
 
-use App\Filament\Resources\TaskResource\Pages\ManageTasks;
+use App\Filament\Resources\TaskResource;
 use App\Models\Task;
 use App\Models\User;
 use Filament\Actions\Action;
+use Filament\Actions\EditAction;
 use Filament\Notifications\Notification;
 use Filament\Support\Icons\Heroicon;
 
@@ -54,7 +55,10 @@ final readonly class NotifyTaskAssignees
     private function resolveTaskUrl(Task $task): string
     {
         try {
-            return ManageTasks::getUrl(['record' => $task]);
+            return TaskResource::getUrl('index', [
+                'tableAction' => EditAction::getDefaultName(),
+                'tableActionRecord' => $task,
+            ]);
         } catch (\Throwable) {
             return '#';
         }

--- a/packages/Chat/src/Support/RecordReferenceResolver.php
+++ b/packages/Chat/src/Support/RecordReferenceResolver.php
@@ -15,6 +15,7 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\Task;
 use App\Models\User;
+use Filament\Actions\EditAction;
 use Throwable;
 
 final readonly class RecordReferenceResolver
@@ -80,8 +81,14 @@ final readonly class RecordReferenceResolver
                 'company' => CompanyResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
                 'people' => PeopleResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
                 'opportunity' => OpportunityResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
-                'task' => TaskResource::getUrl('index', panel: 'app', tenant: $team),
-                'note' => NoteResource::getUrl('index', panel: 'app', tenant: $team),
+                'task' => TaskResource::getUrl('index', [
+                    'tableAction' => EditAction::getDefaultName(),
+                    'tableActionRecord' => $recordId,
+                ], panel: 'app', tenant: $team),
+                'note' => NoteResource::getUrl('index', [
+                    'tableAction' => EditAction::getDefaultName(),
+                    'tableActionRecord' => $recordId,
+                ], panel: 'app', tenant: $team),
                 default => null,
             };
         } catch (Throwable) {

--- a/tests/Feature/Chat/RecordReferenceResolverJobContextTest.php
+++ b/tests/Feature/Chat/RecordReferenceResolverJobContextTest.php
@@ -47,20 +47,24 @@ it('resolves an opportunity URL without Filament tenant bound', function (): voi
         ->and($ref['url'])->toContain('/opportunities/');
 });
 
-it('resolves task to an index URL without Filament tenant bound', function (): void {
+it('resolves task to a record edit deep-link without Filament tenant bound', function (): void {
     $ref = resolve(RecordReferenceResolver::class)->resolve('task', 'any-id');
 
     expect($ref)->not->toBeNull()
         ->and($ref['url'])->toBeString()
-        ->and($ref['url'])->toContain('/tasks');
+        ->and($ref['url'])->toContain('/tasks')
+        ->and($ref['url'])->toContain('tableAction=edit')
+        ->and($ref['url'])->toContain('tableActionRecord=any-id');
 });
 
-it('resolves note to an index URL without Filament tenant bound', function (): void {
+it('resolves note to a record edit deep-link without Filament tenant bound', function (): void {
     $ref = resolve(RecordReferenceResolver::class)->resolve('note', 'any-id');
 
     expect($ref)->not->toBeNull()
         ->and($ref['url'])->toBeString()
-        ->and($ref['url'])->toContain('/notes');
+        ->and($ref['url'])->toContain('/notes')
+        ->and($ref['url'])->toContain('tableAction=edit')
+        ->and($ref['url'])->toContain('tableActionRecord=any-id');
 });
 
 it('returns null when the user has no current team', function (): void {

--- a/tests/Feature/Filament/App/Resources/TaskResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/TaskResourceTest.php
@@ -115,6 +115,27 @@ it('can create a task', function (): void {
     ]);
 });
 
+it('notifies a newly assigned member with a deep-link that opens the task edit modal', function (): void {
+    $this->withoutDefer();
+
+    $assignee = User::factory()->create();
+    $this->team->users()->attach($assignee, ['role' => 'admin']);
+
+    livewire(ManageTasks::class)
+        ->callAction('create', data: [
+            'title' => 'Assigned Task',
+            'assignees' => [$assignee->id],
+        ])
+        ->assertHasNoActionErrors();
+
+    $task = Task::query()->where('title', 'Assigned Task')->sole();
+    $url = data_get($assignee->notifications()->sole()->data, 'actions.0.url');
+
+    expect($url)->toContain('/tasks')
+        ->and($url)->toContain('tableAction=edit')
+        ->and($url)->toContain('tableActionRecord='.$task->getKey());
+});
+
 it('can edit a task', function (): void {
     $record = Task::factory()->recycle([$this->user, $this->team])->create();
 


### PR DESCRIPTION
Task and Note are Filament simple resources (`ManageRecords`) with no record route, so the "View Task"/"View Note" links in task-assignment notifications and chat proposal cards passed `?record=<id>`, which the page ignores — opening the list instead of the record. This switches those links to Filament's documented `tableAction`/`tableActionRecord` deep-link (matching the existing dashboard `MyTasksService` pattern), so the record's edit modal opens on page load. Company/People/Opportunity were already correct via their real `view` pages and are untouched.

Added a feature test through the real `ManageTasks` create flow asserting the notification URL carries the deep-link, and strengthened the chat resolver tests for task/note. Verified in-browser that the deep-link opens the exact Task and Note edit modals; all affected tests pass with pint, phpstan, and 100% type-coverage clean.