### PR TITLE
fix: render SystemAdmin activity changes from spatie v5 attribute_changes

### DIFF
--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -187,8 +187,14 @@ final class ActivityResource extends Resource
      */
     public static function buildChangeSummary(Activity $record): array
     {
+        // Spatie activitylog v5 stores trait-logged native diffs in `attribute_changes`,
+        // while manual `activity()->withProperties()` calls (custom-field edits, etc.)
+        // use `properties`. Merge both, mirroring the timeline's ActivityLogSource.
         /** @var array<string, mixed> $properties */
-        $properties = $record->properties?->toArray() ?? [];
+        $properties = [
+            ...($record->properties?->toArray() ?? []),
+            ...($record->attribute_changes?->toArray() ?? []),
+        ];
 
         if (isset($properties['custom_field_changes']) && is_array($properties['custom_field_changes'])) {
             return collect($properties['custom_field_changes'])

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -112,6 +112,39 @@ it('renders the view page with a standard attribute diff', function (): void {
         ->assertSee('New Co');
 });
 
+it('renders the native diff stored in attribute_changes for an updated activity', function (): void {
+    $activity = seedActivity($this->teamA, $this->ownerA, [
+        'event' => 'updated',
+        'description' => 'updated',
+        'properties' => [],
+        'attribute_changes' => ['attributes' => ['name' => 'New Co'], 'old' => ['name' => 'Old Co']],
+    ]);
+
+    livewire(ViewActivity::class, [
+        'record' => $activity->getKey(),
+    ])
+        ->assertOk()
+        ->assertSee('Old Co')
+        ->assertSee('New Co')
+        ->assertDontSee('No field changes recorded');
+});
+
+it('renders the native initial values stored in attribute_changes for a created activity', function (): void {
+    $activity = seedActivity($this->teamA, $this->ownerA, [
+        'event' => 'created',
+        'description' => 'created',
+        'properties' => [],
+        'attribute_changes' => ['attributes' => ['name' => 'Fresh Co']],
+    ]);
+
+    livewire(ViewActivity::class, [
+        'record' => $activity->getKey(),
+    ])
+        ->assertOk()
+        ->assertSee('Fresh Co')
+        ->assertDontSee('No field changes recorded');
+});
+
 it('renders the view page for a custom-field-changes activity', function (): void {
     $activity = seedActivity($this->teamA, $this->ownerA, [
         'event' => 'custom_field_changes',


### PR DESCRIPTION
The SystemAdmin Activity panel rendered "No field changes recorded" for every native CRM created/updated/deleted event (e.g. `/activity/6266`). Root cause: spatie/laravel-activitylog v5 moved trait-logged native diffs into the new `attribute_changes` column, leaving only manual `withProperties()` payloads (custom-field edits, etc.) in `properties` — but `ActivityResource::buildChangeSummary()` read `properties` only. The fix merges both sources, mirroring the timeline's `ActivityLogSource::extractProperties()`. Two feature tests were added covering the real v5 shape (diff in `attribute_changes`, empty `properties`) for updated and created activities.

Note: native events also log denormalized analytics counters (`email_count`, `meeting_count`, etc.) that aren't in the models' `logExcept`, so they now surface as diff noise — a pre-existing logging-config choice that affects the app timeline identically and is left as a separate decision.