### PR TITLE
fix: remove duplicated profile and notifications settings tabs

### DIFF
--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -13,9 +13,7 @@ use App\Filament\Pages\Auth\Login;
 use App\Filament\Pages\Auth\Register;
 use App\Filament\Pages\CreateTeam;
 use App\Filament\Pages\Dashboard;
-use App\Filament\Pages\EditProfile;
 use App\Filament\Pages\EditTeam;
-use App\Filament\Pages\NotificationPreferences;
 use App\Filament\Resources\OpportunityResource;
 use App\Filament\Resources\TaskResource;
 use App\Http\Middleware\ApplyTenantScopes;
@@ -151,11 +149,6 @@ final class AppPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters')
             ->readOnlyRelationManagersOnResourceViewPagesByDefault(false)
-            ->pages([
-                EditProfile::class,
-                NotificationPreferences::class,
-                AccessTokens::class,
-            ])
             ->spa()
             ->routes(function (): void {
                 Route::get('/scheduled-deletion', ScheduledDeletionInterstitial::class)

--- a/tests/Feature/Routing/AppPanelRoutingTest.php
+++ b/tests/Feature/Routing/AppPanelRoutingTest.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Filament\Clusters\Settings;
+use App\Filament\Pages\EditProfile;
+use App\Filament\Pages\NotificationPreferences;
+use App\Providers\Filament\AppPanelProvider;
 use App\Providers\MacroServiceProvider;
 use Filament\Facades\Filament;
 
-mutates(MacroServiceProvider::class);
+mutates(MacroServiceProvider::class, AppPanelProvider::class);
 
 describe('app panel configuration - path mode (default)', function () {
     it('registers panel with path prefix and no domain constraint', function () {
@@ -19,6 +23,14 @@ describe('app panel configuration - path mode (default)', function () {
         $panelPath = config('app.app_panel_path', 'app');
 
         $this->get("/{$panelPath}/login")->assertOk();
+    });
+
+    it('registers each Settings cluster page once so sub-nav tabs are not duplicated', function () {
+        $components = Filament::getPanel('app')->getClusteredComponents(Settings::class);
+
+        expect($components)
+            ->toContain(EditProfile::class, NotificationPreferences::class)
+            ->and(array_count_values($components))->each->toBe(1);
     });
 });
 


### PR DESCRIPTION
The Settings cluster pages (`EditProfile`, `NotificationPreferences`) were registered twice — once via `discoverPages()` over `app/Filament/Pages` and again via the explicit `->pages([])` array — and Filament's `registerToCluster()` appends without deduplication, so the settings sub-navigation rendered each tab twice ("Profile · Profile · Notifications · Notifications"). This removes the redundant `->pages([])` array, since `discoverPages()` already registers all three pages (including `AccessTokens`, verified still routing). Reproduced and re-verified in the browser (tabs now render once each), and added a regression test asserting each Settings cluster page is registered exactly once — proven load-bearing (it fails if the duplicate registration returns).

## Test plan
- `php artisan test tests/Feature/Routing/AppPanelRoutingTest.php` (+ Profile / Notifications / AccessTokens suites) — 112 passing
- Browser: `/app/{tenant}/settings/profile` sub-nav shows `Profile` and `Notifications` once each