### PR TITLE
feat(sysadmin): per-user notification toggles and three panel bug fixes

### DIFF
--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -27,6 +27,10 @@ return [
             'label' => 'Task Assignments',
             'description' => 'Notify me when I\'m assigned a task.',
         ],
+        'task_digest' => [
+            'label' => 'Daily Digest',
+            'description' => 'Notify me every morning about tasks overdue and due today.',
+        ],
     ],
 
     'saved' => 'Notification preferences updated.',

--- a/packages/SystemAdmin/src/Filament/Resources/SystemAdministrators/Pages/CreateSystemAdministrator.php
+++ b/packages/SystemAdmin/src/Filament/Resources/SystemAdministrators/Pages/CreateSystemAdministrator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\SystemAdministrators\Pages;
 
-use Filament\Actions\Action;
 use Filament\Resources\Pages\CreateRecord;
 use Relaticle\SystemAdmin\Filament\Resources\SystemAdministrators\SystemAdministratorResource;
 
@@ -15,16 +14,8 @@ final class CreateSystemAdministrator extends CreateRecord
     protected function getFormActions(): array
     {
         return [
-            $this->getCreateAction(),
-            $this->getCancelAction(),
+            $this->getCreateFormAction(),
+            $this->getCancelFormAction(),
         ];
-    }
-
-    private function getCancelAction(): Action
-    {
-        return Action::make('cancel')
-            ->label('Cancel')
-            ->url($this->getResource()::getUrl('index'))
-            ->color('gray');
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/SystemAdministrators/Schemas/SystemAdministratorForm.php
+++ b/packages/SystemAdmin/src/Filament/Resources/SystemAdministrators/Schemas/SystemAdministratorForm.php
@@ -50,7 +50,7 @@ final class SystemAdministratorForm
                         TextInput::make('password')
                             ->password()
                             ->dehydrateStateUsing(fn (?string $state): ?string => in_array($state, [null, '', '0'], true) ? null : Hash::make($state))
-                            ->dehydrated(filled(...))
+                            ->dehydrated(fn (?string $state): bool => filled($state))
                             ->required(fn (Get $get): bool => ! $get('id'))
                             ->maxLength(255)
                             ->confirmed()

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources;
 
+use App\Enums\Notifications\NotificationChannel;
+use App\Enums\Notifications\NotificationType;
 use App\Enums\SubscriberTagEnum;
 use App\Models\User;
 use Filament\Actions\BulkActionGroup;
@@ -13,9 +15,11 @@ use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
@@ -72,12 +76,38 @@ final class UserResource extends Resource
                 TextInput::make('password')
                     ->password()
                     ->maxLength(255)
-                    ->dehydrated(filled(...))
+                    ->dehydrated(fn (?string $state): bool => filled($state))
                     ->required(fn (string $operation): bool => $operation === 'create'),
                 Select::make('current_team_id')
                     ->searchable()
                     ->relationship('currentTeam', 'name'),
+                Section::make('Notifications')
+                    ->description('Overrides what this user receives. Mirrors their own notification settings page.')
+                    ->schema(self::notificationPreferenceFields())
+                    ->columnSpanFull(),
             ]);
+    }
+
+    /**
+     * @return array<int, Fieldset>
+     */
+    private static function notificationPreferenceFields(): array
+    {
+        return array_map(
+            fn (NotificationType $type): Fieldset => Fieldset::make($type->label())
+                ->schema(array_map(
+                    fn (NotificationChannel $channel): Toggle => Toggle::make(
+                        "notification_preferences.{$type->value}.{$channel->value}"
+                    )
+                        ->label($channel->label())
+                        ->formatStateUsing(
+                            fn (?User $record): bool => $record?->wantsNotification($type, $channel)
+                                ?? $type->defaultEnabled($channel)
+                        ),
+                    $type->channels(),
+                )),
+            NotificationType::cases(),
+        );
     }
 
     #[Override]

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource/Pages/EditUser.php
@@ -7,7 +7,6 @@ namespace Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\EditRecord;
-use Illuminate\Support\Facades\Hash;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 
 final class EditUser extends EditRecord
@@ -20,16 +19,5 @@ final class EditUser extends EditRecord
             ViewAction::make(),
             DeleteAction::make(),
         ];
-    }
-
-    protected function mutateFormDataBeforeSave(array $data): array
-    {
-        if (filled($data['password'])) {
-            $data['password'] = Hash::make($data['password']);
-        } else {
-            unset($data['password']);
-        }
-
-        return $data;
     }
 }

--- a/tests/Feature/SystemAdmin/SystemAdministratorResourceTest.php
+++ b/tests/Feature/SystemAdmin/SystemAdministratorResourceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
+use Relaticle\SystemAdmin\Filament\Resources\SystemAdministrators\Pages\CreateSystemAdministrator;
+use Relaticle\SystemAdmin\Filament\Resources\SystemAdministrators\Pages\EditSystemAdministrator;
+use Relaticle\SystemAdmin\Filament\Resources\SystemAdministrators\SystemAdministratorResource;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+mutates(SystemAdministratorResource::class);
+
+beforeEach(function (): void {
+    $this->actingAs(
+        SystemAdministrator::factory()->create(['role' => SystemAdministratorRole::SuperAdministrator]),
+        'sysadmin',
+    );
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+});
+
+it('renders the create page', function (): void {
+    livewire(CreateSystemAdministrator::class)->assertOk();
+});
+
+it('creates an administrator who can authenticate with the given password', function (): void {
+    livewire(CreateSystemAdministrator::class)
+        ->fillForm([
+            'name' => 'New Admin',
+            'email' => 'new-admin@example.test',
+            'role' => SystemAdministratorRole::SuperAdministrator->value,
+            'password' => 'creation-password',
+            'password_confirmation' => 'creation-password',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $created = SystemAdministrator::query()->where('email', 'new-admin@example.test')->firstOrFail();
+
+    expect($created->password)->not->toBe('creation-password')
+        ->and(Auth::guard('sysadmin')->attempt([
+            'email' => 'new-admin@example.test',
+            'password' => 'creation-password',
+        ]))->toBeTrue();
+});
+
+it('changes an administrator password', function (): void {
+    $target = SystemAdministrator::factory()->create();
+
+    livewire(EditSystemAdministrator::class, ['record' => $target->getKey()])
+        ->fillForm([
+            'password' => 'rotated-password',
+            'password_confirmation' => 'rotated-password',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(Auth::guard('sysadmin')->attempt([
+        'email' => $target->email,
+        'password' => 'rotated-password',
+    ]))->toBeTrue();
+});
+
+it('keeps the existing password when the field is left blank', function (): void {
+    $target = SystemAdministrator::factory()->create(['password' => 'original-password']);
+
+    livewire(EditSystemAdministrator::class, ['record' => $target->getKey()])
+        ->fillForm(['name' => 'Renamed Admin'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($target->fresh()->name)->toBe('Renamed Admin')
+        ->and(Auth::guard('sysadmin')->attempt([
+            'email' => $target->email,
+            'password' => 'original-password',
+        ]))->toBeTrue();
+});

--- a/tests/Feature/SystemAdmin/UserResourceTest.php
+++ b/tests/Feature/SystemAdmin/UserResourceTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Notifications\NotificationChannel;
+use App\Enums\Notifications\NotificationType;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\CreateUser;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\EditUser;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+mutates(UserResource::class);
+
+beforeEach(function (): void {
+    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+});
+
+it('saves a user without touching the password when the field is left blank', function (): void {
+    $user = User::factory()->create();
+    $originalPassword = $user->password;
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->fillForm(['name' => 'Renamed'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $user->refresh();
+
+    expect($user->name)->toBe('Renamed')
+        ->and($user->password)->toBe($originalPassword);
+});
+
+it('hashes a new password when one is entered', function (): void {
+    $user = User::factory()->create();
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->fillForm(['password' => 'new-password'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $user->refresh();
+
+    expect($user->password)->not->toBe('new-password')
+        ->and(Hash::check('new-password', $user->password))->toBeTrue();
+});
+
+it('lets the user authenticate with a password set by a sysadmin', function (): void {
+    $user = User::factory()->create();
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->fillForm(['password' => 'admin-set-password'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(Auth::guard('web')->attempt([
+        'email' => $user->email,
+        'password' => 'admin-set-password',
+    ]))->toBeTrue();
+});
+
+it('keeps the old password working when the field is left blank', function (): void {
+    $user = User::factory()->create(['password' => 'original-password']);
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->fillForm(['name' => 'Renamed'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(Auth::guard('web')->attempt([
+        'email' => $user->email,
+        'password' => 'original-password',
+    ]))->toBeTrue();
+});
+
+it('lets a sysadmin-created user authenticate with the password given at creation', function (): void {
+    livewire(CreateUser::class)
+        ->fillForm([
+            'name' => 'Created By Admin',
+            'email' => 'created-by-admin@example.test',
+            'password' => 'creation-password',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $created = User::query()->where('email', 'created-by-admin@example.test')->firstOrFail();
+
+    expect($created->password)->not->toBe('creation-password')
+        ->and(Auth::guard('web')->attempt([
+            'email' => 'created-by-admin@example.test',
+            'password' => 'creation-password',
+        ]))->toBeTrue();
+});
+
+it('exposes a notification toggle for every type and channel', function (): void {
+    $user = User::factory()->create();
+
+    $component = livewire(EditUser::class, ['record' => $user->getKey()]);
+
+    foreach (NotificationType::cases() as $type) {
+        foreach ($type->channels() as $channel) {
+            $component->assertFormFieldExists("notification_preferences.{$type->value}.{$channel->value}");
+        }
+    }
+});
+
+it('hydrates notification toggles from the enum defaults', function (): void {
+    $user = User::factory()->create(['notification_preferences' => null]);
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->assertFormSet([
+            'notification_preferences' => [
+                'task_assigned' => ['in_app' => true, 'email' => false],
+                'task_digest' => ['email' => true],
+            ],
+        ]);
+});
+
+it('disables notifications for a single user', function (): void {
+    $user = User::factory()->create(['notification_preferences' => null]);
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->fillForm([
+            'notification_preferences' => [
+                'task_assigned' => ['in_app' => false, 'email' => false],
+                'task_digest' => ['email' => false],
+            ],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $user->refresh();
+
+    expect($user->wantsNotification(NotificationType::TaskAssigned, NotificationChannel::InApp))->toBeFalse()
+        ->and($user->wantsNotification(NotificationType::TaskAssigned, NotificationChannel::Email))->toBeFalse()
+        ->and($user->wantsNotification(NotificationType::TaskDigest, NotificationChannel::Email))->toBeFalse();
+});
+
+it('leaves other users untouched when one user is muted', function (): void {
+    $muted = User::factory()->create(['notification_preferences' => null]);
+    $other = User::factory()->create(['notification_preferences' => null]);
+
+    livewire(EditUser::class, ['record' => $muted->getKey()])
+        ->fillForm([
+            'notification_preferences' => [
+                'task_assigned' => ['in_app' => false, 'email' => false],
+                'task_digest' => ['email' => false],
+            ],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($other->fresh()->wantsNotification(NotificationType::TaskAssigned, NotificationChannel::InApp))->toBeTrue()
+        ->and($other->fresh()->wantsNotification(NotificationType::TaskDigest, NotificationChannel::Email))->toBeTrue();
+});


### PR DESCRIPTION
Adds a Notifications section to the sysadmin user form so an admin can turn a specific user's notifications on or off per type and channel; the toggles are generated from `NotificationType::cases()`, hydrate from that user's overrides with the enum defaults as fallback, and write the same `users.notification_preferences` map the self-service settings page uses, so the existing gates in `NotifyTaskAssignees` and `SendTaskDigestCommand` apply unchanged.

While building it I found and fixed three pre-existing bugs: saving any user from the sysadmin panel crashed with `Undefined array key "password"`, and the password field on both the user and the system administrator forms silently discarded every change — the latter two caused by `->dehydrated(filled(...))`, whose closure parameter Filament cannot resolve by name, leaving the condition permanently false. The create system administrator page also fataled on render because it called `getCreateAction()` instead of Filament v5's `getCreateFormAction()`, so no administrator could be created from the panel at all.

Also adds the missing `task_digest` translation keys so `NotificationType::label()` resolves for every enum case.

## Verification

- 13 new tests across `UserResourceTest` and `SystemAdministratorResourceTest`, written test-first; full suite 2398 passing
- pint, rector, phpstan (0 errors), type coverage 100%, arch suite passing
- Browser-walked both panels: toggles render in light and dark and persist in both directions; a password set through the panel authenticates on login while the old one is rejected; the create administrator page renders and produces an admin who can sign in