### PR TITLE
fix(security): gate Horizon on a configured allowlist, not a hardcoded email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ SAIL_FILES=compose.dev.yml
 # SYSADMIN_DOMAIN=sysadmin.example.com
 SYSADMIN_PATH=sysadmin
 
+# Horizon Dashboard Access
+# Comma-separated emails allowed to open Horizon outside the local environment.
+# Leave empty to deny everyone.
+# HORIZON_ADMIN_EMAILS=ops@example.com,admin@example.com
+
 # Application Panel Configuration
 # By default, the CRM panel is served at /app (path-based routing)
 # For subdomain routing, set APP_PANEL_DOMAIN (e.g., app.example.com)

--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -28,9 +28,24 @@ final class HorizonServiceProvider extends HorizonApplicationServiceProvider
      * Register the Horizon gate.
      *
      * This gate determines who can access Horizon in non-local environments.
+     * The allowlist comes from HORIZON_ADMIN_EMAILS and defaults to empty, so
+     * a deployment that has not opted anyone in denies everyone.
      */
     protected function gate(): void
     {
-        Gate::define('viewHorizon', fn (User $user): bool => $user->email === 'manuk.minasyan1@gmail.com');
+        Gate::define('viewHorizon', function (User $user): bool {
+            /** @var array<int, string> $adminEmails */
+            $adminEmails = config('relaticle.horizon.admin_emails', []);
+
+            if ($adminEmails === []) {
+                return false;
+            }
+
+            return in_array(
+                mb_strtolower($user->email),
+                array_map(mb_strtolower(...), $adminEmails),
+                strict: true,
+            );
+        });
     }
 }

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -29,6 +29,24 @@ return [
         'reminder_days_before' => 5,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Horizon Access
+    |--------------------------------------------------------------------------
+    |
+    | Comma-separated list of email addresses allowed to open the Horizon
+    | dashboard outside the local environment. Empty denies everyone, so a
+    | deployment that never sets this exposes nothing.
+    |
+    */
+
+    'horizon' => [
+        'admin_emails' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('HORIZON_ADMIN_EMAILS', '')),
+        ))),
+    ],
+
     'features' => [
         'onboard_seed' => (bool) env('RELATICLE_FEATURE_ONBOARD_SEED', true),
         'social_auth' => (bool) env('RELATICLE_FEATURE_SOCIAL_AUTH', true),

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -42,7 +42,7 @@ return [
 
     'horizon' => [
         'admin_emails' => array_values(array_filter(array_map(
-            'trim',
+            trim(...),
             explode(',', (string) env('HORIZON_ADMIN_EMAILS', '')),
         ))),
     ],

--- a/tests/Feature/HorizonGateTest.php
+++ b/tests/Feature/HorizonGateTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+it('denies every user when no administrator emails are configured', function (): void {
+    config()->set('relaticle.horizon.admin_emails', []);
+
+    $user = User::factory()->create(['email' => 'someone@example.com']);
+
+    expect(Gate::forUser($user)->allows('viewHorizon'))->toBeFalse();
+});
+
+it('allows a user whose email is configured', function (): void {
+    config()->set('relaticle.horizon.admin_emails', ['ops@self-hosted.test']);
+
+    $user = User::factory()->create(['email' => 'ops@self-hosted.test']);
+
+    expect(Gate::forUser($user)->allows('viewHorizon'))->toBeTrue();
+});
+
+it('denies a user whose email is not configured', function (): void {
+    config()->set('relaticle.horizon.admin_emails', ['ops@self-hosted.test']);
+
+    $user = User::factory()->create(['email' => 'attacker@example.com']);
+
+    expect(Gate::forUser($user)->allows('viewHorizon'))->toBeFalse();
+});
+
+it('does not grant access to any hardcoded upstream address', function (): void {
+    config()->set('relaticle.horizon.admin_emails', ['ops@self-hosted.test']);
+
+    $user = User::factory()->create(['email' => 'manuk.minasyan1@gmail.com']);
+
+    expect(Gate::forUser($user)->allows('viewHorizon'))->toBeFalse();
+});
+
+it('matches configured emails case-insensitively', function (): void {
+    config()->set('relaticle.horizon.admin_emails', ['Ops@Self-Hosted.test']);
+
+    $user = User::factory()->create(['email' => 'ops@self-hosted.test']);
+
+    expect(Gate::forUser($user)->allows('viewHorizon'))->toBeTrue();
+});


### PR DESCRIPTION
## What

The Horizon gate resolved to a single hardcoded address, so the allowlist could not be configured per deployment and self-hosters had no supported way to grant themselves access.

```php
// before
Gate::define('viewHorizon', fn (User $user): bool => $user->email === '<hardcoded address>');
```

## Change

`config/relaticle.php` gains a `horizon.admin_emails` key, populated from a comma-separated `HORIZON_ADMIN_EMAILS`. The gate reads that allowlist, matches case-insensitively, and **fails closed** — an empty allowlist denies everyone, so a deployment that has not opted anyone in grants nothing.

`.env.example` documents the variable.

## Tests

`tests/Feature/HorizonGateTest.php` pins five behaviours:

- empty allowlist denies everyone
- a configured address is allowed
- an unconfigured address is denied
- no address is granted access unless present in the configured allowlist
- matching is case-insensitive

Written before the change and run against the old gate first: **3 of 5 failed.** All 5 pass after.

## Verification

- `pest tests/Feature/HorizonGateTest.php` — 5/5
- `pest tests/Arch tests/Feature/HorizonGateTest.php tests/Feature/FeatureFlagsTest.php` — 37/37, 124 assertions
- `pint --test` — clean
- `phpstan analyse` on changed files — 0 errors

## Deployment note

Existing deployments must set `HORIZON_ADMIN_EMAILS` or Horizon access will be denied to everyone. That is the intended default.