### PR TITLE
fix(mcp): render the OAuth consent screen with real design tokens

### DIFF
--- a/lang/en/mcp.php
+++ b/lang/en/mcp.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'consent' => [
+        'title' => 'Authorize :client',
+        'intro' => ':client is asking to connect to your Relaticle workspace.',
+        'signed_in_as' => 'Signed in as',
+
+        'workspace' => [
+            'heading' => 'Which workspace?',
+            'description' => ':client will only see data from the workspace you choose. To use a different one later, revoke this connector on the Access Tokens page in Relaticle and add it again.',
+            'aria_label' => 'Workspace selection',
+            'personal' => 'Personal',
+            'paused' => 'Paused — subscribe to connect',
+            'all_paused' => 'Every workspace on this account is paused. Subscribe to Cloud Pro before connecting — a connector authorized against a paused workspace cannot read or write any data.',
+            'none' => [
+                'heading' => 'You do not belong to any workspaces.',
+                'description' => 'Create or join a workspace in Relaticle before authorizing this connector.',
+            ],
+        ],
+
+        'permissions' => [
+            'heading' => 'What it will be able to do',
+            'description' => 'In the workspace above, and nowhere else.',
+            'read' => [
+                'title' => 'Read and search your records',
+                'description' => 'Companies, people, opportunities, tasks and notes.',
+            ],
+            'write' => [
+                'title' => 'Create and update them',
+                'description' => 'Add records, change fields, and link notes and tasks to them.',
+            ],
+            'delete' => [
+                'title' => 'Delete them',
+                'description' => 'Removing a record is permanent.',
+            ],
+            'excluded' => 'It cannot reach your other workspaces, team members, billing, or account settings.',
+        ],
+
+        'actions' => [
+            'cancel' => 'Cancel',
+            'authorize' => 'Authorize',
+            'authorizing' => 'Authorizing...',
+        ],
+
+        'revoke_hint' => 'You can revoke this connector at any time from the Access Tokens page in Relaticle.',
+    ],
+];

--- a/resources/views/mcp/authorize.blade.php
+++ b/resources/views/mcp/authorize.blade.php
@@ -21,15 +21,17 @@
 
     <style>
         html {
-            background-color: oklch(1 0 0);
+            background-color: oklch(0.985 0.002 247.839); /* gray-50 */
+            color-scheme: light;
         }
 
         html.dark {
-            background-color: oklch(0.145 0 0);
+            background-color: oklch(0.13 0.028 261.692); /* gray-950 */
+            color-scheme: dark;
         }
     </style>
 
-    <title>Authorize Application - {{ config('app.name', 'MCP Server') }}</title>
+    <title>{{ __('mcp.consent.title', ['client' => $client->name]) }} - {{ config('app.name', 'MCP Server') }}</title>
 
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -38,55 +40,49 @@
     <meta name="apple-mobile-web-app-title" content="Authorize MCP" />
     <link rel="manifest" href="/site.webmanifest" />
 
-    <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
-
     @vite(['resources/css/app.css'])
 </head>
-<body class="font-sans antialiased bg-background text-foreground">
-<div class="min-h-screen flex items-center justify-center p-4">
+<body class="font-sans antialiased bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+<div class="min-h-screen flex items-center justify-center p-4 sm:p-6">
     <div class="w-full max-w-md">
-        <!-- Card Container -->
-        <div class="rounded-lg border bg-card text-card-foreground shadow-sm">
+        <div class="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
             <!-- Header -->
-            <div class="flex flex-col space-y-1.5 p-6">
-                <div class="flex items-center justify-center mb-4">
-                    <!-- Shield Icon -->
-                    <svg class="h-12 w-12 text-primary" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.618 5.984A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.031 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
-                    </svg>
+            <div class="flex flex-col items-center gap-4 px-6 pt-8 pb-6 text-center">
+                <x-brand.logo-lockup size="md" class="text-gray-900 dark:text-white" />
+
+                <div class="space-y-1.5">
+                    <h1 class="text-xl font-semibold tracking-tight text-gray-900 dark:text-white">
+                        {{ __('mcp.consent.title', ['client' => $client->name]) }}
+                    </h1>
+
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ __('mcp.consent.intro', ['client' => $client->name]) }}
+                    </p>
                 </div>
-
-                <h3 class="text-2xl font-semibold leading-none tracking-tight text-center">
-                    Authorize {{ $client->name }}
-                </h3>
-
-                <p class="text-sm text-muted-foreground text-center">
-                    This application will be able to:<br/>Use available MCP functionality.
-                </p>
             </div>
 
-            <!-- Content -->
-            <div class="p-6 pt-0 space-y-4">
+            <div class="space-y-6 border-t border-gray-200 px-6 py-6 dark:border-gray-800">
                 <!-- User Info -->
-                <div class="rounded-lg border p-4 bg-muted/50">
-                    <p class="text-sm text-muted-foreground mb-2">Logged in as:</p>
-                    <p class="font-medium">{{ $user->email }}</p>
+                <div class="flex flex-col gap-0.5 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-3 dark:border-gray-800 dark:bg-gray-800/40">
+                    <span class="shrink-0 text-sm text-gray-500 dark:text-gray-400">{{ __('mcp.consent.signed_in_as') }}</span>
+                    <span class="text-sm font-medium break-all text-gray-900 dark:text-white">{{ $user->email }}</span>
                 </div>
 
-                <!-- Team Picker -->
+                <!-- Workspace Picker -->
                 @if($teams->count() > 0)
-                    <div class="space-y-2">
-                        <p class="text-sm font-medium">Connect to which team?</p>
-                        <p class="text-xs text-muted-foreground">This connector will only see data from the team you choose. To use a different team later, revoke the connector on your Access Tokens page and add it again.</p>
+                    <div>
+                        <h2 class="text-sm font-semibold text-gray-900 dark:text-white">{{ __('mcp.consent.workspace.heading') }}</h2>
+                        <p class="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                            {{ __('mcp.consent.workspace.description', ['client' => $client->name]) }}
+                        </p>
 
-                        <div class="space-y-2 mt-2" role="radiogroup" aria-label="Team selection">
+                        <div class="mt-3 space-y-2" role="radiogroup" aria-label="{{ __('mcp.consent.workspace.aria_label') }}">
                             @foreach($teams as $team)
                                 @php($isPaused = in_array($team->getKey(), $pausedTeamIds, true))
                                 <label @class([
-                                    'flex items-center gap-3 rounded-md border p-3',
-                                    'cursor-pointer hover:bg-muted/50' => ! $isPaused,
-                                    'opacity-60 cursor-not-allowed bg-muted/30' => $isPaused,
+                                    'flex flex-wrap items-center gap-x-3 gap-y-1 rounded-xl border px-4 py-3 transition-colors',
+                                    'cursor-pointer border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50 has-[:checked]:border-primary has-[:checked]:bg-primary-50 dark:border-gray-800 dark:bg-gray-900 dark:hover:border-gray-700 dark:hover:bg-gray-800/50 dark:has-[:checked]:border-primary-400 dark:has-[:checked]:bg-primary-950/50' => ! $isPaused,
+                                    'cursor-not-allowed border-gray-200 bg-gray-50 opacity-60 dark:border-gray-800 dark:bg-gray-800/30' => $isPaused,
                                 ])>
                                     <input
                                         type="radio"
@@ -96,52 +92,87 @@
                                         required
                                         @disabled($isPaused)
                                         @checked($team->getKey() === $selectedTeamId)
-                                        class="h-4 w-4"
+                                        class="size-4 shrink-0 accent-primary"
                                     >
-                                    <span class="text-sm font-medium">{{ $team->name }}</span>
+                                    <span class="min-w-0 flex-1 text-sm font-medium break-words text-gray-900 dark:text-white">{{ $team->name }}</span>
+                                    {{-- The card is narrower than the `sm` breakpoint, so these badges sit
+                                         inline on desktop and drop to their own line on a phone rather than
+                                         squeezing the workspace name into one word per line. --}}
                                     @if($isPaused)
-                                        <span class="text-xs text-destructive ml-auto whitespace-nowrap">Paused — subscribe to connect</span>
+                                        <span class="w-full pl-7 text-xs font-medium text-red-600 sm:w-auto sm:pl-0 sm:text-right dark:text-red-400">{{ __('mcp.consent.workspace.paused') }}</span>
                                     @elseif($team->personal_team)
-                                        <span class="text-xs text-muted-foreground ml-auto">Personal</span>
+                                        <span class="w-full pl-7 text-xs text-gray-500 sm:w-auto sm:pl-0 sm:text-right dark:text-gray-400">{{ __('mcp.consent.workspace.personal') }}</span>
                                     @endif
                                 </label>
                             @endforeach
                         </div>
 
                         @if($teams->count() === count($pausedTeamIds))
-                            <p class="text-xs text-destructive mt-2">Every workspace on this account is paused. Subscribe to Cloud Pro before connecting — a connector authorized against a paused workspace cannot read or write any data.</p>
+                            <p class="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs leading-relaxed text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+                                {{ __('mcp.consent.workspace.all_paused') }}
+                            </p>
                         @endif
                     </div>
-                @else
-                    <div class="rounded-lg border border-destructive/50 p-4 bg-destructive/10">
-                        <p class="text-sm font-medium">You don't belong to any teams.</p>
-                        <p class="text-xs text-muted-foreground mt-1">Create or join a team in Relaticle before authorizing this connector.</p>
-                    </div>
-                @endif
 
-                <!-- Scopes / Permissions -->
-                @if(count($scopes) > 0)
-                    <div class="space-y-2">
-                        <p class="text-sm font-medium">Permissions:</p>
+                    <!-- Permissions -->
+                    <div>
+                        <h2 class="text-sm font-semibold text-gray-900 dark:text-white">{{ __('mcp.consent.permissions.heading') }}</h2>
+                        <p class="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                            {{ __('mcp.consent.permissions.description') }}
+                        </p>
 
-                        <ul class="space-y-2">
-                            @foreach($scopes as $scope)
-                                <li class="flex items-start gap-2">
-                                    <div class="rounded-full bg-primary/10 p-1 mt-0.5">
-                                        <div class="h-1.5 w-1.5 rounded-full bg-primary"></div>
-                                    </div>
-                                    <span class="text-sm text-muted-foreground">
-                                        {{ $scope->description }}
-                                    </span>
-                                </li>
-                            @endforeach
+                        <ul class="mt-3 space-y-3">
+                            <li class="flex items-start gap-3">
+                                <span class="mt-px flex size-6 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                                    <svg class="size-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35M17 11a6 6 0 1 1-12 0 6 6 0 0 1 12 0Z"/>
+                                    </svg>
+                                </span>
+                                <span class="min-w-0">
+                                    <span class="block text-sm font-medium text-gray-900 dark:text-white">{{ __('mcp.consent.permissions.read.title') }}</span>
+                                    <span class="mt-0.5 block text-xs leading-relaxed text-gray-500 dark:text-gray-400">{{ __('mcp.consent.permissions.read.description') }}</span>
+                                </span>
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <span class="mt-px flex size-6 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                                    <svg class="size-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.86 4.49a2.1 2.1 0 1 1 2.97 2.97L8.4 18.9l-3.9.98.98-3.9L16.86 4.49Z"/>
+                                    </svg>
+                                </span>
+                                <span class="min-w-0">
+                                    <span class="block text-sm font-medium text-gray-900 dark:text-white">{{ __('mcp.consent.permissions.write.title') }}</span>
+                                    <span class="mt-0.5 block text-xs leading-relaxed text-gray-500 dark:text-gray-400">{{ __('mcp.consent.permissions.write.description') }}</span>
+                                </span>
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <span class="mt-px flex size-6 shrink-0 items-center justify-center rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-950/60 dark:text-amber-400">
+                                    <svg class="size-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16M10 11v6M14 11v6M6 7l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+                                    </svg>
+                                </span>
+                                <span class="min-w-0">
+                                    <span class="block text-sm font-medium text-gray-900 dark:text-white">{{ __('mcp.consent.permissions.delete.title') }}</span>
+                                    <span class="mt-0.5 block text-xs leading-relaxed text-gray-500 dark:text-gray-400">{{ __('mcp.consent.permissions.delete.description') }}</span>
+                                </span>
+                            </li>
                         </ul>
+
+                        <p class="mt-4 rounded-lg bg-gray-50 px-3 py-2 text-xs leading-relaxed text-gray-500 dark:bg-gray-800/40 dark:text-gray-400">
+                            {{ __('mcp.consent.permissions.excluded') }}
+                        </p>
+                    </div>
+                @else
+                    <div class="rounded-xl border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/40">
+                        <p class="text-sm font-medium text-red-800 dark:text-red-200">{{ __('mcp.consent.workspace.none.heading') }}</p>
+                        <p class="mt-1 text-xs leading-relaxed text-red-700 dark:text-red-300">
+                            {{ __('mcp.consent.workspace.none.description') }}
+                        </p>
                     </div>
                 @endif
             </div>
 
             <!-- Footer With Buttons -->
-            <div class="flex items-center p-6 pt-0 gap-3">
+            <div class="flex items-center gap-3 border-t border-gray-200 px-6 py-4 dark:border-gray-800">
                 <!-- Deny Form -->
                 <form method="POST" action="{{ route('passport.authorizations.deny') }}" class="flex-1">
                     @csrf
@@ -149,11 +180,11 @@
                     <input type="hidden" name="state" value="{{ $request->state }}">
                     <input type="hidden" name="client_id" value="{{ $client->id }}">
                     <input type="hidden" name="auth_token" value="{{ $authToken }}">
-                    <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full">
-                        <svg class="mr-2 h-4 w-4" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <button type="submit" class="inline-flex h-10 w-full items-center justify-center gap-2 whitespace-nowrap rounded-lg border border-gray-300 bg-white px-4 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800">
+                        <svg class="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>
-                        Cancel
+                        {{ __('mcp.consent.actions.cancel') }}
                     </button>
                 </form>
 
@@ -163,17 +194,21 @@
                     <input type="hidden" name="state" value="{{ $request->state }}">
                     <input type="hidden" name="client_id" value="{{ $client->id }}">
                     <input type="hidden" name="auth_token" value="{{ $authToken }}">
-                    <button type="submit" @disabled($teams->count() === 0 || $teams->count() === count($pausedTeamIds)) class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 w-full" id="authorizeButton">
-                        <span id="authorizeText">Authorize</span>
-
-                        <svg id="loadingSpinner" class="animate-spin -ml-1 mr-3 h-4 w-4 text-white hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <button type="submit" @disabled($teams->count() === 0 || $teams->count() === count($pausedTeamIds)) class="inline-flex h-10 w-full items-center justify-center gap-2 whitespace-nowrap rounded-lg bg-primary px-4 text-sm font-medium text-white transition-colors hover:bg-primary-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:pointer-events-none disabled:opacity-50" id="authorizeButton">
+                        <svg id="loadingSpinner" class="hidden size-4 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                         </svg>
+
+                        <span id="authorizeText">{{ __('mcp.consent.actions.authorize') }}</span>
                     </button>
                 </form>
             </div>
         </div>
+
+        <p class="mt-4 text-center text-xs text-gray-500 dark:text-gray-400">
+            {{ __('mcp.consent.revoke_hint') }}
+        </p>
     </div>
 </div>
 
@@ -187,7 +222,7 @@
         form.addEventListener('submit', function(e) {
             // Show loading state...
             button.disabled = true;
-            authorizeText.textContent = 'Authorizing...';
+            authorizeText.textContent = @js(__('mcp.consent.actions.authorizing'));
             loadingSpinner.classList.remove('hidden');
 
             // After form submission, watch for redirect and close window...

--- a/tests/Feature/Mcp/OAuthTeamPickerTest.php
+++ b/tests/Feature/Mcp/OAuthTeamPickerTest.php
@@ -71,6 +71,18 @@ it('renders the consent view with the user\'s teams', function (): void {
     $response->assertSee('name="team_id"', false);
 });
 
+it('spells out what the connector will be able to do, including deletion', function (): void {
+    $this->actingAs($this->user);
+
+    $response = $this->get(authorizeUrl($this->client));
+
+    $response->assertOk();
+    $response->assertSee('Read and search your records');
+    $response->assertSee('Create and update them');
+    $response->assertSee('Delete them');
+    $response->assertSee('Companies, people, opportunities, tasks and notes.');
+});
+
 it('rejects the approve POST without a team_id', function (): void {
     $this->actingAs($this->user);
 


### PR DESCRIPTION
`resources/views/mcp/authorize.blade.php` was published verbatim from `vendor/laravel/mcp`, which is written for the Laravel starter kits' shadcn token set — but `resources/css/theme.css` defines only `--color-primary-*`, and Tailwind v4 emits nothing for undefined theme keys, so `bg-card`, `text-muted-foreground`, `border-input`, `text-destructive`, `text-primary-foreground` and `ring-ring` were all dead classes (0 hits in the built bundle). The visible fallout: dark mode was black text on a near-black page, the Authorize label rendered black on purple-600 (~3.7:1, failing WCAG AA), the paused-workspace and no-workspace warnings lost their red, borders fell back to `currentColor`, there were no focus rings, and the header shield rendered as a black blob for want of `fill="none"`. This ports the view onto the tokens the app actually defines, adds the Relaticle logo, replaces the vendor placeholder "Use available MCP functionality" with the abilities a connector actually receives (read/search, create/update, and delete called out separately since it is permanent, plus what it cannot reach), fixes the email and long workspace names overflowing on mobile, drops an unused Instrument Sans web font, and moves the copy into `lang/en/mcp.php`. No behaviour change — the grant is unchanged and still full access.

## Test plan

- `php artisan test tests/Feature/Mcp` — 204/204 pass, including a new test asserting the ability list renders. (The failures on a first run were pre-existing missing local Passport keys, confirmed identical with the branch stashed.)
- Pint, Rector, PHPStan (0 errors), type coverage 100%, `tests/Arch` 24/24.
- Browser-verified on a local Herd site in light, dark (`prefers-color-scheme: dark`), and 390px mobile; both flows clicked through end to end — Authorize redirects with `code=` and the auth code carries the right `team_id`, Cancel redirects with `error=access_denied`.