### PR TITLE
fix(mcp): keep the root info banner off oauth discovery probes

### DIFF
--- a/app/Http/Middleware/SubdomainRootResponse.php
+++ b/app/Http/Middleware/SubdomainRootResponse.php
@@ -13,7 +13,7 @@ final readonly class SubdomainRootResponse
 {
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->path() !== '/' || ! $this->isRootVisit($request)) {
+        if ($request->path() !== '/' || ! $request->isMethod('GET')) {
             return $next($request);
         }
 
@@ -27,7 +27,7 @@ final readonly class SubdomainRootResponse
             ]);
         }
 
-        if ($host === config('app.mcp_domain')) {
+        if ($host === config('app.mcp_domain') && $this->isBrowserNavigation($request)) {
             return new JsonResponse([
                 'name' => 'Relaticle MCP Server',
                 'version' => '1.0.0',
@@ -39,20 +39,21 @@ final readonly class SubdomainRootResponse
     }
 
     /**
-     * Whether this is someone landing on the subdomain root rather than a
-     * protocol client talking to a server mounted there.
+     * Whether this is a person opening the URL in a browser rather than a
+     * client speaking a protocol to the server mounted there.
      *
-     * When MCP_DOMAIN is set the MCP server is mounted at the subdomain root
-     * and speaks over POST (JSON-RPC), GET (SSE stream), and DELETE (session
-     * teardown). Answering any of those with the static info payload would
-     * make the endpoint unreachable, so only a plain GET gets the banner.
+     * When MCP_DOMAIN is set the MCP server is mounted at the subdomain root,
+     * which is also its OAuth protected resource identifier. RFC 9728 clients
+     * open discovery by GETting that URL and read any 200 as "this URL is the
+     * protected resource metadata document", so answering a probe with the
+     * info payload aborts the login with "metadata missing required resource
+     * field" before the /.well-known fallback is ever tried. Sec-Fetch-Mode is
+     * sent by browsers on top level navigations and by no HTTP client library,
+     * which keeps the banner off every machine code path.
      */
-    private function isRootVisit(Request $request): bool
+    private function isBrowserNavigation(Request $request): bool
     {
-        if (! $request->isMethod('GET')) {
-            return false;
-        }
-
-        return ! str_contains((string) $request->header('Accept'), 'text/event-stream');
+        return $request->header('Sec-Fetch-Mode') === 'navigate'
+            && str_contains((string) $request->header('Accept'), 'text/html');
     }
 }

--- a/tests/Feature/Routing/SubdomainRoutingTest.php
+++ b/tests/Feature/Routing/SubdomainRoutingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Mcp\Servers\RelaticleServer;
 use App\Models\User;
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Support\Facades\Route;
 use Laravel\Mcp\Facades\Mcp;
 use Laravel\Sanctum\Sanctum;
@@ -87,6 +88,12 @@ describe('MCP routing - subdomain mode', function () {
      * Mount the real MCP server at the subdomain root exactly as routes/ai.php
      * does when MCP_DOMAIN is set, so the globally prepended
      * SubdomainRootResponse middleware is exercised against the real endpoint.
+     *
+     * routes/ai.php is registered ahead of routes/web.php, so in production the
+     * MCP endpoint — not the domainless "/" home route — owns the root of the
+     * MCP domain. Routes added mid-test instead land in the dynamic tail of a
+     * compiled collection, where the home route matches first; rehydrating a
+     * plain collection restores the domain-first matching production has.
      */
     beforeEach(function (): void {
         config(['app.mcp_domain' => 'mcp.example.com']);
@@ -94,16 +101,52 @@ describe('MCP routing - subdomain mode', function () {
         Route::domain('mcp.example.com')->group(function (): void {
             Mcp::web('/', RelaticleServer::class);
         });
+
+        $routes = new RouteCollection;
+
+        foreach (Route::getRoutes()->getRoutes() as $route) {
+            $routes->add($route);
+        }
+
+        Route::setRoutes($routes);
     });
 
     it('returns JSON info when a browser visits the MCP subdomain root', function (): void {
-        $response = $this->get('http://mcp.example.com/', ['Accept' => 'text/html,application/xhtml+xml']);
+        $response = $this->get('http://mcp.example.com/', [
+            'Accept' => 'text/html,application/xhtml+xml',
+            'Sec-Fetch-Mode' => 'navigate',
+        ]);
 
         $response->assertOk();
 
         $json = $response->json();
         expect($json)->toHaveKeys(['name', 'version', 'docs']);
         expect($json['name'])->toBe('Relaticle MCP Server');
+    });
+
+    /**
+     * RFC 9728 clients (Codex via the rmcp SDK, among others) begin discovery by
+     * GETting the MCP endpoint itself and treat *any* 200 as "this URL is the
+     * protected resource metadata document". Answering that probe with the info
+     * payload aborts the login with "metadata missing required resource field"
+     * before the /.well-known fallback is ever tried.
+     */
+    it('does not answer a non-browser GET probe of the MCP root with the info payload', function (): void {
+        $this->get('http://mcp.example.com/')->assertStatus(405);
+
+        $this->get('http://mcp.example.com/', ['MCP-Protocol-Version' => '2024-11-05'])
+            ->assertStatus(405);
+
+        $this->get('http://mcp.example.com/', ['Accept' => '*/*'])->assertStatus(405);
+    });
+
+    it('exposes protected resource metadata that identifies the MCP root as the resource', function (): void {
+        $response = $this->get('http://mcp.example.com/.well-known/oauth-protected-resource');
+
+        $response->assertOk();
+
+        expect($response->json('resource'))->toBe('http://mcp.example.com');
+        expect($response->json('authorization_servers'))->toBe(['http://mcp.example.com']);
     });
 
     it('routes JSON-RPC POST to the MCP server instead of the info payload', function (): void {
@@ -118,8 +161,7 @@ describe('MCP routing - subdomain mode', function () {
     });
 
     it('routes an SSE stream GET to the MCP server instead of the info payload', function (): void {
-        $response = $this->get('http://mcp.example.com/', ['Accept' => 'text/event-stream']);
-
-        expect((string) $response->getContent())->not->toContain('Relaticle MCP Server');
+        $this->get('http://mcp.example.com/', ['Accept' => 'text/event-stream'])
+            ->assertStatus(405);
     });
 });


### PR DESCRIPTION
`GET https://mcp.relaticle.com/` answered every plain GET with the info banner, and because that URL is also the OAuth protected resource identifier, RFC 9728 clients (Codex, via the rmcp SDK) read the 200 as the protected-resource metadata document and aborted login with `Protected resource metadata missing required resource field` — the `/.well-known` fallback only runs when the base probe returns nothing, so it was never reached. This inverts the default so correct protocol behaviour (405) is what every machine client gets, and only a top-level browser navigation (`Sec-Fetch-Mode: navigate` plus an explicit `text/html` Accept) opts into the banner; `Sec-Fetch-*` is a forbidden header name, so no HTTP client can obtain it. Claude and ChatGPT were never affected and are unchanged here — the TypeScript SDK only fetches `/.well-known` paths, never the base URL — which is exactly why this reached production unnoticed.

## Test plan

- `codex mcp login` against production today fails with `Protected resource metadata missing required resource field`; against a local MCP-domain instance carrying this change it reports `Successfully logged in to MCP server` after the full discovery → dynamic client registration → consent → callback flow, minting a real Passport token (`client=Codex`, `scopes=["mcp:use"]`, team-bound, not revoked).
- Real Chrome: navigating to the MCP root renders the banner, while an in-page `fetch('/')` from that same page gets 405 — so the banner is unreachable programmatically.
- New regression test covers the bare, `MCP-Protocol-Version` and `Accept: */*` probes; it fails when the middleware change is reverted and passes with it.
- `vendor/bin/pint` ✅, `vendor/bin/rector --dry-run` ✅, `phpstan` 0 errors ✅, type coverage 100% ✅, full suite 2577 passed ✅, Arch 24 passed ✅.