### PR TITLE
fix: cancel out of workspace creation, open board card edit on click

### DIFF
--- a/app/Filament/Pages/CreateTeam.php
+++ b/app/Filament/Pages/CreateTeam.php
@@ -14,6 +14,7 @@ use App\Models\User;
 use App\Rules\ValidTeamSlug;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Repeater;
@@ -69,6 +70,23 @@ final class CreateTeam extends RegisterTenant
     public function getSubheading(): ?string
     {
         return null;
+    }
+
+    /**
+     * Where "Cancel" returns to when the user backs out of creating another
+     * workspace. Null during first-run onboarding — a user with no workspace
+     * has nowhere to go back to, so no cancel affordance is offered.
+     */
+    public function getCancelUrl(): ?string
+    {
+        /** @var User $user */
+        $user = auth('web')->user();
+
+        $tenant = Filament::getUserDefaultTenant($user);
+
+        return $tenant instanceof Team
+            ? Dashboard::getUrl(['tenant' => $tenant])
+            : null;
     }
 
     #[Override]

--- a/app/Filament/Resources/OpportunityResource/Pages/OpportunitiesBoard.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/OpportunitiesBoard.php
@@ -159,6 +159,7 @@ final class OpportunitiesBoard extends BoardResourcePage
                         return $opportunity;
                     }),
             ])
+            ->cardAction('edit')
             ->cardActions([
                 Action::make('edit')
                     ->label(__('filament/pages/boards.opportunities.actions.edit'))

--- a/app/Filament/Resources/TaskResource/Pages/TasksBoard.php
+++ b/app/Filament/Resources/TaskResource/Pages/TasksBoard.php
@@ -144,6 +144,7 @@ final class TasksBoard extends BoardResourcePage
                         return $task;
                     }),
             ])
+            ->cardAction('edit')
             ->cardActions([
                 Action::make('edit')
                     ->label(__('filament/pages/boards.tasks.actions.edit'))

--- a/lang/en/filament/pages/teams.php
+++ b/lang/en/filament/pages/teams.php
@@ -17,6 +17,7 @@ return [
             'get_started' => 'Get started',
             'copy_invite_link' => 'Copy invite link',
             'add_more' => 'Add more',
+            'cancel' => 'Cancel',
         ],
         'form' => [
             'company_name' => [

--- a/resources/views/filament/pages/create-team.blade.php
+++ b/resources/views/filament/pages/create-team.blade.php
@@ -8,9 +8,23 @@
     {{-- Main card --}}
     <div class="mx-auto w-full max-w-[960px] flex-1 overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
         <div class="flex h-full">
-            {{-- Left: form --}}
+            {{-- Left: form, with a way back out for anyone who already has a workspace --}}
             <div class="flex flex-1 flex-col px-10 py-10 sm:px-12 sm:py-12">
                 {{ $this->content }}
+
+                @php($cancelUrl = $this->getCancelUrl())
+
+                @if (filled($cancelUrl))
+                    <div class="mt-3 text-center">
+                        <a
+                            href="{{ $cancelUrl }}"
+                            wire:navigate
+                            class="text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                        >
+                            {{ __('filament/pages/teams.create_team.actions.cancel') }}
+                        </a>
+                    </div>
+                @endif
             </div>
 
             {{-- Right: CRM preview (step-aware) --}}

--- a/tests/Feature/Filament/App/Pages/OpportunitiesBoardTest.php
+++ b/tests/Feature/Filament/App/Pages/OpportunitiesBoardTest.php
@@ -99,3 +99,18 @@ it('moves a card between columns via moveCard', function (): void {
 
     expect($updatedValue)->toBe($qualification->getKey());
 });
+
+it('opens the edit action when a card is clicked', function (): void {
+    $prospecting = $this->stageField->options->firstWhere('name', 'Prospecting');
+
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity->saveCustomFieldValue($this->stageField, $prospecting->getKey());
+
+    $component = livewire(OpportunitiesBoard::class);
+
+    expect($component->instance()->getBoard()->getCardAction())->toBe('edit');
+
+    $component
+        ->call('mountAction', 'edit', [], ['recordKey' => (string) $opportunity->id])
+        ->assertSet('mountedActions.0.data.name', $opportunity->name);
+});

--- a/tests/Feature/Filament/App/Pages/TasksBoardTest.php
+++ b/tests/Feature/Filament/App/Pages/TasksBoardTest.php
@@ -138,3 +138,18 @@ it('moves a card between columns via moveCard', function (): void {
 
     expect($updatedValue)->toBe($inProgress->getKey());
 });
+
+it('opens the edit action when a card is clicked', function (): void {
+    $todo = $this->statusField->options->firstWhere('name', 'To do');
+
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
+    $task->saveCustomFieldValue($this->statusField, $todo->getKey());
+
+    $component = livewire(TasksBoard::class);
+
+    expect($component->instance()->getBoard()->getCardAction())->toBe('edit');
+
+    $component
+        ->call('mountAction', 'edit', [], ['recordKey' => (string) $task->id])
+        ->assertSet('mountedActions.0.data.title', $task->title);
+});

--- a/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
+++ b/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
@@ -55,6 +55,31 @@ it('renders wizard for users who already have a team', function (): void {
         ->assertSee('Create your workspace');
 });
 
+it('offers a way back to the current workspace for users who already have one', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $this->actingAs($user);
+
+    $component = livewire(CreateTeam::class);
+
+    expect($component->instance()->getCancelUrl())
+        ->toBe(Dashboard::getUrl(['tenant' => $user->currentTeam]));
+
+    $component->assertSee(__('filament/pages/teams.create_team.actions.cancel'));
+});
+
+it('offers no way back for teamless users, who have nowhere to go', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    $component = livewire(CreateTeam::class);
+
+    expect($component->instance()->getCancelUrl())->toBeNull();
+
+    $component->assertDontSee(__('filament/pages/teams.create_team.actions.cancel'));
+});
+
 it('creates a team with onboarding fields', function (): void {
     $user = User::factory()->create();
 


### PR DESCRIPTION
Two unrelated dead ends in the app panel. `/new` offered no way back, so anyone who opened "New workspace" from the tenant menu was stuck with sign out as the only exit — a Cancel link now sits under the wizard's primary action and returns to the user's default workspace, hidden for teamless first-run users who have nowhere to go. On the opportunity and task boards, cards were drag-only because Flowforge only wires a card's click handler when the board declares a `cardAction`, and both boards registered edit/delete as `cardActions` (which only populates the three-dot menu); declaring `edit` as the card action restores click-to-edit while leaving drag untouched, since that runs through the separate sortable handle.

## Test plan

- 4 new tests, each verified load-bearing (reverting the production change fails them): cancel URL/link present for a user with a workspace and absent for a teamless one; card action resolves to `edit` and mounting it with a `recordKey` fills the form with that record.
- Walked both fixes in a real browser with real mouse events — clicking a card opens the Edit slide-over pre-filled including custom fields, dragging a card across columns still persists the stage change through a reload, and cancelling from wizard step 2 leaves no orphaned team behind. Checked light/dark and mobile.
- `pint`, `rector --dry-run`, `phpstan`, and 100% type coverage all clean; full suite passes apart from `tests/Feature/Mcp/`, which fails identically on a stashed clean tree because this workspace has no Passport OAuth keys.