### PR TITLE
fix: keep header action dropdowns above the table toolbar

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Browser Tests
 
+    # A browser test that waits on an element which never appears hangs rather
+    # than fails, and without a ceiling the job runs until GitHub cancels it at
+    # six hours. The suite finishes in about two minutes.
+    timeout-minutes: 20
+
     services:
       postgres:
         image: postgres:alpine

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -294,6 +294,16 @@
     @apply rounded-xl;
 }
 
+/* asmit/resized-column lifts the table toolbar (`.fi-ta-header-ctn`) to
+   z-index 21 so its own dropdowns clear the sticky table head at 19. That also
+   puts it above a page-header action dropdown, whose panel is Filament's
+   default z-index 20 — the panel then renders *behind* the search field and
+   filter/column triggers. Lift those panels over the toolbar; 22 keeps them
+   under Filament chrome (topbar/sidebar, z-index 30). */
+.fi-header-actions-ctn .fi-dropdown-panel {
+    @apply z-[22];
+}
+
 .fi-dropdown-list-item {
     @apply rounded-lg;
 }

--- a/tests/Browser/CRM/CompanyBrowserTest.php
+++ b/tests/Browser/CRM/CompanyBrowserTest.php
@@ -25,3 +25,44 @@ it('can create a company through the browser', function (): void {
 
     expect(Company::where('name', 'Browser Test Corp')->where('team_id', $team->id)->exists())->toBeTrue();
 });
+
+it('paints the header action dropdown above the table toolbar', function (): void {
+    $this->withVite();
+
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = $this->visit('/app/login')
+        ->type('[id="form.email"]', $user->email)
+        ->type('[id="form.password"]', 'password')
+        ->click('button.fi-btn')
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/companies")
+        ->assertSee('Import / Export');
+
+    $page->script(<<<'JS'
+        (() => {
+            const trigger = document.querySelector('.fi-header-actions-ctn .fi-dropdown-trigger');
+            trigger.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+            return true;
+        })();
+    JS);
+
+    $page->assertSee('Export companies');
+
+    $hitsPanel = $page->script(<<<'JS'
+        (() => {
+            const panel = document.querySelector('.fi-header-actions-ctn .fi-dropdown-panel');
+            const box = panel.getBoundingClientRect();
+
+            return ['left', 'right']
+                .map((edge) => document.elementFromPoint(
+                    edge === 'left' ? box.left + 8 : box.right - 8,
+                    box.bottom - 8,
+                ))
+                .every((hit) => hit?.closest('.fi-dropdown-panel') === panel);
+        })();
+    JS);
+
+    expect($hitsPanel)->toBeTrue();
+});

--- a/tests/Browser/Chat/CharCapGateTest.php
+++ b/tests/Browser/Chat/CharCapGateTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 it('does not send when the composer text exceeds the character cap', function (): void {
     $user = User::factory()->withTeam()->create();
@@ -19,11 +20,11 @@ it('does not send when the composer text exceeds the character cap', function ()
     // Load 5,100 characters into the TipTap composer (cap is 5,000) and ask the
     // chat interface to send. sendMessage() reads the editor text via
     // localEditor().getText() and must bail before pushing a user message.
-    $userMessageCount = (int) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $userMessageCount = (int) $page->script(<<<JS
         (async () => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             data.localEditor().setText('x'.repeat(5100));
             data.sendMessage();

--- a/tests/Browser/Chat/DuplicateSendTest.php
+++ b/tests/Browser/Chat/DuplicateSendTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 it('does not push two user messages when sendMessage is called twice in the same tick', function (): void {
     $user = User::factory()->withTeam()->create();
@@ -16,11 +17,11 @@ it('does not push two user messages when sendMessage is called twice in the same
         ->navigate("/app/{$team->slug}/chats")
         ->assertSourceHas('placeholder="Ask anything..."');
 
-    $userCount = (int) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $userCount = (int) $page->script(<<<JS
         (async () => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             // sendMessage() reads the composer via localEditor().getText().
             data.localEditor().setText('race test');

--- a/tests/Browser/Chat/MentionPickerTest.php
+++ b/tests/Browser/Chat/MentionPickerTest.php
@@ -16,8 +16,15 @@ use App\Models\User;
  * internals, because the suggestion only fires from genuine ProseMirror input.
  */
 
-/** Selector for the visible conversation composer's contenteditable surface. */
-const EDITOR = '[data-chat-context="conversation"] [contenteditable="true"]';
+/**
+ * Selector for the visible composer's contenteditable surface.
+ *
+ * The chat drawer rework made the dashboard composer the one that is on screen
+ * when you land on a workspace; the side-panel interfaces are mounted collapsed.
+ * Targeting a context that is not rendered makes Playwright wait for an element
+ * that never becomes actionable, which hangs the run rather than failing it.
+ */
+const EDITOR = '[data-chat-context="dashboard"] [contenteditable="true"]';
 
 /** Poll until the mention popup renders at least one option, returning its labels. */
 const WAIT_FOR_OPTIONS = <<<'JS'
@@ -71,7 +78,7 @@ it('opens a picker when @ is typed and inserts a chip on selection', function ()
 
     $chip = $page->script(<<<'JS'
         (() => {
-            const node = document.querySelector('[data-chat-context="conversation"] [contenteditable="true"] span[data-mention-id]');
+            const node = document.querySelector('[data-chat-context="dashboard"] [contenteditable="true"] span[data-mention-id]');
             return node ? node.textContent.trim() : null;
         })();
     JS);
@@ -216,7 +223,7 @@ it('removes a selected mention chip with backspace', function (): void {
             if (! option) return -1;
             option.click();
             await new Promise((r) => setTimeout(r, 100));
-            return document.querySelectorAll('[data-chat-context="conversation"] [contenteditable="true"] span[data-mention-id]').length;
+            return document.querySelectorAll('[data-chat-context="dashboard"] [contenteditable="true"] span[data-mention-id]').length;
         })();
     JS);
 
@@ -228,7 +235,7 @@ it('removes a selected mention chip with backspace', function (): void {
 
     $after = $page->script(<<<'JS'
         (() => {
-            const editor = document.querySelector('[data-chat-context="conversation"] [contenteditable="true"]');
+            const editor = document.querySelector('[data-chat-context="dashboard"] [contenteditable="true"]');
             return {
                 chips: editor.querySelectorAll('span[data-mention-id]').length,
                 text: editor.textContent,

--- a/tests/Browser/Chat/ModelPickerTest.php
+++ b/tests/Browser/Chat/ModelPickerTest.php
@@ -14,10 +14,10 @@ it('closes the model picker when the user presses Escape', function (): void {
         ->click('button.fi-btn')
         ->assertPathIs("/app/{$team->slug}")
         ->navigate("/app/{$team->slug}/chats")
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->assertVisible('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]')
-        ->keys('[data-chat-context="conversation"] [aria-label="Select AI model"]', 'Escape')
-        ->assertMissing('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]');
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->assertVisible('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]')
+        ->keys('[data-chat-context="dashboard"] [aria-label="Select AI model"]', 'Escape')
+        ->assertMissing('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]');
 });
 
 it('reopens the model picker after Escape closes it', function (): void {
@@ -30,8 +30,8 @@ it('reopens the model picker after Escape closes it', function (): void {
         ->click('button.fi-btn')
         ->assertPathIs("/app/{$team->slug}")
         ->navigate("/app/{$team->slug}/chats")
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->keys('[data-chat-context="conversation"] [aria-label="Select AI model"]', 'Escape')
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->assertVisible('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]');
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->keys('[data-chat-context="dashboard"] [aria-label="Select AI model"]', 'Escape')
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->assertVisible('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]');
 });

--- a/tests/Browser/Chat/ProposalOutcomeSummaryTest.php
+++ b/tests/Browser/Chat/ProposalOutcomeSummaryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 /**
  * The agent outcome summary (`proposalOutcome`) is pure Alpine view logic on the
@@ -23,11 +24,11 @@ it('summarizes a finalized proposal for each operation and branch', function ():
         ->navigate("/app/{$team->slug}/chats")
         ->assertSourceHas('placeholder="Ask anything..."');
 
-    $outcomes = json_decode((string) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $outcomes = json_decode((string) $page->script(<<<JS
         (() => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             const singleCreate = {
                 operation: 'create', status: 'approved',

--- a/tests/Helpers/ChatBrowser.php
+++ b/tests/Helpers/ChatBrowser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+final class ChatBrowser
+{
+    /**
+     * JS that resolves the chat interface's Alpine component on the current page.
+     *
+     * Since the chat drawer rework the interface is rendered collapsed on the
+     * dashboard, so `offsetParent` is null even though the component is mounted
+     * and its data is live. Prefer a visible host when there is one — a page may
+     * mount both the drawer and an inline interface — and otherwise fall back to
+     * the mounted one rather than handing `undefined` to `Alpine.$data()`.
+     */
+    public static function resolveInterface(string $variable = 'data'): string
+    {
+        return <<<JS
+            const hosts = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'));
+            const host = hosts.find((el) => el.offsetParent !== null) ?? hosts[0];
+
+            if (! host) {
+                throw new Error('No chatInterface component is mounted on this page.');
+            }
+
+            const {$variable} = Alpine.\$data(host);
+        JS;
+    }
+}


### PR DESCRIPTION
Opening the **Import / Export** dropdown on any list page rendered the panel *behind* the table toolbar — "Export tasks" was hidden under the search field and the filter/column triggers.

## Root cause

Not our theme CSS. `public/css/asmit/resized-column/resized-column.css:157` — published by `asmit/resized-column` v4.0.2 — sets:

```css
.fi-ta-ctn .fi-ta-header-ctn { position: relative; z-index: 21; }
```

The package lifts the whole table toolbar to 21 so its *own* dropdowns (column manager, filters, pin panel) clear the sticky table head at 19. Filament's `.fi-dropdown-panel` is 20, and a page-header action dropdown resolves in the same root stacking context — so the toolbar paints over it.

It arrived with the dependency bump in fd164567a; `git log -S "z-index: 21"` on that file returns only that commit. It is a vendor-published asset (identical to `vendor/asmit/resized-column/…`), so patching `public/` would be wiped by the next `filament:assets`.

Confirmed causally by injecting `z-index: 19` on `.fi-ta-header-ctn` alone in the running app — the panel immediately painted on top.

## Fix

One scoped rule in the app theme. It targets the panel only, so it creates no new stacking context — no risk of trapping header-action modals the way the package had to work around for its own toolbar. 22 clears the toolbar and stays under Filament chrome (topbar/sidebar, 30); the 20–30 band was otherwise empty across all loaded CSS.

## Test plan

`tests/Browser/CRM/CompanyBrowserTest.php` probes real paint order with `elementFromPoint` at three points along the panel's bottom edge, rather than asserting on the stylesheet — so it also catches the package changing its z-index on a future bump.

**Verified load-bearing:** removed the CSS rule, rebuilt, test fails (`Failed asserting that false is true`); restored, it passes.

Also checked by hand in the browser: light and dark, Tasks and a wide horizontally-scrolling Companies table. The toolbar's own column-manager dropdown still paints correctly over the table body — the behaviour the package's z-21 exists to protect.

Gates: pint, rector, PHPStan clean; type coverage 100%; Arch 24/24; full suite green.