### PR TITLE
feat: move workspace settings behind tabs and fix billing redirects

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Browser Tests
 
+    # A browser test that waits on an element which never appears hangs rather
+    # than fails, and without a ceiling the job runs until GitHub cancels it at
+    # six hours. The suite finishes in about two minutes.
+    timeout-minutes: 20
+
     services:
       postgres:
         image: postgres:alpine

--- a/app/Filament/Pages/Billing.php
+++ b/app/Filament/Pages/Billing.php
@@ -9,6 +9,7 @@ use App\Actions\Billing\CreateProCheckout;
 use App\Actions\Billing\StartProTrial;
 use App\Enums\Plan;
 use App\Features\Billing as BillingFeature;
+use App\Filament\Pages\Concerns\HasWorkspaceSettingsNavigation;
 use App\Models\Team;
 use App\Models\User;
 use App\Services\Billing\CreditPackCatalog;
@@ -17,7 +18,6 @@ use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Http\RedirectResponse;
 use Laravel\Pennant\Feature;
 use Livewire\Attributes\Url;
 use Override;
@@ -26,6 +26,8 @@ use Throwable;
 
 final class Billing extends Page
 {
+    use HasWorkspaceSettingsNavigation;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-credit-card';
 
     protected static ?string $slug = 'billing';
@@ -86,57 +88,51 @@ final class Billing extends Page
         Notification::make()->title(__('billing.trial.started'))->success()->send();
     }
 
-    public function upgrade(CreateProCheckout $createCheckout, string $interval = 'monthly'): ?RedirectResponse
+    public function upgrade(CreateProCheckout $createCheckout, string $interval = 'monthly'): void
     {
         $team = $this->team();
 
         if (! $this->user()->ownsTeam($team) || $team->subscribed()) {
-            return null;
+            return;
         }
 
         try {
-            return redirect()->away($createCheckout->execute($team, $interval));
+            $this->redirect($createCheckout->execute($team, $interval));
         } catch (Throwable $exception) {
             report($exception);
             $this->notifyCheckoutFailed();
-
-            return null;
         }
     }
 
-    public function managePortal(): ?RedirectResponse
+    public function managePortal(): void
     {
         $team = $this->team();
 
         if (! $this->user()->ownsTeam($team)) {
-            return null;
+            return;
         }
 
         try {
-            return $team->redirectToBillingPortal(self::getUrl(panel: 'app', tenant: $team));
+            $this->redirect($team->billingPortalUrl(self::getUrl(panel: 'app', tenant: $team)));
         } catch (Throwable $exception) {
             report($exception);
             $this->notifyCheckoutFailed();
-
-            return null;
         }
     }
 
-    public function buyCredits(CreateCreditPackCheckout $createCheckout, string $pack): ?RedirectResponse
+    public function buyCredits(CreateCreditPackCheckout $createCheckout, string $pack): void
     {
         $team = $this->team();
 
         if (! $this->user()->ownsTeam($team) || ! resolve(HostedWorkspaceAccess::class)->allows($team)) {
-            return null;
+            return;
         }
 
         try {
-            return redirect()->away($createCheckout->execute($team, $pack));
+            $this->redirect($createCheckout->execute($team, $pack));
         } catch (Throwable $exception) {
             report($exception);
             $this->notifyCheckoutFailed();
-
-            return null;
         }
     }
 

--- a/app/Filament/Pages/Concerns/HasWorkspaceSettingsNavigation.php
+++ b/app/Filament/Pages/Concerns/HasWorkspaceSettingsNavigation.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages\Concerns;
+
+use App\Features\Billing as BillingFeature;
+use App\Filament\Pages\Billing;
+use App\Filament\Pages\EditTeam;
+use App\Filament\Pages\Team\CustomFields;
+use App\Filament\Pages\Team\Members;
+use App\Models\Team;
+use Filament\Facades\Filament;
+use Filament\Navigation\NavigationItem;
+use Filament\Pages\Enums\SubNavigationPosition;
+use Filament\Support\Icons\Heroicon;
+use Laravel\Pennant\Feature;
+
+/**
+ * The workspace settings tab strip. Every page it links to uses this concern, so
+ * the strip is identical whichever tab you land on.
+ *
+ * Filament builds sub-navigation from the page class, not from panel config, and
+ * hides items whose `visible()` resolves false — so each tab carries the same
+ * guard as its page.
+ */
+trait HasWorkspaceSettingsNavigation
+{
+    public static function getSubNavigationPosition(): SubNavigationPosition
+    {
+        return SubNavigationPosition::Top;
+    }
+
+    /**
+     * @return array<NavigationItem>
+     */
+    public function getSubNavigation(): array
+    {
+        /** @var Team $tenant */
+        $tenant = Filament::getTenant();
+
+        return [
+            NavigationItem::make()
+                ->label(__('teams.tabs.general'))
+                ->icon(Heroicon::OutlinedCog6Tooth)
+                ->url(fn (): string => EditTeam::getUrl())
+                ->isActiveWhen(fn (): bool => request()->routeIs(EditTeam::getRouteName()))
+                ->visible(fn (): bool => EditTeam::canView($tenant)),
+
+            NavigationItem::make()
+                ->label(__('teams.tabs.members'))
+                ->icon(Heroicon::OutlinedUsers)
+                ->url(fn (): string => Members::getUrl())
+                ->isActiveWhen(fn (): bool => request()->routeIs(Members::getRouteName()))
+                ->visible(fn (): bool => Members::canAccess()),
+
+            NavigationItem::make()
+                ->label(__('teams.tabs.custom_fields'))
+                ->icon(Heroicon::OutlinedCube)
+                ->url(fn (): string => CustomFields::getUrl())
+                ->isActiveWhen(fn (): bool => request()->routeIs(CustomFields::getRouteName()))
+                ->visible(fn (): bool => CustomFields::canAccess()),
+
+            NavigationItem::make()
+                ->label(__('teams.tabs.billing'))
+                ->icon(Heroicon::OutlinedCreditCard)
+                ->url(fn (): string => Billing::getUrl())
+                ->isActiveWhen(fn (): bool => request()->routeIs(Billing::getRouteName()))
+                ->visible(fn (): bool => Feature::active(BillingFeature::class)),
+        ];
+    }
+}

--- a/app/Filament/Pages/EditTeam.php
+++ b/app/Filament/Pages/EditTeam.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\Filament\Pages;
 
-use App\Livewire\App\Teams\AddTeamMember;
+use App\Filament\Pages\Concerns\HasWorkspaceSettingsNavigation;
 use App\Livewire\App\Teams\DeleteTeam;
-use App\Livewire\App\Teams\PendingTeamInvitations;
-use App\Livewire\App\Teams\TeamMembers;
 use App\Livewire\App\Teams\UpdateTeamName;
 use App\Models\Team;
 use Filament\Pages\Tenancy\EditTenantProfile;
@@ -16,6 +14,8 @@ use Filament\Schemas\Schema;
 
 final class EditTeam extends EditTenantProfile
 {
+    use HasWorkspaceSettingsNavigation;
+
     protected string $view = 'filament.pages.edit-team';
 
     protected static ?string $slug = 'team';
@@ -29,12 +29,6 @@ final class EditTeam extends EditTenantProfile
 
         return $schema->components([
             Livewire::make(UpdateTeamName::class)
-                ->data(['team' => $tenant]),
-            Livewire::make(AddTeamMember::class)
-                ->data(['team' => $tenant]),
-            Livewire::make(PendingTeamInvitations::class)
-                ->data(['team' => $tenant]),
-            Livewire::make(TeamMembers::class)
                 ->data(['team' => $tenant]),
             Livewire::make(DeleteTeam::class)
                 ->visible(fn (): bool => $tenant->isPersonalTeam() === false)

--- a/app/Filament/Pages/Team/CustomFields.php
+++ b/app/Filament/Pages/Team/CustomFields.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages\Team;
+
+use App\Filament\Pages\Concerns\HasWorkspaceSettingsNavigation;
+use Filament\Panel;
+use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
+
+/**
+ * The packaged custom fields screen, rendered as a workspace settings tab.
+ *
+ * Registered through `CustomFieldsPlugin::managementPage()` so it replaces the
+ * packaged page rather than sitting beside it — there is one route to this
+ * screen, not two.
+ */
+final class CustomFields extends CustomFieldsManagementPage
+{
+    use HasWorkspaceSettingsNavigation;
+
+    public static function getSlug(?Panel $panel = null): string
+    {
+        return 'team/custom-fields';
+    }
+}

--- a/app/Filament/Pages/Team/Members.php
+++ b/app/Filament/Pages/Team/Members.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages\Team;
+
+use App\Filament\Pages\Concerns\HasWorkspaceSettingsNavigation;
+use App\Livewire\App\Teams\AddTeamMember;
+use App\Livewire\App\Teams\PendingTeamInvitations;
+use App\Livewire\App\Teams\TeamMembers;
+use App\Models\Team;
+use BackedEnum;
+use Filament\Facades\Filament;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Livewire;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Override;
+
+/**
+ * @property-read Schema $form
+ */
+final class Members extends Page
+{
+    use HasWorkspaceSettingsNavigation;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
+
+    protected static ?string $slug = 'team/members';
+
+    protected string $view = 'filament.pages.team.members';
+
+    #[Override]
+    public static function shouldRegisterNavigation(): bool
+    {
+        return false;
+    }
+
+    public static function canAccess(): bool
+    {
+        /** @var Team $tenant */
+        $tenant = Filament::getTenant();
+
+        return auth()->user()?->can('update', $tenant) === true;
+    }
+
+    public static function getLabel(): string
+    {
+        return __('teams.tabs.members');
+    }
+
+    public function getTitle(): string
+    {
+        return __('teams.tabs.members');
+    }
+
+    public function mount(): void
+    {
+        abort_unless(self::canAccess(), 403);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        /** @var Team $tenant */
+        $tenant = Filament::getTenant();
+
+        return $schema->components([
+            Livewire::make(AddTeamMember::class)
+                ->data(['team' => $tenant]),
+            Livewire::make(PendingTeamInvitations::class)
+                ->data(['team' => $tenant]),
+            Livewire::make(TeamMembers::class)
+                ->data(['team' => $tenant]),
+        ]);
+    }
+}

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -16,6 +16,7 @@ use App\Filament\Pages\Billing;
 use App\Filament\Pages\CreateTeam;
 use App\Filament\Pages\Dashboard;
 use App\Filament\Pages\EditTeam;
+use App\Filament\Pages\Team\CustomFields;
 use App\Filament\Resources\OpportunityResource;
 use App\Filament\Resources\TaskResource;
 use App\Http\Middleware\ApplyTenantScopes;
@@ -64,7 +65,6 @@ use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Laravel\Jetstream\Features;
 use Laravel\Pennant\Feature;
 use Relaticle\CustomFields\CustomFieldsPlugin;
-use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
 use Relaticle\ImportWizard\Filament\Pages\ImportHistory;
 
 final class AppPanelProvider extends PanelProvider
@@ -210,7 +210,8 @@ final class AppPanelProvider extends PanelProvider
             )
             ->plugins([
                 CustomFieldsPlugin::make()
-                    ->authorize(fn () => Gate::check('update', Filament::getTenant())),
+                    ->authorize(fn () => Gate::check('update', Filament::getTenant()))
+                    ->managementPage(CustomFields::class),
                 ResizedColumnPlugin::make(),
             ])
             ->renderHook(
@@ -254,10 +255,6 @@ final class AppPanelProvider extends PanelProvider
             ->tenantRegistration(CreateTeam::class)
             ->tenantProfile(EditTeam::class)
             ->tenantMenuItems([
-                Action::make('custom_fields')
-                    ->label(__('filament/panel.tenant_menu.custom_fields'))
-                    ->icon(Heroicon::OutlinedCube)
-                    ->url(fn (): string => CustomFieldsManagementPage::getUrl()),
                 Action::make('import_history')
                     ->label(__('filament/panel.tenant_menu.import_history'))
                     ->icon(Heroicon::OutlinedClock)

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ralphjsmit/laravel-filament-seo": "^2.2",
         "ralphjsmit/laravel-seo": "^1.8",
         "relaticle/activity-log": "^1.2",
-        "relaticle/custom-fields": "dev-feat/configurable-management-page as 3.7.0",
+        "relaticle/custom-fields": "^3.6.2",
         "relaticle/flowforge": "^4.0",
         "relaticle/ink": "^2.3",
         "ryangjchandler/laravel-cloudflare-turnstile": "^3.0",
@@ -183,11 +183,5 @@
         }
     },
     "minimum-stability": "beta",
-    "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Relaticle/custom-fields"
-        }
-    ]
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ralphjsmit/laravel-filament-seo": "^2.2",
         "ralphjsmit/laravel-seo": "^1.8",
         "relaticle/activity-log": "^1.2",
-        "relaticle/custom-fields": "^3.0",
+        "relaticle/custom-fields": "dev-feat/configurable-management-page as 3.7.0",
         "relaticle/flowforge": "^4.0",
         "relaticle/ink": "^2.3",
         "ryangjchandler/laravel-cloudflare-turnstile": "^3.0",
@@ -183,5 +183,11 @@
         }
     },
     "minimum-stability": "beta",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/Relaticle/custom-fields"
+        }
+    ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48a96002b0c0bfceb9543646481bf64a",
+    "content-hash": "bd5a9dcec5a9b9aa2b461e51895367b6",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -10129,16 +10129,16 @@
         },
         {
             "name": "relaticle/custom-fields",
-            "version": "v3.6.1",
+            "version": "dev-feat/configurable-management-page",
             "source": {
                 "type": "git",
                 "url": "https://github.com/relaticle/custom-fields.git",
-                "reference": "fcd2b9973e7692d463957f82a60fc8a8255b9352"
+                "reference": "8ab37e9c8b4e52f5a77608a128270f99167f3861"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/relaticle/custom-fields/zipball/fcd2b9973e7692d463957f82a60fc8a8255b9352",
-                "reference": "fcd2b9973e7692d463957f82a60fc8a8255b9352",
+                "url": "https://api.github.com/repos/relaticle/custom-fields/zipball/8ab37e9c8b4e52f5a77608a128270f99167f3861",
+                "reference": "8ab37e9c8b4e52f5a77608a128270f99167f3861",
                 "shasum": ""
             },
             "require": {
@@ -10170,12 +10170,12 @@
             "type": "library",
             "extra": {
                 "laravel": {
-                    "aliases": {
-                        "CustomFields": "Relaticle\\CustomFields\\Facades\\CustomFields"
-                    },
                     "providers": [
                         "Relaticle\\CustomFields\\CustomFieldsServiceProvider"
-                    ]
+                    ],
+                    "aliases": {
+                        "CustomFields": "Relaticle\\CustomFields\\Facades\\CustomFields"
+                    }
                 }
             },
             "autoload": {
@@ -10184,7 +10184,48 @@
                     "Relaticle\\CustomFields\\Database\\Factories\\": "database/factories/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Relaticle\\CustomFields\\Tests\\": "tests/",
+                    "Relaticle\\CustomFields\\Tests\\Database\\Factories\\": "tests/database/factories/"
+                }
+            },
+            "scripts": {
+                "post-autoload-dump": [
+                    "@php ./vendor/bin/testbench package:discover --ansi"
+                ],
+                "lint": [
+                    "rector && pint --parallel"
+                ],
+                "test:lint": [
+                    "pint --test"
+                ],
+                "test:refactor": [
+                    "rector --dry-run"
+                ],
+                "test:types": [
+                    "phpstan analyse"
+                ],
+                "test:arch": [
+                    "pest --filter=arch"
+                ],
+                "test:type-coverage": [
+                    "pest --type-coverage --min=100.0"
+                ],
+                "test:pest": [
+                    "pest --parallel"
+                ],
+                "test": [
+                    "@test:lint",
+                    "@test:refactor",
+                    "@test:types",
+                    "@test:type-coverage",
+                    "@test:pest"
+                ],
+                "test-coverage": [
+                    "vendor/bin/pest --coverage"
+                ]
+            },
             "license": [
                 "AGPL-3.0"
             ],
@@ -10198,8 +10239,6 @@
             "description": "User Defined Custom Fields for Laravel Filament",
             "homepage": "https://github.com/relaticle/custom-fields",
             "keywords": [
-                "Forms",
-                "Relaticle",
                 "admin-panel",
                 "conditional-fields",
                 "csv-export",
@@ -10213,18 +10252,20 @@
                 "filamentphp",
                 "form-builder",
                 "form-fields",
+                "forms",
                 "laravel",
                 "laravel-package",
                 "manukminasyan",
                 "multi-tenancy",
                 "no-migration",
+                "relaticle",
                 "validation"
             ],
             "support": {
                 "issues": "https://github.com/relaticle/custom-fields/issues",
                 "source": "https://github.com/relaticle/custom-fields"
             },
-            "time": "2026-08-08T14:16:41+00:00"
+            "time": "2026-08-11T21:24:59+00:00"
         },
         {
             "name": "relaticle/flowforge",
@@ -24281,9 +24322,17 @@
             "time": "2026-07-29T20:32:37+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "relaticle/custom-fields",
+            "version": "dev-feat/configurable-management-page",
+            "alias": "3.7.0",
+            "alias_normalized": "3.7.0.0"
+        }
+    ],
     "minimum-stability": "beta",
     "stability-flags": {
+        "relaticle/custom-fields": 20,
         "spatie/guidelines-skills": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd5a9dcec5a9b9aa2b461e51895367b6",
+    "content-hash": "9b48b77ef7280b5c8a7f687be55df560",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -316,16 +316,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.391.1",
+            "version": "3.392.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "90920ce5518aa864e04da0224bb0ba0ee9e31d7f"
+                "reference": "c6bb281dfbfd4c8c2d0bd2c3b95242af41bb1b4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/90920ce5518aa864e04da0224bb0ba0ee9e31d7f",
-                "reference": "90920ce5518aa864e04da0224bb0ba0ee9e31d7f",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c6bb281dfbfd4c8c2d0bd2c3b95242af41bb1b4c",
+                "reference": "c6bb281dfbfd4c8c2d0bd2c3b95242af41bb1b4c",
                 "shasum": ""
             },
             "require": {
@@ -407,9 +407,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.391.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.392.0"
             },
-            "time": "2026-08-07T20:18:18+00:00"
+            "time": "2026-08-11T18:12:10+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -3606,16 +3606,16 @@
         },
         {
             "name": "laravel/fortify",
-            "version": "v1.37.3",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/fortify.git",
-                "reference": "66b9503330e7c18b3edebb9c3b4087037826573b"
+                "reference": "c04ca2998631e1816f2e94a78b668f3a59b3962d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/fortify/zipball/66b9503330e7c18b3edebb9c3b4087037826573b",
-                "reference": "66b9503330e7c18b3edebb9c3b4087037826573b",
+                "url": "https://api.github.com/repos/laravel/fortify/zipball/c04ca2998631e1816f2e94a78b668f3a59b3962d",
+                "reference": "c04ca2998631e1816f2e94a78b668f3a59b3962d",
                 "shasum": ""
             },
             "require": {
@@ -3629,7 +3629,7 @@
             },
             "require-dev": {
                 "orchestra/testbench": "^9.15|^10.8|^11.0",
-                "phpstan/phpstan": "^1.10"
+                "phpstan/phpstan": "^2.2.6"
             },
             "type": "library",
             "extra": {
@@ -3666,24 +3666,24 @@
                 "issues": "https://github.com/laravel/fortify/issues",
                 "source": "https://github.com/laravel/fortify"
             },
-            "time": "2026-06-29T16:22:02+00:00"
+            "time": "2026-08-07T14:07:45+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v13.24.0",
+            "version": "v13.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0"
+                "reference": "ed36fe882bd4eed4e6ff75343cbad8dbda03fdba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6d481710375d2aa67656922ef760cdd2b18bcfe0",
-                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/ed36fe882bd4eed4e6ff75343cbad8dbda03fdba",
+                "reference": "ed36fe882bd4eed4e6ff75343cbad8dbda03fdba",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17 || ^0.18",
+                "brick/math": "^0.14.2 || ^0.15 || ^0.16 || ^0.17 || ^0.18 || ^0.19",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -3893,20 +3893,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-08-04T15:54:59+00:00"
+            "time": "2026-08-11T13:56:22+00:00"
         },
         {
             "name": "laravel/horizon",
-            "version": "v5.48.2",
+            "version": "v5.48.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/horizon.git",
-                "reference": "2ebe3cb25ab6461b53a4e3ef42e167edeafe7932"
+                "reference": "2d1045db2ecdc7842a13e96a7c21773f32c93ab3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/horizon/zipball/2ebe3cb25ab6461b53a4e3ef42e167edeafe7932",
-                "reference": "2ebe3cb25ab6461b53a4e3ef42e167edeafe7932",
+                "url": "https://api.github.com/repos/laravel/horizon/zipball/2d1045db2ecdc7842a13e96a7c21773f32c93ab3",
+                "reference": "2d1045db2ecdc7842a13e96a7c21773f32c93ab3",
                 "shasum": ""
             },
             "require": {
@@ -3971,9 +3971,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/horizon/issues",
-                "source": "https://github.com/laravel/horizon/tree/v5.48.2"
+                "source": "https://github.com/laravel/horizon/tree/v5.48.3"
             },
-            "time": "2026-07-27T13:13:49+00:00"
+            "time": "2026-08-10T13:09:54+00:00"
         },
         {
             "name": "laravel/jetstream",
@@ -4043,16 +4043,16 @@
         },
         {
             "name": "laravel/mcp",
-            "version": "v0.9.2",
+            "version": "v0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/mcp.git",
-                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3"
+                "reference": "534b29f18418673033ec918c5a840b6ce9c08327"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
-                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/534b29f18418673033ec918c5a840b6ce9c08327",
+                "reference": "534b29f18418673033ec918c5a840b6ce9c08327",
                 "shasum": ""
             },
             "require": {
@@ -4113,7 +4113,7 @@
                 "issues": "https://github.com/laravel/mcp/issues",
                 "source": "https://github.com/laravel/mcp"
             },
-            "time": "2026-08-06T15:59:47+00:00"
+            "time": "2026-08-10T18:01:31+00:00"
         },
         {
             "name": "laravel/passkeys",
@@ -4185,16 +4185,16 @@
         },
         {
             "name": "laravel/passport",
-            "version": "v13.7.5",
+            "version": "v13.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/passport.git",
-                "reference": "90053dc4ba681c076855779250109bb624f961f6"
+                "reference": "980ed27da1da67408754b7e0c13989fe05327d9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/passport/zipball/90053dc4ba681c076855779250109bb624f961f6",
-                "reference": "90053dc4ba681c076855779250109bb624f961f6",
+                "url": "https://api.github.com/repos/laravel/passport/zipball/980ed27da1da67408754b7e0c13989fe05327d9e",
+                "reference": "980ed27da1da67408754b7e0c13989fe05327d9e",
                 "shasum": ""
             },
             "require": {
@@ -4256,20 +4256,20 @@
                 "issues": "https://github.com/laravel/passport/issues",
                 "source": "https://github.com/laravel/passport"
             },
-            "time": "2026-04-16T14:00:29+00:00"
+            "time": "2026-07-22T09:24:32+00:00"
         },
         {
             "name": "laravel/pennant",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pennant.git",
-                "reference": "b99fbc8038eb2c0a2642e9e13077a75e892b61d9"
+                "reference": "021ea6d4545ff2caa7dbd9fd7ada5b82da33c211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pennant/zipball/b99fbc8038eb2c0a2642e9e13077a75e892b61d9",
-                "reference": "b99fbc8038eb2c0a2642e9e13077a75e892b61d9",
+                "url": "https://api.github.com/repos/laravel/pennant/zipball/021ea6d4545ff2caa7dbd9fd7ada5b82da33c211",
+                "reference": "021ea6d4545ff2caa7dbd9fd7ada5b82da33c211",
                 "shasum": ""
             },
             "require": {
@@ -4333,7 +4333,7 @@
                 "issues": "https://github.com/laravel/pennant/issues",
                 "source": "https://github.com/laravel/pennant"
             },
-            "time": "2026-06-28T17:14:13+00:00"
+            "time": "2026-08-11T13:50:32+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -4396,16 +4396,16 @@
         },
         {
             "name": "laravel/reverb",
-            "version": "v1.11.0",
+            "version": "v1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/reverb.git",
-                "reference": "dca414f38e0f7acc237890ca18edfb5f3d535f86"
+                "reference": "52ce5fd88cd1d7eacfdcf6b91cea4704cc546f27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/reverb/zipball/dca414f38e0f7acc237890ca18edfb5f3d535f86",
-                "reference": "dca414f38e0f7acc237890ca18edfb5f3d535f86",
+                "url": "https://api.github.com/repos/laravel/reverb/zipball/52ce5fd88cd1d7eacfdcf6b91cea4704cc546f27",
+                "reference": "52ce5fd88cd1d7eacfdcf6b91cea4704cc546f27",
                 "shasum": ""
             },
             "require": {
@@ -4469,9 +4469,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/reverb/issues",
-                "source": "https://github.com/laravel/reverb/tree/v1.11.0"
+                "source": "https://github.com/laravel/reverb/tree/v1.11.1"
             },
-            "time": "2026-06-25T02:41:17+00:00"
+            "time": "2026-08-06T14:48:58+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -4869,16 +4869,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.9.1",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "73cb188c785abfa7a7bec73487148202968274c6"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/73cb188c785abfa7a7bec73487148202968274c6",
-                "reference": "73cb188c785abfa7a7bec73487148202968274c6",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -4915,7 +4915,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.10-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -4972,7 +4972,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-08-09T14:10:38+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",
@@ -5924,16 +5924,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.3.5",
+            "version": "v4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "7ef4b2a876c71744e86463079dd506b26eeab624"
+                "reference": "514b29d5a23594d4e4846494f580268b20c2f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/7ef4b2a876c71744e86463079dd506b26eeab624",
-                "reference": "7ef4b2a876c71744e86463079dd506b26eeab624",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/514b29d5a23594d4e4846494f580268b20c2f11e",
+                "reference": "514b29d5a23594d4e4846494f580268b20c2f11e",
                 "shasum": ""
             },
             "require": {
@@ -5988,7 +5988,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.3.5"
+                "source": "https://github.com/livewire/livewire/tree/v4.4.0"
             },
             "funding": [
                 {
@@ -5996,7 +5996,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-03T04:09:44+00:00"
+            "time": "2026-08-10T15:24:22+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -10129,16 +10129,16 @@
         },
         {
             "name": "relaticle/custom-fields",
-            "version": "dev-feat/configurable-management-page",
+            "version": "v3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/relaticle/custom-fields.git",
-                "reference": "8ab37e9c8b4e52f5a77608a128270f99167f3861"
+                "reference": "926f37cc4df69b1138f08d932bbfa1c0bec8e0f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/relaticle/custom-fields/zipball/8ab37e9c8b4e52f5a77608a128270f99167f3861",
-                "reference": "8ab37e9c8b4e52f5a77608a128270f99167f3861",
+                "url": "https://api.github.com/repos/relaticle/custom-fields/zipball/926f37cc4df69b1138f08d932bbfa1c0bec8e0f1",
+                "reference": "926f37cc4df69b1138f08d932bbfa1c0bec8e0f1",
                 "shasum": ""
             },
             "require": {
@@ -10170,12 +10170,12 @@
             "type": "library",
             "extra": {
                 "laravel": {
-                    "providers": [
-                        "Relaticle\\CustomFields\\CustomFieldsServiceProvider"
-                    ],
                     "aliases": {
                         "CustomFields": "Relaticle\\CustomFields\\Facades\\CustomFields"
-                    }
+                    },
+                    "providers": [
+                        "Relaticle\\CustomFields\\CustomFieldsServiceProvider"
+                    ]
                 }
             },
             "autoload": {
@@ -10184,48 +10184,7 @@
                     "Relaticle\\CustomFields\\Database\\Factories\\": "database/factories/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Relaticle\\CustomFields\\Tests\\": "tests/",
-                    "Relaticle\\CustomFields\\Tests\\Database\\Factories\\": "tests/database/factories/"
-                }
-            },
-            "scripts": {
-                "post-autoload-dump": [
-                    "@php ./vendor/bin/testbench package:discover --ansi"
-                ],
-                "lint": [
-                    "rector && pint --parallel"
-                ],
-                "test:lint": [
-                    "pint --test"
-                ],
-                "test:refactor": [
-                    "rector --dry-run"
-                ],
-                "test:types": [
-                    "phpstan analyse"
-                ],
-                "test:arch": [
-                    "pest --filter=arch"
-                ],
-                "test:type-coverage": [
-                    "pest --type-coverage --min=100.0"
-                ],
-                "test:pest": [
-                    "pest --parallel"
-                ],
-                "test": [
-                    "@test:lint",
-                    "@test:refactor",
-                    "@test:types",
-                    "@test:type-coverage",
-                    "@test:pest"
-                ],
-                "test-coverage": [
-                    "vendor/bin/pest --coverage"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "AGPL-3.0"
             ],
@@ -10239,6 +10198,8 @@
             "description": "User Defined Custom Fields for Laravel Filament",
             "homepage": "https://github.com/relaticle/custom-fields",
             "keywords": [
+                "Forms",
+                "Relaticle",
                 "admin-panel",
                 "conditional-fields",
                 "csv-export",
@@ -10252,20 +10213,18 @@
                 "filamentphp",
                 "form-builder",
                 "form-fields",
-                "forms",
                 "laravel",
                 "laravel-package",
                 "manukminasyan",
                 "multi-tenancy",
                 "no-migration",
-                "relaticle",
                 "validation"
             ],
             "support": {
                 "issues": "https://github.com/relaticle/custom-fields/issues",
                 "source": "https://github.com/relaticle/custom-fields"
             },
-            "time": "2026-08-11T21:24:59+00:00"
+            "time": "2026-08-12T18:08:56+00:00"
         },
         {
             "name": "relaticle/flowforge",
@@ -11521,22 +11480,22 @@
         },
         {
             "name": "spatie/laravel-activitylog",
-            "version": "5.0.0",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-activitylog.git",
-                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd"
+                "reference": "97c9f7e82033b18dc9db25de276f9b71e01449ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/0e00fe74fd071cc572a045459f6d4c9de33130bd",
-                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd",
+                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/97c9f7e82033b18dc9db25de276f9b71e01449ea",
+                "reference": "97c9f7e82033b18dc9db25de276f9b71e01449ea",
                 "shasum": ""
             },
             "require": {
-                "illuminate/config": "^12.0 || ^13.0",
-                "illuminate/database": "^12.0 || ^13.0",
-                "illuminate/support": "^12.0 || ^13.0",
+                "illuminate/config": "^13.0",
+                "illuminate/database": "^13.0",
+                "illuminate/support": "^13.0",
                 "php": "^8.4",
                 "spatie/laravel-package-tools": "^1.6.3"
             },
@@ -11544,8 +11503,8 @@
                 "ext-json": "*",
                 "larastan/larastan": "^3.0",
                 "laravel/pint": "^1.29",
-                "orchestra/testbench": "^10.0 || ^11.0",
-                "pestphp/pest": "^4.0"
+                "orchestra/testbench": "^11.0",
+                "pestphp/pest": "^5.0"
             },
             "type": "library",
             "extra": {
@@ -11588,7 +11547,7 @@
                 }
             ],
             "description": "A very simple activity logger to monitor the users of your website or application",
-            "homepage": "https://github.com/spatie/activitylog",
+            "homepage": "https://github.com/spatie/laravel-activitylog",
             "keywords": [
                 "activity",
                 "laravel",
@@ -11598,7 +11557,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-activitylog/issues",
-                "source": "https://github.com/spatie/laravel-activitylog/tree/5.0.0"
+                "source": "https://github.com/spatie/laravel-activitylog/tree/5.1.0"
             },
             "funding": [
                 {
@@ -11610,7 +11569,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-25T10:04:54+00:00"
+            "time": "2026-08-12T12:07:38+00:00"
         },
         {
             "name": "spatie/laravel-data",
@@ -12233,16 +12192,16 @@
         },
         {
             "name": "spatie/laravel-medialibrary",
-            "version": "11.23.4",
+            "version": "11.23.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-medialibrary.git",
-                "reference": "9f28da2b45ba5330887b307140c7a00dd2b0adcf"
+                "reference": "8ca16954d607de1853c9609e88eb91eab43d67b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/9f28da2b45ba5330887b307140c7a00dd2b0adcf",
-                "reference": "9f28da2b45ba5330887b307140c7a00dd2b0adcf",
+                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/8ca16954d607de1853c9609e88eb91eab43d67b9",
+                "reference": "8ca16954d607de1853c9609e88eb91eab43d67b9",
                 "shasum": ""
             },
             "require": {
@@ -12327,7 +12286,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-medialibrary/issues",
-                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.23.4"
+                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.23.5"
             },
             "funding": [
                 {
@@ -12339,7 +12298,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-07T08:08:26+00:00"
+            "time": "2026-08-10T08:15:27+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
@@ -19457,16 +19416,16 @@
         },
         {
             "name": "brianium/paratest",
-            "version": "v7.23.1",
+            "version": "v7.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paratestphp/paratest.git",
-                "reference": "6b2aaf7d0e8d5220710d78921f28e5464a816596"
+                "reference": "c63bfd148355e6aeb9e22697bae6c0fee2dfe96c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/6b2aaf7d0e8d5220710d78921f28e5464a816596",
-                "reference": "6b2aaf7d0e8d5220710d78921f28e5464a816596",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/c63bfd148355e6aeb9e22697bae6c0fee2dfe96c",
+                "reference": "c63bfd148355e6aeb9e22697bae6c0fee2dfe96c",
                 "shasum": ""
             },
             "require": {
@@ -19477,12 +19436,12 @@
                 "fidry/cpu-core-counter": "^1.3.0",
                 "jean85/pretty-package-versions": "^2.1.1",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/php-code-coverage": "^14.2.3",
+                "phpunit/php-code-coverage": "^14.3.0",
                 "phpunit/php-file-iterator": "^7",
                 "phpunit/php-timer": "^9",
-                "phpunit/phpunit": "^13.2.5",
+                "phpunit/phpunit": "^13.3.0",
                 "sebastian/environment": "^9.3.2",
-                "symfony/console": "^7.4.8 || ^8.1.1",
+                "symfony/console": "^7.4.8 || ^8.1.2",
                 "symfony/process": "^7.4.8 || ^8.1.0"
             },
             "require-dev": {
@@ -19490,11 +19449,11 @@
                 "ext-pcntl": "*",
                 "ext-pcov": "*",
                 "ext-posix": "*",
-                "phpstan/phpstan": "^2.2.6",
+                "phpstan/phpstan": "^2.2.8",
                 "phpstan/phpstan-deprecation-rules": "^2.0.5",
                 "phpstan/phpstan-phpunit": "^2.0.18",
                 "phpstan/phpstan-strict-rules": "^2.0.12",
-                "symfony/filesystem": "^7.4.8 || ^8.1.0"
+                "symfony/filesystem": "^7.4.8 || ^8.1.2"
             },
             "bin": [
                 "bin/paratest",
@@ -19534,7 +19493,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paratestphp/paratest/issues",
-                "source": "https://github.com/paratestphp/paratest/tree/v7.23.1"
+                "source": "https://github.com/paratestphp/paratest/tree/v7.24.0"
             },
             "funding": [
                 {
@@ -19546,7 +19505,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2026-07-28T13:47:02+00:00"
+            "time": "2026-08-07T13:03:48+00:00"
         },
         {
             "name": "daverandom/libdns",
@@ -20232,16 +20191,16 @@
         },
         {
             "name": "laravel-lang/lang",
-            "version": "15.34.0",
+            "version": "15.34.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/lang.git",
-                "reference": "333718a7ce92c92bfb9f1625467792b048cfcfbd"
+                "reference": "3149a2cea69aa16469ebf44bcb58f3d25920a620"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/lang/zipball/333718a7ce92c92bfb9f1625467792b048cfcfbd",
-                "reference": "333718a7ce92c92bfb9f1625467792b048cfcfbd",
+                "url": "https://api.github.com/repos/Laravel-Lang/lang/zipball/3149a2cea69aa16469ebf44bcb58f3d25920a620",
+                "reference": "3149a2cea69aa16469ebf44bcb58f3d25920a620",
                 "shasum": ""
             },
             "require": {
@@ -20302,7 +20261,7 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-08-03T21:33:23+00:00"
+            "time": "2026-08-11T18:30:36+00:00"
         },
         {
             "name": "laravel-lang/locale-list",
@@ -20999,16 +20958,16 @@
         },
         {
             "name": "laravel/pao",
-            "version": "v1.1.3",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pao.git",
-                "reference": "322f22095f3639551b64db9a13dfd8ab09c8206b"
+                "reference": "5aee99c8c37565e9c457c33f4d36aa363a389dc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pao/zipball/322f22095f3639551b64db9a13dfd8ab09c8206b",
-                "reference": "322f22095f3639551b64db9a13dfd8ab09c8206b",
+                "url": "https://api.github.com/repos/laravel/pao/zipball/5aee99c8c37565e9c457c33f4d36aa363a389dc8",
+                "reference": "5aee99c8c37565e9c457c33f4d36aa363a389dc8",
                 "shasum": ""
             },
             "require": {
@@ -21022,15 +20981,15 @@
                 "phpunit/phpunit": "<12.5.23 || >=13.0.0 <13.1.7 || >=14.0.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.23.0",
-                "laravel/pint": "^1.30.0",
+                "brianium/paratest": "^7.20.0",
+                "laravel/pint": "^1.30.5",
                 "orchestra/testbench": "^10.11.0 || ^11.1.0",
-                "pestphp/pest": "^4.7.2 || ^5.0.1",
-                "pestphp/pest-plugin-type-coverage": "^4.0.4 || ^5.0.0",
-                "phpstan/phpstan": "^2.2.7",
-                "rector/rector": "^2.5.8",
-                "symfony/process": "^7.4.8 || ^8.1.0",
-                "symfony/var-dumper": "^7.4.8 || ^8.1.2"
+                "pestphp/pest": "^4.7.8 || ^5.1.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.4 || ^5.0.2",
+                "phpstan/phpstan": "^2.2.8",
+                "rector/rector": "^2.6.1",
+                "symfony/process": "^7.4.13 || ^8.1.0",
+                "symfony/var-dumper": "^7.4.15 || ^8.1.2"
             },
             "type": "library",
             "extra": {
@@ -21080,20 +21039,20 @@
                 "issues": "https://github.com/laravel/pao/issues",
                 "source": "https://github.com/laravel/pao"
             },
-            "time": "2026-07-29T18:38:14+00:00"
+            "time": "2026-08-10T23:45:44+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.30.4",
+            "version": "v1.30.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28"
+                "reference": "fe4148c503a0e266353d61396b79bbf7f35122df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/a96cb6eee2961905d2fce7207aefb80945bf6b28",
-                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/fe4148c503a0e266353d61396b79bbf7f35122df",
+                "reference": "fe4148c503a0e266353d61396b79bbf7f35122df",
                 "shasum": ""
             },
             "require": {
@@ -21101,19 +21060,19 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.2.0"
+                "php": "^8.3.0"
             },
             "require-dev": {
                 "composer/semver": "^3.4.4",
                 "friendsofphp/php-cs-fixer": "^3.95.18",
-                "illuminate/view": "^12.65.0",
+                "illuminate/view": "^13.24.0",
                 "larastan/larastan": "^3.10.0",
-                "laravel-zero/framework": "^12.1.0",
+                "laravel-zero/framework": "^13.0.0",
                 "laravel/agent-detector": "^2.0.2",
                 "laravel/prompts": "^0.3.22",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.7"
+                "pestphp/pest": "^4.7.8"
             },
             "bin": [
                 "builds/pint"
@@ -21150,7 +21109,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-08-05T16:47:22+00:00"
+            "time": "2026-08-10T15:35:50+00:00"
         },
         {
             "name": "laravel/roster",
@@ -21216,16 +21175,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.65.0",
+            "version": "v1.66.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "d4b92139858d2a189a6302ca133e494f58afe20b"
+                "reference": "ebf286104306c50c8fd060cbc57de35b9dffa779"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/d4b92139858d2a189a6302ca133e494f58afe20b",
-                "reference": "d4b92139858d2a189a6302ca133e494f58afe20b",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/ebf286104306c50c8fd060cbc57de35b9dffa779",
+                "reference": "ebf286104306c50c8fd060cbc57de35b9dffa779",
                 "shasum": ""
             },
             "require": {
@@ -21275,7 +21234,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-08-03T18:00:17+00:00"
+            "time": "2026-08-10T13:09:27+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -21362,20 +21321,20 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.4",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
-                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
+                "reference": "8680aa248f8e07bc8fb43f56f0f5fc77a0c96aae",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.0"
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
@@ -21410,15 +21369,15 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.14.0"
             },
             "funding": [
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
+                    "url": "https://github.com/mnapoli",
+                    "type": "github"
                 }
             ],
-            "time": "2025-08-01T08:46:24+00:00"
+            "time": "2026-08-11T10:17:44+00:00"
         },
         {
             "name": "nunomaduro/pokio",
@@ -21501,41 +21460,41 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v5.0.4",
+            "version": "v5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "7b6415ccd07c1e68031fa47c0999ed680cf717bd"
+                "reference": "208f447a10fc416397edf00a5fc6380aa284d393"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/7b6415ccd07c1e68031fa47c0999ed680cf717bd",
-                "reference": "7b6415ccd07c1e68031fa47c0999ed680cf717bd",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/208f447a10fc416397edf00a5fc6380aa284d393",
+                "reference": "208f447a10fc416397edf00a5fc6380aa284d393",
                 "shasum": ""
             },
             "require": {
-                "brianium/paratest": "^7.23.1",
+                "brianium/paratest": "^7.24.0",
                 "nunomaduro/collision": "^8.9.5",
                 "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^5.0.0",
                 "pestphp/pest-plugin-arch": "^5.0.0",
-                "pestphp/pest-plugin-mutate": "^5.0.1",
+                "pestphp/pest-plugin-mutate": "^5.0.2",
                 "pestphp/pest-plugin-profanity": "^5.0.0",
                 "php": "^8.4",
-                "phpunit/phpunit": "^13.2.6",
+                "phpunit/phpunit": "^13.3.0",
                 "symfony/process": "^8.1.0"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">13.2.6",
+                "phpunit/phpunit": ">13.3.0",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
                 "pestphp/pest-dev-tools": "^5.0.0",
-                "pestphp/pest-plugin-browser": "^5.0.0",
-                "pestphp/pest-plugin-phpstan": "^5.0.0",
-                "pestphp/pest-plugin-rector": "^5.0.2",
+                "pestphp/pest-plugin-browser": "^5.0.1",
+                "pestphp/pest-plugin-phpstan": "^5.0.2",
+                "pestphp/pest-plugin-rector": "^5.0.3",
                 "pestphp/pest-plugin-type-coverage": "^5.0.2",
                 "psy/psysh": "^0.12.24"
             },
@@ -21604,7 +21563,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v5.0.4"
+                "source": "https://github.com/pestphp/pest/tree/v5.1.1"
             },
             "funding": [
                 {
@@ -21616,7 +21575,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-07T02:15:22+00:00"
+            "time": "2026-08-12T14:29:21+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -21763,24 +21722,24 @@
         },
         {
             "name": "pestphp/pest-plugin-browser",
-            "version": "v5.0.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-browser.git",
-                "reference": "cfe0fc085c2d1ea33d9dec6e014c486ba3e2f525"
+                "reference": "8f1c2103dea37f68a674e59869e42a80fbf8a679"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/cfe0fc085c2d1ea33d9dec6e014c486ba3e2f525",
-                "reference": "cfe0fc085c2d1ea33d9dec6e014c486ba3e2f525",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/8f1c2103dea37f68a674e59869e42a80fbf8a679",
+                "reference": "8f1c2103dea37f68a674e59869e42a80fbf8a679",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^3.1.2",
+                "amphp/amp": "^3.1.3",
                 "amphp/http-server": "^3.4.6",
                 "amphp/websocket-client": "^2.0.2",
                 "ext-sockets": "*",
-                "pestphp/pest": "^5.0.0",
+                "pestphp/pest": "^5.0.4",
                 "pestphp/pest-plugin": "^5.0.0",
                 "php": "^8.4",
                 "symfony/process": "^8.1.0"
@@ -21789,12 +21748,12 @@
                 "pestphp/pest": "<5.0.0"
             },
             "require-dev": {
-                "livewire/livewire": "^4.3.3",
+                "livewire/livewire": "^4.3.5",
                 "nunomaduro/collision": "^8.9.5",
                 "orchestra/testbench": "^11.1",
                 "pestphp/pest-dev-tools": "^5.0.0",
-                "pestphp/pest-plugin-laravel": "^5.0.0",
-                "pestphp/pest-plugin-type-coverage": "^5.0.0"
+                "pestphp/pest-plugin-laravel": "^5.0.1",
+                "pestphp/pest-plugin-type-coverage": "^5.0.2"
             },
             "type": "library",
             "extra": {
@@ -21827,7 +21786,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-browser/tree/v5.0.0"
+                "source": "https://github.com/pestphp/pest-plugin-browser/tree/v5.0.1"
             },
             "funding": [
                 {
@@ -21843,7 +21802,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-07-21T07:48:55+00:00"
+            "time": "2026-08-10T14:48:55+00:00"
         },
         {
             "name": "pestphp/pest-plugin-laravel",
@@ -21924,31 +21883,32 @@
         },
         {
             "name": "pestphp/pest-plugin-mutate",
-            "version": "v5.0.1",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest-plugin-mutate.git",
-                "reference": "ca1e6e6402323353ef4c1dd5bf034e6f4ab17fbf"
+                "reference": "d0c87110416b699413cc073b8dcc92e440d81931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/ca1e6e6402323353ef4c1dd5bf034e6f4ab17fbf",
-                "reference": "ca1e6e6402323353ef4c1dd5bf034e6f4ab17fbf",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/d0c87110416b699413cc073b8dcc92e440d81931",
+                "reference": "d0c87110416b699413cc073b8dcc92e440d81931",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.8.0",
                 "pestphp/pest-plugin": "^5.0.0",
                 "php": "^8.4",
+                "phpunit/php-code-coverage": "^14.3.0",
                 "psr/simple-cache": "^3.0.0"
             },
             "conflict": {
                 "pestphp/pest": "<5.0.0"
             },
             "require-dev": {
-                "pestphp/pest": "^5.0.3",
+                "pestphp/pest": "^5.0.4",
                 "pestphp/pest-dev-tools": "^5.0.0",
-                "pestphp/pest-plugin-type-coverage": "^5.0.0"
+                "pestphp/pest-plugin-type-coverage": "^5.0.2"
             },
             "type": "library",
             "autoload": {
@@ -21983,7 +21943,7 @@
                 "unit"
             ],
             "support": {
-                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v5.0.1"
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v5.0.2"
             },
             "funding": [
                 {
@@ -21999,7 +21959,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-04T15:26:47+00:00"
+            "time": "2026-08-10T11:01:27+00:00"
         },
         {
             "name": "pestphp/pest-plugin-profanity",
@@ -22407,23 +22367,23 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50"
+                "reference": "3ccaa29123548190af12fee7af078dcd7f3ddfab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
-                "reference": "6e5aa1fb0a95b1703d83e721299ee18bb4e2de50",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3ccaa29123548190af12fee7af078dcd7f3ddfab",
+                "reference": "3ccaa29123548190af12fee7af078dcd7f3ddfab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.3.0"
             },
             "type": "library",
             "extra": {
@@ -22456,7 +22416,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/7.0.1"
             },
             "funding": [
                 {
@@ -22476,7 +22436,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:33:26+00:00"
+            "time": "2026-08-10T06:43:12+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -22700,16 +22660,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.2.6",
+            "version": "13.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508"
+                "reference": "346fcba6ce7ab89bb1b0675feac6bc29c0f7711b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5d2afe181339a56348ef9a80fa7eb806b7eae508",
-                "reference": "5d2afe181339a56348ef9a80fa7eb806b7eae508",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/346fcba6ce7ab89bb1b0675feac6bc29c0f7711b",
+                "reference": "346fcba6ce7ab89bb1b0675feac6bc29c0f7711b",
                 "shasum": ""
             },
             "require": {
@@ -22723,21 +22683,21 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.2.3",
+                "phpunit/php-code-coverage": "^14.3",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
                 "phpunit/php-timer": "^9.0.0",
-                "sebastian/cli-parser": "^5.0.0",
-                "sebastian/comparator": "^8.3.0",
+                "sebastian/cli-parser": "^5.0.1",
+                "sebastian/comparator": "^8.4",
                 "sebastian/diff": "^9.0",
                 "sebastian/environment": "^9.3.2",
-                "sebastian/exporter": "^8.1.1",
+                "sebastian/exporter": "^8.2.1",
                 "sebastian/file-filter": "^1.0",
                 "sebastian/git-state": "^1.0",
                 "sebastian/global-state": "^9.0.1",
                 "sebastian/object-enumerator": "^8.0.0",
-                "sebastian/recursion-context": "^8.0.0",
+                "sebastian/recursion-context": "^8.0.1",
                 "sebastian/type": "^7.0.1",
                 "sebastian/version": "^7.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -22748,7 +22708,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "13.2-dev"
+                    "dev-main": "13.3-dev"
                 }
             },
             "autoload": {
@@ -22780,7 +22740,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.2.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.3.0"
             },
             "funding": [
                 {
@@ -22788,20 +22748,20 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-07-28T14:00:09+00:00"
+            "time": "2026-08-07T07:37:01+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95"
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b8e68f058bca43e01a2e1caa51ef022d6551ed95",
-                "reference": "b8e68f058bca43e01a2e1caa51ef022d6551ed95",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/03cd615cdd5648abb5f10ff3a684fdb976687190",
+                "reference": "03cd615cdd5648abb5f10ff3a684fdb976687190",
                 "shasum": ""
             },
             "require": {
@@ -22840,7 +22800,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.6.1"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.2"
             },
             "funding": [
                 {
@@ -22848,7 +22808,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-03T17:30:34+00:00"
+            "time": "2026-08-12T06:23:05+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -23896,23 +23856,23 @@
         },
         {
             "name": "sebastian/type",
-            "version": "7.0.1",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
+                "reference": "bd1df467864cb95140414059a535b2d906173fcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
-                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/bd1df467864cb95140414059a535b2d906173fcf",
+                "reference": "bd1df467864cb95140414059a535b2d906173fcf",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.1.10"
+                "phpunit/phpunit": "^13.3.0"
             },
             "type": "library",
             "extra": {
@@ -23941,7 +23901,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.2"
             },
             "funding": [
                 {
@@ -23961,7 +23921,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T06:49:11+00:00"
+            "time": "2026-08-10T08:00:57+00:00"
         },
         {
             "name": "sebastian/version",
@@ -24322,17 +24282,9 @@
             "time": "2026-07-29T20:32:37+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "relaticle/custom-fields",
-            "version": "dev-feat/configurable-management-page",
-            "alias": "3.7.0",
-            "alias_normalized": "3.7.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "beta",
     "stability-flags": {
-        "relaticle/custom-fields": 20,
         "spatie/guidelines-skills": 20
     },
     "prefer-stable": true,

--- a/lang/en/filament/panel.php
+++ b/lang/en/filament/panel.php
@@ -17,7 +17,6 @@ return [
     ],
 
     'tenant_menu' => [
-        'custom_fields' => 'Custom Fields',
         'import_history' => 'Import History',
     ],
 ];

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -105,6 +105,13 @@ return [
 
     'edit_team' => 'Workspace Settings',
 
+    'tabs' => [
+        'general' => 'General',
+        'members' => 'Members',
+        'custom_fields' => 'Custom Fields',
+        'billing' => 'Billing',
+    ],
+
     'roles' => [
         'admin' => [
             'description' => 'Administrator users can perform any action.',

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
             }
         },
         "node_modules/@alpinejs/collapse": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.12.tgz",
-            "integrity": "sha512-BKNANLtNXuWYOSAnajSKLPjTsmHRNrv0ALFTbpmqt2/klHFooPhctSwkhFVPQb7rZ8BjEKHmNaBwnSbgtpk6xg==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.16.1.tgz",
+            "integrity": "sha512-02tk8uxvujlHAawm/0RIgmf0Myf08wMDSBRgmAGrvyuvhDgaZ8xArQFtFesINqp5DOblVUnMWiqe4kYN6/odhQ==",
             "license": "MIT"
         },
         "node_modules/@floating-ui/core": {
@@ -120,18 +120,18 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.143.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
-            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+            "version": "0.144.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+            "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
-            "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+            "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
             "cpu": [
                 "arm64"
             ],
@@ -145,9 +145,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
-            "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
             "cpu": [
                 "arm64"
             ],
@@ -161,9 +161,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
-            "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
             "cpu": [
                 "x64"
             ],
@@ -177,9 +177,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
-            "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+            "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
             "cpu": [
                 "x64"
             ],
@@ -193,9 +193,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
-            "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+            "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
             "cpu": [
                 "arm"
             ],
@@ -209,9 +209,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
-            "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+            "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
             "cpu": [
                 "arm64"
             ],
@@ -225,9 +225,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
-            "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+            "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
             "cpu": [
                 "arm64"
             ],
@@ -241,9 +241,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
-            "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+            "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -257,9 +257,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
-            "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+            "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
             "cpu": [
                 "s390x"
             ],
@@ -273,9 +273,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
-            "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+            "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
             "cpu": [
                 "x64"
             ],
@@ -289,9 +289,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
-            "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+            "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
             "cpu": [
                 "x64"
             ],
@@ -305,9 +305,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
-            "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+            "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
             "cpu": [
                 "arm64"
             ],
@@ -321,9 +321,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
-            "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+            "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
             "cpu": [
                 "arm64"
             ],
@@ -337,9 +337,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
-            "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+            "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
             "cpu": [
                 "x64"
             ],
@@ -359,13 +359,13 @@
             "license": "MIT"
         },
         "node_modules/@shikijs/core": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.2.tgz",
-            "integrity": "sha512-StyzbAyxg2/tBGf78gwbBkGyeQ73lf8UiJArFaQhTQIDqQOCKPCQFanvrs4/Yv3Yfyc+ONInJM6K+FMIf+P+kA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+            "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/primitive": "4.4.2",
-                "@shikijs/types": "4.4.2",
+                "@shikijs/primitive": "4.4.3",
+                "@shikijs/types": "4.4.3",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.5",
                 "hast-util-to-html": "^9.0.5"
@@ -375,12 +375,12 @@
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.2.tgz",
-            "integrity": "sha512-MnIkeqWdVPUWsxlx8gKLVCJFTsqrQJgpTPBPpQwaFeJ56lOnJxj5aN2LUFnfxUEcvOQuNocmbaMnVrCEln6rkw==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+            "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.4.2",
+                "@shikijs/types": "4.4.3",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "oniguruma-to-es": "^4.3.6"
             },
@@ -389,12 +389,12 @@
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.2.tgz",
-            "integrity": "sha512-GLhowz1+jixjz+wiZ3wMnOn1jTxiFCGl2PkXufivbnwPHKuyw1AYqu5/hbWhZZ2oAb0NP05WUJhYeigY14drnw==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+            "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.4.2",
+                "@shikijs/types": "4.4.3",
                 "@shikijs/vscode-textmate": "^10.0.2"
             },
             "engines": {
@@ -402,24 +402,24 @@
             }
         },
         "node_modules/@shikijs/langs": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.2.tgz",
-            "integrity": "sha512-8DfeusD+Zdv/eYIDdXyJTUnSMHt+aAWjAOCXV20HNGAHRlInXpG8wh421v6B91WOm9TFwRLN+b/LG5F2NAIojg==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+            "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.4.2"
+                "@shikijs/types": "4.4.3"
             },
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/@shikijs/primitive": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.2.tgz",
-            "integrity": "sha512-l6fQQKsOMlz72n38fztmSgZ76MO6KSWuw8o+GJ+FhmqrpC9pIOJNQNXGgbb5yX2AwpzlEHwsaLPnk/8o4Fm+rA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+            "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.4.2",
+                "@shikijs/types": "4.4.3",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.5"
             },
@@ -428,21 +428,21 @@
             }
         },
         "node_modules/@shikijs/themes": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.2.tgz",
-            "integrity": "sha512-H0CFoL07ddDC2Dd6EdrPYNkRhUR6YCkJlnuYFceYYUJJA5TIm2b5B33qqiDYryBExgbKMndFJPb2u1gTuqO37g==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+            "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "4.4.2"
+                "@shikijs/types": "4.4.3"
             },
             "engines": {
                 "node": ">=20"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.2.tgz",
-            "integrity": "sha512-PFYitV4vpDr/iPCIhnHp+Q4ftic5N5VeNJ3KQ1O8gn3h2ar8qgwMAXF7tq4m1CWaMS60fV4VqF6vfnWH4F7vqQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+            "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
             "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.2",
@@ -742,102 +742,102 @@
             }
         },
         "node_modules/@tiptap/core": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.2.tgz",
-            "integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.30.0.tgz",
+            "integrity": "sha512-jlR5STfcpoYxvqnWoR6dhnkB0OBTNbTWd/Jw10wx1LLCrUOK2vrM1z3rXdiVSqqoDjphEu8HX/k4q+Okt+5YGg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/pm": "3.29.2"
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-document": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
-            "integrity": "sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.30.0.tgz",
+            "integrity": "sha512-gSXVcISMkK9IXa2YUc0TM+lkyCWaK6KgcsIoePnCWWdUGs0wtcktz3XK9mmcVu5xntg7AR7AT9B6gvl1k+MKYA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.29.2"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-hard-break": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
-            "integrity": "sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.30.0.tgz",
+            "integrity": "sha512-JzDGLfVMyvjqTPlfZ6f7+lfVu3nNg9RuhAY+N1clCr5JTzmxHsgvvpDYlkMyUvnqTbWlvW379+wtxi9BiDOpRg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.29.2"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-mention": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.29.2.tgz",
-            "integrity": "sha512-WF8ugDa2IRbgyRW+PffPYg8ZI+Qp9azvIsNoyuf+VSg5Vp7ze2TuJXUTObSckyiN5Ann8bDNM9Hbu3TdoI0DFQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.30.0.tgz",
+            "integrity": "sha512-DAaQYFzgwrfFNyeCi3r6u5JbKEDiX959pb3NqNAwHhoBEAh6SlkFgp5U+zOOdmK7Lgq404uMNwSuNIygUA2/9g==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.29.2",
-                "@tiptap/pm": "3.29.2",
-                "@tiptap/suggestion": "3.29.2"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0",
+                "@tiptap/suggestion": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-paragraph": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
-            "integrity": "sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.30.0.tgz",
+            "integrity": "sha512-xfGv8ZRYncPCQyKViTLAA52n9wbb1CnjxMezKbQVmckOMWroRxtT+4zmbpOslnR0cuNHIYAWMZ25MM+wxAQpsw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.29.2"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-placeholder": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.29.2.tgz",
-            "integrity": "sha512-/BlpPIq2JZk6zLaeYVOXazi6dmd0iRriTymNEnFn1doManN1y5HED9LsMeb/AhNhauL5AgmcHgpvAjbsN9k4SA==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.30.0.tgz",
+            "integrity": "sha512-X0UviJeJREXzOerehTlmYmq7WWrA+c4PNjXFqje3r2MR4Vp9GN9lQweTfo9FHjfA7pv7ps1RHN3fuXspk5u6DA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.29.2"
+                "@tiptap/extensions": "3.30.0"
             }
         },
         "node_modules/@tiptap/extension-text": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
-            "integrity": "sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.30.0.tgz",
+            "integrity": "sha512-NjsZzbuCkDth/XIpXQbcdoDpXQarQlISBARdwVEEXq2Cv8YEJRERblO8PHUdaP7AxuxPru5ZfgbnAkbopy/fwQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.29.2"
+                "@tiptap/core": "3.30.0"
             }
         },
         "node_modules/@tiptap/extensions": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.2.tgz",
-            "integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.30.0.tgz",
+            "integrity": "sha512-dCevnLGpISgrMqnEse3BeZPpaPtYBdIWONIiVSl4ODDCMUthcs8QqM5qi192f0fT+jnYikD7UP3zn+hdCFOtaw==",
             "license": "MIT",
             "peer": true,
             "funding": {
@@ -845,14 +845,14 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.29.2",
-                "@tiptap/pm": "3.29.2"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@tiptap/pm": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.2.tgz",
-            "integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.30.0.tgz",
+            "integrity": "sha512-0if2mMq/9nZ/IOiuuyvo36OEz/fhwFJiHNy49+NywUkkKVSsa6S7Pcsxb03RnKzW648EanOjE5oqTd4jCkgRKg==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-changeset": "^2.4.1",
@@ -875,9 +875,9 @@
             }
         },
         "node_modules/@tiptap/suggestion": {
-            "version": "3.29.2",
-            "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.29.2.tgz",
-            "integrity": "sha512-ZEhRm0gnRCwCScR9IrnIBhm9sr6U8vpR9oeznYk3hiedZ48zsgohqvgoIYpWcwYWrT2Pb0NrfhCT8IuSzdJHzQ==",
+            "version": "3.30.0",
+            "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.30.0.tgz",
+            "integrity": "sha512-ed/SvldxK2GbDgL0QlKjKMARvMHQNSCp/xZXXRVXtJZUTsMq2NPnKQWlyATxxmpIfOTzOOhwPGa1Uz/ED/hIMA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -885,8 +885,8 @@
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "3.29.2",
-                "@tiptap/pm": "3.29.2"
+                "@tiptap/core": "3.30.0",
+                "@tiptap/pm": "3.30.0"
             }
         },
         "node_modules/@types/hast": {
@@ -942,9 +942,9 @@
             "license": "MIT"
         },
         "node_modules/alpinejs": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
-            "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
+            "version": "3.16.1",
+            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.1.tgz",
+            "integrity": "sha512-QXcW8MK9JoG8GZ7vCt2cXJlcEPIA7Xk/7IQ1+L2iLp7sXcIxct0PrgidmHzK97gD9QlfUjHXPxujdZ1mC2PYVg==",
             "license": "MIT",
             "dependencies": {
                 "@vue/reactivity": "~3.1.1"
@@ -1165,9 +1165,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.403",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
-            "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
+            "version": "1.5.405",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+            "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
             "dev": true,
             "license": "ISC"
         },
@@ -1226,9 +1226,9 @@
             }
         },
         "node_modules/framer-motion": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.0.0.tgz",
-            "integrity": "sha512-nQGZXlsiigN48nzvE7AL1GLekql+etcphp8v+PQ0X04oxO20yVmV9rU9XQ25c136RdeIYoaWlKT9oAwvJza3mg==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.0.tgz",
+            "integrity": "sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==",
             "license": "MIT",
             "dependencies": {
                 "motion-dom": "^13.0.0",
@@ -1346,9 +1346,9 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.3.tgz",
-            "integrity": "sha512-cI5Anw4QHY+UzvZczFaj+j8NhwT2FtyEN8aqS/hOdt6DpEFBsn6x3GENxALem3cc+TsGvd9MacneimEvShvKMA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.2.0.tgz",
+            "integrity": "sha512-xSxY9Gzeb/eancd8WeK09piAFP+a6i5QIBqNCKNv9L0Eq6wziwzSem7F1GvMSrtjMh5F/QVKFxn8t9naGOA66A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1763,12 +1763,12 @@
             }
         },
         "node_modules/motion": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/motion/-/motion-13.0.0.tgz",
-            "integrity": "sha512-RYZjEpgHUCKjBNqjmUQzW93VJWLvEZGTPdKRFSqOdOl07IIMvz+WrsZmD1XXAkoFLruW/8bO1L7UF+ViQTxtLg==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/motion/-/motion-13.1.0.tgz",
+            "integrity": "sha512-qtvscq59uCPdWnNW4SdSkrxR+BS/QYsa923bx7ocA+4p+ZGNbbVQwkSnG4aukB81QWjtl3AxX36plxNyZLmHCA==",
             "license": "MIT",
             "dependencies": {
-                "framer-motion": "^13.0.0",
+                "framer-motion": "^13.1.0",
                 "tslib": "^2.4.0"
             },
             "peerDependencies": {
@@ -2234,12 +2234,12 @@
             "license": "MIT"
         },
         "node_modules/rolldown": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
-            "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+            "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.143.0",
+                "@oxc-project/types": "=0.144.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -2249,20 +2249,20 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.2.3",
-                "@rolldown/binding-darwin-arm64": "1.2.3",
-                "@rolldown/binding-darwin-x64": "1.2.3",
-                "@rolldown/binding-freebsd-x64": "1.2.3",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
-                "@rolldown/binding-linux-arm64-gnu": "1.2.3",
-                "@rolldown/binding-linux-arm64-musl": "1.2.3",
-                "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
-                "@rolldown/binding-linux-s390x-gnu": "1.2.3",
-                "@rolldown/binding-linux-x64-gnu": "1.2.3",
-                "@rolldown/binding-linux-x64-musl": "1.2.3",
-                "@rolldown/binding-openharmony-arm64": "1.2.3",
-                "@rolldown/binding-win32-arm64-msvc": "1.2.3",
-                "@rolldown/binding-win32-x64-msvc": "1.2.3"
+                "@rolldown/binding-android-arm64": "1.2.4",
+                "@rolldown/binding-darwin-arm64": "1.2.4",
+                "@rolldown/binding-darwin-x64": "1.2.4",
+                "@rolldown/binding-freebsd-x64": "1.2.4",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+                "@rolldown/binding-linux-arm64-musl": "1.2.4",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+                "@rolldown/binding-linux-x64-gnu": "1.2.4",
+                "@rolldown/binding-linux-x64-musl": "1.2.4",
+                "@rolldown/binding-openharmony-arm64": "1.2.4",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+                "@rolldown/binding-win32-x64-msvc": "1.2.4"
             }
         },
         "node_modules/rope-sequence": {
@@ -2272,17 +2272,17 @@
             "license": "MIT"
         },
         "node_modules/shiki": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.2.tgz",
-            "integrity": "sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+            "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "4.4.2",
-                "@shikijs/engine-javascript": "4.4.2",
-                "@shikijs/engine-oniguruma": "4.4.2",
-                "@shikijs/langs": "4.4.2",
-                "@shikijs/themes": "4.4.2",
-                "@shikijs/types": "4.4.2",
+                "@shikijs/core": "4.4.3",
+                "@shikijs/engine-javascript": "4.4.3",
+                "@shikijs/engine-oniguruma": "4.4.3",
+                "@shikijs/langs": "4.4.3",
+                "@shikijs/themes": "4.4.3",
+                "@shikijs/types": "4.4.3",
                 "@shikijs/vscode-textmate": "^10.0.2",
                 "@types/hast": "^3.0.5"
             },
@@ -2449,9 +2449,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
-            "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "dev": true,
             "funding": [
                 {

--- a/packages/Chat/src/Support/DestinationResolver.php
+++ b/packages/Chat/src/Support/DestinationResolver.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\Chat\Support;
 
-use App\Filament\Pages\EditTeam;
+use App\Filament\Pages\Team\CustomFields;
+use App\Filament\Pages\Team\Members;
 use App\Models\Team;
-use Relaticle\CustomFields\Filament\Management\Pages\CustomFieldsManagementPage;
 use Relaticle\ImportWizard\Filament\Pages\ImportCompanies;
 use Relaticle\ImportWizard\Filament\Pages\ImportNotes;
 use Relaticle\ImportWizard\Filament\Pages\ImportOpportunities;
@@ -38,13 +38,13 @@ final readonly class DestinationResolver
     {
         try {
             return match ($destination) {
-                'custom_fields' => CustomFieldsManagementPage::getUrl(panel: 'app', tenant: $team),
+                'custom_fields' => CustomFields::getUrl(panel: 'app', tenant: $team),
                 'import_companies' => ImportCompanies::getUrl(panel: 'app', tenant: $team),
                 'import_people' => ImportPeople::getUrl(panel: 'app', tenant: $team),
                 'import_opportunities' => ImportOpportunities::getUrl(panel: 'app', tenant: $team),
                 'import_tasks' => ImportTasks::getUrl(panel: 'app', tenant: $team),
                 'import_notes' => ImportNotes::getUrl(panel: 'app', tenant: $team),
-                'team_members' => EditTeam::getUrl(panel: 'app', tenant: $team),
+                'team_members' => Members::getUrl(panel: 'app', tenant: $team),
                 default => null,
             };
         } catch (Throwable) {

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -289,6 +289,13 @@
     @apply rounded-xl;
 }
 
+/* Page sub-navigation tabs (workspace settings). Filament centres the strip;
+   every heading and section on these pages is left-aligned, so a centred strip
+   reads as a stray floating element. */
+.fi-page-sub-navigation-tabs {
+    @apply mx-0;
+}
+
 /* Dropdowns */
 .fi-dropdown-panel {
     @apply rounded-xl;

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -294,6 +294,16 @@
     @apply rounded-xl;
 }
 
+/* asmit/resized-column lifts the table toolbar (`.fi-ta-header-ctn`) to
+   z-index 21 so its own dropdowns clear the sticky table head at 19. That also
+   puts it above a page-header action dropdown, whose panel is Filament's
+   default z-index 20 — the panel then renders *behind* the search field and
+   filter/column triggers. Lift those panels over the toolbar; 22 keeps them
+   under Filament chrome (topbar/sidebar, z-index 30). */
+.fi-header-actions-ctn .fi-dropdown-panel {
+    @apply z-[22];
+}
+
 .fi-dropdown-list-item {
     @apply rounded-lg;
 }

--- a/resources/views/filament/pages/team/members.blade.php
+++ b/resources/views/filament/pages/team/members.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->form }}
+</x-filament-panels::page>

--- a/tests/Browser/CRM/CompanyBrowserTest.php
+++ b/tests/Browser/CRM/CompanyBrowserTest.php
@@ -25,3 +25,44 @@ it('can create a company through the browser', function (): void {
 
     expect(Company::where('name', 'Browser Test Corp')->where('team_id', $team->id)->exists())->toBeTrue();
 });
+
+it('paints the header action dropdown above the table toolbar', function (): void {
+    $this->withVite();
+
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = $this->visit('/app/login')
+        ->type('[id="form.email"]', $user->email)
+        ->type('[id="form.password"]', 'password')
+        ->click('button.fi-btn')
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/companies")
+        ->assertSee('Import / Export');
+
+    $page->script(<<<'JS'
+        (() => {
+            const trigger = document.querySelector('.fi-header-actions-ctn .fi-dropdown-trigger');
+            trigger.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+            return true;
+        })();
+    JS);
+
+    $page->assertSee('Export companies');
+
+    $hitsPanel = $page->script(<<<'JS'
+        (() => {
+            const panel = document.querySelector('.fi-header-actions-ctn .fi-dropdown-panel');
+            const box = panel.getBoundingClientRect();
+
+            return ['left', 'right']
+                .map((edge) => document.elementFromPoint(
+                    edge === 'left' ? box.left + 8 : box.right - 8,
+                    box.bottom - 8,
+                ))
+                .every((hit) => hit?.closest('.fi-dropdown-panel') === panel);
+        })();
+    JS);
+
+    expect($hitsPanel)->toBeTrue();
+});

--- a/tests/Browser/Chat/CharCapGateTest.php
+++ b/tests/Browser/Chat/CharCapGateTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 it('does not send when the composer text exceeds the character cap', function (): void {
     $user = User::factory()->withTeam()->create();
@@ -19,11 +20,11 @@ it('does not send when the composer text exceeds the character cap', function ()
     // Load 5,100 characters into the TipTap composer (cap is 5,000) and ask the
     // chat interface to send. sendMessage() reads the editor text via
     // localEditor().getText() and must bail before pushing a user message.
-    $userMessageCount = (int) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $userMessageCount = (int) $page->script(<<<JS
         (async () => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             data.localEditor().setText('x'.repeat(5100));
             data.sendMessage();

--- a/tests/Browser/Chat/DuplicateSendTest.php
+++ b/tests/Browser/Chat/DuplicateSendTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 it('does not push two user messages when sendMessage is called twice in the same tick', function (): void {
     $user = User::factory()->withTeam()->create();
@@ -16,11 +17,11 @@ it('does not push two user messages when sendMessage is called twice in the same
         ->navigate("/app/{$team->slug}/chats")
         ->assertSourceHas('placeholder="Ask anything..."');
 
-    $userCount = (int) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $userCount = (int) $page->script(<<<JS
         (async () => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             // sendMessage() reads the composer via localEditor().getText().
             data.localEditor().setText('race test');

--- a/tests/Browser/Chat/MentionPickerTest.php
+++ b/tests/Browser/Chat/MentionPickerTest.php
@@ -16,8 +16,15 @@ use App\Models\User;
  * internals, because the suggestion only fires from genuine ProseMirror input.
  */
 
-/** Selector for the visible conversation composer's contenteditable surface. */
-const EDITOR = '[data-chat-context="conversation"] [contenteditable="true"]';
+/**
+ * Selector for the visible composer's contenteditable surface.
+ *
+ * The chat drawer rework made the dashboard composer the one that is on screen
+ * when you land on a workspace; the side-panel interfaces are mounted collapsed.
+ * Targeting a context that is not rendered makes Playwright wait for an element
+ * that never becomes actionable, which hangs the run rather than failing it.
+ */
+const EDITOR = '[data-chat-context="dashboard"] [contenteditable="true"]';
 
 /** Poll until the mention popup renders at least one option, returning its labels. */
 const WAIT_FOR_OPTIONS = <<<'JS'
@@ -71,7 +78,7 @@ it('opens a picker when @ is typed and inserts a chip on selection', function ()
 
     $chip = $page->script(<<<'JS'
         (() => {
-            const node = document.querySelector('[data-chat-context="conversation"] [contenteditable="true"] span[data-mention-id]');
+            const node = document.querySelector('[data-chat-context="dashboard"] [contenteditable="true"] span[data-mention-id]');
             return node ? node.textContent.trim() : null;
         })();
     JS);
@@ -216,7 +223,7 @@ it('removes a selected mention chip with backspace', function (): void {
             if (! option) return -1;
             option.click();
             await new Promise((r) => setTimeout(r, 100));
-            return document.querySelectorAll('[data-chat-context="conversation"] [contenteditable="true"] span[data-mention-id]').length;
+            return document.querySelectorAll('[data-chat-context="dashboard"] [contenteditable="true"] span[data-mention-id]').length;
         })();
     JS);
 
@@ -228,7 +235,7 @@ it('removes a selected mention chip with backspace', function (): void {
 
     $after = $page->script(<<<'JS'
         (() => {
-            const editor = document.querySelector('[data-chat-context="conversation"] [contenteditable="true"]');
+            const editor = document.querySelector('[data-chat-context="dashboard"] [contenteditable="true"]');
             return {
                 chips: editor.querySelectorAll('span[data-mention-id]').length,
                 text: editor.textContent,

--- a/tests/Browser/Chat/ModelPickerTest.php
+++ b/tests/Browser/Chat/ModelPickerTest.php
@@ -14,10 +14,10 @@ it('closes the model picker when the user presses Escape', function (): void {
         ->click('button.fi-btn')
         ->assertPathIs("/app/{$team->slug}")
         ->navigate("/app/{$team->slug}/chats")
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->assertVisible('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]')
-        ->keys('[data-chat-context="conversation"] [aria-label="Select AI model"]', 'Escape')
-        ->assertMissing('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]');
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->assertVisible('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]')
+        ->keys('[data-chat-context="dashboard"] [aria-label="Select AI model"]', 'Escape')
+        ->assertMissing('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]');
 });
 
 it('reopens the model picker after Escape closes it', function (): void {
@@ -30,8 +30,8 @@ it('reopens the model picker after Escape closes it', function (): void {
         ->click('button.fi-btn')
         ->assertPathIs("/app/{$team->slug}")
         ->navigate("/app/{$team->slug}/chats")
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->keys('[data-chat-context="conversation"] [aria-label="Select AI model"]', 'Escape')
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->assertVisible('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]');
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->keys('[data-chat-context="dashboard"] [aria-label="Select AI model"]', 'Escape')
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->assertVisible('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]');
 });

--- a/tests/Browser/Chat/ProposalOutcomeSummaryTest.php
+++ b/tests/Browser/Chat/ProposalOutcomeSummaryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 /**
  * The agent outcome summary (`proposalOutcome`) is pure Alpine view logic on the
@@ -23,11 +24,11 @@ it('summarizes a finalized proposal for each operation and branch', function ():
         ->navigate("/app/{$team->slug}/chats")
         ->assertSourceHas('placeholder="Ask anything..."');
 
-    $outcomes = json_decode((string) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $outcomes = json_decode((string) $page->script(<<<JS
         (() => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             const singleCreate = {
                 operation: 'create', status: 'approved',

--- a/tests/Feature/Billing/BillingCheckoutRedirectTest.php
+++ b/tests/Feature/Billing/BillingCheckoutRedirectTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Plan;
+use App\Features\Billing as BillingFeature;
+use App\Filament\Pages\Billing;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Laravel\Pennant\Feature;
+use Stripe\ApiRequestor;
+use Stripe\HttpClient\ClientInterface;
+
+mutates(Billing::class);
+
+/**
+ * Stripe's SDK talks HTTP directly, so the only way to exercise the real
+ * checkout path offline is to hand it a client that answers with a canned
+ * session. Everything above it — Cashier, the action, the Livewire method —
+ * runs for real.
+ */
+function fakeStripeCheckoutSession(string $url): void
+{
+    ApiRequestor::setHttpClient(new class($url) implements ClientInterface
+    {
+        public function __construct(private readonly string $url) {}
+
+        public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1', $maxNetworkRetries = null): array
+        {
+            $body = match (true) {
+                str_contains((string) $absUrl, '/checkout/sessions') => [
+                    'id' => 'cs_test_fake',
+                    'object' => 'checkout.session',
+                    'url' => $this->url,
+                ],
+                str_contains((string) $absUrl, '/billing_portal/sessions') => [
+                    'id' => 'bps_test_fake',
+                    'object' => 'billing_portal.session',
+                    'url' => $this->url,
+                ],
+                str_contains((string) $absUrl, '/customers') => [
+                    'id' => 'cus_test_fake',
+                    'object' => 'customer',
+                    'email' => 'billing@example.test',
+                ],
+                default => ['id' => 'obj_test_fake', 'object' => 'object'],
+            };
+
+            return [json_encode($body), 200, []];
+        }
+    });
+}
+
+beforeEach(function (): void {
+    Feature::define(BillingFeature::class, true);
+    config()->set('cashier.secret', 'sk_test_fake');
+    config()->set('services.stripe.prices.pro_monthly', 'price_pro_monthly_test');
+    config()->set('services.stripe.credit_packs.small', ['price' => 'price_credits_1k_test', 'credits' => 1000]);
+
+    $user = User::factory()->withPersonalTeam()->create();
+
+    /** @var Team $team */
+    $team = $user->currentTeam;
+    $team->forceFill([
+        'hosted_free_grandfathered_at' => now(),
+        'plan' => Plan::Free,
+        'stripe_id' => 'cus_test_fake',
+    ])->save();
+
+    $this->actingAs($user);
+    Filament::setTenant($team);
+    $this->team = $team;
+});
+
+afterEach(function (): void {
+    ApiRequestor::setHttpClient(null);
+});
+
+it('redirects the owner to the Stripe checkout url when upgrading', function (): void {
+    fakeStripeCheckoutSession('https://checkout.stripe.com/c/pay/cs_test_fake');
+
+    livewire(Billing::class)
+        ->call('upgrade', 'monthly')
+        ->assertRedirect('https://checkout.stripe.com/c/pay/cs_test_fake')
+        ->assertNotNotified();
+});
+
+it('redirects the owner to the Stripe checkout url when buying a credit pack', function (): void {
+    fakeStripeCheckoutSession('https://checkout.stripe.com/c/pay/cs_test_credits');
+
+    livewire(Billing::class)
+        ->call('buyCredits', 'small')
+        ->assertRedirect('https://checkout.stripe.com/c/pay/cs_test_credits')
+        ->assertNotNotified();
+});
+
+it('redirects the owner to the Stripe billing portal', function (): void {
+    fakeStripeCheckoutSession('https://billing.stripe.com/p/session/test');
+    $this->team->forceFill(['plan' => Plan::Pro])->save();
+
+    livewire(Billing::class)
+        ->call('managePortal')
+        ->assertRedirect('https://billing.stripe.com/p/session/test')
+        ->assertNotNotified();
+});

--- a/tests/Feature/Teams/TeamSettingsInvitationFlowTest.php
+++ b/tests/Feature/Teams/TeamSettingsInvitationFlowTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Filament\Pages\EditTeam;
+use App\Filament\Pages\Team\Members;
 use App\Livewire\App\Teams\AddTeamMember;
 use App\Livewire\App\Teams\PendingTeamInvitations;
 use App\Livewire\App\Teams\TeamMembers;
@@ -24,19 +25,30 @@ beforeEach(function () {
     Filament::setTenant($this->team);
 });
 
-test('team settings page does not render ManageInviteLink', function () {
+test('the general tab owns workspace name and deletion', function () {
     $page = app(EditTeam::class);
     $page->tenant = $this->team;
 
-    $schema = $page->form(Schema::make($page));
-
-    $components = collect($schema->getComponents())
-        ->filter(fn ($c) => $c instanceof LivewireComponent)
-        ->map(fn (LivewireComponent $c) => $c->getComponent())
+    $components = collect($page->form(Schema::make($page))->getComponents())
+        ->filter(fn ($c): bool => $c instanceof LivewireComponent)
+        ->map(fn (LivewireComponent $c): string => $c->getComponent())
         ->all();
 
     expect($components)->toContain(UpdateTeamName::class)
-        ->and($components)->toContain(AddTeamMember::class)
+        ->and($components)->not->toContain(AddTeamMember::class)
+        ->and($components)->not->toContain(PendingTeamInvitations::class)
+        ->and($components)->not->toContain(TeamMembers::class);
+});
+
+test('the members tab owns invitations and membership, and does not render ManageInviteLink', function () {
+    $page = app(Members::class);
+
+    $components = collect($page->form(Schema::make($page))->getComponents())
+        ->filter(fn ($c): bool => $c instanceof LivewireComponent)
+        ->map(fn (LivewireComponent $c): string => $c->getComponent())
+        ->all();
+
+    expect($components)->toContain(AddTeamMember::class)
         ->and($components)->toContain(PendingTeamInvitations::class)
         ->and($components)->toContain(TeamMembers::class)
         ->and($components)->not->toContain('App\\Livewire\\App\\Teams\\ManageInviteLink');

--- a/tests/Feature/Teams/WorkspaceSettingsNavigationTest.php
+++ b/tests/Feature/Teams/WorkspaceSettingsNavigationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\Billing as BillingFeature;
+use App\Filament\Pages\Billing;
+use App\Filament\Pages\EditTeam;
+use App\Filament\Pages\Team\CustomFields;
+use App\Filament\Pages\Team\Members;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Navigation\NavigationItem;
+use Illuminate\Support\Facades\Route;
+use Laravel\Pennant\Feature;
+
+mutates(Members::class, CustomFields::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    $this->team = $this->user->currentTeam;
+    Filament::setTenant($this->team);
+});
+
+/** @return list<string> */
+function workspaceTabLabels(object $page): array
+{
+    return collect($page->getSubNavigation())
+        ->filter(fn (NavigationItem $item): bool => $item->isVisible())
+        ->map(fn (NavigationItem $item): string => $item->getLabel())
+        ->values()
+        ->all();
+}
+
+test('every workspace settings page renders the same tab strip', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $expected = [
+        __('teams.tabs.general'),
+        __('teams.tabs.members'),
+        __('teams.tabs.custom_fields'),
+        __('teams.tabs.billing'),
+    ];
+
+    foreach ([EditTeam::class, Members::class, CustomFields::class, Billing::class] as $page) {
+        expect(workspaceTabLabels(app($page)))
+            ->toBe($expected, "[{$page}] should render the full tab strip");
+    }
+});
+
+test('the custom fields tab lives under the team url and the standalone route is gone', function (): void {
+    expect(CustomFields::getSlug())->toBe('team/custom-fields')
+        ->and(Members::getSlug())->toBe('team/members')
+        ->and(Route::has('filament.app.pages.custom-fields'))->toBeFalse()
+        ->and(Route::has('filament.app.pages.team.custom-fields'))->toBeTrue();
+});
+
+test('billing keeps its own url so the paywall allowlist keeps matching', function (): void {
+    expect(Billing::getSlug())->toBe('billing')
+        ->and(Route::has('filament.app.pages.billing'))->toBeTrue();
+});
+
+test('a workspace admin can open every tab', function (): void {
+    foreach ([
+        EditTeam::getUrl(tenant: $this->team),
+        Members::getUrl(tenant: $this->team),
+        CustomFields::getUrl(tenant: $this->team),
+    ] as $url) {
+        $this->get($url)->assertSuccessful();
+    }
+});
+
+test('a user outside the workspace cannot open the members tab', function (): void {
+    $url = Members::getUrl(tenant: $this->team);
+
+    // Filament's tenancy answers 404 rather than 403 so it does not leak that
+    // the workspace exists.
+    $this->actingAs(User::factory()->withTeam()->create())
+        ->get($url)
+        ->assertNotFound();
+});
+
+test('the tab strip drops billing when the feature is off', function (): void {
+    Feature::define(BillingFeature::class, false);
+
+    expect(workspaceTabLabels(app(EditTeam::class)))
+        ->not->toContain(__('teams.tabs.billing'));
+});

--- a/tests/Helpers/ChatBrowser.php
+++ b/tests/Helpers/ChatBrowser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+final class ChatBrowser
+{
+    /**
+     * JS that resolves the chat interface's Alpine component on the current page.
+     *
+     * Since the chat drawer rework the interface is rendered collapsed on the
+     * dashboard, so `offsetParent` is null even though the component is mounted
+     * and its data is live. Prefer a visible host when there is one — a page may
+     * mount both the drawer and an inline interface — and otherwise fall back to
+     * the mounted one rather than handing `undefined` to `Alpine.$data()`.
+     */
+    public static function resolveInterface(string $variable = 'data'): string
+    {
+        return <<<JS
+            const hosts = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'));
+            const host = hosts.find((el) => el.offsetParent !== null) ?? hosts[0];
+
+            if (! host) {
+                throw new Error('No chatInterface component is mounted on this page.');
+            }
+
+            const {$variable} = Alpine.\$data(host);
+        JS;
+    }
+}


### PR DESCRIPTION
> **Draft — blocked on a package release.** `composer.json` currently points at the branch behind Relaticle/custom-fields#200. Once that merges and is tagged `v3.7.0`, the `repositories` block goes away and the constraint becomes `^3.7`. Everything else is ready to review.

Workspace Settings was one long scroll, and custom fields lived on an unrelated top-level route reachable only from the workspace dropdown.

## Tabs

| Tab | Route |
|---|---|
| General — workspace name + delete | `/team` *(unchanged)* |
| Members — add member, pending invitations, member list | `/team/members` *(new)* |
| Custom Fields | `/team/custom-fields` |
| Billing | `/billing` *(unchanged)* |

Rendered as Filament page sub-navigation (`getSubNavigation()` + `SubNavigationPosition::Top`) via one shared concern, so the strip is identical whichever tab you land on and each tab carries its page's own access guard.

**Billing keeps `/billing` deliberately.** Its route name `filament.app.pages.billing` is hardcoded in `EnsureHostedWorkspaceAccess`'s paywall allowlist, in `ProTrialEndingSoonMail`, in both checkout actions and in `HostedWorkspaceAccessTest`. Renaming the slug renames the route to `…pages.team.billing`, dropping it out of the allowlist — a redirect loop on the billing page itself. Sub-nav items are just links; they do not need a shared prefix.

**`/custom-fields` is gone, with no duplicate route.** The page is registered through the new `CustomFieldsPlugin::managementPage()` seam (Relaticle/custom-fields#200), which swaps the packaged page instead of joining it. The workspace-menu entry is removed; Import History and Billing stay.

Filament centres the top tab strip; every heading and section on these pages is left-aligned, so the strip is aligned to the content column.

## Two breakages the split would have caused

`packages/Chat/src/Support/DestinationResolver.php` pointed the assistant's `custom_fields` link at the vendor page that is no longer registered, and its `team_members` link at the General tab that no longer lists members. Both now resolve to the new pages.

## Billing redirects (RELATICLE-CRM-5R)

Reported as `TypeError: Billing::upgrade(): Return value must be of type ?RedirectResponse, Livewire\Features\SupportRedirects\Redirector returned`.

Inside a Livewire component `redirect()` resolves Livewire's `Redirector`, whose `away()` registers the redirect effect and returns `$this`. So the sequence was: Stripe session created → redirect effect registered → return-type check throws → caught by the method's own `catch (Throwable)` → `report()` + a red "we couldn't start checkout" toast. Users were redirected to Stripe *and* shown an error, and every upgrade click logged a TypeError.

Reproduced with a fake Stripe HTTP client: `effects: {"returns":[null], "redirect":"https://checkout.stripe.com/…"}` alongside the danger notification.

Swept the siblings, and `managePortal()` was worse — Cashier builds its own `RedirectResponse`, which Livewire does not act on, so **"Manage subscription" silently did nothing**. Proven by reverting it: *"Component did not perform a redirect."*

All three now use `$this->redirect()` and return `void`.

## Test plan

- `tests/Feature/Teams/WorkspaceSettingsNavigationTest.php` — all four pages render the same strip; slugs; `/custom-fields` no longer resolves; billing keeps its route; admin can open every tab; outsider gets 404 (Filament's tenancy does not leak workspace existence); the strip follows the billing feature flag.
- `tests/Feature/Teams/TeamSettingsInvitationFlowTest.php` — updated to the new split. The old assertion that `EditTeam` renders the member components was stale, not wrong production behaviour.
- `tests/Feature/Billing/BillingCheckoutRedirectTest.php` — drives the real path through a fake Stripe HTTP client, so the **success** case is covered rather than only the failure case, which is why this reached production.

Each new billing test verified load-bearing by reverting the fix individually.

Gates: pint, rector, PHPStan clean; type coverage 100%; Arch 24/24; full suite 2632 passed / 0 failures.

Browser-checked in light and dark: all four tabs, active states, and the custom fields screen intact inside the tab (entity list, counts, search, Add Field, drag handles).

## Why a shared concern rather than a cluster

The app already has `App\Filament\Clusters\Settings` (`/settings`, `SubNavigationPosition::Top`) grouping `EditProfile` and `NotificationPreferences` — the *user's* settings. Workspace settings are a different scope, but the obvious question is why they are not a second cluster.

Because `EditTeam` is a tenant-profile page. Filament registers its route through `->tenantProfile()` at a fixed `/{tenant}/team`, and `Page::getRoutePath()` applies the cluster slug as a route prefix — joining a cluster would move it to `/{tenant}/<cluster>/team` and break the `filament.app.tenant.profile` route.

So these pages get their sub-navigation from a shared concern instead. It resolves to the same `SubNavigationPosition::Top` and renders through Filament's own `x-filament-panels::page.sub-navigation.tabs`, so the strip is visually identical to the Settings cluster's — only the wiring differs.


**Note on blast radius:** the tab-strip alignment rule targets `.fi-page-sub-navigation-tabs` globally, so it also left-aligns the existing Settings cluster's strip (`/settings/profile`, `/settings/notifications`), which Filament was centring. Verified in the browser: strip and content column both start at the same x. That is the intended consistency, but it is a visual change to pages outside this feature.
