### PR TITLE
fix(tests): repoint the chat browser tests at the reworked drawer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Browser Tests
 
+    # A browser test that waits on an element which never appears hangs rather
+    # than fails, and without a ceiling the job runs until GitHub cancels it at
+    # six hours. The suite finishes in about two minutes.
+    timeout-minutes: 20
+
     services:
       postgres:
         image: postgres:alpine

--- a/tests/Browser/Chat/CharCapGateTest.php
+++ b/tests/Browser/Chat/CharCapGateTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 it('does not send when the composer text exceeds the character cap', function (): void {
     $user = User::factory()->withTeam()->create();
@@ -19,11 +20,11 @@ it('does not send when the composer text exceeds the character cap', function ()
     // Load 5,100 characters into the TipTap composer (cap is 5,000) and ask the
     // chat interface to send. sendMessage() reads the editor text via
     // localEditor().getText() and must bail before pushing a user message.
-    $userMessageCount = (int) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $userMessageCount = (int) $page->script(<<<JS
         (async () => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             data.localEditor().setText('x'.repeat(5100));
             data.sendMessage();

--- a/tests/Browser/Chat/DuplicateSendTest.php
+++ b/tests/Browser/Chat/DuplicateSendTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 it('does not push two user messages when sendMessage is called twice in the same tick', function (): void {
     $user = User::factory()->withTeam()->create();
@@ -16,11 +17,11 @@ it('does not push two user messages when sendMessage is called twice in the same
         ->navigate("/app/{$team->slug}/chats")
         ->assertSourceHas('placeholder="Ask anything..."');
 
-    $userCount = (int) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $userCount = (int) $page->script(<<<JS
         (async () => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             // sendMessage() reads the composer via localEditor().getText().
             data.localEditor().setText('race test');

--- a/tests/Browser/Chat/MentionPickerTest.php
+++ b/tests/Browser/Chat/MentionPickerTest.php
@@ -16,8 +16,15 @@ use App\Models\User;
  * internals, because the suggestion only fires from genuine ProseMirror input.
  */
 
-/** Selector for the visible conversation composer's contenteditable surface. */
-const EDITOR = '[data-chat-context="conversation"] [contenteditable="true"]';
+/**
+ * Selector for the visible composer's contenteditable surface.
+ *
+ * The chat drawer rework made the dashboard composer the one that is on screen
+ * when you land on a workspace; the side-panel interfaces are mounted collapsed.
+ * Targeting a context that is not rendered makes Playwright wait for an element
+ * that never becomes actionable, which hangs the run rather than failing it.
+ */
+const EDITOR = '[data-chat-context="dashboard"] [contenteditable="true"]';
 
 /** Poll until the mention popup renders at least one option, returning its labels. */
 const WAIT_FOR_OPTIONS = <<<'JS'
@@ -71,7 +78,7 @@ it('opens a picker when @ is typed and inserts a chip on selection', function ()
 
     $chip = $page->script(<<<'JS'
         (() => {
-            const node = document.querySelector('[data-chat-context="conversation"] [contenteditable="true"] span[data-mention-id]');
+            const node = document.querySelector('[data-chat-context="dashboard"] [contenteditable="true"] span[data-mention-id]');
             return node ? node.textContent.trim() : null;
         })();
     JS);
@@ -216,7 +223,7 @@ it('removes a selected mention chip with backspace', function (): void {
             if (! option) return -1;
             option.click();
             await new Promise((r) => setTimeout(r, 100));
-            return document.querySelectorAll('[data-chat-context="conversation"] [contenteditable="true"] span[data-mention-id]').length;
+            return document.querySelectorAll('[data-chat-context="dashboard"] [contenteditable="true"] span[data-mention-id]').length;
         })();
     JS);
 
@@ -228,7 +235,7 @@ it('removes a selected mention chip with backspace', function (): void {
 
     $after = $page->script(<<<'JS'
         (() => {
-            const editor = document.querySelector('[data-chat-context="conversation"] [contenteditable="true"]');
+            const editor = document.querySelector('[data-chat-context="dashboard"] [contenteditable="true"]');
             return {
                 chips: editor.querySelectorAll('span[data-mention-id]').length,
                 text: editor.textContent,

--- a/tests/Browser/Chat/ModelPickerTest.php
+++ b/tests/Browser/Chat/ModelPickerTest.php
@@ -14,10 +14,10 @@ it('closes the model picker when the user presses Escape', function (): void {
         ->click('button.fi-btn')
         ->assertPathIs("/app/{$team->slug}")
         ->navigate("/app/{$team->slug}/chats")
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->assertVisible('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]')
-        ->keys('[data-chat-context="conversation"] [aria-label="Select AI model"]', 'Escape')
-        ->assertMissing('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]');
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->assertVisible('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]')
+        ->keys('[data-chat-context="dashboard"] [aria-label="Select AI model"]', 'Escape')
+        ->assertMissing('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]');
 });
 
 it('reopens the model picker after Escape closes it', function (): void {
@@ -30,8 +30,8 @@ it('reopens the model picker after Escape closes it', function (): void {
         ->click('button.fi-btn')
         ->assertPathIs("/app/{$team->slug}")
         ->navigate("/app/{$team->slug}/chats")
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->keys('[data-chat-context="conversation"] [aria-label="Select AI model"]', 'Escape')
-        ->click('[data-chat-context="conversation"] [aria-label="Select AI model"]')
-        ->assertVisible('[data-chat-context="conversation"] [role="listbox"][aria-label="AI model options"]');
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->keys('[data-chat-context="dashboard"] [aria-label="Select AI model"]', 'Escape')
+        ->click('[data-chat-context="dashboard"] [aria-label="Select AI model"]')
+        ->assertVisible('[data-chat-context="dashboard"] [role="listbox"][aria-label="AI model options"]');
 });

--- a/tests/Browser/Chat/ProposalOutcomeSummaryTest.php
+++ b/tests/Browser/Chat/ProposalOutcomeSummaryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Tests\Helpers\ChatBrowser;
 
 /**
  * The agent outcome summary (`proposalOutcome`) is pure Alpine view logic on the
@@ -23,11 +24,11 @@ it('summarizes a finalized proposal for each operation and branch', function ():
         ->navigate("/app/{$team->slug}/chats")
         ->assertSourceHas('placeholder="Ask anything..."');
 
-    $outcomes = json_decode((string) $page->script(<<<'JS'
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $outcomes = json_decode((string) $page->script(<<<JS
         (() => {
-            const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
-                .find((el) => el.offsetParent !== null);
-            const data = Alpine.$data(host);
+            {$resolveInterface}
 
             const singleCreate = {
                 operation: 'create', status: 'approved',

--- a/tests/Helpers/ChatBrowser.php
+++ b/tests/Helpers/ChatBrowser.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+final class ChatBrowser
+{
+    /**
+     * JS that resolves the chat interface's Alpine component on the current page.
+     *
+     * Since the chat drawer rework the interface is rendered collapsed on the
+     * dashboard, so `offsetParent` is null even though the component is mounted
+     * and its data is live. Prefer a visible host when there is one — a page may
+     * mount both the drawer and an inline interface — and otherwise fall back to
+     * the mounted one rather than handing `undefined` to `Alpine.$data()`.
+     */
+    public static function resolveInterface(string $variable = 'data'): string
+    {
+        return <<<JS
+            const hosts = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'));
+            const host = hosts.find((el) => el.offsetParent !== null) ?? hosts[0];
+
+            if (! host) {
+                throw new Error('No chatInterface component is mounted on this page.');
+            }
+
+            const {$variable} = Alpine.\$data(host);
+        JS;
+    }
+}


### PR DESCRIPTION
**Browser Tests has been red on `main` since #449 merged, and every PR opened against `main` since has inherited it.** The job does not fail — it hangs, and GitHub cancels it at the six-hour ceiling.

## Root cause

The chat drawer rework (#449) renamed the composer's context from `conversation` to `dashboard` / `side-panel`, and left the side-panel interfaces mounted but collapsed. The browser tests still targeted the old context. That broke them in two different ways:

**1. Alpine lookup returns `undefined` (fails fast, ~32s)**

`CharCapGateTest`, `DuplicateSendTest` and `ProposalOutcomeSummaryTest` resolved the component with:

```js
const host = Array.from(document.querySelectorAll('[x-data^="chatInterface"]'))
    .find((el) => el.offsetParent !== null);
const data = Alpine.$data(host); // TypeError: Cannot read properties of undefined
```

The component *is* mounted, but collapsed — so `offsetParent` is null and the `find` yields `undefined`. `LoadingShimmerTest` already had a `?? candidates[0]` fallback, which is exactly why it kept passing while its siblings did not.

**2. Playwright waits forever (hangs the job)**

`MentionPickerTest` and `ModelPickerTest` drove `[data-chat-context="conversation"]` through `->click()`. That element no longer exists on the page, so Playwright waits for it to become actionable rather than failing. That is the six-hour job.

## Fix

Point the selectors at the dashboard composer — the one actually on screen when a workspace loads — and centralise the Alpine lookup in `Tests\Helpers\ChatBrowser` so the next context rename is a one-line change rather than five.

Test-layer only; no production code is touched. The product behaviour is correct — the tests were describing a UI that no longer exists.

## Evidence

Bisected:

| Commit | Result |
|---|---|
| `8cbe640b9` (parent of #449) | PASS 2.6s |
| `b14acc9c3` — #449 | FAIL 33.0s |
| `18f73fe52` (main HEAD) | FAIL 32.5s |

The last green Browser Tests run (`ea5daad47671`) does not contain `b14acc9c3` — confirmed with `git merge-base --is-ancestor`.

Before: `CharCapGateTest` 32s timeout; suite hangs at `MentionPickerTest`.
After, on this branch, running exactly what CI runs (`vendor/bin/pest tests/Browser/ --configuration phpunit.ci.xml`):

```
Tests: 33 total, 32 passed, 1 skipped, 0 failed — 35.8s
```