### PR TITLE
fix(ci): generate passport keys in the deploy workflow

### DIFF
--- a/.claude/skills/agent-browser-relaticle/SKILL.md
+++ b/.claude/skills/agent-browser-relaticle/SKILL.md
@@ -24,10 +24,18 @@ php artisan tinker --execute 'echo json_encode([
 
 - app panel = `https://{app_domain}` if set, else `{base}/{app_path}`
 - sysadmin  = `https://{sysadmin_domain}` if set, else `{base}/{sysadmin_path}`
-- Current local env (verified: 2026-06-12): domain-routed —
-  `https://app.relaticle.test`, `https://sysadmin.relaticle.test`, base
-  `https://relaticle.test`. **Older docs said `/app` paths — that is the path-routed
-  fallback, only valid when the `*_DOMAIN` envs are unset.**
+- **Routing mode is per-checkout — derive it, never carry it over from another
+  workspace.** Both modes are live in the wild:
+  - Conductor workspace `bamako`, `APP_PANEL_DOMAIN`/`SYSADMIN_DOMAIN` empty →
+    path-routed: `https://bamako.test/app`, `https://bamako.test/sysadmin`
+    (verified: 2026-08-12).
+  - A checkout with the `*_DOMAIN` envs set → domain-routed, e.g.
+    `https://app.relaticle.test`, `https://sysadmin.relaticle.test`
+    (verified: 2026-06-12).
+
+  Each Conductor workspace is served by Herd under its own `https://<workspace>.test`,
+  so the host changes too. Run the `tinker` block above every run and use what it
+  returns.
 - Login entry points are Filament-registered routes; ground truth:
   `php artisan route:list --json` filtered for `login` (names like
   `filament.app.auth.login`). If a URL 404s, check the route table before anything else.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           cp .env.ci .env
           php artisan key:generate
+          php artisan passport:keys --force --no-interaction
 
       - name: Run Lint
         run: composer test:lint
@@ -141,6 +142,7 @@ jobs:
         run: |
           cp .env.ci .env
           php artisan key:generate
+          php artisan passport:keys --force --no-interaction
 
       - name: Tests
         run: composer test:pest:ci
@@ -214,6 +216,7 @@ jobs:
         run: |
           cp .env.ci .env
           php artisan key:generate
+          php artisan passport:keys --force --no-interaction
 
       - name: Install NPM dependencies
         run: npm ci


### PR DESCRIPTION
## What

`Deploy` has failed on every release since **v3.4.5**. v3.4.5, v3.4.6 and v3.4.7 were tagged and published on GitHub but **never deployed** — `Deploy to Forge` is gated on the test jobs, and two shards go red before it runs.

Deploy history: `v3.4.4 success → v3.4.5 failure → v3.4.6 failure → v3.4.7 failure`.

## Root cause

Passport's signing keys live in `storage/*.key`, which is gitignored (`.gitignore:11`), so every CI job has to generate its own. `3720e0f3f` (#255, 2026-08-10) added the MCP OAuth tests *and* the `passport:keys` step — but only to `tests.yml`. `deploy.yml` kept running `key:generate` alone.

Every Deploy run since fails with:

```
LogicException: Invalid key supplied
  vendor/league/oauth2-server/src/CryptKey.php:77
```

17 failures across `Tests\Feature\Mcp\OAuthTeamPickerTest` (15) and `TokenAbilitiesMcpTest` (2) → shards 3/5 and 5/5 red → `Deploy to Forge` skipped. v3.4.4 shipped on 2026-08-09, the day before those tests landed, and was the last release to reach production.

## Fix

Add `php artisan passport:keys --force --no-interaction` to all three `Prepare Laravel` steps in `deploy.yml`, mirroring `tests.yml`. The drift between the two workflows is the bug, so this closes it rather than patching only the shard that happened to fail.

## Test plan

Reproduced and verified locally:

| Step | Result |
|---|---|
| `composer test:pest` with no `storage/oauth-*.key` | 13 failed + 4 errors — the same 17, same two files as CI |
| `php artisan passport:keys` → re-run those two files | **30 passed** (67 assertions) |
| Full suite after the fix | **2632 passed**, 2 skipped, 0 failures |
| Pint / Rector / PHPStan / type coverage | passed / 0 changed / 0 errors / **100.0%** |

`Deploy to Forge` is unchanged since the successful v3.4.4 run (`git diff v3.4.4..HEAD -- .github/workflows/deploy.yml` was empty before this change) and only gates on the test jobs, so restoring the tests restores the deploy.

## Also in this PR

A `docs(skills)` commit: the `agent-browser-relaticle` cookbook asserted the local app is domain-routed (`app.relaticle.test`). Conductor workspaces with empty `*_DOMAIN` envs are path-routed under their own host (`bamako.test/app`), so the cached claim points agents at URLs that don't resolve. Happy to drop this commit if you'd rather keep the PR to the CI fix alone.

## Follow-up, not included

`relaticle:install` runs `key:generate` but never `passport:keys`, and `PASSPORT_PRIVATE_KEY`/`PASSPORT_PUBLIC_KEY` ship empty in `.env.example`. A fresh self-hosted install therefore has no OAuth signing keys, so the MCP connector flow (shipped v3.4.5) fails the same way. Left out because it needs a decision: re-running install must **not** overwrite existing keys, or every issued token is invalidated.