### PR TITLE
fix(seo): align marketing doc links with the help/developers split

### DIFF
--- a/packages/Documentation/resources/views/docs/article.blade.php
+++ b/packages/Documentation/resources/views/docs/article.blade.php
@@ -27,7 +27,7 @@
             $page,
             route('documentation.show', ['type' => $page->slug]),
             [
-                ['name' => __('Documentation'), 'url' => route('documentation.index')],
+                ['name' => __('Developer Documentation'), 'url' => route('documentation.index')],
                 ['name' => $page->title, 'url' => route('documentation.show', ['type' => $page->slug])],
             ],
         );

--- a/packages/Documentation/resources/views/docs/hub.blade.php
+++ b/packages/Documentation/resources/views/docs/hub.blade.php
@@ -1,6 +1,6 @@
 @php
-    $baseTitle = __('Documentation');
-    $pageDescription = __('Guides and resources to help you get the most out of Relaticle CRM.');
+    $baseTitle = __('Developer Documentation');
+    $pageDescription = __('Self-host Relaticle with Docker, build integrations on the REST API, and connect AI agents over MCP. Guides for developers building on Relaticle CRM.');
 
     $sections = collect($nav)->where('area', \Relaticle\Documentation\Support\DocUrl::DOCS);
 @endphp
@@ -11,7 +11,7 @@
     :nav="$nav">
     <div class="mx-auto max-w-3xl">
         <p class="text-pico font-semibold tracking-[0.08em] text-primary-600 uppercase dark:text-primary-400">
-            {{ __('Developers') }}
+            {{ __('Build on Relaticle') }}
         </p>
         <h1 class="font-display mt-3 text-4xl font-bold tracking-[-0.02em] text-gray-950 sm:text-[2.75rem] dark:text-white">
             {{ $baseTitle }}

--- a/packages/Documentation/src/Http/Controllers/HelpController.php
+++ b/packages/Documentation/src/Http/Controllers/HelpController.php
@@ -122,7 +122,7 @@ final readonly class HelpController
         $docs = $this->llmsTxtDocsEntries();
 
         if ($docs !== []) {
-            array_push($lines, '', '## '.__('Documentation'), '', ...$docs);
+            array_push($lines, '', '## '.__('Developer Documentation'), '', ...$docs);
         }
 
         return implode("\n", $lines)."\n";

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -26,9 +26,13 @@
 
                     <div class="mt-8 space-y-4">
                         @feature(App\Features\Documentation::class)
+                        <a href="{{ route('help.index') }}" class="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 transition-colors">
+                            <x-ri-lifebuoy-line class="w-4 h-4"/>
+                            Help Centre
+                        </a>
                         <a href="{{ route('documentation.index') }}" class="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 transition-colors">
                             <x-ri-book-open-line class="w-4 h-4"/>
-                            Documentation
+                            Developer Docs
                         </a>
                         @endfeature
                         <a href="{{ route('discord') }}" target="_blank" class="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 transition-colors">

--- a/resources/views/home/partials/community.blade.php
+++ b/resources/views/home/partials/community.blade.php
@@ -19,7 +19,7 @@
                 ];
 
                 if (\Laravel\Pennant\Feature::active(\App\Features\Documentation::class)) {
-                    $cards[] = ['url' => route('documentation.index'), 'icon' => 'ri-book-open-line', 'iconClass' => 'text-primary dark:text-primary-400', 'title' => 'Documentation', 'desc' => 'Learn how to use Relaticle. Comprehensive guides for users and developers alike.', 'cta' => 'Read the Docs', 'external' => false];
+                    $cards[] = ['url' => route('documentation.index'), 'icon' => 'ri-book-open-line', 'iconClass' => 'text-primary dark:text-primary-400', 'title' => 'Developer Docs', 'desc' => 'Self-host with Docker, build on the REST API, and connect AI agents over MCP.', 'cta' => 'Read the Docs', 'external' => false];
                 }
             @endphp
             @foreach($cards as $card)

--- a/tests/Feature/Documentation/DocumentationMetaTest.php
+++ b/tests/Feature/Documentation/DocumentationMetaTest.php
@@ -13,5 +13,5 @@ it('uses the configured per-document description as the meta description', funct
 it('titles the documentation index with the brand-suffix convention', function (): void {
     $this->get('/developers')
         ->assertOk()
-        ->assertSee('<title>Documentation - Relaticle</title>', false);
+        ->assertSee('<title>Developer Documentation - Relaticle</title>', false);
 });


### PR DESCRIPTION
After the docs split (user guides at /help, developer docs at /developers), several marketing surfaces still presented /developers as general-purpose documentation.

- The homepage "Built in the Open" card promised "comprehensive guides for users and developers alike" but links to /developers, which no longer holds user guides — it is now a Developer Docs card whose copy matches what actually lives there (self-hosting, REST API, MCP).
- The contact page offered only a Documentation link; it now leads with a Help Centre link for support-seekers, with the developer link relabelled accordingly.
- The /developers hub itself is retitled "Developer Documentation" with a developer-focused meta description, and its JSON-LD breadcrumbs and the llms.txt section heading follow the same name.

## Test plan

- `tests/Feature/Documentation` (56 passing) and `tests/Smoke` (69 passing); pint, rector, PHPStan, and 100% type coverage all clean.
- Homepage, contact, and /developers verified in the browser in light and dark modes.