### PR TITLE
fix(chat): surface proposal approval failures instead of dead-ending

### DIFF
--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -1055,15 +1055,12 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
         // Bridge the docked livewire proposal-card's resolution lifecycle back
         // into Alpine state. window.Livewire.on returns an unsubscribe fn (v4);
         // named-arg dispatches arrive as a single params object (e.detail).
+        // A FAILED resolve needs no bridge: the proposal stays pending, so the dock
+        // keeps rendering it and owns the error message (`resolve` error bag).
         this._proposalListeners = [
             window.Livewire.on('proposal:resolved', (payload) => {
                 if ((payload?.context ?? 'conversation') !== this.context) return;
                 this.applyProposalResolution(payload);
-            }),
-            window.Livewire.on('proposal:resolve-failed', (payload) => {
-                if ((payload?.context ?? 'conversation') !== this.context) return;
-                const action = this.findPendingAction(payload?.pendingActionId);
-                if (action) action.error = 'Could not complete the action. Please try again.';
             }),
         ];
 
@@ -1110,7 +1107,6 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
     applyProposalResolution(payload) {
         const action = this.findPendingAction(payload.pendingActionId);
         if (!action) return;
-        action.error = null;
 
         if (payload.index === null || payload.index === undefined) {
             // Single proposal.
@@ -1454,7 +1450,6 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
                 if (action.status !== 'pending') continue;
                 if (idFilter && !idFilter.has(action.pending_action_id)) continue;
                 action.status = 'superseded';
-                action.error = null;
             }
         }
     },

--- a/packages/Chat/resources/views/livewire/chat/proposal-card.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/proposal-card.blade.php
@@ -109,6 +109,12 @@
                 @endforeach
             </div>
 
+            @error('resolve')
+                <p class="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-400" role="alert">
+                    {{ $message }}
+                </p>
+            @enderror
+
             <div class="mt-3 flex items-center justify-between gap-2">
                 <div class="flex items-center gap-1">
                     @if ($remainingCount > 1)

--- a/packages/Chat/src/Livewire/Chat/ProposalCard.php
+++ b/packages/Chat/src/Livewire/Chat/ProposalCard.php
@@ -13,6 +13,7 @@ use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\On;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Enums\PendingActionStatus;
@@ -467,13 +468,12 @@ final class ProposalCard extends BaseLivewireComponent
                 $finalized = true;
                 $record = $this->recordReferenceFor($resolved);
             }
-        } catch (RuntimeException $exception) {
-            $this->dispatch(
-                'proposal:resolve-failed',
-                pendingActionId: $pendingAction->getKey(),
-                message: $exception->getMessage(),
-                context: $this->context,
-            );
+        } catch (RuntimeException|ValidationException $exception) {
+            // ValidationException is thrown by the action's tenant guards when a
+            // referenced record or assignee stopped being reachable between the
+            // proposal and the approval. Livewire would otherwise absorb it into an
+            // error bag nothing renders, leaving the button a permanent no-op.
+            $this->reportResolveFailure($pendingAction, $exception->getMessage());
 
             return;
         }
@@ -528,12 +528,7 @@ final class ProposalCard extends BaseLivewireComponent
                 $finalized = true;
             }
         } catch (RuntimeException $exception) {
-            $this->dispatch(
-                'proposal:resolve-failed',
-                pendingActionId: $pendingAction->getKey(),
-                message: $exception->getMessage(),
-                context: $this->context,
-            );
+            $this->reportResolveFailure($pendingAction, $exception->getMessage());
 
             return;
         }
@@ -555,6 +550,24 @@ final class ProposalCard extends BaseLivewireComponent
         }
 
         $this->cursor = $this->firstUnresolvedIndex($pendingAction->fresh() ?? $pendingAction);
+    }
+
+    /**
+     * Report a failed resolve on the card itself AND to the transcript. The
+     * dispatched event alone is not user-visible, so the message is also bound to
+     * the `resolve` error bag which the dock renders — a proposal that cannot be
+     * resolved must say so rather than leave the button dead.
+     */
+    private function reportResolveFailure(PendingAction $pendingAction, string $message): void
+    {
+        $this->addError('resolve', $message);
+
+        $this->dispatch(
+            'proposal:resolve-failed',
+            pendingActionId: $pendingAction->getKey(),
+            message: $message,
+            context: $this->context,
+        );
     }
 
     private function ensureTenantContext(): void

--- a/packages/Chat/src/Tools/Concerns/NormalizesToolInput.php
+++ b/packages/Chat/src/Tools/Concerns/NormalizesToolInput.php
@@ -37,8 +37,14 @@ trait NormalizesToolInput
 
         $clean = [];
         foreach ($candidates as $id) {
-            if (is_string($id) && $id !== '') {
-                $clean[] = $id;
+            if (! is_scalar($id)) {
+                continue;
+            }
+
+            $trimmed = trim((string) $id);
+
+            if ($trimmed !== '') {
+                $clean[] = $trimmed;
             }
         }
 
@@ -61,21 +67,16 @@ trait NormalizesToolInput
     }
 
     /**
+     * Coerce a record field into a list of ids, or null when it carries nothing
+     * usable. Unlike idListOrNull() an empty list collapses to null: the create
+     * path treats "no ids" as "omit the field" rather than "clear the relation".
+     *
      * @param  array<string, mixed>  $record
      * @return list<string>|null
      */
     protected function idListFromArray(array $record, string $key): ?array
     {
-        $value = $record[$key] ?? null;
-
-        if (! is_array($value)) {
-            return null;
-        }
-
-        $ids = array_values(array_filter(array_map(
-            static fn (mixed $id): string => is_scalar($id) ? trim((string) $id) : '',
-            $value,
-        ), static fn (string $id): bool => $id !== ''));
+        $ids = $this->coerceIdList($record[$key] ?? null);
 
         return $ids === [] ? null : $ids;
     }

--- a/tests/Feature/Chat/NoteLinkedCreationTest.php
+++ b/tests/Feature/Chat/NoteLinkedCreationTest.php
@@ -143,3 +143,21 @@ it('renders linked names in the proposal display data', function (): void {
     expect($fields->firstWhere('label', 'Linked people')['value'] ?? '')->toContain('Angel');
     expect($fields->firstWhere('label', 'Linked companies')['value'] ?? '')->toContain('Acme');
 });
+
+it('coerces a scalar people_ids into a list instead of dropping it', function (): void {
+    $angel = People::factory()->for($this->team)->create(['name' => 'Angel']);
+
+    $tool = resolve(CreateNoteTool::class);
+    $tool->setConversationId('019df800-4444-7000-8000-000000000001');
+
+    $tool->handle(new Request([
+        'records' => [['title' => 'Scalar people', 'people_ids' => (string) $angel->id]],
+    ]));
+
+    $pending = PendingAction::query()
+        ->where('team_id', $this->team->getKey())
+        ->latest()
+        ->firstOrFail();
+
+    expect($pending->action_data)->toHaveKey('people_ids', [(string) $angel->id]);
+});

--- a/tests/Feature/Chat/ProposalCardComponentTest.php
+++ b/tests/Feature/Chat/ProposalCardComponentTest.php
@@ -843,3 +843,52 @@ it('offers no inline-edit codes for a delete proposal', function (): void {
 
     expect($codes)->toBe([]);
 });
+
+it('surfaces a failure when the assignee left the workspace between proposal and approval', function (): void {
+    $member = User::factory()->create();
+    $this->team->users()->attach($member, ['role' => 'editor']);
+
+    $action = PendingAction::query()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'conversation_id' => null,
+        'action_class' => 'App\\Actions\\Task\\CreateTask',
+        'operation' => PendingActionOperation::Create,
+        'entity_type' => 'task',
+        'action_data' => ['title' => 'Follow up call', 'assignee_ids' => [(string) $member->getKey()]],
+        'display_data' => ['title' => 'Create Task', 'summary' => 'Create task "Follow up call"', 'fields' => []],
+        'status' => PendingActionStatus::Pending,
+        'expires_at' => now()->addMinutes(15),
+    ]);
+
+    $this->team->users()->detach($member);
+
+    Livewire::test(ProposalCard::class, ['context' => 'conversation'])
+        ->dispatch('proposal:set-active', id: $action->getKey(), context: 'conversation')
+        ->call('createCurrent')
+        ->assertDispatched('proposal:resolve-failed')
+        ->assertHasErrors('resolve');
+
+    expect(Task::query()->where('title', 'Follow up call')->exists())->toBeFalse()
+        ->and($action->fresh()->status)->toBe(PendingActionStatus::Pending);
+});
+
+it('renders the resolve failure in the dock so the approval is never a silent no-op', function (): void {
+    $action = PendingAction::query()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'conversation_id' => null,
+        'action_class' => 'App\\Actions\\Task\\CreateTask',
+        'operation' => PendingActionOperation::Create,
+        'entity_type' => 'task',
+        'action_data' => ['title' => 'Ghost assignee', 'assignee_ids' => [(string) User::factory()->create()->getKey()]],
+        'display_data' => ['title' => 'Create Task', 'summary' => 'Create task "Ghost assignee"', 'fields' => []],
+        'status' => PendingActionStatus::Pending,
+        'expires_at' => now()->addMinutes(15),
+    ]);
+
+    Livewire::test(ProposalCard::class, ['context' => 'conversation'])
+        ->dispatch('proposal:set-active', id: $action->getKey(), context: 'conversation')
+        ->call('createCurrent')
+        ->assertSee('not in your workspace');
+});

--- a/tests/Feature/Chat/TaskLinkedCreationTest.php
+++ b/tests/Feature/Chat/TaskLinkedCreationTest.php
@@ -104,3 +104,43 @@ it('renders linked names in the proposal display data', function (): void {
     expect($fields->pluck('label')->all())->toContain('Linked people');
     expect($fields->firstWhere('label', 'Linked people')['value'] ?? '')->toContain('Angel');
 });
+
+it('coerces a scalar assignee_ids into a list instead of dropping it', function (): void {
+    $member = User::factory()->create();
+    $this->team->users()->attach($member, ['role' => 'editor']);
+
+    $tool = resolve(CreateTaskTool::class);
+    $tool->setConversationId('019df800-3333-7000-8000-000000000001');
+
+    // LLMs sometimes emit a scalar where an array is declared.
+    $tool->handle(new Request([
+        'records' => [['title' => 'Scalar assignee', 'assignee_ids' => (string) $member->getKey()]],
+    ]));
+
+    $pending = PendingAction::query()
+        ->where('team_id', $this->team->getKey())
+        ->latest()
+        ->firstOrFail();
+
+    expect($pending->action_data)->toHaveKey('assignee_ids', [(string) $member->getKey()]);
+});
+
+it('shows the assignee row on the card when assignee_ids arrives as a scalar', function (): void {
+    $member = User::factory()->create(['name' => 'Dana Scully']);
+    $this->team->users()->attach($member, ['role' => 'editor']);
+
+    $tool = resolve(CreateTaskTool::class);
+    $tool->setConversationId('019df800-3333-7000-8000-000000000001');
+
+    $tool->handle(new Request([
+        'records' => [['title' => 'Scalar assignee display', 'assignee_ids' => (string) $member->getKey()]],
+    ]));
+
+    $pending = PendingAction::query()
+        ->where('team_id', $this->team->getKey())
+        ->latest()
+        ->firstOrFail();
+
+    $fields = collect($pending->display_data['fields'] ?? []);
+    expect($fields->firstWhere('label', 'Assignees')['value'] ?? '')->toContain('Dana Scully');
+});


### PR DESCRIPTION
Approving a chat proposal whose assignee or linked record stopped being reachable between the proposal and the approval threw a `ValidationException` that escaped `ProposalCard`'s `catch (RuntimeException)` — Livewire absorbed it into an error bag nothing rendered, so the button became a permanent silent no-op with no record written and no explanation. It is now caught and bound to a `resolve` error bag the dock renders, so the failure states its reason and stays retryable once the cause is fixed; discard failures route through the same path, and the Alpine `action.error` state it replaces (written in three places, read by no template) is removed. Separately, `idListFromArray()` dropped a present-but-scalar value, so an `assignee_ids: "01K…"` emitted by the model was silently lost from both the payload and the proposal card — it now shares `coerceIdList()`, matching what the update path already did, which fixes `CreateTaskTool` and `CreateNoteTool` alike.

## Test plan

- 5 new tests (red before, green after) across `ProposalCardComponentTest`, `TaskLinkedCreationTest`, `NoteLinkedCreationTest`
- `tests/Feature/Chat` 647 passed; `tests/Arch` 24 passed; pint / rector / phpstan clean; type coverage 100%
- Browser walk-through with the real assistant and queue: proposed a task linked to a person and assigned to a member, removed the assignee from the workspace, clicked **Create** → card showed "One or more assignees are not in your workspace." and no task was written; re-added the member, clicked **Create** → task created with both the link and the assignee, error cleared, no JS errors

## Note

This does **not** close the "Error while loading page" report it came from — that toast requires a non-2xx response and this path returns 200. It fixes the "task is not created, with no feedback" half and makes any future occurrence self-describing rather than silent.