### PR TITLE
fix(geo): tables and entities survive markdown-for-agents output

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -35,6 +35,7 @@ use App\Services\GitHubService;
 use App\Services\TurnstileClient;
 use App\Support\ActivityLog\MergedActivityRenderer;
 use App\Support\ActivityLog\RequestActivityBatch;
+use App\Support\Markdown\TableAwareLeagueDriver;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Livewire\Notifications;
@@ -110,6 +111,16 @@ final class AppServiceProvider extends ServiceProvider
         // provider registers after the package's, so this binding wins;
         // Turnstile::fake() still swaps it, as it goes through the facade.
         $this->app->scoped(ClientInterface::class, fn (): TurnstileClient => new TurnstileClient);
+
+        // Spatie's LeagueDriver never registers TableConverter, so <table>
+        // markup collapses to a run-on line in the markdown-response channel.
+        // Our provider registers after the package's, so this binding wins.
+        $this->app->singleton(
+            'markdown-response.driver.league',
+            fn (): TableAwareLeagueDriver => new TableAwareLeagueDriver(
+                config('markdown-response.driver_options.league.options', []),
+            ),
+        );
     }
 
     /**

--- a/app/Support/Markdown/DecodeHtmlEntitiesPostprocessor.php
+++ b/app/Support/Markdown/DecodeHtmlEntitiesPostprocessor.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Markdown;
+
+use Spatie\MarkdownResponse\Postprocessors\Postprocessor;
+
+/**
+ * league/html-to-markdown's TextConverter escapes '&', '<', and '>' via
+ * htmlspecialchars() before writing markdown text back into a DOM text node.
+ * DOMDocument::saveHTML() then escapes that literal text a second time on
+ * serialization (e.g. "&" becomes "&amp;" becomes "&amp;amp;" on the wire),
+ * and the library's own HtmlConverter::sanitize() only runs html_entity_decode()
+ * once, so one level of escaping survives into the final markdown ("Import
+ * &amp; Export" instead of "Import & Export"). This postprocessor runs the
+ * second decode pass the library never does.
+ */
+final readonly class DecodeHtmlEntitiesPostprocessor implements Postprocessor
+{
+    public function __invoke(string $markdown): string
+    {
+        return html_entity_decode($markdown, ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/app/Support/Markdown/TableAwareLeagueDriver.php
+++ b/app/Support/Markdown/TableAwareLeagueDriver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Markdown;
+
+use League\HTMLToMarkdown\Converter\TableConverter;
+use League\HTMLToMarkdown\HtmlConverter;
+use Spatie\MarkdownResponse\Drivers\MarkdownDriver;
+
+/**
+ * league/html-to-markdown's default Environment never registers TableConverter,
+ * so <table> markup collapses into a run-on line of cell text instead of a pipe
+ * table. Spatie's own LeagueDriver just does `new HtmlConverter($options)`, which
+ * takes the library default — there is no config option to add converters, so
+ * this driver builds the same HtmlConverter and adds TableConverter to its
+ * environment before converting. Registered in place of the vendor binding in
+ * AppServiceProvider.
+ */
+final readonly class TableAwareLeagueDriver implements MarkdownDriver
+{
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function __construct(
+        private array $options = [],
+    ) {}
+
+    public function convert(string $html): string
+    {
+        $converter = new HtmlConverter($this->options);
+        $converter->getEnvironment()->addConverter(new TableConverter);
+
+        return $converter->convert($html);
+    }
+}

--- a/config/markdown-response.php
+++ b/config/markdown-response.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Support\DetectsPublicMarkdownRequest;
+use App\Support\Markdown\DecodeHtmlEntitiesPostprocessor;
 use Spatie\MarkdownResponse\Actions\GeneratesCacheKey;
 use Spatie\MarkdownResponse\Postprocessors\CollapseBlankLinesPostprocessor;
 use Spatie\MarkdownResponse\Postprocessors\RemoveHtmlTagsPostprocessor;
@@ -80,6 +81,7 @@ return [
      */
     'postprocessors' => [
         RemoveHtmlTagsPostprocessor::class,
+        DecodeHtmlEntitiesPostprocessor::class,
         CollapseBlankLinesPostprocessor::class,
     ],
 

--- a/tests/Feature/MarkdownResponseTest.php
+++ b/tests/Feature/MarkdownResponseTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Route;
+use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
+
 it('serves docs pages as clean article markdown without site chrome', function (): void {
     $markdown = $this->get('/developers/self-hosting', ['Accept' => 'text/markdown'])
         ->assertOk()
@@ -14,4 +18,59 @@ it('serves docs pages as clean article markdown without site chrome', function (
         ->and($markdown)->not->toContain('Skip to content')
         ->and($markdown)->not->toContain('Searching help and developer docs')
         ->and($markdown)->not->toContain('On this page');
+});
+
+it('serves the homepage as markdown without nav chrome or alpine fragments', function (): void {
+    Http::fake([
+        'api.github.com/*' => Http::response(['stargazers_count' => 42], 200),
+    ]);
+
+    $markdown = $this->get('/', ['Accept' => 'text/markdown'])
+        ->assertOk()
+        ->getContent();
+
+    expect($markdown)->not->toContain('mobileMenu')
+        ->and($markdown)->not->toContain('Skip to main content')
+        ->and(substr_count($markdown, 'Pricing'))->toBeLessThanOrEqual(1);
+});
+
+it('decodes html entities instead of leaking double-escaped ampersands', function (): void {
+    Http::fake([
+        'api.github.com/*' => Http::response(['stargazers_count' => 42], 200),
+    ]);
+
+    $markdown = $this->get('/', ['Accept' => 'text/markdown'])
+        ->assertOk()
+        ->getContent();
+
+    expect($markdown)->toContain('Import & Export')
+        ->and($markdown)->not->toContain('Import &amp; Export');
+});
+
+it('converts a real html table to pipe-table markdown', function (): void {
+    Route::middleware(ProvideMarkdownResponse::class)->get('/__markdown-table-fixture', fn () => response(<<<'HTML'
+        <html>
+        <body>
+        <main>
+            <table>
+                <thead>
+                    <tr><th>Plan</th><th>Price</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Free</td><td>$0</td></tr>
+                    <tr><td>Pro</td><td>$29</td></tr>
+                </tbody>
+            </table>
+        </main>
+        </body>
+        </html>
+        HTML));
+
+    $markdown = $this->get('/__markdown-table-fixture', ['Accept' => 'text/markdown'])
+        ->assertOk()
+        ->getContent();
+
+    expect($markdown)->toContain('| Plan | Price |')
+        ->and($markdown)->toContain('| Free | $0 |')
+        ->and($markdown)->toContain('| Pro | $29 |');
 });


### PR DESCRIPTION
## Summary

Three agent-readable-web (GEO) pipeline fixes:

- **Tables now survive html→markdown**: league/html-to-markdown's default environment never registers `TableConverter`, so every `<table>` was silently destroyed in `Accept: text/markdown` responses. New `TableAwareLeagueDriver` bound via the package's documented driver key (inert unless `driver=league`). This unblocks the table-first content strategy — blog posts and comparison pages keep their tables for GPTBot/ClaudeBot/PerplexityBot.
- **Entity double-escaping fixed**: `&` rendered as `&amp;amp;` in markdown output (converter pre-escape + saveHTML re-escape, only one decode). New `DecodeHtmlEntitiesPostprocessor` compensates exactly the extra layer, ordered after tag-stripping so escaped script text can never become live tags.
- **Homepage chrome regression test**: the previously-reported homepage nav/Alpine leak is already fixed on main (the repro came from a stale Herd checkout) — pinned with a regression test so it can't silently return.

## Test plan

- TDD RED→GREEN for the table and entity fixes; homepage regression test green on main's code.
- `MarkdownResponseTest` 4/4; markdown/docs/help sweep 96/96; full suite 2762 passed / 0 failed; pint/rector/phpstan/type-coverage clean.
- Browser-verified: homepage light/dark rendering and mobile-menu behavior unchanged (this PR only alters the text/markdown representation).