### PR TITLE
feat(sysadmin): signup-to-subscription funnel widget

### DIFF
--- a/packages/SystemAdmin/src/Filament/Pages/EngagementDashboard.php
+++ b/packages/SystemAdmin/src/Filament/Pages/EngagementDashboard.php
@@ -11,6 +11,7 @@ use Filament\Pages\Dashboard\Concerns\HasFiltersAction;
 use Filament\Widgets\WidgetConfiguration;
 use Relaticle\SystemAdmin\Filament\Widgets\ActivationRateWidget;
 use Relaticle\SystemAdmin\Filament\Widgets\AiSpendStatsWidget;
+use Relaticle\SystemAdmin\Filament\Widgets\FunnelWidget;
 use Relaticle\SystemAdmin\Filament\Widgets\UserRetentionChartWidget;
 
 final class EngagementDashboard extends BaseDashboard
@@ -37,6 +38,7 @@ final class EngagementDashboard extends BaseDashboard
     public function getWidgets(): array
     {
         return [
+            FunnelWidget::class,
             ActivationRateWidget::class,
             UserRetentionChartWidget::class,
             AiSpendStatsWidget::class,

--- a/packages/SystemAdmin/src/Filament/Widgets/Concerns/HasPeriodComparison.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/Concerns/HasPeriodComparison.php
@@ -86,18 +86,35 @@ trait HasPeriodComparison
      */
     private function getActiveCreatorIds(CarbonImmutable $start, CarbonImmutable $end): Collection
     {
+        return $this->getDistinctActiveColumnValues('creator_id', $start, $end);
+    }
+
+    /**
+     * The shared "did something real" filter behind activation metrics: a
+     * non-null creator, a non-system creation source, within the period, on a
+     * non-deleted row — applied across every entity table and unioned.
+     *
+     * $column selects the grain (e.g. `creator_id` for active users,
+     * `team_id` for active teams); it is only ever a trusted internal literal,
+     * never user input, so it is safe to interpolate into the identifier
+     * position.
+     *
+     * @return Collection<int, int|string>
+     */
+    private function getDistinctActiveColumnValues(string $column, CarbonImmutable $start, CarbonImmutable $end): Collection
+    {
         $unionParts = [];
         $bindings = [];
 
         foreach (self::ENTITY_TABLES as $table) {
-            $unionParts[] = "SELECT DISTINCT \"creator_id\" FROM \"{$table}\" WHERE \"creator_id\" IS NOT NULL AND \"creation_source\" != ? AND \"created_at\" BETWEEN ? AND ? AND \"deleted_at\" IS NULL";
+            $unionParts[] = "SELECT DISTINCT \"{$column}\" FROM \"{$table}\" WHERE \"creator_id\" IS NOT NULL AND \"creation_source\" != ? AND \"created_at\" BETWEEN ? AND ? AND \"deleted_at\" IS NULL";
             $bindings[] = CreationSource::SYSTEM->value;
             $bindings[] = $start->toDateTimeString();
             $bindings[] = $end->toDateTimeString();
         }
 
-        $sql = 'SELECT DISTINCT creator_id FROM ('.implode(' UNION ', $unionParts).') AS all_creators';
+        $sql = "SELECT DISTINCT {$column} FROM (".implode(' UNION ', $unionParts).') AS active_rows';
 
-        return collect(DB::select($sql, $bindings))->pluck('creator_id');
+        return collect(DB::select($sql, $bindings))->pluck($column);
     }
 }

--- a/packages/SystemAdmin/src/Filament/Widgets/FunnelWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/FunnelWidget.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Widgets;
+
+use App\Enums\CreationSource;
+use Carbon\CarbonImmutable;
+use Filament\Widgets\Concerns\InteractsWithPageFilters;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\DB;
+use Laravel\Cashier\Subscription;
+use Relaticle\SystemAdmin\Filament\Widgets\Concerns\HasPeriodComparison;
+
+/**
+ * Signup -> activation -> subscription funnel for the selected period.
+ *
+ * "Organic sign-up" excludes invited members: a user who accepted an
+ * invitation gets a `team_user` row for the inviting (unowned) team within
+ * seconds of registering, so a pivot row created within 24h of the user's
+ * own `created_at` marks them as invited rather than organic.
+ *
+ * "Activated team" and "Subscribed team" mirror ActivationRateWidget's
+ * creator-source filter and the app's own subscription-validity predicate,
+ * at team grain, restricted to the selected period.
+ */
+final class FunnelWidget extends StatsOverviewWidget
+{
+    use HasPeriodComparison;
+    use InteractsWithPageFilters;
+
+    protected static ?int $sort = 4;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected ?string $pollingInterval = null;
+
+    protected function getStats(): array
+    {
+        [$currentStart, $currentEnd, $previousStart, $previousEnd] = $this->getPeriodDates();
+
+        $currentSignups = $this->countOrganicSignups($currentStart, $currentEnd);
+        $previousSignups = $this->countOrganicSignups($previousStart, $previousEnd);
+
+        $currentActivatedTeams = $this->countActivatedTeams($currentStart, $currentEnd);
+        $previousActivatedTeams = $this->countActivatedTeams($previousStart, $previousEnd);
+
+        $currentSubscribedTeams = $this->countSubscribedTeams($currentStart, $currentEnd);
+        $previousSubscribedTeams = $this->countSubscribedTeams($previousStart, $previousEnd);
+
+        return [
+            $this->buildCountStat('Organic Sign-ups', 'this period', $currentSignups, $previousSignups),
+            $this->buildCountStat('Activated Teams', 'created a record', $currentActivatedTeams, $previousActivatedTeams),
+            $this->buildCountStat('Subscribed Teams', 'this period', $currentSubscribedTeams, $previousSubscribedTeams),
+        ];
+    }
+
+    /**
+     * A user counts as an organic sign-up unless they were added to a team
+     * they do not own within 24h of registering — the signature of accepting
+     * an invitation (register -> immediately attached to the inviter's team).
+     */
+    private function countOrganicSignups(CarbonImmutable $start, CarbonImmutable $end): int
+    {
+        $sql = <<<'SQL'
+            SELECT COUNT(*) AS cnt
+            FROM users u
+            WHERE u.created_at BETWEEN ? AND ?
+            AND NOT EXISTS (
+                SELECT 1
+                FROM team_user tu
+                INNER JOIN teams t ON t.id = tu.team_id
+                WHERE tu.user_id = u.id
+                  AND t.user_id != u.id
+                  AND tu.created_at <= u.created_at + INTERVAL '24 hours'
+            )
+            SQL;
+
+        $row = DB::selectOne($sql, [$start->toDateTimeString(), $end->toDateTimeString()]);
+
+        return (int) ($row->cnt ?? 0);
+    }
+
+    /**
+     * Mirrors HasPeriodComparison::getActiveCreatorIds() at team grain: same
+     * non-system, non-deleted, period-scoped filter across the entity tables,
+     * counted by distinct team_id instead of creator_id.
+     */
+    private function countActivatedTeams(CarbonImmutable $start, CarbonImmutable $end): int
+    {
+        $unionParts = [];
+        $bindings = [];
+
+        foreach (self::ENTITY_TABLES as $table) {
+            $unionParts[] = "SELECT DISTINCT \"team_id\" FROM \"{$table}\" WHERE \"creator_id\" IS NOT NULL AND \"creation_source\" != ? AND \"created_at\" BETWEEN ? AND ? AND \"deleted_at\" IS NULL";
+            $bindings[] = CreationSource::SYSTEM->value;
+            $bindings[] = $start->toDateTimeString();
+            $bindings[] = $end->toDateTimeString();
+        }
+
+        $sql = 'SELECT COUNT(DISTINCT team_id) AS cnt FROM ('.implode(' UNION ', $unionParts).') AS activated_teams';
+
+        $row = DB::selectOne($sql, $bindings);
+
+        return (int) ($row->cnt ?? 0);
+    }
+
+    /**
+     * Reuses Cashier's own `active` scope (the same predicate
+     * SyncTeamPlanFromSubscription/HostedWorkspaceAccess rely on via
+     * Subscription::valid()) rather than hardcoding a stripe_status list —
+     * this app also calls Cashier::keepPastDueSubscriptionsActive(), so the
+     * "active" set is wider than a literal ['active', 'trialing'].
+     */
+    private function countSubscribedTeams(CarbonImmutable $start, CarbonImmutable $end): int
+    {
+        return Subscription::query()
+            ->active()
+            ->whereBetween('created_at', [$start, $end])
+            ->distinct('team_id')
+            ->count();
+    }
+
+    private function buildCountStat(string $label, string $description, int $current, int $previous): Stat
+    {
+        $change = $this->calculateChange($current, $previous);
+
+        return Stat::make($label, number_format($current))
+            ->description("{$description}{$this->formatChange($change)}")
+            ->descriptionIcon($change >= 0 ? 'heroicon-o-arrow-trending-up' : 'heroicon-o-arrow-trending-down')
+            ->color($change >= 0 ? 'success' : 'danger');
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/FunnelWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/FunnelWidget.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Widgets;
 
-use App\Enums\CreationSource;
 use Carbon\CarbonImmutable;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Filament\Widgets\StatsOverviewWidget;
@@ -83,27 +82,14 @@ final class FunnelWidget extends StatsOverviewWidget
     }
 
     /**
-     * Mirrors HasPeriodComparison::getActiveCreatorIds() at team grain: same
-     * non-system, non-deleted, period-scoped filter across the entity tables,
-     * counted by distinct team_id instead of creator_id.
+     * Reuses HasPeriodComparison::getDistinctActiveColumnValues() — the same
+     * helper ActivationRateWidget's getActiveCreatorIds() calls — at team
+     * grain instead of creator grain, so the source filter only lives in one
+     * place.
      */
     private function countActivatedTeams(CarbonImmutable $start, CarbonImmutable $end): int
     {
-        $unionParts = [];
-        $bindings = [];
-
-        foreach (self::ENTITY_TABLES as $table) {
-            $unionParts[] = "SELECT DISTINCT \"team_id\" FROM \"{$table}\" WHERE \"creator_id\" IS NOT NULL AND \"creation_source\" != ? AND \"created_at\" BETWEEN ? AND ? AND \"deleted_at\" IS NULL";
-            $bindings[] = CreationSource::SYSTEM->value;
-            $bindings[] = $start->toDateTimeString();
-            $bindings[] = $end->toDateTimeString();
-        }
-
-        $sql = 'SELECT COUNT(DISTINCT team_id) AS cnt FROM ('.implode(' UNION ', $unionParts).') AS activated_teams';
-
-        $row = DB::selectOne($sql, $bindings);
-
-        return (int) ($row->cnt ?? 0);
+        return $this->getDistinctActiveColumnValues('team_id', $start, $end)->count();
     }
 
     /**

--- a/tests/Feature/SystemAdmin/EngagementDashboardTest.php
+++ b/tests/Feature/SystemAdmin/EngagementDashboardTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use Relaticle\SystemAdmin\Filament\Pages\EngagementDashboard;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+it('shows the funnel widget on the engagement dashboard', function (): void {
+    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    Filament::setCurrentPanel('sysadmin');
+
+    livewire(EngagementDashboard::class)->assertOk();
+});

--- a/tests/Feature/SystemAdmin/FunnelWidgetTest.php
+++ b/tests/Feature/SystemAdmin/FunnelWidgetTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CreationSource;
+use App\Enums\TeamRole;
+use App\Models\Company;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\DB;
+use Relaticle\SystemAdmin\Filament\Widgets\FunnelWidget;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+mutates(FunnelWidget::class);
+
+beforeEach(function (): void {
+    $this->admin = SystemAdministrator::factory()->create();
+    $this->actingAs($this->admin, 'sysadmin');
+    Filament::setCurrentPanel('sysadmin');
+});
+
+it('can render the funnel widget', function (): void {
+    livewire(FunnelWidget::class)
+        ->assertOk();
+});
+
+it('counts an organic team owner as a sign-up', function (): void {
+    User::factory()->withTeam()->create([
+        'created_at' => now()->subDays(5),
+    ]);
+
+    livewire(FunnelWidget::class)
+        ->assertSee('Organic Sign-ups')
+        ->assertSee('1');
+});
+
+it('excludes an invited member attached to another team within 24h of registering', function (): void {
+    $owner = User::factory()->withTeam()->create([
+        'created_at' => now()->subDays(10),
+    ]);
+
+    $invited = User::factory()->create([
+        'created_at' => now()->subDays(5),
+    ]);
+
+    DB::table('team_user')->insert([
+        'team_id' => $owner->currentTeam->id,
+        'user_id' => $invited->id,
+        'role' => TeamRole::Editor->value,
+        'created_at' => $invited->created_at->addMinutes(3),
+        'updated_at' => $invited->created_at->addMinutes(3),
+    ]);
+
+    livewire(FunnelWidget::class)
+        ->assertSee('Organic Sign-ups')
+        ->assertSee('1');
+});
+
+it('still counts a user joining another team long after registering as organic', function (): void {
+    $owner = User::factory()->withTeam()->create([
+        'created_at' => now()->subDays(10),
+    ]);
+
+    $laterJoiner = User::factory()->create([
+        'created_at' => now()->subDays(5),
+    ]);
+
+    DB::table('team_user')->insert([
+        'team_id' => $owner->currentTeam->id,
+        'user_id' => $laterJoiner->id,
+        'role' => TeamRole::Editor->value,
+        'created_at' => $laterJoiner->created_at->addDays(2),
+        'updated_at' => $laterJoiner->created_at->addDays(2),
+    ]);
+
+    livewire(FunnelWidget::class)
+        ->assertSee('Organic Sign-ups')
+        ->assertSee('2');
+});
+
+it('counts a team as activated once a non-system record is created within the period', function (): void {
+    $owner = User::factory()->withTeam()->create([
+        'created_at' => now()->subDays(10),
+    ]);
+    $team = $owner->currentTeam;
+
+    Company::withoutEvents(fn () => Company::factory()
+        ->for($team)
+        ->create([
+            'creator_id' => $owner->id,
+            'creation_source' => CreationSource::WEB,
+            'created_at' => now()->subDays(4),
+        ]));
+
+    livewire(FunnelWidget::class)
+        ->assertSee('Activated Teams')
+        ->assertSee('1');
+});
+
+it('excludes system-created records from the activated teams count', function (): void {
+    $owner = User::factory()->withTeam()->create([
+        'created_at' => now()->subDays(10),
+    ]);
+    $team = $owner->currentTeam;
+
+    Company::withoutEvents(fn () => Company::factory()
+        ->for($team)
+        ->create([
+            'creator_id' => $owner->id,
+            'creation_source' => CreationSource::SYSTEM,
+            'created_at' => now()->subDays(4),
+        ]));
+
+    livewire(FunnelWidget::class)
+        ->assertSee('Activated Teams')
+        ->assertSee('0');
+});
+
+it('counts a team as subscribed once it holds an active subscription created within the period', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_funnel_active',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+        'created_at' => now()->subDays(2),
+    ]);
+
+    livewire(FunnelWidget::class)
+        ->assertSee('Subscribed Teams')
+        ->assertSee('1');
+});
+
+it('excludes an unpaid subscription from the subscribed teams count', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_funnel_unpaid',
+        'stripe_status' => 'unpaid',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+        'created_at' => now()->subDays(2),
+    ]);
+
+    livewire(FunnelWidget::class)
+        ->assertSee('Subscribed Teams')
+        ->assertSee('0');
+});


### PR DESCRIPTION
## Summary

- New `FunnelWidget` on the sysadmin Engagement dashboard: **Organic sign-ups → Activated teams → Subscribed teams** for the selected period, with period-over-period comparison — the growth program's S2 funnel metrics.
- Organic sign-ups exclude invited members (no `team_user` pivot for a foreign team within 24h of registration — verified against every current join path: invitations and join-links both require an authenticated user).
- Activated teams reuse the exact creation-source filter the existing activation metric applies, via a new shared `HasPeriodComparison::getDistinctActiveColumnValues()` helper (one definition, two callers — no duplicated SQL).
- Subscribed teams use Cashier's `active()` scope (closest queryable proxy to `HostedWorkspaceAccess`'s `valid()`, correct under `keepPastDueSubscriptionsActive()`). Counts subscriptions created in the period, consistent with the sibling stats' framing; a "currently subscribed" variant is a one-line flip if preferred.

## Test plan

- 10 new tests (FunnelWidgetTest + dashboard render), `Funnel|ActivationRate|Engagement` 13/13, SystemAdmin suite 132/132, Arch 24/24; pint/rector/phpstan/type-coverage clean.
- Dashboard screenshot verified against seeded local data.