### PR TITLE
Fix company team recipient options

### DIFF
--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -798,7 +798,11 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         foreach ($people as $person) {
             $email = $this->primaryEmailForPersonId($primaryEmailEntries, (string) $person->getKey());
 
-            if ($email === null || $person->company_id === null) {
+            if ($email === null) {
+                continue;
+            }
+
+            if ($person->company_id === null) {
                 continue;
             }
 

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -692,8 +692,6 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
         $primaryEmailEntries = $this->primaryEmailEntriesForPeople($peopleIds, $teamId);
         $options = [];
-        $companyCounts = [];
-        $companyEmails = [];
 
         foreach ($people as $person) {
             $personId = (string) $person->getKey();
@@ -710,36 +708,9 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                 'description' => $email,
                 'email' => $email,
             ];
-
-            if ($person->company_id === null) {
-                continue;
-            }
-
-            $companyId = (string) $person->company_id;
-            $companyCounts[$companyId] = ($companyCounts[$companyId] ?? 0) + 1;
-            $companyEmails[$companyId][] = $email;
         }
 
-        $companyOptions = Company::query()
-            ->where('team_id', $teamId)
-            ->whereKey(array_keys($companyCounts))
-            ->orderBy('name')
-            ->limit(100)
-            ->get(['id', 'name'])
-            ->map(function (Company $company) use ($companyCounts, $companyEmails): array {
-                $companyId = (string) $company->getKey();
-
-                return [
-                    'type' => 'company_team',
-                    'id' => $companyId,
-                    'label' => $company->name,
-                    'description' => __('filament/emails/composer.fields.company_team'),
-                    'count' => $companyCounts[$companyId],
-                    'emails' => $companyEmails[$companyId],
-                ];
-            });
-
-        foreach ($companyOptions as $companyOption) {
+        foreach ($this->companyTeamRecipientOptions($teamId) as $companyOption) {
             $options[] = $companyOption;
         }
 
@@ -794,6 +765,72 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         }
 
         $this->to = $nextRecipients;
+    }
+
+    /**
+     * @return list<array{
+     *     type: 'company_team',
+     *     id: string,
+     *     label: string,
+     *     description: string,
+     *     count: int,
+     *     emails: list<string>,
+     * }>
+     */
+    private function companyTeamRecipientOptions(string $teamId): array
+    {
+        $people = People::query()
+            ->where('team_id', $teamId)
+            ->whereNotNull('company_id')
+            ->orderBy('name')
+            ->get(['id', 'name', 'company_id']);
+
+        $peopleIds = [];
+
+        foreach ($people as $person) {
+            $peopleIds[] = (string) $person->getKey();
+        }
+
+        $primaryEmailEntries = $this->primaryEmailEntriesForPeople($peopleIds, $teamId);
+        $companyCounts = [];
+        $companyEmails = [];
+
+        foreach ($people as $person) {
+            $email = $this->primaryEmailForPersonId($primaryEmailEntries, (string) $person->getKey());
+
+            if ($email === null || $person->company_id === null) {
+                continue;
+            }
+
+            $companyId = (string) $person->company_id;
+            $companyCounts[$companyId] = ($companyCounts[$companyId] ?? 0) + 1;
+            $companyEmails[$companyId][] = $email;
+        }
+
+        if ($companyCounts === []) {
+            return [];
+        }
+
+        /** @var list<array{type: 'company_team', id: string, label: string, description: string, count: int, emails: list<string>}> */
+        return Company::query()
+            ->where('team_id', $teamId)
+            ->whereKey(array_keys($companyCounts))
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(function (Company $company) use ($companyCounts, $companyEmails): array {
+                $companyId = (string) $company->getKey();
+
+                return [
+                    'type' => 'company_team',
+                    'id' => $companyId,
+                    'label' => $company->name,
+                    'description' => __('filament/emails/composer.fields.company_team'),
+                    'count' => $companyCounts[$companyId],
+                    'emails' => $companyEmails[$companyId],
+                ];
+            })
+            ->values()
+            ->all();
     }
 
     /**

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -9,6 +9,7 @@ use App\Models\People;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
@@ -448,6 +449,52 @@ it('adds every company team member primary email to recipients', function (): vo
             'existing@example.com',
             'natalie@example.com',
             'asha@example.com',
+        ]);
+});
+
+it('includes company team recipient options outside the first person option page', function (): void {
+    $earlyCompany = Company::factory()->for($this->user->currentTeam)->create(['name' => 'Alpha']);
+    $targetCompany = Company::factory()->for($this->user->currentTeam)->create(['name' => 'Zephyr']);
+
+    People::factory()
+        ->count(300)
+        ->for($this->user->currentTeam)
+        ->for($earlyCompany)
+        ->sequence(fn (Sequence $sequence): array => [
+            'name' => sprintf('A Contact %03d', $sequence->index),
+        ])
+        ->create();
+
+    $person = People::factory()
+        ->for($this->user->currentTeam)
+        ->for($targetCompany)
+        ->create(['name' => 'Zoe Late']);
+
+    $emailField = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $this->user->current_team_id)
+        ->where('entity_type', 'people')
+        ->where('code', 'emails')
+        ->sole();
+
+    CustomFieldValue::query()->create([
+        'custom_field_id' => $emailField->id,
+        'entity_type' => 'people',
+        'entity_id' => $person->id,
+        'tenant_id' => $this->user->current_team_id,
+        'json_value' => ['zoe@example.com'],
+    ]);
+
+    $options = Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->instance()
+        ->recipientOptions();
+
+    expect(collect($options)
+        ->first(fn (array $option): bool => $option['type'] === 'company_team' && $option['label'] === 'Zephyr'))
+        ->toMatchArray([
+            'count' => 1,
+            'emails' => ['zoe@example.com'],
         ]);
 });
 


### PR DESCRIPTION
## Summary
- Build company team recipient options independently from the capped person suggestion list
- Keep company options limited to companies with emailable contacts
- Add regression coverage for companies outside the first person option page

## Tests
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/EmailIntegration/EmailComposerTest.php