### PR TITLE
fix(auth): keep turnstile wired after spa navigation to register

### DIFF
--- a/resources/views/filament/forms/components/turnstile.blade.php
+++ b/resources/views/filament/forms/components/turnstile.blade.php
@@ -1,12 +1,66 @@
+{{--
+    The package's <x-turnstile> wires its callbacks inside a `livewire:initialized`
+    listener, which fires once per full page load. The app panel runs in SPA mode,
+    so arriving here through any wire:navigate link (e.g. the login page's sign-up
+    link) leaves the callbacks unregistered: the widget solves, the token is
+    dropped, and every submit fails with the "required" message. Alpine's init()
+    runs on every DOM insertion — full load, wire:navigate, and morph alike — so
+    the widget is rendered explicitly from here instead.
+--}}
 <x-dynamic-component
     :component="$getFieldWrapperView()"
     :field="$field"
 >
-    <x-turnstile.scripts />
+    <div
+        wire:ignore
+        x-data="{
+            widgetId: null,
 
-    <x-turnstile
-        wire:model="{{ $getStatePath() }}"
-        data-action="register"
-        data-theme="auto"
-    />
+            init() {
+                if (window.turnstile) {
+                    this.render();
+
+                    return;
+                }
+
+                (window.turnstileRenderQueue ??= []).push(() => this.render());
+                window.turnstileReady ??= () => window.turnstileRenderQueue.splice(0).forEach((render) => render());
+
+                if (! window.turnstileScriptInjected) {
+                    window.turnstileScriptInjected = true;
+
+                    const script = document.createElement('script');
+                    script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=turnstileReady';
+                    script.async = true;
+                    script.defer = true;
+                    document.head.appendChild(script);
+                }
+            },
+
+            render() {
+                this.widgetId = window.turnstile.render(this.$refs.widget, {
+                    sitekey: @js(config('services.turnstile.key')),
+                    action: 'register',
+                    theme: 'auto',
+                    callback: (token) => this.$wire.set(@js($getStatePath()), token),
+                    'expired-callback': () => window.turnstile.reset(this.widgetId),
+                    'timeout-callback': () => window.turnstile.reset(this.widgetId),
+                });
+
+                this.$wire.watch(@js($getStatePath()), (value, old) => {
+                    if (!!old && ! value) {
+                        window.turnstile.reset(this.widgetId);
+                    }
+                });
+            },
+
+            destroy() {
+                if (this.widgetId !== null && window.turnstile) {
+                    window.turnstile.remove(this.widgetId);
+                }
+            },
+        }"
+    >
+        <div x-ref="widget"></div>
+    </div>
 </x-dynamic-component>

--- a/tests/Browser/Auth/RegistrationBrowserTest.php
+++ b/tests/Browser/Auth/RegistrationBrowserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\Auth\Register;
+use App\Models\User;
+use RyanChandler\LaravelCloudflareTurnstile\Facades\Turnstile;
+
+mutates(Register::class);
+
+it('completes a turnstile-protected registration after arriving via the login page link', function (): void {
+    config([
+        'services.turnstile.key' => '1x00000000000000000000AA',
+        'services.turnstile.secret' => '1x0000000000000000000000000000000AA',
+    ]);
+
+    Turnstile::fake();
+
+    $page = $this->visit('/app/login')
+        ->click('a[href*="register"]')
+        ->assertPathContains('/register')
+        ->type('[id="form.name"]', 'Jane Doe')
+        ->type('[id="form.email"]', 'jane-spa-turnstile@gmail.com')
+        ->type('[id="form.password"]', 'Password123!')
+        ->type('[id="form.passwordConfirmation"]', 'Password123!');
+
+    $token = '';
+
+    foreach (range(1, 30) as $attempt) {
+        $token = (string) $page->script("document.querySelector('input[name=\"cf-turnstile-response\"]')?.value ?? ''");
+
+        if ($token !== '') {
+            break;
+        }
+
+        $page->wait(0.5);
+    }
+
+    expect($token)->not->toBe('', 'The turnstile widget never issued a token.');
+
+    $page->click('button[type="submit"]');
+
+    foreach (range(1, 30) as $attempt) {
+        if ($page->script('window.location.pathname') !== '/app/register') {
+            break;
+        }
+
+        $page->wait(0.5);
+    }
+
+    expect($page->script('window.location.pathname'))->not->toBe('/app/register')
+        ->and(User::where('email', 'jane-spa-turnstile@gmail.com')->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Problem

Production registration at app.relaticle.com/register failed with **"Please complete the verification challenge."** even after the Cloudflare Turnstile widget was solved.

## Root cause

`ryangjchandler/laravel-cloudflare-turnstile`'s `<x-turnstile>` component registers its token callback (`window.captchaCallback`) inside a `document.addEventListener('livewire:initialized', ...)` listener. That event fires once per full page load. The app panel runs in SPA mode (`->spa()`), so arriving at /register through any `wire:navigate` link — most commonly the login page's *"sign up for an account"* link — executes after Livewire is already initialized: the listener never fires, `window.captchaCallback` stays undefined, the widget solves but the token is dropped, and every submit fails the `required` rule on `cf_turnstile_response`.

Reproduced on production and locally: after `login → sign-up link`, `typeof window.captchaCallback === 'undefined'` while a direct load of /register has it defined.

## Fix

`resources/views/filament/forms/components/turnstile.blade.php` now renders the widget explicitly from an Alpine component instead of the package's blade component. Alpine's `init()` runs on every DOM insertion — full load, `wire:navigate`, and morph alike — so the token callback, expiry reset, and the state watcher that re-arms the widget after `resetTurnstileChallenge()` all survive SPA navigation. `api.js` is loaded once (explicit render mode, guarded by a window flag), and the widget is removed on Alpine `destroy()`.

The contact form is unaffected (plain form POST, no `wire:model`).

## Test plan

- New browser regression test `tests/Browser/Auth/RegistrationBrowserTest.php`: walks login → sign-up link (SPA nav) → real Turnstile widget (Cloudflare always-pass test sitekey) → submit → asserts the user is registered and redirected. Fails on the old view (stuck on /app/register), passes with the fix.
- `tests/Feature/Auth/RegistrationTest.php` (32 tests) and `tests/Browser/Auth` all pass.
- Manually verified in a real browser (agent-browser, Cloudflare test keys): direct load, SPA-navigated load, and the validation-error path (duplicate email → widget resets → fresh token → resubmit succeeds).
- pint / rector / phpstan / 100% type coverage all green.