### PR TITLE
feat(teams): workspace activity log for admins

### DIFF
--- a/app/Filament/Pages/Concerns/HasWorkspaceSettingsNavigation.php
+++ b/app/Filament/Pages/Concerns/HasWorkspaceSettingsNavigation.php
@@ -7,6 +7,7 @@ namespace App\Filament\Pages\Concerns;
 use App\Features\Billing as BillingFeature;
 use App\Filament\Pages\Billing;
 use App\Filament\Pages\EditTeam;
+use App\Filament\Pages\Team\ActivityLog;
 use App\Filament\Pages\Team\CustomFields;
 use App\Filament\Pages\Team\Members;
 use App\Models\Team;
@@ -60,6 +61,13 @@ trait HasWorkspaceSettingsNavigation
                 ->url(fn (): string => CustomFields::getUrl())
                 ->isActiveWhen(fn (): bool => request()->routeIs(CustomFields::getRouteName()))
                 ->visible(fn (): bool => CustomFields::canAccess()),
+
+            NavigationItem::make()
+                ->label(__('teams.tabs.activity'))
+                ->icon(Heroicon::OutlinedClock)
+                ->url(fn (): string => ActivityLog::getUrl())
+                ->isActiveWhen(fn (): bool => request()->routeIs(ActivityLog::getRouteName()))
+                ->visible(fn (): bool => ActivityLog::canAccess()),
 
             NavigationItem::make()
                 ->label(__('teams.tabs.billing'))

--- a/app/Filament/Pages/Team/ActivityLog.php
+++ b/app/Filament/Pages/Team/ActivityLog.php
@@ -25,7 +25,10 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Url;
@@ -85,6 +88,9 @@ final class ActivityLog extends Page implements HasTable
     #[Url(as: 'sort')]
     public ?string $tableSort = null;
 
+    /** @var array<string, Model>|null */
+    private ?array $liveSubjects = null;
+
     #[Override]
     public static function shouldRegisterNavigation(): bool
     {
@@ -125,10 +131,11 @@ final class ActivityLog extends Page implements HasTable
     }
 
     /**
-     * One save writes two rows — the trait's own event and, when custom fields
-     * moved, a sibling under `custom_field_changes` sharing a `batch_uuid`.
-     * Reporting both would show a phantom update alongside every create, so the
-     * sibling is dropped and its payload carried onto the surviving row.
+     * One save writes the trait's own event plus one `custom_field_changes` row
+     * per custom field that moved, all sharing a `batch_uuid`. Reporting them
+     * all put a phantom update next to every create, so they collapse onto a
+     * single surviving row — the native event when there is one, otherwise the
+     * first custom-field row — which carries every sibling payload with it.
      */
     public function table(Table $table): Table
     {
@@ -137,16 +144,18 @@ final class ActivityLog extends Page implements HasTable
                 Activity::query()
                     ->select('activity_log.*')
                     ->addSelect(['batch_custom_field_properties' => $this->sameSave(DB::table('activity_log', 'sibling'))
-                        ->select('sibling.properties')
-                        ->where('sibling.event', self::CUSTOM_FIELD_EVENT)
-                        ->limit(1),
+                        ->selectRaw('json_agg(sibling.properties order by sibling.id)')
+                        ->where('sibling.event', self::CUSTOM_FIELD_EVENT),
                     ])
                     ->whereNot(fn (Builder $query): Builder => $query
                         ->where('event', self::CUSTOM_FIELD_EVENT)
                         ->whereNotNull('batch_uuid')
                         ->whereExists(fn (QueryBuilder $sibling): QueryBuilder => $this->sameSave($sibling)
-                            ->whereNot('sibling.event', self::CUSTOM_FIELD_EVENT)))
-                    ->with(['causer', 'subject'])
+                            ->whereRaw(
+                                '(case when sibling.event = ? then 1 else 0 end, sibling.id) < (1, activity_log.id)',
+                                [self::CUSTOM_FIELD_EVENT],
+                            )))
+                    ->with('causer')
             )
             ->defaultSort('created_at', 'desc')
             ->recordUrl($this->subjectUrl(...))
@@ -259,7 +268,7 @@ final class ActivityLog extends Page implements HasTable
             }
         }
 
-        $subject = $record->subject;
+        $subject = $this->liveSubject($record);
 
         if ($subject instanceof Model) {
             $name = $subject->getAttribute('name') ?? $subject->getAttribute('title');
@@ -276,11 +285,64 @@ final class ActivityLog extends Page implements HasTable
     {
         $resource = self::SUBJECT_RESOURCES[$record->subject_type] ?? null;
 
-        if ($resource === null || ! $record->subject instanceof Model) {
+        if ($resource === null || ! $this->liveSubject($record) instanceof Model) {
             return null;
         }
 
         return $resource::getUrl('view', ['record' => $record->subject_id]);
+    }
+
+    /**
+     * Resolved for the whole page at once rather than through `subject`, because
+     * a morph alias whose model has since been removed from the codebase — a
+     * stale row from a retired feature — makes eager loading the relation throw
+     * and takes the entire audit log down with it. Unknown aliases simply have
+     * no live record; the row still renders from its own payload.
+     */
+    private function liveSubject(Activity $record): ?Model
+    {
+        $this->liveSubjects ??= $this->resolveLiveSubjects();
+
+        return $this->liveSubjects[$record->subject_type.':'.$record->subject_id] ?? null;
+    }
+
+    /**
+     * @return array<string, Model>
+     */
+    private function resolveLiveSubjects(): array
+    {
+        $this->liveSubjects = [];
+
+        $morphMap = Relation::morphMap();
+        $idsByType = [];
+
+        $records = $this->getTableRecords();
+
+        foreach ($records instanceof Collection ? $records->all() : $records->items() as $row) {
+            $type = (string) $row->getAttribute('subject_type');
+
+            if (isset($morphMap[$type])) {
+                $idsByType[$type][] = $row->getAttribute('subject_id');
+            }
+        }
+
+        $resolved = [];
+
+        foreach ($idsByType as $type => $ids) {
+            /** @var class-string<Model> $model */
+            $model = $morphMap[$type];
+
+            $subjects = $model::query()
+                ->withoutGlobalScopes([SoftDeletingScope::class])
+                ->whereKey(array_values(array_unique($ids)))
+                ->get();
+
+            foreach ($subjects as $subject) {
+                $resolved[$type.':'.$subject->getKey()] = $subject;
+            }
+        }
+
+        return $resolved;
     }
 
     private function eventLabel(?string $state): string

--- a/app/Filament/Pages/Team/ActivityLog.php
+++ b/app/Filament/Pages/Team/ActivityLog.php
@@ -11,6 +11,7 @@ use App\Filament\Resources\PeopleResource;
 use App\Models\ActivityLog\Activity;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\ActivityLog\ActivityChangeSummary;
 use BackedEnum;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\DatePicker;
@@ -24,7 +25,10 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Livewire\Attributes\Url;
 use Override;
 
 /**
@@ -58,11 +62,28 @@ final class ActivityLog extends Page implements HasTable
         'updated' => ['updated', 'custom_field_changes'],
     ];
 
+    private const string CUSTOM_FIELD_EVENT = 'custom_field_changes';
+
+    private const string NOTHING = '—';
+
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedClock;
 
     protected static ?string $slug = 'team/activity';
 
     protected string $view = 'filament.pages.team.activity-log';
+
+    /**
+     * Filament binds these on resource list pages but not on a plain page, so a
+     * filtered audit view could not be reloaded, bookmarked, or handed to a
+     * colleague. Declared here to match every other table in the app.
+     *
+     * @var array<string, mixed>|null
+     */
+    #[Url(as: 'filters')]
+    public ?array $tableFilters = null;
+
+    #[Url(as: 'sort')]
+    public ?string $tableSort = null;
 
     #[Override]
     public static function shouldRegisterNavigation(): bool
@@ -103,10 +124,30 @@ final class ActivityLog extends Page implements HasTable
         return __('teams.activity.description');
     }
 
+    /**
+     * One save writes two rows — the trait's own event and, when custom fields
+     * moved, a sibling under `custom_field_changes` sharing a `batch_uuid`.
+     * Reporting both would show a phantom update alongside every create, so the
+     * sibling is dropped and its payload carried onto the surviving row.
+     */
     public function table(Table $table): Table
     {
         return $table
-            ->query(Activity::query()->with(['causer', 'subject']))
+            ->query(
+                Activity::query()
+                    ->select('activity_log.*')
+                    ->addSelect(['batch_custom_field_properties' => $this->sameSave(DB::table('activity_log', 'sibling'))
+                        ->select('sibling.properties')
+                        ->where('sibling.event', self::CUSTOM_FIELD_EVENT)
+                        ->limit(1),
+                    ])
+                    ->whereNot(fn (Builder $query): Builder => $query
+                        ->where('event', self::CUSTOM_FIELD_EVENT)
+                        ->whereNotNull('batch_uuid')
+                        ->whereExists(fn (QueryBuilder $sibling): QueryBuilder => $this->sameSave($sibling)
+                            ->whereNot('sibling.event', self::CUSTOM_FIELD_EVENT)))
+                    ->with(['causer', 'subject'])
+            )
             ->defaultSort('created_at', 'desc')
             ->recordUrl($this->subjectUrl(...))
             ->emptyStateHeading(__('teams.activity.empty.heading'))
@@ -139,6 +180,14 @@ final class ActivityLog extends Page implements HasTable
                     ->label(__('teams.activity.columns.record'))
                     ->state($this->recordName(...))
                     ->wrap(),
+                TextColumn::make('batch_uuid')
+                    ->label(__('teams.activity.columns.changes'))
+                    ->state(ActivityChangeSummary::for(...))
+                    ->listWithLineBreaks()
+                    ->limitList(2)
+                    ->expandableLimitedList()
+                    ->placeholder(self::NOTHING)
+                    ->wrap(),
             ])
             ->filters([
                 SelectFilter::make('event')
@@ -169,35 +218,51 @@ final class ActivityLog extends Page implements HasTable
     }
 
     /**
-     * The record still on screen wins; otherwise fall back to the name captured
-     * in the activity payload, which is all that is left after a force delete.
+     * Rows written for one record inside one request. The batch is stamped per
+     * request, not per save, so a request touching several records shares it —
+     * the subject columns are what keep one record's payload off another's row.
+     *
+     * Only ever used to fold a `custom_field_changes` row into its native
+     * sibling. Collapsing the batch itself would swallow a genuine event, since
+     * a single request can legitimately create and then delete a record.
+     */
+    private function sameSave(QueryBuilder $sibling): QueryBuilder
+    {
+        return $sibling
+            ->from('activity_log', 'sibling')
+            ->whereColumn('sibling.batch_uuid', 'activity_log.batch_uuid')
+            ->whereColumn('sibling.team_id', 'activity_log.team_id')
+            ->whereColumn('sibling.subject_type', 'activity_log.subject_type')
+            ->whereColumn('sibling.subject_id', 'activity_log.subject_id');
+    }
+
+    /**
+     * The name the record carried at the time of the event wins. Reading the
+     * live record instead would rewrite history on every rename — and there is
+     * no live record left to read once it has been destroyed.
      */
     private function recordName(Activity $record): string
     {
-        $subject = $record->subject;
+        $changes = $record->attribute_changes?->toArray() ?? [];
 
-        if ($subject instanceof Model) {
-            $name = $subject->getAttribute('name') ?? $subject->getAttribute('title');
-
-            if (is_string($name) && $name !== '') {
-                return $name;
-            }
-        }
-
-        /** @var array<string, mixed> $properties */
-        $properties = [
-            ...($record->properties?->toArray() ?? []),
-            ...($record->attribute_changes?->toArray() ?? []),
-        ];
-
-        foreach (['old', 'attributes'] as $side) {
-            $values = $properties[$side] ?? null;
+        foreach (['attributes', 'old'] as $side) {
+            $values = $changes[$side] ?? null;
 
             if (! is_array($values)) {
                 continue;
             }
 
             $name = $values['name'] ?? $values['title'] ?? null;
+
+            if (is_string($name) && $name !== '') {
+                return $name;
+            }
+        }
+
+        $subject = $record->subject;
+
+        if ($subject instanceof Model) {
+            $name = $subject->getAttribute('name') ?? $subject->getAttribute('title');
 
             if (is_string($name) && $name !== '') {
                 return $name;

--- a/app/Filament/Pages/Team/ActivityLog.php
+++ b/app/Filament/Pages/Team/ActivityLog.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages\Team;
+
+use App\Filament\Pages\Concerns\HasWorkspaceSettingsNavigation;
+use App\Filament\Resources\CompanyResource;
+use App\Filament\Resources\OpportunityResource;
+use App\Filament\Resources\PeopleResource;
+use App\Models\ActivityLog\Activity;
+use App\Models\Team;
+use App\Models\User;
+use BackedEnum;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\DatePicker;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Override;
+
+/**
+ * The workspace audit trail: who changed or deleted which record, and when.
+ *
+ * A record's own timeline disappears with the record on a permanent delete, so
+ * this page reads the activity rows directly — they outlive their subject, and
+ * the name captured in the delete payload still identifies what was destroyed.
+ */
+final class ActivityLog extends Page implements HasTable
+{
+    use HasWorkspaceSettingsNavigation;
+    use InteractsWithTable;
+
+    /**
+     * Only the record types with a view page can be linked to; tasks and notes
+     * are managed from their list screens and have no record route.
+     */
+    private const array SUBJECT_RESOURCES = [
+        'company' => CompanyResource::class,
+        'people' => PeopleResource::class,
+        'opportunity' => OpportunityResource::class,
+    ];
+
+    /**
+     * Custom-field edits are logged under their own event name rather than the
+     * trait's `updated`, but to an admin they are the same act — so they share a
+     * label, and filtering on it has to match both.
+     */
+    private const array EVENT_ALIASES = [
+        'updated' => ['updated', 'custom_field_changes'],
+    ];
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedClock;
+
+    protected static ?string $slug = 'team/activity';
+
+    protected string $view = 'filament.pages.team.activity-log';
+
+    #[Override]
+    public static function shouldRegisterNavigation(): bool
+    {
+        return false;
+    }
+
+    public static function canAccess(): bool
+    {
+        $tenant = Filament::getTenant();
+
+        if (! $tenant instanceof Team) {
+            return false;
+        }
+
+        $user = auth()->user();
+
+        return $user instanceof User && $user->hasTeamRoleForTeamId($tenant->getKey(), 'admin');
+    }
+
+    public function mount(): void
+    {
+        abort_unless(self::canAccess(), 403);
+    }
+
+    public static function getLabel(): string
+    {
+        return __('teams.tabs.activity');
+    }
+
+    public function getTitle(): string
+    {
+        return __('teams.tabs.activity');
+    }
+
+    public function getSubheading(): string
+    {
+        return __('teams.activity.description');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Activity::query()->with(['causer', 'subject']))
+            ->defaultSort('created_at', 'desc')
+            ->recordUrl($this->subjectUrl(...))
+            ->emptyStateHeading(__('teams.activity.empty.heading'))
+            ->emptyStateDescription(__('teams.activity.empty.description'))
+            ->emptyStateIcon(Heroicon::OutlinedClock)
+            ->columns([
+                TextColumn::make('created_at')
+                    ->label(__('teams.activity.columns.created_at'))
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('causer.name')
+                    ->label(__('teams.activity.columns.causer'))
+                    ->placeholder(__('teams.activity.system')),
+                TextColumn::make('event')
+                    ->label(__('teams.activity.columns.event'))
+                    ->badge()
+                    ->color(fn (?string $state): string => match ($state) {
+                        'created' => 'success',
+                        'deleted' => 'danger',
+                        'restored' => 'warning',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing($this->eventLabel(...)),
+                TextColumn::make('subject_type')
+                    ->label(__('teams.activity.columns.subject_type'))
+                    ->badge()
+                    ->color('gray')
+                    ->formatStateUsing($this->typeLabel(...)),
+                TextColumn::make('subject_id')
+                    ->label(__('teams.activity.columns.record'))
+                    ->state($this->recordName(...))
+                    ->wrap(),
+            ])
+            ->filters([
+                SelectFilter::make('event')
+                    ->label(__('teams.activity.filters.event'))
+                    ->options($this->eventOptions())
+                    ->query(fn (Builder $query, array $data): Builder => filled($data['value'] ?? null)
+                        ? $query->whereIn('event', self::EVENT_ALIASES[$data['value']] ?? [$data['value']])
+                        : $query),
+                SelectFilter::make('subject_type')
+                    ->label(__('teams.activity.filters.subject_type'))
+                    ->options($this->typeOptions()),
+                SelectFilter::make('causer')
+                    ->label(__('teams.activity.filters.causer'))
+                    ->options($this->causerOptions(...))
+                    ->searchable()
+                    ->query(fn (Builder $query, array $data): Builder => filled($data['value'] ?? null)
+                        ? $query->where('causer_type', 'user')->where('causer_id', $data['value'])
+                        : $query),
+                Filter::make('created_at')
+                    ->schema([
+                        DatePicker::make('from')->label(__('teams.activity.filters.from')),
+                        DatePicker::make('until')->label(__('teams.activity.filters.until')),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when(filled($data['from'] ?? null), fn (Builder $q): Builder => $q->whereDate('activity_log.created_at', '>=', $data['from']))
+                        ->when(filled($data['until'] ?? null), fn (Builder $q): Builder => $q->whereDate('activity_log.created_at', '<=', $data['until']))),
+            ]);
+    }
+
+    /**
+     * The record still on screen wins; otherwise fall back to the name captured
+     * in the activity payload, which is all that is left after a force delete.
+     */
+    private function recordName(Activity $record): string
+    {
+        $subject = $record->subject;
+
+        if ($subject instanceof Model) {
+            $name = $subject->getAttribute('name') ?? $subject->getAttribute('title');
+
+            if (is_string($name) && $name !== '') {
+                return $name;
+            }
+        }
+
+        /** @var array<string, mixed> $properties */
+        $properties = [
+            ...($record->properties?->toArray() ?? []),
+            ...($record->attribute_changes?->toArray() ?? []),
+        ];
+
+        foreach (['old', 'attributes'] as $side) {
+            $values = $properties[$side] ?? null;
+
+            if (! is_array($values)) {
+                continue;
+            }
+
+            $name = $values['name'] ?? $values['title'] ?? null;
+
+            if (is_string($name) && $name !== '') {
+                return $name;
+            }
+        }
+
+        return '#'.$record->subject_id;
+    }
+
+    private function subjectUrl(Activity $record): ?string
+    {
+        $resource = self::SUBJECT_RESOURCES[$record->subject_type] ?? null;
+
+        if ($resource === null || ! $record->subject instanceof Model) {
+            return null;
+        }
+
+        return $resource::getUrl('view', ['record' => $record->subject_id]);
+    }
+
+    private function eventLabel(?string $state): string
+    {
+        if ($state === null) {
+            return '—';
+        }
+
+        if ($state === 'custom_field_changes') {
+            return __('teams.activity.events.updated');
+        }
+
+        return $this->eventOptions()[$state] ?? Str::headline(str_replace('.', ' ', $state));
+    }
+
+    private function typeLabel(?string $state): string
+    {
+        if ($state === null) {
+            return '—';
+        }
+
+        return $this->typeOptions()[$state] ?? Str::headline($state);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function eventOptions(): array
+    {
+        return [
+            'created' => __('teams.activity.events.created'),
+            'updated' => __('teams.activity.events.updated'),
+            'deleted' => __('teams.activity.events.deleted'),
+            'restored' => __('teams.activity.events.restored'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function typeOptions(): array
+    {
+        return [
+            'company' => __('teams.activity.types.company'),
+            'people' => __('teams.activity.types.people'),
+            'opportunity' => __('teams.activity.types.opportunity'),
+            'task' => __('teams.activity.types.task'),
+            'note' => __('teams.activity.types.note'),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function causerOptions(): array
+    {
+        $tenant = Filament::getTenant();
+
+        if (! $tenant instanceof Team) {
+            return [];
+        }
+
+        return $tenant->allUsers()
+            ->sortBy('name')
+            ->mapWithKeys(fn (User $user): array => [(string) $user->getKey() => $user->name])
+            ->all();
+    }
+}

--- a/app/Support/ActivityLog/ActivityChangeSummary.php
+++ b/app/Support/ActivityLog/ActivityChangeSummary.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\ActivityLog;
+
+use App\Models\ActivityLog\Activity;
+use Illuminate\Support\Str;
+
+/**
+ * Turns one activity row into the "old → new" lines an admin reads in the
+ * workspace audit log.
+ *
+ * Only genuine before/after pairs are emitted. A create or a delete carries the
+ * whole record in its payload, which says nothing the event badge does not
+ * already say, so those produce no lines at all.
+ */
+final readonly class ActivityChangeSummary
+{
+    private const string ARROW = ' → ';
+
+    private const string EMPTY = '—';
+
+    /**
+     * @return list<string>
+     */
+    public static function for(Activity $activity): array
+    {
+        return [
+            ...self::nativeLines($activity),
+            ...self::customFieldLines($activity),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function nativeLines(Activity $activity): array
+    {
+        $changes = $activity->attribute_changes?->toArray() ?? [];
+
+        $new = $changes['attributes'] ?? null;
+        $old = $changes['old'] ?? null;
+
+        if (! is_array($new) || ! is_array($old)) {
+            return [];
+        }
+
+        $lines = [];
+
+        foreach ($new as $key => $value) {
+            $before = self::stringify($old[$key] ?? null);
+            $after = self::stringify($value);
+
+            if ($before === $after) {
+                continue;
+            }
+
+            $lines[] = Str::headline((string) $key).': '.$before.self::ARROW.$after;
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The custom-field half of a save is logged as its own row. The audit table
+     * collapses a save to a single row, so the surviving row carries its
+     * sibling's payload in `batch_custom_field_properties`.
+     *
+     * @return list<string>
+     */
+    private static function customFieldLines(Activity $activity): array
+    {
+        $properties = $activity->properties?->toArray() ?? [];
+
+        $sibling = $activity->getAttribute('batch_custom_field_properties');
+
+        if (is_string($sibling)) {
+            /** @var array<string, mixed>|null $decoded */
+            $decoded = json_decode($sibling, true);
+
+            if (is_array($decoded)) {
+                $properties = [...$properties, ...$decoded];
+            }
+        }
+
+        $changes = $properties['custom_field_changes'] ?? null;
+
+        if (! is_array($changes)) {
+            return [];
+        }
+
+        $lines = [];
+
+        foreach ($changes as $change) {
+            if (! is_array($change)) {
+                continue;
+            }
+
+            $label = $change['label'] ?? $change['code'] ?? null;
+            $before = self::stringify($change['old'] ?? null);
+            $after = self::stringify($change['new'] ?? null);
+
+            if (! is_string($label) || $before === $after) {
+                continue;
+            }
+
+            $lines[] = $label.': '.$before.self::ARROW.$after;
+        }
+
+        return $lines;
+    }
+
+    private static function stringify(mixed $value): string
+    {
+        if (is_array($value)) {
+            $label = $value['label'] ?? null;
+
+            return is_string($label) && $label !== '' ? $label : self::EMPTY;
+        }
+
+        if (in_array($value, [null, '', []], true)) {
+            return self::EMPTY;
+        }
+
+        if (is_bool($value)) {
+            return $value ? __('teams.activity.yes') : __('teams.activity.no');
+        }
+
+        return is_scalar($value) ? (string) $value : self::EMPTY;
+    }
+}

--- a/app/Support/ActivityLog/ActivityChangeSummary.php
+++ b/app/Support/ActivityLog/ActivityChangeSummary.php
@@ -63,52 +63,70 @@ final readonly class ActivityChangeSummary
     }
 
     /**
-     * The custom-field half of a save is logged as its own row. The audit table
-     * collapses a save to a single row, so the surviving row carries its
-     * sibling's payload in `batch_custom_field_properties`.
+     * Each custom field that moved is logged as its own row. The audit table
+     * collapses a save to a single row, so the survivor carries every sibling
+     * payload — including its own — aggregated into
+     * `batch_custom_field_properties`. Rows written outside a batch have no
+     * aggregate and speak for themselves.
      *
      * @return list<string>
      */
     private static function customFieldLines(Activity $activity): array
     {
-        $properties = $activity->properties?->toArray() ?? [];
-
-        $sibling = $activity->getAttribute('batch_custom_field_properties');
-
-        if (is_string($sibling)) {
-            /** @var array<string, mixed>|null $decoded */
-            $decoded = json_decode($sibling, true);
-
-            if (is_array($decoded)) {
-                $properties = [...$properties, ...$decoded];
-            }
-        }
-
-        $changes = $properties['custom_field_changes'] ?? null;
-
-        if (! is_array($changes)) {
-            return [];
-        }
+        $payloads = self::aggregatedPayloads($activity)
+            ?? [$activity->properties?->toArray() ?? []];
 
         $lines = [];
 
-        foreach ($changes as $change) {
-            if (! is_array($change)) {
+        foreach ($payloads as $payload) {
+            $changes = $payload['custom_field_changes'] ?? null;
+
+            if (! is_array($changes)) {
                 continue;
             }
 
-            $label = $change['label'] ?? $change['code'] ?? null;
-            $before = self::stringify($change['old'] ?? null);
-            $after = self::stringify($change['new'] ?? null);
+            foreach ($changes as $change) {
+                if (! is_array($change)) {
+                    continue;
+                }
 
-            if (! is_string($label) || $before === $after) {
-                continue;
+                $label = $change['label'] ?? $change['code'] ?? null;
+                $before = self::stringify($change['old'] ?? null);
+                $after = self::stringify($change['new'] ?? null);
+
+                if (! is_string($label) || $before === $after) {
+                    continue;
+                }
+
+                $line = $label.': '.$before.self::ARROW.$after;
+
+                if (! in_array($line, $lines, true)) {
+                    $lines[] = $line;
+                }
             }
-
-            $lines[] = $label.': '.$before.self::ARROW.$after;
         }
 
         return $lines;
+    }
+
+    /**
+     * @return list<array<string, mixed>>|null
+     */
+    private static function aggregatedPayloads(Activity $activity): ?array
+    {
+        $aggregate = $activity->getAttribute('batch_custom_field_properties');
+
+        if (! is_string($aggregate)) {
+            return null;
+        }
+
+        $decoded = json_decode($aggregate, true);
+
+        if (! is_array($decoded)) {
+            return null;
+        }
+
+        return array_values(array_filter($decoded, is_array(...)));
     }
 
     private static function stringify(mixed $value): string

--- a/composer.lock
+++ b/composer.lock
@@ -10075,16 +10075,16 @@
         },
         {
             "name": "relaticle/activity-log",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/relaticle/activity-log.git",
-                "reference": "62aad8a05d8484f176a91497139313f14a862c30"
+                "reference": "638ee8ddddf6277df91da377cdd8d4efcb30c0e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/relaticle/activity-log/zipball/62aad8a05d8484f176a91497139313f14a862c30",
-                "reference": "62aad8a05d8484f176a91497139313f14a862c30",
+                "url": "https://api.github.com/repos/relaticle/activity-log/zipball/638ee8ddddf6277df91da377cdd8d4efcb30c0e3",
+                "reference": "638ee8ddddf6277df91da377cdd8d4efcb30c0e3",
                 "shasum": ""
             },
             "require": {
@@ -10123,9 +10123,9 @@
             "description": "Reusable Filament plugin that renders a unified activity-log timeline for any Eloquent model",
             "support": {
                 "issues": "https://github.com/relaticle/activity-log/issues",
-                "source": "https://github.com/relaticle/activity-log/tree/v1.2.1"
+                "source": "https://github.com/relaticle/activity-log/tree/v1.2.2"
             },
-            "time": "2026-08-08T07:11:00+00:00"
+            "time": "2026-08-14T16:14:55+00:00"
         },
         {
             "name": "relaticle/custom-fields",

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -109,7 +109,44 @@ return [
         'general' => 'General',
         'members' => 'Members',
         'custom_fields' => 'Custom Fields',
+        'activity' => 'Activity',
         'billing' => 'Billing',
+    ],
+
+    'activity' => [
+        'description' => 'Every change your members make to records, including deletions.',
+        'system' => 'System',
+        'columns' => [
+            'created_at' => 'When',
+            'causer' => 'Who',
+            'event' => 'Action',
+            'subject_type' => 'Type',
+            'record' => 'Record',
+        ],
+        'filters' => [
+            'event' => 'Action',
+            'subject_type' => 'Type',
+            'causer' => 'Who',
+            'from' => 'From',
+            'until' => 'Until',
+        ],
+        'events' => [
+            'created' => 'Created',
+            'updated' => 'Updated',
+            'deleted' => 'Deleted',
+            'restored' => 'Restored',
+        ],
+        'types' => [
+            'company' => 'Company',
+            'people' => 'Person',
+            'opportunity' => 'Opportunity',
+            'task' => 'Task',
+            'note' => 'Note',
+        ],
+        'empty' => [
+            'heading' => 'No activity yet',
+            'description' => 'Changes your members make to records will show up here.',
+        ],
     ],
 
     'roles' => [

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -116,12 +116,15 @@ return [
     'activity' => [
         'description' => 'Every change your members make to records, including deletions.',
         'system' => 'System',
+        'yes' => 'Yes',
+        'no' => 'No',
         'columns' => [
             'created_at' => 'When',
             'causer' => 'Who',
             'event' => 'Action',
             'subject_type' => 'Type',
             'record' => 'Record',
+            'changes' => 'Changes',
         ],
         'filters' => [
             'event' => 'Action',

--- a/resources/views/filament/pages/team/activity-log.blade.php
+++ b/resources/views/filament/pages/team/activity-log.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/tests/Feature/ActivityLog/TrashedSubjectTimelineTest.php
+++ b/tests/Feature/ActivityLog/TrashedSubjectTimelineTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\CompanyResource\Pages\ViewCompany;
+use App\Models\Company;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\ActivityLog\Filament\Livewire\ActivityLogLivewire;
+use Relaticle\ActivityLog\Filament\RelationManagers\ActivityLogRelationManager;
+
+/**
+ * A trashed record is still reachable — the resources drop the soft-delete scope
+ * so it can be reviewed and restored — and its timeline has to load with it.
+ * Resolving the subject without dropping that scope 404s the whole tab, which is
+ * exactly the history an admin opens a deleted record to read.
+ */
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    $this->team = $this->user->currentTeam;
+    Filament::setTenant($this->team);
+
+    $this->company = Company::factory()->for($this->team)->create(['name' => 'Trashed Timeline Co']);
+    $this->company->update(['name' => 'Renamed Before Deletion']);
+    $this->company->delete();
+});
+
+it('renders the timeline component for a trashed subject', function (): void {
+    livewire(ActivityLogLivewire::class, [
+        'subjectClass' => Company::class,
+        'subjectKey' => $this->company->getKey(),
+    ])->assertOk();
+});
+
+it('renders the activity relation manager for a trashed owner record', function (): void {
+    livewire(ActivityLogRelationManager::class, [
+        'ownerRecord' => $this->company,
+        'pageClass' => ViewCompany::class,
+    ])->assertOk();
+});

--- a/tests/Feature/Teams/WorkspaceActivityLogTest.php
+++ b/tests/Feature/Teams/WorkspaceActivityLogTest.php
@@ -9,6 +9,8 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Url;
 
 mutates(ActivityLog::class);
 
@@ -104,6 +106,153 @@ test('a member without the admin role cannot open the audit log', function (): v
 
 test('an admin can open the audit log over http', function (): void {
     $this->get(ActivityLog::getUrl(tenant: $this->team))->assertSuccessful();
+});
+
+test('one save is one row, even when custom fields log their own event', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Batched Co']);
+
+    $batch = (string) Str::uuid();
+
+    $native = Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => 'created',
+        'event' => 'created',
+        'subject_type' => $company->getMorphClass(),
+        'subject_id' => $company->getKey(),
+        'causer_type' => 'user',
+        'causer_id' => $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'batch_uuid' => $batch,
+        'attribute_changes' => ['attributes' => ['name' => 'Batched Co']],
+    ]);
+
+    $sibling = Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => 'custom_field_changes',
+        'event' => 'custom_field_changes',
+        'subject_type' => $company->getMorphClass(),
+        'subject_id' => $company->getKey(),
+        'causer_type' => 'user',
+        'causer_id' => $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'batch_uuid' => $batch,
+        'properties' => ['custom_field_changes' => [['label' => 'ICP', 'old' => null, 'new' => 'Yes']]],
+    ]);
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$native])
+        ->assertCanNotSeeTableRecords([$sibling])
+        ->assertSee('ICP: — → Yes', escape: false);
+});
+
+test('one batch spanning two records keeps each record its own row and payload', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Batch Company']);
+    $person = People::factory()->for($this->team)->create(['name' => 'Batch Person']);
+
+    $batch = (string) Str::uuid();
+
+    $rows = collect([$company, $person])->map(fn ($record, $index) => Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => 'updated',
+        'event' => 'updated',
+        'subject_type' => $record->getMorphClass(),
+        'subject_id' => $record->getKey(),
+        'causer_type' => 'user',
+        'causer_id' => $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'batch_uuid' => $batch,
+        'attribute_changes' => ['attributes' => ['name' => $record->name], 'old' => ['name' => 'Was '.$index]],
+    ]));
+
+    Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => 'custom_field_changes',
+        'event' => 'custom_field_changes',
+        'subject_type' => $company->getMorphClass(),
+        'subject_id' => $company->getKey(),
+        'causer_type' => 'user',
+        'causer_id' => $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'batch_uuid' => $batch,
+        'properties' => ['custom_field_changes' => [['label' => 'Company Only Field', 'old' => null, 'new' => 'Set']]],
+    ]);
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords($rows->all())
+        ->assertSee('Batch Company')
+        ->assertSee('Batch Person')
+        ->assertSee('Company Only Field: — → Set', escape: false);
+});
+
+test('a create and a delete in one request both stay on the record', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Short Lived Co']);
+    $batch = (string) Str::uuid();
+
+    $rows = collect(['created', 'deleted'])->map(fn (string $event) => Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => $event,
+        'event' => $event,
+        'subject_type' => $company->getMorphClass(),
+        'subject_id' => $company->getKey(),
+        'causer_type' => 'user',
+        'causer_id' => $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'batch_uuid' => $batch,
+        'attribute_changes' => ['attributes' => ['name' => 'Short Lived Co']],
+    ]));
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords($rows->all())
+        ->assertSee(__('teams.activity.events.created'))
+        ->assertSee(__('teams.activity.events.deleted'));
+});
+
+test('renaming a record does not rewrite its history', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Original Name Ltd']);
+    $company->update(['name' => 'Renamed Name Ltd']);
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee('Original Name Ltd')
+        ->assertSee('Renamed Name Ltd');
+});
+
+test('it spells out what actually changed on a row', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Diff Co']);
+    $company->update(['name' => 'Diff Co Renamed']);
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee('Diff Co → Diff Co Renamed', escape: false);
+});
+
+test('filter and sort state is bound to the url so a view can be shared', function (): void {
+    $page = new ReflectionClass(ActivityLog::class);
+
+    $bound = [];
+
+    foreach (['tableFilters', 'tableSort'] as $property) {
+        $attributes = $page->getProperty($property)->getAttributes(Url::class);
+        $bound[$property] = $attributes !== [];
+    }
+
+    expect($bound)->toBe([
+        'tableFilters' => true,
+        'tableSort' => true,
+    ]);
+});
+
+test('a shared filtered url renders already filtered', function (): void {
+    Company::factory()->for($this->team)->create(['name' => 'Still Here']);
+    Company::factory()->for($this->team)->create(['name' => 'Gone Already'])->delete();
+
+    livewire(ActivityLog::class, ['tableFilters' => ['event' => ['value' => 'deleted']]])
+        ->assertOk()
+        ->assertSee('Gone Already')
+        ->assertDontSee('Still Here');
 });
 
 test('a custom field edit reads as an update, not its raw event name', function (): void {

--- a/tests/Feature/Teams/WorkspaceActivityLogTest.php
+++ b/tests/Feature/Teams/WorkspaceActivityLogTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\Team\ActivityLog;
+use App\Models\ActivityLog\Activity;
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
+use App\Models\User;
+use Filament\Facades\Filament;
+
+mutates(ActivityLog::class);
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withTeam()->create(['name' => 'Ada Owner']);
+    $this->actingAs($this->owner);
+    $this->team = $this->owner->currentTeam;
+    Filament::setTenant($this->team);
+
+    Activity::withoutGlobalScopes()->delete();
+});
+
+test('an admin sees who deleted a record and when', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Lumen Robotics']);
+    $company->delete();
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee('Ada Owner')
+        ->assertSee('Lumen Robotics')
+        ->assertSee(__('teams.activity.events.deleted'));
+});
+
+test('the audit row survives a permanent delete', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Vanished Corp']);
+    $company->delete();
+    $company->forceDelete();
+
+    expect(Company::withTrashed()->find($company->getKey()))->toBeNull();
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee('Vanished Corp')
+        ->assertSee('Ada Owner');
+});
+
+test('a record that still exists links back to it, a destroyed one does not', function (): void {
+    $alive = Company::factory()->for($this->team)->create(['name' => 'Alive Corp']);
+    $alive->delete();
+
+    $destroyed = Company::factory()->for($this->team)->create(['name' => 'Vanished Corp']);
+    $destroyedId = $destroyed->getKey();
+    $destroyed->delete();
+    $destroyed->forceDelete();
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee("companies/{$alive->getKey()}")
+        ->assertDontSee("companies/{$destroyedId}");
+});
+
+test('it lists deletions across every crm record type', function (string $factory, string $name): void {
+    $record = $factory::factory()->for($this->team)->create(['name' => $name]);
+    $record->delete();
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee($name);
+})->with([
+    'company' => [Company::class, 'Deleted Company'],
+    'people' => [People::class, 'Deleted Person'],
+    'opportunity' => [Opportunity::class, 'Deleted Opportunity'],
+]);
+
+test('another workspace activity never leaks in', function (): void {
+    $stranger = User::factory()->withTeam()->create(['name' => 'Mallory Stranger']);
+    $strangerTeam = $stranger->currentTeam;
+
+    $this->actingAs($stranger);
+    Filament::setTenant($strangerTeam);
+    Company::factory()->for($strangerTeam)->create(['name' => 'Foreign Holdings'])->delete();
+
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertDontSee('Foreign Holdings')
+        ->assertDontSee('Mallory Stranger');
+});
+
+test('a member without the admin role cannot open the audit log', function (): void {
+    $editor = User::factory()->create(['name' => 'Eddie Editor']);
+    $this->team->users()->attach($editor, ['role' => 'editor']);
+
+    $this->actingAs($editor);
+    Filament::setTenant($this->team);
+
+    expect(ActivityLog::canAccess())->toBeFalse();
+
+    $this->get(ActivityLog::getUrl(tenant: $this->team))->assertForbidden();
+});
+
+test('an admin can open the audit log over http', function (): void {
+    $this->get(ActivityLog::getUrl(tenant: $this->team))->assertSuccessful();
+});
+
+test('a custom field edit reads as an update, not its raw event name', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Field Edited Co']);
+
+    activity()
+        ->performedOn($company)
+        ->causedBy($this->owner)
+        ->event('custom_field_changes')
+        ->log('custom field changed');
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee(__('teams.activity.events.updated'))
+        ->assertDontSee('custom_field_changes');
+});
+
+test('filtering on updated covers custom field edits too', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Field Edited Co']);
+    Company::factory()->for($this->team)->create(['name' => 'Untouched Co'])->delete();
+
+    activity()
+        ->performedOn($company)
+        ->causedBy($this->owner)
+        ->event('custom_field_changes')
+        ->log('custom field changed');
+
+    livewire(ActivityLog::class)
+        ->filterTable('event', 'updated')
+        ->assertSee('Field Edited Co')
+        ->assertDontSee('Untouched Co');
+});
+
+test('it filters down to deletions only', function (): void {
+    Company::factory()->for($this->team)->create(['name' => 'Still Here']);
+    Company::factory()->for($this->team)->create(['name' => 'Gone Already'])->delete();
+
+    livewire(ActivityLog::class)
+        ->filterTable('event', 'deleted')
+        ->assertSee('Gone Already')
+        ->assertDontSee('Still Here');
+});

--- a/tests/Feature/Teams/WorkspaceActivityLogTest.php
+++ b/tests/Feature/Teams/WorkspaceActivityLogTest.php
@@ -210,6 +210,94 @@ test('a create and a delete in one request both stay on the record', function ()
         ->assertSee(__('teams.activity.events.deleted'));
 });
 
+/**
+ * Each custom field that moves is logged as its own row, so a save touching
+ * three fields writes three siblings — not one.
+ */
+function seedCustomFieldRow(object $test, Company $company, string $batch, string $label, string $old, string $new): Activity
+{
+    return Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => 'custom_field_changes',
+        'event' => 'custom_field_changes',
+        'subject_type' => $company->getMorphClass(),
+        'subject_id' => $company->getKey(),
+        'causer_type' => 'user',
+        'causer_id' => $test->owner->getKey(),
+        'team_id' => $test->team->getKey(),
+        'batch_uuid' => $batch,
+        'properties' => ['custom_field_changes' => [['label' => $label, 'old' => $old, 'new' => $new]]],
+    ]);
+}
+
+test('a save touching several custom fields shows every one of them', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Many Fields Co']);
+    $batch = (string) Str::uuid();
+
+    Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => 'created',
+        'event' => 'created',
+        'subject_type' => $company->getMorphClass(),
+        'subject_id' => $company->getKey(),
+        'causer_type' => 'user',
+        'causer_id' => $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'batch_uuid' => $batch,
+        'attribute_changes' => ['attributes' => ['name' => 'Many Fields Co']],
+    ]);
+
+    seedCustomFieldRow($this, $company, $batch, 'Status', 'None', 'To do');
+    seedCustomFieldRow($this, $company, $batch, 'Priority', 'None', 'High');
+    seedCustomFieldRow($this, $company, $batch, 'Due Date', 'None', '2026-08-08');
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertSee('Status: None → To do', escape: false)
+        ->assertSee('Priority: None → High', escape: false)
+        ->assertSee('Due Date: None → 2026-08-08', escape: false);
+});
+
+test('custom field rows with no native sibling collapse without borrowing each others diffs', function (): void {
+    $company = Company::factory()->for($this->team)->create(['name' => 'Field Only Co']);
+    $batch = (string) Str::uuid();
+
+    $first = seedCustomFieldRow($this, $company, $batch, 'Priority', 'Medium', 'High');
+    $second = seedCustomFieldRow($this, $company, $batch, 'Description', 'Old copy', 'New copy');
+    $third = seedCustomFieldRow($this, $company, $batch, 'Due Date', '2026-07-20', '2026-08-20');
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$first])
+        ->assertCanNotSeeTableRecords([$second, $third])
+        ->assertSee('Priority: Medium → High', escape: false)
+        ->assertSee('Description: Old copy → New copy', escape: false)
+        ->assertSee('Due Date: 2026-07-20 → 2026-08-20', escape: false);
+});
+
+test('a stale morph alias whose model is gone does not take the page down', function (): void {
+    $orphan = Activity::withoutGlobalScopes()->create([
+        'log_name' => 'crm',
+        'description' => 'meeting.created',
+        'event' => 'meeting.created',
+        'subject_type' => 'meeting',
+        'subject_id' => '01kxn0qpzsz9hb0tseg3xy01mm',
+        'causer_type' => 'user',
+        'causer_id' => $this->owner->getKey(),
+        'team_id' => $this->team->getKey(),
+        'properties' => ['title' => 'Quarterly review call'],
+    ]);
+
+    Company::factory()->for($this->team)->create(['name' => 'Neighbour Co'])->delete();
+
+    livewire(ActivityLog::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$orphan])
+        ->assertSee('Neighbour Co')
+        ->sortTable('created_at')
+        ->assertOk();
+});
+
 test('renaming a record does not rewrite its history', function (): void {
     $company = Company::factory()->for($this->team)->create(['name' => 'Original Name Ltd']);
     $company->update(['name' => 'Renamed Name Ltd']);

--- a/tests/Feature/Teams/WorkspaceSettingsNavigationTest.php
+++ b/tests/Feature/Teams/WorkspaceSettingsNavigationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Features\Billing as BillingFeature;
 use App\Filament\Pages\Billing;
 use App\Filament\Pages\EditTeam;
+use App\Filament\Pages\Team\ActivityLog;
 use App\Filament\Pages\Team\CustomFields;
 use App\Filament\Pages\Team\Members;
 use App\Models\User;
@@ -13,7 +14,7 @@ use Filament\Navigation\NavigationItem;
 use Illuminate\Support\Facades\Route;
 use Laravel\Pennant\Feature;
 
-mutates(Members::class, CustomFields::class);
+mutates(Members::class, CustomFields::class, ActivityLog::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -39,10 +40,11 @@ test('every workspace settings page renders the same tab strip', function (): vo
         __('teams.tabs.general'),
         __('teams.tabs.members'),
         __('teams.tabs.custom_fields'),
+        __('teams.tabs.activity'),
         __('teams.tabs.billing'),
     ];
 
-    foreach ([EditTeam::class, Members::class, CustomFields::class, Billing::class] as $page) {
+    foreach ([EditTeam::class, Members::class, CustomFields::class, ActivityLog::class, Billing::class] as $page) {
         expect(workspaceTabLabels(app($page)))
             ->toBe($expected, "[{$page}] should render the full tab strip");
     }
@@ -65,6 +67,7 @@ test('a workspace admin can open every tab', function (): void {
         EditTeam::getUrl(tenant: $this->team),
         Members::getUrl(tenant: $this->team),
         CustomFields::getUrl(tenant: $this->team),
+        ActivityLog::getUrl(tenant: $this->team),
     ] as $url) {
         $this->get($url)->assertSuccessful();
     }
@@ -78,6 +81,16 @@ test('a user outside the workspace cannot open the members tab', function (): vo
     $this->actingAs(User::factory()->withTeam()->create())
         ->get($url)
         ->assertNotFound();
+});
+
+test('the tab strip hides activity from members without the admin role', function (): void {
+    $editor = User::factory()->create();
+    $this->team->users()->attach($editor, ['role' => 'editor']);
+
+    $this->actingAs($editor);
+
+    expect(workspaceTabLabels(app(EditTeam::class)))
+        ->not->toContain(__('teams.tabs.activity'));
 });
 
 test('the tab strip drops billing when the feature is off', function (): void {


### PR DESCRIPTION
## Why

A workspace admin had **nowhere** to see who deleted a record.

- The trashed filter on each resource shows *that* a record is gone and *when* (`deleted_at`, hidden by default) — never *who*, and only while it is still soft-deleted.
- The per-record Activity tab does read the causer, but it dies with the record on a permanent delete.
- There was no workspace-level audit surface at all — no page, no API route, no chat tool. The only cross-record activity browser is SystemAdmin's `ActivityResource`, which runs on the `sysadmin` guard and is deliberately cross-tenant. Customer admins cannot reach it.

Meanwhile `CompanyPolicy::delete` is `belongsToTeamId` — **any** member, including Editors, can trash a record. The causer was already being written to `activity_log` on every event; nothing read it back.

## What

An admin-gated **Activity** tab in workspace settings (between Custom Fields and Billing).

- Reads `activity_log` rows directly, so an entry **outlives its subject** — the name captured in the delete payload still identifies a record that no longer exists in the database.
- Columns: When / Who / Action / Type / Record. Filters: action, type, actor, date range.
- Rows link back to the record while it still resolves (including soft-deleted); a destroyed record degrades to plain text rather than dead-ending in a 404.
- Custom-field edits are logged under their own `custom_field_changes` event — 89% of rows in a real workspace. They render *and filter* as "Updated" so the table does not read as raw database values.

Access is `hasTeamRoleForTeamId(..., 'admin')`, matching the existing force-delete gate and covering owners. Tenant isolation comes from the `Activity` model's `TeamScope`, which fails closed when no tenant is bound.

## Test plan

`tests/Feature/Teams/WorkspaceActivityLogTest.php` — 12 tests:

- an admin sees who deleted a record and when
- the audit row survives a permanent delete
- a record that still exists links back to it, a destroyed one does not
- deletions across company / people / opportunity
- another workspace's activity never leaks in
- a member without the admin role cannot open it (403) and does not see the tab
- a custom field edit reads as an update, not its raw event name
- filtering on "updated" covers custom-field edits too

Suite: `composer test:pest` → **2771 passed, 0 failed**. Pint, Rector, PHPStan clean; type coverage 100%.

Browser-verified on the real app (light + dark, 1920x1080): tab strip renders in the right position, the Deleted filter narrows to deletion rows only, and destroyed records (`Final Verify Co`) show their name with no link while resolvable ones link through.

## Dependency

`relaticle/activity-log` bumped to **v1.2.2**, which fixes the record's own Activity tab 404ing for a soft-deleted record (`ActivityLogLivewire::resolveSubject()` called `findOrFail()` without dropping the soft-delete scope). Locked in by `tests/Feature/ActivityLog/TrashedSubjectTimelineTest.php`, which fails on v1.2.1 with the original `ModelNotFoundException` and passes on v1.2.2.

The tag sat unindexed on Packagist for three days and needed a manual refresh. GitHub *did* deliver it — `push` / `refs/tags/v1.2.2` / `created: true`, accepted `202` — and Packagist crawled the same commit (`1.x-dev` points at `638ee8d`) but never created the version. Two webhooks landed 22 seconds apart (branch push, then tag), so the tag update was most likely coalesced into the already-queued job for the branch. Five prior releases indexed fine, so this is a race rather than a broken hook.
