### PR TITLE
feat(billing): grant the pro trial per workspace instead of per user

### DIFF
--- a/app/Actions/Billing/StartProTrial.php
+++ b/app/Actions/Billing/StartProTrial.php
@@ -22,14 +22,11 @@ final readonly class StartProTrial
     {
         throw_unless($user->ownsTeam($team), AuthorizationException::class, 'Only the workspace owner can start a trial.');
 
-        $started = DB::transaction(function () use ($user, $team): bool {
-            /** @var User $lockedUser */
-            $lockedUser = User::query()->whereKey($user)->lockForUpdate()->firstOrFail();
-
+        $started = DB::transaction(function () use ($team): bool {
             /** @var Team $lockedTeam */
             $lockedTeam = Team::query()->whereKey($team)->lockForUpdate()->firstOrFail();
 
-            if ($lockedUser->pro_trial_used_at !== null
+            if ($lockedTeam->pro_trial_used_at !== null
                 || $lockedTeam->plan !== Plan::Free
                 || $lockedTeam->subscriptions()->exists()) {
                 return false;
@@ -38,9 +35,8 @@ final readonly class StartProTrial
             $lockedTeam->forceFill([
                 'plan' => Plan::Pro,
                 'trial_ends_at' => now()->addDays(self::TRIAL_DAYS),
+                'pro_trial_used_at' => now(),
             ])->save();
-
-            $lockedUser->forceFill(['pro_trial_used_at' => now()])->save();
 
             $this->credits->resetPeriod($lockedTeam);
 
@@ -48,7 +44,6 @@ final readonly class StartProTrial
         });
 
         if ($started) {
-            $user->refresh();
             $team->refresh();
         }
 

--- a/app/Filament/Pages/Billing.php
+++ b/app/Filament/Pages/Billing.php
@@ -63,7 +63,7 @@ final class Billing extends Page
 
     public function startTrial(StartProTrial $startProTrial): void
     {
-        // The button is only rendered for a grandfathered workspace, but the
+        // The button is only rendered for an eligible workspace, but the
         // Livewire method is reachable regardless — enforce it server-side.
         if (! $this->trialAvailable()) {
             Notification::make()->title(__('billing.trial.not_available'))->danger()->send();
@@ -169,16 +169,16 @@ final class Billing extends Page
     }
 
     /**
-     * A manual trial is offered only to a grandfathered workspace — a new
-     * hosted workspace receives its trial automatically at creation.
+     * A manual trial start is the escape hatch for a workspace that never
+     * received its automatic creation-time trial — grandfathered pre-billing
+     * workspaces and workspaces created while trials were per-user.
      */
     private function trialAvailable(): bool
     {
         $team = $this->team();
 
-        return $team->hosted_free_grandfathered_at !== null
-            && $team->plan === Plan::Free
-            && $this->user()->pro_trial_used_at === null
+        return $team->plan === Plan::Free
+            && $team->pro_trial_used_at === null
             && ! $team->subscriptions()->exists();
     }
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -44,6 +44,7 @@ use Spatie\Sluggable\SlugOptions;
  * @property ?string $pm_type
  * @property ?string $pm_last_four
  * @property Carbon|null $trial_ends_at
+ * @property Carbon|null $pro_trial_used_at
  * @property Carbon|null $hosted_free_grandfathered_at
  * @property-read Membership|null $membership the `team_user` row, populated only when the team was
  *     loaded through `User::teams()`; null on a team reached any other way
@@ -162,6 +163,7 @@ final class Team extends JetstreamTeam implements HasAvatar
             'invite_link_token_expires_at' => 'datetime',
             'scheduled_deletion_at' => 'datetime',
             'trial_ends_at' => 'datetime',
+            'pro_trial_used_at' => 'datetime',
             'hosted_free_grandfathered_at' => 'datetime',
         ];
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -53,7 +53,6 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $subscriber_recency_bucket
  * @property string|null $remember_token
  * @property Carbon|null $scheduled_deletion_at
- * @property Carbon|null $pro_trial_used_at
  * @property string|null $two_factor_recovery_codes
  * @property string|null $two_factor_secret
  * @property array<string, mixed>|null $ai_preferences
@@ -107,7 +106,6 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
             'ai_preferences' => 'array',
             'notification_preferences' => 'array',
             'scheduled_deletion_at' => 'datetime',
-            'pro_trial_used_at' => 'datetime',
         ];
     }
 

--- a/database/migrations/2026_08_18_031107_move_pro_trial_marker_from_users_to_teams.php
+++ b/database/migrations/2026_08_18_031107_move_pro_trial_marker_from_users_to_teams.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table): void {
+            $table->timestamp('pro_trial_used_at')->nullable();
+        });
+
+        // A team mid-trial must not become eligible for a second trial once
+        // this one expires. Teams whose trial already expired carry no marker
+        // (trial_ends_at was nulled on expiry) and deliberately regain one
+        // trial under the per-workspace policy.
+        DB::table('teams')
+            ->whereNotNull('trial_ends_at')
+            ->update(['pro_trial_used_at' => DB::raw('now()')]);
+
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('pro_trial_used_at');
+        });
+    }
+};

--- a/tests/Feature/Billing/BillingPageTest.php
+++ b/tests/Feature/Billing/BillingPageTest.php
@@ -48,24 +48,24 @@ it('shows trial CTA to an owner who never trialed', function (): void {
         ->assertSee(__('billing.trial.start_button'));
 });
 
-it('hides the trial CTA once the user used a trial', function (): void {
-    [$user] = billingPageOwner();
-    $user->forceFill(['pro_trial_used_at' => now()])->save();
+it('hides the trial CTA once the workspace used its trial', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['pro_trial_used_at' => now()])->save();
 
     livewire(Billing::class)
         ->assertDontSee(__('billing.trial.start_button'))
         ->assertSee(__('billing.upgrade.button'));
 });
 
-it('does not offer a manual trial to a new hosted workspace', function (): void {
+it('offers the trial to a hosted workspace that never received one', function (): void {
     config()->set('services.stripe.credit_packs.small', ['price' => 'price_credits_1k_test', 'credits' => 1000]);
     [, $team] = billingPageOwner();
     $team->forceFill(['hosted_free_grandfathered_at' => null])->save();
 
     livewire(Billing::class)
-        ->assertDontSee(__('billing.trial.start_button'))
+        ->assertSee(__('billing.trial.start_button'))
         ->assertSee(__('billing.paused.title'))
-        ->assertSee(__('billing.upgrade.unlock'))
+        ->assertSee(__('billing.upgrade.now'))
         ->assertSee('$19')
         ->assertSee(__('billing.pro_plan.billed_yearly'))
         ->assertDontSee(__('billing.packs.buy', ['credits' => number_format(1000)]));
@@ -80,9 +80,9 @@ it('starts a trial via the page action', function (): void {
         ->and($team->onGenericTrial())->toBeTrue();
 });
 
-it('refuses a manual trial to a new hosted workspace even when called directly', function (): void {
+it('refuses a second trial on a workspace even when called directly', function (): void {
     [, $team] = billingPageOwner();
-    $team->forceFill(['hosted_free_grandfathered_at' => null])->save();
+    $team->forceFill(['pro_trial_used_at' => now()])->save();
 
     livewire(Billing::class)->call('startTrial');
 

--- a/tests/Feature/Billing/TrialLifecycleTest.php
+++ b/tests/Feature/Billing/TrialLifecycleTest.php
@@ -37,19 +37,30 @@ it('starts a pro trial for an eligible owner', function (): void {
     expect($started)->toBeTrue()
         ->and($team->refresh()->plan)->toBe(Plan::Pro)
         ->and($team->trial_ends_at?->isSameDay(now()->addDays(14)))->toBeTrue()
-        ->and($user->refresh()->pro_trial_used_at)->not->toBeNull()
+        ->and($team->pro_trial_used_at)->not->toBeNull()
         ->and($balance->credits_remaining)->toBe(Plan::Pro->credits());
 });
 
-it('does not start a second trial for the same user even on another team', function (): void {
+it('starts a separate trial for each workspace the user creates', function (): void {
     [$user, $team] = trialOwnerAndTeam();
     app(StartProTrial::class)->execute($user, $team);
 
     $otherTeam = Team::factory()->create(['user_id' => $user->getKey(), 'personal_team' => false]);
 
-    expect(app(StartProTrial::class)->execute($user, $otherTeam->refresh()))->toBeFalse()
-        ->and($otherTeam->refresh()->plan)->toBe(Plan::Free)
-        ->and($otherTeam->trial_ends_at)->toBeNull();
+    expect(app(StartProTrial::class)->execute($user, $otherTeam->refresh()))->toBeTrue()
+        ->and($otherTeam->refresh()->plan)->toBe(Plan::Pro)
+        ->and($otherTeam->trial_ends_at?->isSameDay(now()->addDays(14)))->toBeTrue();
+});
+
+it('does not start a second trial on a workspace that already used one', function (): void {
+    [$user, $team] = trialOwnerAndTeam();
+    app(StartProTrial::class)->execute($user, $team);
+
+    $team->forceFill(['plan' => Plan::Free, 'trial_ends_at' => null])->save();
+
+    expect(app(StartProTrial::class)->execute($user, $team->refresh()))->toBeFalse()
+        ->and($team->refresh()->plan)->toBe(Plan::Free)
+        ->and($team->trial_ends_at)->toBeNull();
 });
 
 it('refuses a trial to a non-owner', function (): void {

--- a/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
+++ b/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
@@ -122,16 +122,15 @@ it('automatically starts one 14-day Cloud Pro trial after hosted onboarding', fu
     expect($team->plan)->toBe(Plan::Pro)
         ->and($team->onGenericTrial())->toBeTrue()
         ->and($team->trial_ends_at?->isSameDay(now()->addDays(14)))->toBeTrue()
-        ->and($user->pro_trial_used_at)->not->toBeNull()
+        ->and($team->pro_trial_used_at)->not->toBeNull()
         ->and($balance->credits_remaining)->toBe(Plan::Pro->credits());
 });
 
-it('creates a later hosted workspace paused when the owner already used a trial', function (): void {
+it('starts a fresh trial for each additional hosted workspace', function (): void {
     Feature::define(BillingFeature::class, true);
 
-    $user = User::factory()->withPersonalTeam()->create([
-        'pro_trial_used_at' => now(),
-    ]);
+    $user = User::factory()->withPersonalTeam()->create();
+    $user->currentTeam?->forceFill(['pro_trial_used_at' => now()])->save();
     $this->actingAs($user);
 
     livewire(CreateTeam::class)
@@ -145,8 +144,9 @@ it('creates a later hosted workspace paused when the owner already used a trial'
     /** @var Team $team */
     $team = $user->refresh()->currentTeam;
 
-    expect($team->plan)->toBe(Plan::Free)
-        ->and($team->trial_ends_at)->toBeNull()
+    expect($team->plan)->toBe(Plan::Pro)
+        ->and($team->onGenericTrial())->toBeTrue()
+        ->and($team->pro_trial_used_at)->not->toBeNull()
         ->and($team->hosted_free_grandfathered_at)->toBeNull();
 });
 


### PR DESCRIPTION
## Summary

Moves the Pro-trial marker from `users.pro_trial_used_at` to `teams.pro_trial_used_at`, so every new hosted workspace starts its own 14-day Pro trial instead of being born paused once the owner's single trial is spent. The Billing page's manual trial button drops its grandfathered-only gate and becomes the escape hatch for any Free workspace that never received a trial (grandfathered pre-billing teams and legacy born-paused ones). The migration backfills teams currently mid-trial so they cannot re-trial after expiry, and drops the now-unused users column — deploy the migration and code together, since old code still writes the dropped column. Verified end-to-end in the browser: a legacy paused workspace now shows the trial CTA and unpauses on click, and a second workspace is created with its own active trial and credit allowance.

## Test plan

- `tests/Feature/Billing/TrialLifecycleTest.php` — separate trial per workspace, no second trial on the same team
- `tests/Feature/Billing/BillingPageTest.php` — trial CTA offered/hidden by the team marker, direct-call refusal
- `tests/Feature/Onboarding/CreateTeamOnboardingTest.php` — additional workspaces start their own trial
- Full suite green locally except pre-existing MCP OAuth failures caused by missing local Passport keys (identical on a clean checkout)