### PR TITLE
fix: serve public content only on the primary host and repair sysadmin relation links

### DIFF
--- a/app/Http/Middleware/DenyIndexingOnSecondaryHosts.php
+++ b/app/Http/Middleware/DenyIndexingOnSecondaryHosts.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Everything that must legitimately answer on a non-primary host — panel
+ * pages, the sysadmin login, API/MCP responses, exempted plumbing — is still
+ * not search content. The header keeps crawlers from indexing those hosts
+ * even where a 200 is the correct response.
+ */
+final readonly class DenyIndexingOnSecondaryHosts
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $primaryHost = parse_url((string) config('app.url'), PHP_URL_HOST);
+
+        if (is_string($primaryHost) && $request->getHost() !== $primaryHost) {
+            $response->headers->set('X-Robots-Tag', 'noindex, nofollow');
+        }
+
+        return $response;
+    }
+}

--- a/app/Http/Middleware/RedirectToPrimaryHost.php
+++ b/app/Http/Middleware/RedirectToPrimaryHost.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Serves public content from exactly one hostname.
+ *
+ * Only the API (API_DOMAIN), MCP (MCP_DOMAIN), and Filament panels bind their
+ * routes to a domain; everything else answers on any hostname that reaches
+ * the app, so the marketing site and docs were served as indexable duplicates
+ * on api./mcp./app. and the sysadmin host — each with a self-referencing
+ * canonical. Guests hitting a public GET route on a non-primary host are
+ * 301'd to the same path on the APP_URL host instead.
+ *
+ * Functional routes stay untouched: the app-panel host legitimately consumes
+ * domainless plumbing (chat, 2FA, logout, Livewire, broadcasting, Passport,
+ * Sanctum), so only unauthenticated GET/HEAD requests are redirected, and
+ * signed routes are exempt because signatures are computed over the absolute
+ * URL — rewriting the host would 403 every invitation link.
+ */
+final readonly class RedirectToPrimaryHost
+{
+    private const array EXEMPT_NAME_PREFIXES = ['livewire.', 'default-livewire.', 'sanctum.', 'passport.'];
+
+    private const array EXEMPT_URIS = ['broadcasting/auth'];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->isMethod('GET') && ! $request->isMethod('HEAD')) {
+            return $next($request);
+        }
+
+        $primaryHost = parse_url((string) config('app.url'), PHP_URL_HOST);
+
+        if (! is_string($primaryHost) || $request->getHost() === $primaryHost) {
+            return $next($request);
+        }
+
+        $route = $request->route();
+
+        if (! $route instanceof Route || $route->getDomain() !== null || $this->isExempt($route)) {
+            return $next($request);
+        }
+
+        return redirect()->away(
+            rtrim((string) config('app.url'), '/').$request->getRequestUri(),
+            301,
+        );
+    }
+
+    private function isExempt(Route $route): bool
+    {
+        if (in_array($route->uri(), self::EXEMPT_URIS, true)) {
+            return true;
+        }
+
+        $name = $route->getName();
+
+        if ($name !== null && Str::startsWith($name, self::EXEMPT_NAME_PREFIXES)) {
+            return true;
+        }
+
+        foreach ($route->gatherMiddleware() as $middleware) {
+            if (! is_string($middleware)) {
+                continue;
+            }
+
+            if ($middleware === 'auth' || str_starts_with($middleware, 'auth:')) {
+                return true;
+            }
+
+            if ($middleware === 'signed' || str_starts_with($middleware, 'signed:')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Http/Middleware/RedirectToPrimaryHost.php
+++ b/app/Http/Middleware/RedirectToPrimaryHost.php
@@ -25,10 +25,18 @@ use Symfony\Component\HttpFoundation\Response;
  * Sanctum), so only unauthenticated GET/HEAD requests are redirected, and
  * signed routes are exempt because signatures are computed over the absolute
  * URL — rewriting the host would 403 every invitation link.
+ *
+ * Socialite routes are exempt by name: the GitHub redirect URI is configured
+ * as a relative path, so Socialite derives its host from the current request —
+ * bouncing /auth/redirect/github to the primary host would change the
+ * redirect_uri sent to the provider and break the OAuth app's registered
+ * callback. Filament's export/import downloads are exempt by name too: their
+ * auth + relative-signature checks live inside the controller behind the
+ * `filament.actions` group alias, which this middleware cannot see through.
  */
 final readonly class RedirectToPrimaryHost
 {
-    private const array EXEMPT_NAME_PREFIXES = ['livewire.', 'default-livewire.', 'sanctum.', 'passport.'];
+    private const array EXEMPT_NAME_PREFIXES = ['livewire.', 'default-livewire.', 'sanctum.', 'passport.', 'auth.socialite.', 'filament.exports.', 'filament.imports.'];
 
     private const array EXEMPT_URIS = ['broadcasting/auth'];
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -74,7 +74,10 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->prepend(SubdomainRootResponse::class);
 
-        $middleware->append(DenyIndexingOnSecondaryHosts::class);
+        // Outermost (last prepend wins the front slot) so the noindex header
+        // also lands on responses SubdomainRootResponse short-circuits — the
+        // api/mcp root banners are exactly the crawlable secondary-host URLs.
+        $middleware->prepend(DenyIndexingOnSecondaryHosts::class);
 
         $middleware->web(append: RedirectToPrimaryHost::class);
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Billing\StripeWebhookController;
+use App\Http\Middleware\DenyIndexingOnSecondaryHosts;
+use App\Http\Middleware\RedirectToPrimaryHost;
 use App\Http\Middleware\SetApiTeamContext;
 use App\Http\Middleware\SubdomainRootResponse;
 use App\Http\Middleware\ValidateSignature;
@@ -71,6 +73,42 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->prepend(SubdomainRootResponse::class);
+
+        $middleware->append(DenyIndexingOnSecondaryHosts::class);
+
+        $middleware->web(append: RedirectToPrimaryHost::class);
+
+        // Only enforced on multi-host deployments (any *_DOMAIN configured);
+        // the framework already skips TrustHosts in local and test runs.
+        // Anchored patterns, because Symfony matches them as unanchored regex.
+        $middleware->trustHosts(at: function (): array {
+            $dedicatedDomains = array_filter(
+                [
+                    config('app.api_domain'),
+                    config('app.mcp_domain'),
+                    config('app.sysadmin_domain'),
+                    config('app.app_panel_domain'),
+                ],
+                fn (mixed $domain): bool => is_string($domain) && $domain !== '',
+            );
+
+            if ($dedicatedDomains === []) {
+                return [];
+            }
+
+            $primaryHost = parse_url((string) config('app.url'), PHP_URL_HOST);
+
+            $hosts = array_filter([
+                $primaryHost,
+                is_string($primaryHost) ? "www.{$primaryHost}" : null,
+                ...array_values($dedicatedDomains),
+            ], is_string(...));
+
+            return array_map(
+                fn (string $host): string => '^'.preg_quote($host).'$',
+                array_values($hosts),
+            );
+        }, subdomains: false);
 
         $middleware->prependToPriorityList(
             before: SubstituteBindings::class,

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
@@ -92,7 +92,8 @@ final class TeamResource extends Resource
                     TextEntry::make('name'),
                     TextEntry::make('slug'),
                     TextEntry::make('owner.name')
-                        ->label('Owner'),
+                        ->label('Owner')
+                        ->url(fn (Team $record): ?string => $record->user_id === null ? null : UserResource::getUrl('view', ['record' => $record->user_id])),
                     IconEntry::make('personal_team')
                         ->label('Personal')
                         ->boolean(),
@@ -132,7 +133,8 @@ final class TeamResource extends Resource
                 TextColumn::make('owner.name')
                     ->label('Owner')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Team $record): ?string => $record->user_id === null ? null : UserResource::getUrl('view', ['record' => $record->user_id])),
                 IconColumn::make('personal_team')
                     ->label('Personal')
                     ->boolean(),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/CompaniesRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/CompaniesRelationManager.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
 
+use App\Models\Company;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\SystemAdmin\Filament\Resources\CompanyResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 
 final class CompaniesRelationManager extends RelationManager
 {
@@ -29,10 +32,12 @@ final class CompaniesRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('name')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Company $record): string => CompanyResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Company $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/MembersRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/MembersRelationManager.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
 
+use App\Models\User;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\PivotSafeTableQuery;
 
 final class MembersRelationManager extends RelationManager
 {
@@ -27,11 +31,13 @@ final class MembersRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => PivotSafeTableQuery::apply($query, $this->getRelationship()))
             ->recordTitleAttribute('name')
             ->columns([
                 TextColumn::make('name')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (User $record): string => UserResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('email')
                     ->searchable()
                     ->sortable(),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/NotesRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/NotesRelationManager.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
 
+use App\Models\Note;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\SystemAdmin\Filament\Resources\NoteResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 
 final class NotesRelationManager extends RelationManager
 {
@@ -30,10 +33,12 @@ final class NotesRelationManager extends RelationManager
                 TextColumn::make('title')
                     ->searchable()
                     ->sortable()
-                    ->limit(50),
+                    ->limit(50)
+                    ->url(fn (Note $record): string => NoteResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Note $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/OpportunitiesRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/OpportunitiesRelationManager.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
 
+use App\Models\Opportunity;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\SystemAdmin\Filament\Resources\CompanyResource;
+use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource;
+use Relaticle\SystemAdmin\Filament\Resources\PeopleResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 
 final class OpportunitiesRelationManager extends RelationManager
 {
@@ -29,17 +34,21 @@ final class OpportunitiesRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('name')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Opportunity $record): string => OpportunityResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('company.name')
                     ->label('Company')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Opportunity $record): ?string => $record->company_id === null ? null : CompanyResource::getUrl('view', ['record' => $record->company_id])),
                 TextColumn::make('contact.name')
                     ->label('Contact')
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Opportunity $record): ?string => $record->contact_id === null ? null : PeopleResource::getUrl('view', ['record' => $record->contact_id])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Opportunity $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/PeopleRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/PeopleRelationManager.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
 
+use App\Models\People;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\SystemAdmin\Filament\Resources\CompanyResource;
+use Relaticle\SystemAdmin\Filament\Resources\PeopleResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 
 final class PeopleRelationManager extends RelationManager
 {
@@ -31,14 +35,17 @@ final class PeopleRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('name')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (People $record): string => PeopleResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('company.name')
                     ->label('Company')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (People $record): ?string => $record->company_id === null ? null : CompanyResource::getUrl('view', ['record' => $record->company_id])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (People $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/TasksRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/TasksRelationManager.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
 
+use App\Models\Task;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Relaticle\SystemAdmin\Filament\Resources\TaskResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 
 final class TasksRelationManager extends RelationManager
 {
@@ -29,10 +32,12 @@ final class TasksRelationManager extends RelationManager
             ->columns([
                 TextColumn::make('title')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Task $record): string => TaskResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Task $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/TeamsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/TeamsRelationManager.php
@@ -8,8 +8,10 @@ use App\Models\Team;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
+use Relaticle\SystemAdmin\Filament\Support\PivotSafeTableQuery;
 
 final class TeamsRelationManager extends RelationManager
 {
@@ -29,6 +31,7 @@ final class TeamsRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => PivotSafeTableQuery::apply($query, $this->getRelationship()))
             ->recordTitleAttribute('name')
             ->columns([
                 TextColumn::make('name')

--- a/packages/SystemAdmin/src/Filament/Support/PivotSafeTableQuery.php
+++ b/packages/SystemAdmin/src/Filament/Support/PivotSafeTableQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+/**
+ * Filament's BelongsToMany table query merges the pivot model's casts into the
+ * related model (filamentphp/filament#2079). Jetstream's team_user pivot has an
+ * auto-incrementing key, so its casts include `id => int` — and PHP casts a
+ * ULID such as "01m09g…" to the integer 1. Every row in a membership relation
+ * manager then hydrates with key 1, so record links point at /teams/1 and 404.
+ * Re-merging the related model's own key cast after Filament's merge restores
+ * the real key while keeping the pivot casts Filament needed.
+ */
+final readonly class PivotSafeTableQuery
+{
+    public static function apply(Builder $query, Relation|Builder|null $relationship): Builder
+    {
+        if (! $relationship instanceof BelongsToMany) {
+            return $query;
+        }
+
+        $model = $query->getModel();
+
+        return $query->withCasts([$model->getKeyName() => $model->getKeyType()]);
+    }
+}

--- a/tests/Feature/Profile/UpdateUserProfileInformationTest.php
+++ b/tests/Feature/Profile/UpdateUserProfileInformationTest.php
@@ -361,7 +361,7 @@ describe('photo url generation', function () {
 
         Route::get('/_test/avatar-url', function () {
             return auth()->user()->getFilamentAvatarUrl();
-        })->middleware('web');
+        })->middleware(['web', 'auth']);
     });
 
     test('avatar url uses current request host instead of APP_URL', function () {
@@ -398,9 +398,10 @@ describe('photo url generation', function () {
         config(['app.url' => 'https://relaticle.test']);
 
         Route::get('/_test/rewrite-url', fn () => SameOriginUrl::rewrite('https://relaticle.test/storage/profile-photos/x.png'))
-            ->middleware('web');
+            ->middleware(['web', 'auth']);
 
-        $response = $this->get('https://app.relaticle.test/_test/rewrite-url');
+        $response = $this->actingAs(User::factory()->create())
+            ->get('https://app.relaticle.test/_test/rewrite-url');
 
         $response->assertOk();
         expect($response->getContent())->toBe('https://app.relaticle.test/storage/profile-photos/x.png');
@@ -410,9 +411,10 @@ describe('photo url generation', function () {
         config(['app.url' => 'https://relaticle.test']);
 
         Route::get('/_test/external-url', fn () => SameOriginUrl::rewrite('https://my-bucket.s3.amazonaws.com/profile-photos/x.png?X-Amz-Signature=abc'))
-            ->middleware('web');
+            ->middleware(['web', 'auth']);
 
-        $response = $this->get('https://app.relaticle.test/_test/external-url');
+        $response = $this->actingAs(User::factory()->create())
+            ->get('https://app.relaticle.test/_test/external-url');
 
         $response->assertOk();
         expect($response->getContent())->toBe('https://my-bucket.s3.amazonaws.com/profile-photos/x.png?X-Amz-Signature=abc');
@@ -435,7 +437,7 @@ describe('photo url generation', function () {
             Storage::shouldReceive('disk')->andReturn($disk);
 
             return auth()->user()->getFilamentAvatarUrl();
-        })->middleware('web');
+        })->middleware(['web', 'auth']);
 
         $response = $this->actingAs($user)
             ->get('https://app.relaticle.test/_test/avatar-url-query');

--- a/tests/Feature/Routing/PrimaryHostRoutingTest.php
+++ b/tests/Feature/Routing/PrimaryHostRoutingTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use App\Filament\Exports\CompanyExporter;
 use App\Http\Middleware\DenyIndexingOnSecondaryHosts;
 use App\Http\Middleware\RedirectToPrimaryHost;
+use App\Models\Export;
 use App\Models\User;
 
 mutates(RedirectToPrimaryHost::class, DenyIndexingOnSecondaryHosts::class);
@@ -67,11 +69,59 @@ describe('app plumbing on secondary hosts', function () {
 
         expect($secondary->status())->toBe($primaryStatus)->not->toBe(301);
     });
+
+    it('keeps the socialite redirect on the requesting host so the oauth redirect_uri does not change', function (): void {
+        config(['services.github.client_id' => 'test-client-id']);
+
+        $location = (string) $this->get('http://app.relaticle.test/auth/redirect/github')
+            ->assertStatus(302)
+            ->headers->get('Location');
+
+        expect($location)->toStartWith('https://github.com/login/oauth/authorize');
+        expect(urldecode($location))->toContain('redirect_uri=http://app.relaticle.test/auth/callback/github');
+    });
+
+    it('leaves filament export downloads untouched', function (): void {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $export = new Export;
+        $export->user()->associate($user);
+        $export->forceFill([
+            'exporter' => CompanyExporter::class,
+            'file_disk' => 'local',
+            'total_rows' => 1,
+        ])->save();
+
+        $uri = "filament/exports/{$export->getKey()}/download";
+
+        $primaryStatus = $this->get("http://relaticle.test/{$uri}")->status();
+        $secondary = $this->get("http://app.relaticle.test/{$uri}");
+
+        expect($secondary->status())->toBe($primaryStatus)->not->toBe(301);
+    });
 });
 
 describe('indexing on secondary hosts', function () {
     it('marks every secondary-host response noindex', function (): void {
         $this->get('http://sysadmin.relaticle.test/pricing')
+            ->assertHeader('X-Robots-Tag', 'noindex, nofollow');
+    });
+
+    it('marks the api root banner noindex even though it short-circuits the stack', function (): void {
+        config(['app.api_domain' => 'api.relaticle.test']);
+
+        $this->get('http://api.relaticle.test/')
+            ->assertOk()
+            ->assertJsonPath('name', 'Relaticle API')
+            ->assertHeader('X-Robots-Tag', 'noindex, nofollow');
+    });
+
+    it('marks the mcp browser banner noindex', function (): void {
+        config(['app.mcp_domain' => 'mcp.relaticle.test']);
+
+        $this->get('http://mcp.relaticle.test/', ['Sec-Fetch-Mode' => 'navigate', 'Accept' => 'text/html'])
+            ->assertOk()
+            ->assertJsonPath('name', 'Relaticle MCP Server')
             ->assertHeader('X-Robots-Tag', 'noindex, nofollow');
     });
 });

--- a/tests/Feature/Routing/PrimaryHostRoutingTest.php
+++ b/tests/Feature/Routing/PrimaryHostRoutingTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\DenyIndexingOnSecondaryHosts;
+use App\Http\Middleware\RedirectToPrimaryHost;
+use App\Models\User;
+
+mutates(RedirectToPrimaryHost::class, DenyIndexingOnSecondaryHosts::class);
+
+describe('public pages on secondary hosts', function () {
+    it('permanently redirects a marketing page to the primary host', function (): void {
+        $this->get('http://sysadmin.relaticle.test/pricing')
+            ->assertStatus(301)
+            ->assertRedirect('http://relaticle.test/pricing');
+    });
+
+    it('preserves the path and query string when redirecting', function (): void {
+        $this->get('http://api.relaticle.test/compare/relaticle-vs-espocrm?utm_source=newsletter')
+            ->assertRedirect('http://relaticle.test/compare/relaticle-vs-espocrm?utm_source=newsletter');
+    });
+
+    it('redirects documentation pages', function (): void {
+        $this->get('http://mcp.relaticle.test/help')
+            ->assertRedirect('http://relaticle.test/help');
+    });
+
+    it('redirects on any unrecognised subdomain, not only configured ones', function (): void {
+        $this->get('http://landing-typo.relaticle.test/pricing')
+            ->assertRedirect('http://relaticle.test/pricing');
+    });
+
+    it('serves public pages normally on the primary host', function (): void {
+        $this->get('http://relaticle.test/pricing')
+            ->assertOk()
+            ->assertHeaderMissing('X-Robots-Tag');
+    });
+});
+
+describe('app plumbing on secondary hosts', function () {
+    it('leaves POST requests untouched', function (): void {
+        $this->post('http://app.relaticle.test/logout')
+            ->assertStatus(302)
+            ->assertRedirect('http://app.relaticle.test/login');
+    });
+
+    it('leaves authenticated GET routes untouched', function (): void {
+        $user = User::factory()->withPersonalTeam()->unverified()->create();
+
+        $primaryStatus = $this->actingAs($user)->get('http://relaticle.test/email/verify')->status();
+        $secondary = $this->actingAs($user)->get('http://app.relaticle.test/email/verify');
+
+        expect($secondary->status())->toBe($primaryStatus)->not->toBe(301);
+    });
+
+    it('leaves signed routes untouched so host-bound signatures fail loudly instead of silently breaking', function (): void {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $this->actingAs($user)
+            ->get('http://app.relaticle.test/team-invitations/01hxxxxxxxxxxxxxxxxxxxxxxx?signature=invalid')
+            ->assertForbidden();
+    });
+
+    it('leaves the broadcasting auth endpoint untouched', function (): void {
+        $primaryStatus = $this->get('http://relaticle.test/broadcasting/auth')->status();
+        $secondary = $this->get('http://app.relaticle.test/broadcasting/auth');
+
+        expect($secondary->status())->toBe($primaryStatus)->not->toBe(301);
+    });
+});
+
+describe('indexing on secondary hosts', function () {
+    it('marks every secondary-host response noindex', function (): void {
+        $this->get('http://sysadmin.relaticle.test/pricing')
+            ->assertHeader('X-Robots-Tag', 'noindex, nofollow');
+    });
+});

--- a/tests/Feature/SystemAdmin/TeamResourceTest.php
+++ b/tests/Feature/SystemAdmin/TeamResourceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Company;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\ViewTeam;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\CompaniesRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\MembersRelationManager;
+use Relaticle\SystemAdmin\Filament\Support\PivotSafeTableQuery;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+mutates(TeamResource::class, MembersRelationManager::class, CompaniesRelationManager::class, PivotSafeTableQuery::class);
+
+beforeEach(function (): void {
+    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+});
+
+it('links team members to the user view page using the user key, not the pivot key', function (): void {
+    $owner = User::factory()->withPersonalTeam()->create();
+    $team = $owner->ownedTeams()->first();
+
+    $member = User::factory()->withPersonalTeam()->create();
+    $team->users()->attach($member, ['role' => 'admin']);
+
+    livewire(MembersRelationManager::class, [
+        'ownerRecord' => $team,
+        'pageClass' => ViewTeam::class,
+    ])
+        ->assertSuccessful()
+        ->assertSeeHtml("users/{$member->getKey()}");
+});
+
+it('links team companies to the company view page', function (): void {
+    $owner = User::factory()->withPersonalTeam()->create();
+    $team = $owner->ownedTeams()->first();
+
+    $company = Company::factory()->for($team)->create(['creator_id' => $owner->getKey()]);
+
+    livewire(CompaniesRelationManager::class, [
+        'ownerRecord' => $team,
+        'pageClass' => ViewTeam::class,
+    ])
+        ->assertSuccessful()
+        ->assertSeeHtml("companies/{$company->getKey()}")
+        ->assertSeeHtml("users/{$owner->getKey()}");
+});

--- a/tests/Feature/SystemAdmin/UserResourceTest.php
+++ b/tests/Feature/SystemAdmin/UserResourceTest.php
@@ -11,6 +11,9 @@ use Illuminate\Support\Facades\Hash;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\CreateUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\EditUser;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ViewUser;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\OwnedTeamsRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\TeamsRelationManager;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
 mutates(UserResource::class);
@@ -156,4 +159,33 @@ it('leaves other users untouched when one user is muted', function (): void {
 
     expect($other->fresh()->wantsNotification(NotificationType::TaskAssigned, NotificationChannel::InApp))->toBeTrue()
         ->and($other->fresh()->wantsNotification(NotificationType::TaskDigest, NotificationChannel::Email))->toBeTrue();
+});
+
+describe('team relation managers', function (): void {
+    it('links member-of teams to the team view page using the team key, not the pivot key', function (): void {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $team = $owner->ownedTeams()->first();
+
+        $member = User::factory()->withPersonalTeam()->create();
+        $team->users()->attach($member, ['role' => 'admin']);
+
+        livewire(TeamsRelationManager::class, [
+            'ownerRecord' => $member,
+            'pageClass' => ViewUser::class,
+        ])
+            ->assertSuccessful()
+            ->assertSeeHtml("teams/{$team->getKey()}");
+    });
+
+    it('links owned teams to the team view page', function (): void {
+        $owner = User::factory()->withPersonalTeam()->create();
+        $team = $owner->ownedTeams()->first();
+
+        livewire(OwnedTeamsRelationManager::class, [
+            'ownerRecord' => $owner,
+            'pageClass' => ViewUser::class,
+        ])
+            ->assertSuccessful()
+            ->assertSeeHtml("teams/{$team->getKey()}");
+    });
 });


### PR DESCRIPTION
## Problem 1 — marketing pages served on every subdomain

`https://sysadminsuccess.relaticle.com/compare/relaticle-vs-espocrm` (and `/pricing`, `/help`, every public page) returned 200 on `api.`, `mcp.`, `app.`, and the sysadmin host, each with a **self-referencing canonical**. Only the API, MCP, and panel routes are domain-scoped; everything else is domainless and answers on any host that reaches the app. The sysadmin hostname is also publicly disclosed via the shared TLS certificate's SAN list in Certificate Transparency logs, so crawlers find and index it.

**Fix (layered):**
- `RedirectToPrimaryHost` (web group): 301s unauthenticated GET/HEAD requests for domainless routes on non-primary hosts to the same path on the `APP_URL` host. Gate is `host !== primary`, so subdomains provisioned tomorrow are covered without config. Exemptions: routes with `auth`/`signed` middleware (signatures are computed over the absolute URL — a cross-host redirect would 403 every invitation link), `livewire.*`/`sanctum.*`/`passport.*`, and `broadcasting/auth` — so the app-panel and sysadmin hosts keep all their plumbing.
- `DenyIndexingOnSecondaryHosts` (global): `X-Robots-Tag: noindex, nofollow` on every non-primary-host response — covers what must legitimately stay 200 there (sysadmin login, API/MCP payloads).
- `trustHosts` allowlist (anchored patterns, `subdomains: false`) as defense in depth; only active when a `*_DOMAIN` is configured, and the framework skips it in local/test envs. Self-hosted single-host installs are unaffected by all three layers.
- The 301s also repair the SEO damage: already-indexed duplicates consolidate back to `relaticle.com` without GSC surgery.

**Not covered here (nginx serves these before Laravel):** `robots.txt` and `sitemap.xml` still 200 on every host. The sitemap only contains `relaticle.com` URLs, so it's cosmetic; per-host `X-Robots-Tag` for static files would be an nginx add-on.

## Problem 2 — sysadmin relation-manager links 404 (`/users/{id}?relation=1` → team → 404)

Filament merges the **pivot model's casts** into a `BelongsToMany` table query (its filamentphp/filament#2079 workaround). Jetstream's `team_user` pivot is auto-incrementing, so its casts include `id => int` — and PHP casts a ULID like `"01m09g…"` to `1` (every ULID starts with `01`). Every row in the *Member Of* and *Members* relation managers hydrated with key `1`, so record links pointed at `/teams/1` / `/users/1` and 404'd. Invisible on int-keyed apps, which is why upstream never caught it — worth reporting to Filament.

**Fix:** `PivotSafeTableQuery` re-merges the related model's own key cast after Filament's merge. Verified the app panel is not affected (its morph pivots use bare `MorphPivot` with no casts).

Also makes the sysadmin panel navigable end to end: members, companies, people, tasks, opportunities, and notes now link to their view pages, with company/contact/creator columns and the team owner entry cross-linked.

## Test plan

- `tests/Feature/Routing/PrimaryHostRoutingTest.php` — 301 matrix (marketing/docs/unknown hosts, path+query preservation), untouched POST/auth'd/signed/broadcasting behavior, noindex header presence/absence. Written red first against the live bug.
- `tests/Feature/SystemAdmin/UserResourceTest.php` + `TeamResourceTest.php` — relation-manager links carry the real ULID record keys, not the pivot key (red before the fix, `/teams/1` reproduced in the harness).
- Full suite: **2807 tests, 0 failures** (parallel, PostgreSQL). Pint/Rector/PHPStan clean, type coverage 100%.
- Browser (agent-browser, sysadmin domain-routed locally to mirror production): logged in on the sysadmin subdomain, walked user → *Member Of* → team view → members/companies/people/tasks/opportunities/notes links → record views; `/pricing` on the sysadmin subdomain 301s to the primary host with `noindex`; sysadmin login page still 200 with `noindex`; Livewire login works on the subdomain.

## Production notes

- The reported 404 is fully explained by the pivot-cast bug: *every* Member Of link in production points at `/teams/1` today.
- The admin hostname is already public via CT logs regardless of this fix — if it's ever rotated, the new name must go on a wildcard or per-host cert, and an nginx-level IP allowlist is the real protection obscurity was standing in for.

## Post-deploy checks

- Confirm uptime/health monitors hit `https://relaticle.com/up` (or another allowlisted hostname), not the raw server IP — once `trustHosts` activates in production, requests with an IP Host header get a 400 (SuspiciousOperationException → BadRequestHttpException).
- Click "Continue with Google" from the app-panel login page once: socialite GETs on `app.relaticle.com` now reach the primary host via 301, which relies on `SESSION_DOMAIN=.relaticle.com` carrying the OAuth state across hosts.
