### PR TITLE
feat(chat): polish proposal review ui, fix follow-up chips, sync hero mockup

### DIFF
--- a/.claude/skills/agent-browser-relaticle/SKILL.md
+++ b/.claude/skills/agent-browser-relaticle/SKILL.md
@@ -199,6 +199,13 @@ await comp2.call("callMountedAction");
 - **Stale session after branch switches** → first action of a batch is a fresh login.
 - **AI credits drain during chat testing** → re-seed `LocalSeeder` to top up before
   chat-heavy flows.
+- **Screenshot pipeline can serve STALE FRAMES from a dead target** (verified:
+  2026-08-18): after long sessions / viewport changes, `screenshot` kept returning a
+  frame that no longer matched the DOM (evals said dark theme + correct state; PNG
+  showed an old light half-render). Detection: `eval 'document.body.style.outline="40px
+  solid red"'` → screenshot → if no red border, the pipeline is stale. Fix:
+  `pkill -9 -f agent-browser; sleep 3`, new session, re-login. Don't debug the "bug"
+  in the PNG before running the red-outline probe.
 
 ## 7. DB-assert (corroboration only — the UI is the proof)
 

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -15,4 +15,25 @@ file_include_globs = ".env"
 # (Polyscope), so that orchestrator's folder-based behavior is unchanged.
 setup = 'herd link "$CONDUCTOR_WORKSPACE_NAME" && herd secure "$CONDUCTOR_WORKSPACE_NAME" && bin/setup-workspace.sh'
 archive = 'herd unsecure "$CONDUCTOR_WORKSPACE_NAME" && herd unlink "$CONDUCTOR_WORKSPACE_NAME"'
-run = 'open "https://$CONDUCTOR_WORKSPACE_NAME.test"'
+# Workspaces are fully isolated (own Herd hostname, per-workspace Redis
+# prefixes from setup-workspace.sh, shared Postgres by design), so several can
+# run at once.
+run_mode = "concurrent"
+
+[scripts.run.preview]
+command = 'open "https://$CONDUCTOR_WORKSPACE_NAME.test"'
+default = true
+icon = "globe"
+available_in = ["local"]
+
+# Chat (and any queued work) needs a worker owned by THIS workspace — nothing
+# starts one automatically, and without it sent messages queue forever.
+[scripts.run.horizon]
+command = "php artisan horizon"
+icon = "layers"
+available_in = ["local"]
+
+[scripts.run.vite]
+command = "npm run dev"
+icon = "zap"
+available_in = ["local"]

--- a/bin/setup-workspace.sh
+++ b/bin/setup-workspace.sh
@@ -35,11 +35,31 @@ composer install --no-interaction --prefer-dist
 echo "→ Refreshing JS dependencies"
 npm ci
 
+if [[ ! -f storage/oauth-private.key ]]; then
+    echo "→ Generating Passport keys"
+    php artisan passport:keys --no-interaction
+fi
+
 echo "→ Pointing .env at ${WORKSPACE_HOST}"
 sed -i '' "s|^APP_URL=.*|APP_URL=https://${WORKSPACE_HOST}|" .env
 sed -i '' "s|^SESSION_DOMAIN=.*|SESSION_DOMAIN=.${WORKSPACE_HOST}|" .env
 sed -i '' "s|^APP_PANEL_DOMAIN=.*|APP_PANEL_DOMAIN=|" .env
 sed -i '' "s|^SYSADMIN_DOMAIN=.*|SYSADMIN_DOMAIN=|" .env
+
+# All checkouts share one local Redis. Without per-workspace prefixes, every
+# checkout resolves the same default key prefix (APP_NAME-derived), so another
+# workspace's Horizon/queue worker consumes THIS workspace's jobs with foreign
+# code, and cache entries leak across branches. Explicit prefixes isolate
+# queues, cache, and Horizon per workspace without rationing Redis's 16
+# numeric databases.
+echo "→ Isolating Redis keys for ${WORKSPACE}"
+sed -i '' "/^REDIS_PREFIX=/d; /^CACHE_PREFIX=/d; /^HORIZON_PREFIX=/d" .env
+{
+    echo ""
+    echo "REDIS_PREFIX=${WORKSPACE}_database_"
+    echo "CACHE_PREFIX=${WORKSPACE}_cache_"
+    echo "HORIZON_PREFIX=${WORKSPACE}_horizon:"
+} >> .env
 
 php artisan config:clear --no-interaction
 php artisan route:clear --no-interaction

--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -424,10 +424,20 @@
             {{-- Docked pending proposal: a nested Livewire component hosts the active proposal so it can
                  render real Filament field editors in place (Phase C). Alpine stays the source of truth for
                  whether a proposal is pending and pushes the active id to the card via `proposal:set-active`. --}}
-            <div x-show="hasPendingProposal" x-effect="syncActiveProposal()" class="mb-3">
-                <div class="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400">
-                    <x-heroicon-o-sparkles class="h-3.5 w-3.5" aria-hidden="true" />
-                    <span>Review before continuing</span>
+            <div
+                x-show="hasPendingProposal"
+                x-effect="syncActiveProposal()"
+                x-transition:enter="transition duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]"
+                x-transition:enter-start="translate-y-2 opacity-0"
+                x-transition:enter-end="translate-y-0 opacity-100"
+                x-transition:leave="transition duration-150 ease-in"
+                x-transition:leave-start="translate-y-0 opacity-100"
+                x-transition:leave-end="translate-y-1 opacity-0"
+                class="mb-3"
+            >
+                <div class="mb-2 flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+                    <x-heroicon-o-sparkles class="h-3.5 w-3.5 text-primary-500 dark:text-primary-400" aria-hidden="true" />
+                    <span>{{ __('Review before continuing') }}</span>
                 </div>
                 <div class="max-h-[55vh] overflow-y-auto">
                     <livewire:chat.proposal-card :context="$context ?? 'conversation'" wire:key="proposal-dock-{{ $context ?? 'conversation' }}" />

--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -218,7 +218,7 @@
                                     <template x-for="chip in msg.follow_ups" :key="chip.prompt">
                                         <button
                                             type="button"
-                                            x-on:click="input = chip.prompt; $nextTick(() => sendMessage())"
+                                            x-on:click="input = chip.prompt; localEditor()?.setText(chip.prompt); $nextTick(() => sendMessage())"
                                             x-text="chip.label"
                                             class="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700 transition hover:border-primary-300 hover:bg-primary-50 hover:text-primary-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-primary-700 dark:hover:bg-primary-900/20 dark:hover:text-primary-300"
                                         ></button>

--- a/packages/Chat/resources/views/livewire/chat/partials/_proposal-card.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/partials/_proposal-card.blade.php
@@ -8,7 +8,7 @@
           confusing duplicate.
        2. status !== 'pending' (finalized / single resolved): the full read-only
           audit card. --}}
-<div class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+<div class="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
     {{-- COMPACT progress view while the batch is still docked. --}}
     <template x-if="action.status === 'pending'">
         <div>
@@ -18,12 +18,12 @@
                         <div class="flex items-center gap-2 text-xs">
                             <span class="text-gray-600 dark:text-gray-300" x-text="item.summary"></span>
                             <template x-if="itemResult(action, itemIdx).status === 'approved'">
-                                <span class="inline-flex items-center gap-1 rounded-md bg-green-50 px-1.5 py-0.5 font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
+                                <span class="inline-flex items-center gap-1 rounded-md bg-green-50 px-1.5 py-0.5 font-medium text-green-700 dark:bg-green-400/10 dark:text-green-400">
                                     <x-heroicon-o-check class="h-3 w-3" aria-hidden="true" /> <span x-text="itemVerb(action)"></span>
                                 </span>
                             </template>
                             <template x-if="itemResult(action, itemIdx).status === 'skipped'">
-                                <span class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-1.5 py-0.5 font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                                <span class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-1.5 py-0.5 font-medium text-gray-500 dark:bg-white/10 dark:text-gray-400">
                                     Skipped
                                 </span>
                             </template>
@@ -46,60 +46,94 @@
     {{-- Full read-only audit card once the proposal is finalized. --}}
     <template x-if="action.status !== 'pending'">
         <div>
-            <div class="flex items-center gap-2">
-                <span
-                    class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium"
+            {{-- Header: operation icon tile + human summary + resolution pill --}}
+            <div class="flex items-start gap-3">
+                <div
+                    class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
                     :class="{
-                        'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400': action.operation === 'create',
-                        'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400': action.operation === 'update',
-                        'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400': action.operation === 'delete',
+                        'bg-blue-50 text-blue-600 dark:bg-blue-400/10 dark:text-blue-400': action.operation === 'create',
+                        'bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400': action.operation === 'update',
+                        'bg-red-50 text-red-600 dark:bg-red-400/10 dark:text-red-400': action.operation === 'delete',
                     }"
-                    x-text="action.operation.charAt(0).toUpperCase() + action.operation.slice(1)"
+                    aria-hidden="true"
+                >
+                    <template x-if="action.operation === 'update'">
+                        <x-heroicon-o-pencil-square class="h-4 w-4" />
+                    </template>
+                    <template x-if="action.operation === 'delete'">
+                        <x-heroicon-o-trash class="h-4 w-4" />
+                    </template>
+                    <template x-if="action.operation !== 'update' && action.operation !== 'delete'">
+                        <x-heroicon-o-plus class="h-4 w-4" />
+                    </template>
+                </div>
+
+                <div class="min-w-0 flex-1 pt-1">
+                    <p class="text-sm font-semibold leading-5 text-gray-900 dark:text-white" x-text="action.display?.summary ?? (action.operation.charAt(0).toUpperCase() + action.operation.slice(1))"></p>
+                </div>
+
+                <span
+                    class="mt-0.5 inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                    :class="{
+                        'bg-green-50 text-green-700 dark:bg-green-400/10 dark:text-green-400': action.status === 'approved',
+                        'bg-red-50 text-red-700 dark:bg-red-400/10 dark:text-red-400': action.status === 'rejected',
+                        'bg-gray-100 text-gray-500 dark:bg-white/10 dark:text-gray-400': action.status === 'expired' || action.status === 'superseded',
+                    }"
+                    x-text="action.status.charAt(0).toUpperCase() + action.status.slice(1)"
                 ></span>
-                <span class="text-sm font-medium text-gray-900 dark:text-white" x-text="action.display?.summary"></span>
             </div>
 
             <template x-if="action.display?.duplicate_warning">
-                <div class="mt-2 rounded-md border border-amber-300 bg-amber-50 px-2 py-1.5 text-xs text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200" x-text="action.display.duplicate_warning"></div>
+                <div class="mt-3 flex items-start gap-2 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-400/10 dark:text-amber-200">
+                    <x-heroicon-o-exclamation-triangle class="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    <span x-text="action.display.duplicate_warning"></span>
+                </div>
             </template>
 
-            <div class="mt-2 space-y-1">
-                <template x-for="(field, fieldIdx) in (action.display?.fields || [])" :key="fieldIdx">
-                    @include('chat::livewire.chat.partials._proposal-field')
-                </template>
-            </div>
+            <template x-if="Array.isArray(action.display?.fields) && action.display.fields.length > 0">
+                <div class="mt-3 space-y-1.5 ps-11">
+                    <template x-for="(field, fieldIdx) in (action.display?.fields || [])" :key="fieldIdx">
+                        @include('chat::livewire.chat.partials._proposal-field')
+                    </template>
+                </div>
+            </template>
 
             {{-- Batch items (records[] proposals): per-item summary, fields, and resolved chip. --}}
             <template x-if="Array.isArray(action.display?.items) && action.display.items.length > 0">
-                <div class="mt-2 divide-y divide-gray-100 dark:divide-gray-800">
+                <div class="mt-3 divide-y divide-gray-100 ps-11 dark:divide-white/5">
                     <template x-for="(item, itemIdx) in action.display.items" :key="itemIdx">
-                        <div class="py-2 first:pt-0 last:pb-0">
-                            <div class="text-sm font-medium text-gray-900 dark:text-white" x-text="item.summary"></div>
-                            <div class="mt-1 space-y-0.5">
+                        <div class="py-2.5 first:pt-0 last:pb-0">
+                            <div class="flex items-center justify-between gap-2">
+                                <div class="min-w-0 truncate text-sm font-medium text-gray-900 dark:text-white" x-text="item.summary"></div>
+
+                                {{-- Per-item resolved chip (Created / Skipped). --}}
+                                <template x-if="itemResult(action, itemIdx)">
+                                    <span class="flex shrink-0 items-center gap-2 text-xs">
+                                        <template x-if="itemResult(action, itemIdx).status === 'approved'">
+                                            <span class="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 font-medium text-green-700 dark:bg-green-400/10 dark:text-green-400">
+                                                <x-heroicon-o-check class="h-3 w-3" aria-hidden="true" /> <span x-text="itemVerb(action)"></span>
+                                            </span>
+                                        </template>
+                                        <template x-if="itemResult(action, itemIdx).status === 'skipped'">
+                                            <span class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-500 dark:bg-white/10 dark:text-gray-400">
+                                                Skipped
+                                            </span>
+                                        </template>
+                                    </span>
+                                </template>
+                            </div>
+                            <div class="mt-1.5 space-y-1">
                                 <template x-for="(field, fieldIdx) in (item.fields || [])" :key="fieldIdx">
                                     @include('chat::livewire.chat.partials._proposal-field')
                                 </template>
                             </div>
 
-                            {{-- Per-item resolved chip (Created / Skipped + link). --}}
-                            <template x-if="itemResult(action, itemIdx)">
-                                <div class="mt-1.5 flex items-center gap-2 text-xs">
-                                    <template x-if="itemResult(action, itemIdx).status === 'approved'">
-                                        <span class="inline-flex items-center gap-1 rounded-md bg-green-50 px-1.5 py-0.5 font-medium text-green-700 dark:bg-green-900/20 dark:text-green-400">
-                                            <x-heroicon-o-check class="h-3 w-3" aria-hidden="true" /> <span x-text="itemVerb(action)"></span>
-                                        </span>
-                                    </template>
-                                    <template x-if="itemResult(action, itemIdx).status === 'skipped'">
-                                        <span class="inline-flex items-center gap-1 rounded-md bg-gray-100 px-1.5 py-0.5 font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                                            Skipped
-                                        </span>
-                                    </template>
-                                    <template x-if="itemResult(action, itemIdx).record && itemResult(action, itemIdx).record.url">
-                                        <a :href="itemResult(action, itemIdx).record.url" wire:navigate class="inline-flex items-center gap-1 font-medium text-primary-600 hover:underline dark:text-primary-400">
-                                            <span x-text="itemResult(action, itemIdx).record.label ? 'View ' + itemResult(action, itemIdx).record.label : 'View'"></span>
-                                            <x-heroicon-o-arrow-top-right-on-square class="h-3 w-3" aria-hidden="true" />
-                                        </a>
-                                    </template>
+                            <template x-if="itemResult(action, itemIdx) && itemResult(action, itemIdx).record && itemResult(action, itemIdx).record.url">
+                                <div class="mt-1.5 text-xs">
+                                    <a :href="itemResult(action, itemIdx).record.url" wire:navigate class="inline-flex items-center gap-1 font-medium text-primary-600 hover:underline dark:text-primary-400">
+                                        <span x-text="itemResult(action, itemIdx).record.label ? 'View ' + itemResult(action, itemIdx).record.label : 'View'"></span>
+                                        <x-heroicon-o-arrow-top-right-on-square class="h-3 w-3" aria-hidden="true" />
+                                    </a>
                                 </div>
                             </template>
                         </div>
@@ -107,31 +141,19 @@
                 </div>
             </template>
 
-            {{-- Resolved status badge + record link — SINGLE proposals only. Batch items
-                 each carry their own Created/Skipped chip and View link above, and the
-                 outcome summary sits below the card, so a batch-level status row here
-                 would just repeat the same links a third time. --}}
-            <template x-if="!(Array.isArray(action.display?.items) && action.display.items.length > 0)">
-                <div class="mt-3 flex items-center gap-2">
-                    <span
-                        class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium"
-                        :class="{
-                            'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400': action.status === 'approved',
-                            'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400': action.status === 'rejected',
-                            'bg-gray-50 text-gray-700 dark:bg-gray-900/20 dark:text-gray-400': action.status === 'expired' || action.status === 'superseded',
-                        }"
-                        x-text="action.status.charAt(0).toUpperCase() + action.status.slice(1)"
-                    ></span>
-                    <template x-if="action.status === 'approved' && action.record && action.record.url">
-                        <a
-                            :href="action.record.url"
-                            wire:navigate
-                            class="inline-flex items-center gap-1 text-xs font-medium text-primary-600 hover:underline dark:text-primary-400"
-                        >
-                            <span x-text="action.record.label ? 'View ' + action.record.label : 'View'"></span>
-                            <x-heroicon-o-arrow-top-right-on-square class="h-3 w-3" aria-hidden="true" />
-                        </a>
-                    </template>
+            {{-- Record link — SINGLE proposals only. Batch items each carry their own
+                 View link above, and the outcome summary sits below the card, so a
+                 batch-level link row here would just repeat the same links. --}}
+            <template x-if="!(Array.isArray(action.display?.items) && action.display.items.length > 0) && action.status === 'approved' && action.record && action.record.url">
+                <div class="mt-3 ps-11">
+                    <a
+                        :href="action.record.url"
+                        wire:navigate
+                        class="inline-flex items-center gap-1 text-xs font-medium text-primary-600 hover:underline dark:text-primary-400"
+                    >
+                        <span x-text="action.record.label ? 'View ' + action.record.label : 'View'"></span>
+                        <x-heroicon-o-arrow-top-right-on-square class="h-3 w-3" aria-hidden="true" />
+                    </a>
                 </div>
             </template>
         </div>

--- a/packages/Chat/resources/views/livewire/chat/partials/_proposal-field.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/partials/_proposal-field.blade.php
@@ -1,58 +1,60 @@
 {{-- Type-aware proposal field row. Expects Alpine scope var `field`:
      {label, value?|new?, old?, type?, values?} --}}
-<div class="flex items-start gap-2 text-sm">
-    <span class="shrink-0 font-medium text-gray-500 dark:text-gray-400" x-text="field.label + ':'"></span>
+<div class="flex items-start gap-3">
+    <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-gray-400" x-text="field.label"></span>
 
-    <template x-if="field.old">
-        <span class="flex items-center gap-1">
-            <span class="text-gray-400 line-through" x-text="field.old"></span>
-            <span class="text-gray-400" aria-hidden="true">&rarr;</span>
-        </span>
-    </template>
+    <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-sm">
+        <template x-if="field.old">
+            <span class="flex items-center gap-1.5">
+                <span class="text-gray-400 line-through decoration-gray-300 dark:text-gray-500 dark:decoration-gray-600" x-text="field.old"></span>
+                <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+            </span>
+        </template>
 
-    <template x-if="field.type === 'badges' && Array.isArray(field.values) && field.values.length > 0">
-        <span class="flex flex-wrap gap-1">
-            <template x-for="(badge, badgeIdx) in field.values" :key="badgeIdx">
-                <span class="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300" x-text="badge"></span>
-            </template>
-        </span>
-    </template>
+        <template x-if="field.type === 'badges' && Array.isArray(field.values) && field.values.length > 0">
+            <span class="flex flex-wrap gap-1">
+                <template x-for="(badge, badgeIdx) in field.values" :key="badgeIdx">
+                    <span class="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-white/10 dark:text-gray-300" x-text="badge"></span>
+                </template>
+            </span>
+        </template>
 
-    <template x-if="field.type === 'boolean'">
-        <span
-            class="inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium"
-            :class="(field.new ?? field.value) === 'Yes'
-                ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400'
-                : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'"
-            x-text="field.new ?? field.value"
-        ></span>
-    </template>
+        <template x-if="field.type === 'boolean'">
+            <span
+                class="inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium"
+                :class="(field.new ?? field.value) === 'Yes'
+                    ? 'bg-green-50 text-green-700 dark:bg-green-400/10 dark:text-green-400'
+                    : 'bg-gray-100 text-gray-600 dark:bg-white/10 dark:text-gray-400'"
+                x-text="field.new ?? field.value"
+            ></span>
+        </template>
 
-    <template x-if="field.type === 'link' && Array.isArray(field.values) && field.values.length > 0">
-        <span class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-            <template x-for="(url, urlIdx) in field.values" :key="urlIdx">
-                <a
-                    :href="(String(url).startsWith('http') ? '' : 'https://') + url"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="truncate text-primary-600 hover:underline dark:text-primary-400"
-                    x-text="url"
-                ></a>
-            </template>
-        </span>
-    </template>
+        <template x-if="field.type === 'link' && Array.isArray(field.values) && field.values.length > 0">
+            <span class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                <template x-for="(url, urlIdx) in field.values" :key="urlIdx">
+                    <a
+                        :href="(String(url).startsWith('http') ? '' : 'https://') + url"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="truncate text-primary-600 hover:underline dark:text-primary-400"
+                        x-text="url"
+                    ></a>
+                </template>
+            </span>
+        </template>
 
-    <template x-if="field.type === 'link' && !(Array.isArray(field.values) && field.values.length > 0) && (field.new ?? field.value)">
-        <a
-            :href="(String(field.new ?? field.value).startsWith('http') ? '' : 'https://') + (field.new ?? field.value)"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="truncate text-primary-600 hover:underline dark:text-primary-400"
-            x-text="field.new ?? field.value"
-        ></a>
-    </template>
+        <template x-if="field.type === 'link' && !(Array.isArray(field.values) && field.values.length > 0) && (field.new ?? field.value)">
+            <a
+                :href="(String(field.new ?? field.value).startsWith('http') ? '' : 'https://') + (field.new ?? field.value)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="truncate text-primary-600 hover:underline dark:text-primary-400"
+                x-text="field.new ?? field.value"
+            ></a>
+        </template>
 
-    <template x-if="!['badges', 'boolean', 'link'].includes(field.type)">
-        <span class="text-gray-900 dark:text-white" x-text="field.new ?? field.value"></span>
-    </template>
+        <template x-if="!['badges', 'boolean', 'link'].includes(field.type)">
+            <span class="font-medium text-gray-900 dark:text-white" x-text="field.new ?? field.value"></span>
+        </template>
+    </span>
 </div>

--- a/packages/Chat/resources/views/livewire/chat/proposal-card.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/proposal-card.blade.php
@@ -9,35 +9,78 @@
 
 <div>
     @if ($proposal)
-        <div class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900">
-            <div class="flex items-center gap-2">
-                <span
+        <div class="rounded-2xl border border-gray-200/80 bg-white p-4 shadow-lg shadow-gray-900/[0.04] dark:border-white/10 dark:bg-gray-900 dark:shadow-black/20">
+            {{-- Header: operation icon tile + human summary + batch pager --}}
+            <div class="flex items-start gap-3">
+                <div
                     @class([
-                        'inline-flex items-center rounded-md px-2 py-1 text-xs font-medium',
-                        'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400' => $operation === 'create',
-                        'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400' => $operation === 'update',
-                        'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-400' => $operation === 'delete',
+                        'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+                        'bg-blue-50 text-blue-600 dark:bg-blue-400/10 dark:text-blue-400' => $operation === 'create',
+                        'bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400' => $operation === 'update',
+                        'bg-red-50 text-red-600 dark:bg-red-400/10 dark:text-red-400' => $operation === 'delete',
                     ])
-                >{{ $proposal->display_data['title'] ?? ucfirst((string) $operation).' '.ucfirst($proposal->entity_type) }}</span>
-                <span class="text-sm font-medium text-gray-900 dark:text-white">{{ $record['summary'] ?? '' }}</span>
+                    aria-hidden="true"
+                >
+                    @if ($operation === 'update')
+                        <x-heroicon-o-pencil-square class="h-4 w-4" />
+                    @elseif ($operation === 'delete')
+                        <x-heroicon-o-trash class="h-4 w-4" />
+                    @else
+                        <x-heroicon-o-plus class="h-4 w-4" />
+                    @endif
+                </div>
+
+                <div class="min-w-0 flex-1 pt-1">
+                    <p class="text-sm font-semibold leading-5 text-gray-900 dark:text-white">{{ $record['summary'] ?? $proposal->display_data['summary'] ?? $proposal->display_data['title'] ?? '' }}</p>
+                </div>
+
+                @if ($remainingCount > 1)
+                    <div class="flex shrink-0 items-center gap-0.5 pt-0.5">
+                        <button
+                            type="button"
+                            wire:click="stepPrev"
+                            @disabled($position <= 1)
+                            class="inline-flex h-6 w-6 items-center justify-center rounded-md text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent dark:hover:bg-white/5 dark:hover:text-gray-300"
+                            aria-label="{{ __('Previous record') }}"
+                        >
+                            <x-heroicon-o-chevron-left class="h-3.5 w-3.5" aria-hidden="true" />
+                        </button>
+
+                        <span class="select-none px-0.5 text-xs font-medium tabular-nums text-gray-400 dark:text-gray-500">{{ $position }}&hairsp;/&hairsp;{{ $remainingCount }}</span>
+
+                        <button
+                            type="button"
+                            wire:click="stepNext"
+                            @disabled($position >= $remainingCount)
+                            class="inline-flex h-6 w-6 items-center justify-center rounded-md text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent dark:hover:bg-white/5 dark:hover:text-gray-300"
+                            aria-label="{{ __('Next record') }}"
+                        >
+                            <x-heroicon-o-chevron-right class="h-3.5 w-3.5" aria-hidden="true" />
+                        </button>
+                    </div>
+                @endif
             </div>
 
             @if (! empty($proposal->display_data['duplicate_warning']))
-                <div class="mt-2 rounded-md border border-amber-300 bg-amber-50 px-2 py-1.5 text-xs text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">{{ $proposal->display_data['duplicate_warning'] }}</div>
+                <div class="mt-3 flex items-start gap-2 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-400/10 dark:text-amber-200">
+                    <x-heroicon-o-exclamation-triangle class="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    <span>{{ $proposal->display_data['duplicate_warning'] }}</span>
+                </div>
             @endif
 
-            <div class="mt-2 space-y-1">
+            {{-- Field rows: fixed label column so values align, diffs render old → new --}}
+            <div class="mt-3 space-y-1.5 ps-11">
                 @foreach ($recordFields as $row)
                     @php
                         $code = $row['code'] ?? null;
                         $isEditable = $code !== null && in_array($code, $editableCodes, true);
                     @endphp
 
-                    <div class="group/field flex items-start gap-2 text-sm">
-                        <span class="shrink-0 font-medium text-gray-500 dark:text-gray-400">{{ ($row['label'] ?? '').':' }}</span>
+                    <div class="group/field flex items-start gap-3">
+                        <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-gray-400">{{ $row['label'] ?? '' }}</span>
 
                         @if ($editingFieldCode === $code && $isEditable)
-                            <div class="w-full">
+                            <div class="w-full min-w-0">
                                 {{ $this->form }}
 
                                 @error('field')
@@ -66,11 +109,11 @@
                                 </div>
                             </div>
                         @else
-                            <span class="flex flex-1 flex-wrap items-center gap-1">
+                            <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-sm">
                                 @if (! in_array($row['value'] ?? $row['new'] ?? null, [null, ''], true) || ! empty($row['old']) || ! empty($row['values']))
                                     @if (! empty($row['old']))
-                                        <span class="text-gray-400 line-through">{{ $row['old'] }}</span>
-                                        <span class="text-gray-400" aria-hidden="true">&rarr;</span>
+                                        <span class="text-gray-400 line-through decoration-gray-300 dark:text-gray-500 dark:decoration-gray-600">{{ $row['old'] }}</span>
+                                        <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-gray-500" aria-hidden="true" />
                                     @endif
 
                                     @if (is_array($row['values'] ?? null) && $row['values'] !== [])
@@ -85,11 +128,19 @@
                                             @endforeach
                                         @else
                                             @foreach ($row['values'] as $badge)
-                                                <span class="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300">{{ $badge }}</span>
+                                                <span class="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-white/10 dark:text-gray-300">{{ $badge }}</span>
                                             @endforeach
                                         @endif
+                                    @elseif (($row['type'] ?? null) === 'boolean')
+                                        <span
+                                            @class([
+                                                'inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium',
+                                                'bg-green-50 text-green-700 dark:bg-green-400/10 dark:text-green-400' => ($row['new'] ?? $row['value'] ?? null) === 'Yes',
+                                                'bg-gray-100 text-gray-600 dark:bg-white/10 dark:text-gray-400' => ($row['new'] ?? $row['value'] ?? null) !== 'Yes',
+                                            ])
+                                        >{{ $row['new'] ?? $row['value'] ?? '' }}</span>
                                     @else
-                                        <span class="text-gray-900 dark:text-white">{{ $row['new'] ?? $row['value'] ?? '' }}</span>
+                                        <span class="font-medium text-gray-900 dark:text-white">{{ $row['new'] ?? $row['value'] ?? '' }}</span>
                                     @endif
                                 @endif
 
@@ -97,7 +148,7 @@
                                     <button
                                         type="button"
                                         wire:click="editField(@js($code))"
-                                        class="ml-auto inline-flex shrink-0 items-center justify-center rounded p-0.5 text-gray-400 opacity-0 transition hover:bg-gray-100 hover:text-gray-600 group-hover/field:opacity-100 focus-visible:opacity-100 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+                                        class="ml-auto inline-flex shrink-0 items-center justify-center rounded-md p-1 text-gray-400 opacity-0 transition hover:bg-gray-100 hover:text-gray-600 group-hover/field:opacity-100 focus-visible:opacity-100 dark:hover:bg-white/10 dark:hover:text-gray-300"
                                         aria-label="{{ __('Edit :field', ['field' => $row['label'] ?? '']) }}"
                                     >
                                         <x-heroicon-o-pencil-square class="h-3.5 w-3.5" aria-hidden="true" />
@@ -110,72 +161,45 @@
             </div>
 
             @error('resolve')
-                <p class="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-900/20 dark:text-red-400" role="alert">
+                <p class="mt-3 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-400/10 dark:text-red-400" role="alert">
                     {{ $message }}
                 </p>
             @enderror
 
-            <div class="mt-3 flex items-center justify-between gap-2">
-                <div class="flex items-center gap-1">
-                    @if ($remainingCount > 1)
-                        <button
-                            type="button"
-                            wire:click="stepPrev"
-                            @disabled($position <= 1)
-                            class="inline-flex items-center justify-center rounded-md p-1 text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800"
-                            aria-label="{{ __('Previous record') }}"
-                        >
-                            <x-heroicon-o-chevron-left class="h-4 w-4" aria-hidden="true" />
-                        </button>
+            {{-- Footer: the decision. Separated by a hairline so it reads as one deliberate step. --}}
+            <div class="mt-4 flex items-center justify-end gap-2 border-t border-gray-100 pt-3 dark:border-white/5">
+                <button
+                    type="button"
+                    wire:click="discardCurrent"
+                    wire:loading.attr="disabled"
+                    x-on:click="$el.disabled = true"
+                    @disabled($editingFieldCode !== null)
+                    @class([
+                        'inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 hover:text-gray-900 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent dark:text-gray-300 dark:hover:bg-white/5 dark:hover:text-white',
+                        'opacity-50' => $editingFieldCode !== null,
+                    ])
+                >
+                    {{ __('Discard') }}
+                </button>
 
-                        <span class="select-none text-xs font-medium tabular-nums text-gray-500 dark:text-gray-400">{{ $position }} / {{ $remainingCount }}</span>
-
-                        <button
-                            type="button"
-                            wire:click="stepNext"
-                            @disabled($position >= $remainingCount)
-                            class="inline-flex items-center justify-center rounded-md p-1 text-gray-500 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-400 dark:hover:bg-gray-800"
-                            aria-label="{{ __('Next record') }}"
-                        >
-                            <x-heroicon-o-chevron-right class="h-4 w-4" aria-hidden="true" />
-                        </button>
-                    @endif
-                </div>
-
-                <div class="flex items-center gap-2">
-                    <button
-                        type="button"
-                        wire:click="discardCurrent"
-                        wire:loading.attr="disabled"
-                        x-on:click="$el.disabled = true"
-                        @disabled($editingFieldCode !== null)
-                        @class([
-                            'inline-flex items-center rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700',
-                            'opacity-50' => $editingFieldCode !== null,
-                        ])
-                    >
-                        {{ __('Discard') }}
-                    </button>
-
-                    <button
-                        type="button"
-                        wire:click="createCurrent"
-                        wire:loading.attr="disabled"
-                        x-on:click="$el.disabled = true"
-                        @disabled($editingFieldCode !== null)
-                        @class([
-                            'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-white transition disabled:cursor-not-allowed disabled:opacity-60',
-                            'bg-red-600 hover:bg-red-700' => $operation === 'delete',
-                            'bg-primary-600 hover:bg-primary-700' => $operation !== 'delete',
-                            'opacity-50' => $editingFieldCode !== null,
-                        ])
-                    >
-                        <x-heroicon-o-arrow-path class="h-3.5 w-3.5 animate-spin" wire:loading wire:target="createCurrent" aria-hidden="true" />
-                        <x-heroicon-o-check class="h-3.5 w-3.5" wire:loading.remove wire:target="createCurrent" aria-hidden="true" />
-                        <span>{{ $createLabel }}</span>
-                        <kbd class="hidden rounded bg-white/20 px-1 font-sans text-[10px] sm:inline">&#8984;&#9166;</kbd>
-                    </button>
-                </div>
+                <button
+                    type="button"
+                    wire:click="createCurrent"
+                    wire:loading.attr="disabled"
+                    x-on:click="$el.disabled = true"
+                    @disabled($editingFieldCode !== null)
+                    @class([
+                        'inline-flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60',
+                        'bg-red-600 hover:bg-red-500' => $operation === 'delete',
+                        'bg-primary-600 hover:bg-primary-500' => $operation !== 'delete',
+                        'opacity-50' => $editingFieldCode !== null,
+                    ])
+                >
+                    <x-heroicon-o-arrow-path class="h-3.5 w-3.5 animate-spin" wire:loading wire:target="createCurrent" aria-hidden="true" />
+                    <x-heroicon-o-check class="h-3.5 w-3.5" wire:loading.remove wire:target="createCurrent" aria-hidden="true" />
+                    <span>{{ $createLabel }}</span>
+                    <kbd class="hidden rounded bg-white/20 px-1 font-sans text-[10px] sm:inline">&#8984;&#9166;</kbd>
+                </button>
             </div>
         </div>
     @endif

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -109,9 +109,9 @@ final class CrmAssistant implements Agent, Conversational, HasMiddleware, HasPro
     public array $supersededProposals = [];
 
     /**
-     * Actions already resolved (approved/rejected/expired/superseded) since the
-     * last assistant turn, injected so the model knows their outcome even if the
-     * approval continuation never journaled them into the transcript.
+     * Every terminal action (approved/rejected/expired/superseded) on this
+     * conversation, re-injected each turn: resolutions never reach the replayed
+     * transcript, whose tool results keep claiming the proposal is pending.
      *
      * @var list<array{operation: string, entity_type: string, status: string, label: string|null, record_id?: string|null, record_ids?: list<string>}>
      */
@@ -389,7 +389,9 @@ PROMPT;
         $lines = [
             '',
             '<resolved_actions>',
-            'These proposals were already decided by the user. Do not re-propose them.',
+            'These proposals were already decided by the user and their approval cards are gone.',
+            'NEVER describe a decided proposal as pending, awaiting approval, or "shown above".',
+            'Do not re-propose them on your own initiative. But when the user explicitly asks for the action again (including after rejecting it), call the tool to create a FRESH proposal.',
             'Use an approved record id to continue any multi-step request still in progress.',
         ];
 

--- a/packages/Chat/src/Jobs/ProcessChatMessage.php
+++ b/packages/Chat/src/Jobs/ProcessChatMessage.php
@@ -152,7 +152,7 @@ final class ProcessChatMessage implements ShouldQueue
             $agent->withContextLedger($this->contextLedger());
             $agent->withSupersededProposals($this->summarizeSuperseded($superseded));
             $agent->withResolvedActions(
-                $pendingActions->resolvedSinceLastAssistantMessage($this->conversationId),
+                $pendingActions->resolvedForConversation($this->conversationId),
             );
 
             $channel = new PrivateChannel("chat.conversation.{$this->conversationId}");

--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -462,18 +462,18 @@ final readonly class PendingActionService
     }
 
     /**
-     * Actions on this conversation resolved AFTER the latest assistant message —
-     * i.e. decisions the replayed transcript does not yet reflect. Used to inject
-     * a <resolved_actions> block so the model's knowledge of approvals does not
-     * depend on the AI continuation having successfully journaled them.
+     * Every terminal proposal for the conversation (newest 20, presented
+     * oldest-first). Deliberately NOT windowed to "since the last assistant
+     * turn": resolutions write nothing into the replayed transcript, whose
+     * tool results keep claiming the proposal is pending — so the outcome must
+     * be re-injected on every turn or the model treats a rejected proposal as
+     * still awaiting approval.
      *
      * @return list<array{operation: string, entity_type: string, status: string, label: string|null, record_id: string|null, record_ids: list<string>}>
      */
-    public function resolvedSinceLastAssistantMessage(string $conversationId): array
+    public function resolvedForConversation(string $conversationId): array
     {
-        $lastAssistantAt = $this->lastAssistantMessageAt($conversationId);
-
-        $query = PendingAction::query()
+        $actions = PendingAction::query()
             ->where('conversation_id', $conversationId)
             ->whereIn('status', [
                 PendingActionStatus::Approved->value,
@@ -481,13 +481,13 @@ final readonly class PendingActionService
                 PendingActionStatus::Expired->value,
                 PendingActionStatus::Superseded->value,
             ])
-            ->whereNotNull('resolved_at');
-
-        if ($lastAssistantAt !== null) {
-            $query->where('resolved_at', '>', $lastAssistantAt);
-        }
-
-        $actions = $query->oldest('resolved_at')->limit(20)->get();
+            ->whereNotNull('resolved_at')
+            ->latest('resolved_at')
+            ->orderByDesc('id')
+            ->limit(20)
+            ->get()
+            ->reverse()
+            ->values();
 
         return array_values(array_map(fn (PendingAction $action): array => [
             'operation' => $action->operation->value,
@@ -514,16 +514,6 @@ final readonly class PendingActionService
         }
 
         return null;
-    }
-
-    private function lastAssistantMessageAt(string $conversationId): ?string
-    {
-        return DB::table('agent_conversation_messages')
-            ->where('conversation_id', $conversationId)
-            ->where('role', 'assistant')
-            ->latest('created_at')
-            ->orderByDesc('id')
-            ->value('created_at');
     }
 
     private function resolveResultRecordId(PendingAction $action): ?string

--- a/resources/views/home/partials/hero-agent-composer.blade.php
+++ b/resources/views/home/partials/hero-agent-composer.blade.php
@@ -9,35 +9,38 @@
             <span>Review before continuing</span>
         </div>
 
-        <div class="rounded-2xl border border-gray-200/80 bg-white p-4 shadow-lg shadow-gray-900/[0.04] dark:border-white/10 dark:bg-zinc-900 dark:shadow-black/20">
-            <div class="flex items-start gap-3">
-                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400" aria-hidden="true">
-                    <x-heroicon-o-pencil-square class="h-4 w-4"/>
+        {{-- Internals sit one notch below the real dock card (tile 28px, xs type,
+             compact buttons): the frame depicts the app at ~0.7 scale, so
+             full-size card chrome would read oversized against the shell. --}}
+        <div class="rounded-xl border border-gray-200/80 bg-white p-3 shadow-lg shadow-gray-900/[0.04] dark:border-white/10 dark:bg-zinc-900 dark:shadow-black/20">
+            <div class="flex items-start gap-2.5">
+                <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400" aria-hidden="true">
+                    <x-heroicon-o-pencil-square class="h-3.5 w-3.5"/>
                 </div>
                 <div class="min-w-0 flex-1 pt-1">
-                    <p class="text-sm font-semibold leading-5 text-gray-900 dark:text-white">Update task "Schedule demo with Kovra Systems"</p>
+                    <p class="text-xs font-semibold leading-5 text-gray-900 dark:text-white">Update task "Schedule demo with Kovra Systems"</p>
                 </div>
             </div>
 
-            <div class="mt-3 space-y-1.5 ps-11">
-                <div class="flex items-start gap-3">
-                    <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-zinc-400">Status</span>
-                    <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-sm">
+            <div class="mt-2.5 space-y-1 ps-9">
+                <div class="flex items-start gap-2.5">
+                    <span class="w-24 shrink-0 text-micro font-medium text-gray-500 dark:text-zinc-400">Status</span>
+                    <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-xs">
                         <span class="text-gray-400 line-through decoration-gray-300 dark:text-zinc-500 dark:decoration-zinc-600">To do</span>
-                        <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-zinc-500" aria-hidden="true"/>
+                        <x-heroicon-m-arrow-right class="h-2.5 w-2.5 text-gray-400 dark:text-zinc-500" aria-hidden="true"/>
                         <span class="font-medium text-gray-900 dark:text-white">Done</span>
                     </span>
                 </div>
             </div>
 
-            <div class="mt-4 flex items-center justify-end gap-2 border-t border-gray-100 pt-3 dark:border-white/5">
-                <button type="button" tabindex="-1" class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium text-gray-600 dark:text-zinc-300">
+            <div class="mt-3 flex items-center justify-end gap-2 border-t border-gray-100 pt-2.5 dark:border-white/5">
+                <button type="button" tabindex="-1" class="inline-flex items-center rounded-lg px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-zinc-300">
                     Discard
                 </button>
-                <button id="hero-approve-btn" type="button" tabindex="-1" class="inline-flex items-center gap-1.5 rounded-lg bg-primary-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm">
-                    <x-heroicon-o-check class="h-3.5 w-3.5" aria-hidden="true"/>
+                <button id="hero-approve-btn" type="button" tabindex="-1" class="inline-flex items-center gap-1 rounded-lg bg-primary-600 px-3 py-1.5 text-xs font-semibold text-white shadow-sm">
+                    <x-heroicon-o-check class="h-3 w-3" aria-hidden="true"/>
                     <span>Save changes</span>
-                    <kbd class="hidden rounded bg-white/20 px-1 font-sans text-[10px] sm:inline">&#8984;&#9166;</kbd>
+                    <kbd class="hidden rounded bg-white/20 px-1 font-sans text-pico sm:inline">&#8984;&#9166;</kbd>
                 </button>
             </div>
         </div>

--- a/resources/views/home/partials/hero-agent-composer.blade.php
+++ b/resources/views/home/partials/hero-agent-composer.blade.php
@@ -1,15 +1,15 @@
 {{-- Composer — card-style 2-row layout, mirrors real chat-interface composer --}}
-<div class="border-t border-gray-200 bg-white px-4 py-4 dark:border-gray-700 dark:bg-gray-900">
+<div class="border-t border-gray-200 bg-white px-4 py-4 dark:border-zinc-700 dark:bg-zinc-900">
     {{-- Docked proposal — mirrors the real pending-proposal dock that replaces the
          composer while a write awaits review. Display is toggled by the heroChat
          script (swap with .mcp-input); opacity is animated separately. --}}
     <div id="hero-dock" class="mcp-dock mx-auto w-full max-w-3xl" style="display: none; opacity: 0;">
-        <div class="mb-2 flex items-center gap-1.5 text-micro font-medium text-gray-500 dark:text-gray-400">
+        <div class="mb-2 flex items-center gap-1.5 text-micro font-medium text-gray-500 dark:text-zinc-400">
             <x-heroicon-o-sparkles class="h-3.5 w-3.5 text-primary-500 dark:text-primary-400"/>
             <span>Review before continuing</span>
         </div>
 
-        <div class="rounded-2xl border border-gray-200/80 bg-white p-4 shadow-lg shadow-gray-900/[0.04] dark:border-white/10 dark:bg-gray-900 dark:shadow-black/20">
+        <div class="rounded-2xl border border-gray-200/80 bg-white p-4 shadow-lg shadow-gray-900/[0.04] dark:border-white/10 dark:bg-zinc-900 dark:shadow-black/20">
             <div class="flex items-start gap-3">
                 <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400" aria-hidden="true">
                     <x-heroicon-o-pencil-square class="h-4 w-4"/>
@@ -21,17 +21,17 @@
 
             <div class="mt-3 space-y-1.5 ps-11">
                 <div class="flex items-start gap-3">
-                    <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-gray-400">Status</span>
+                    <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-zinc-400">Status</span>
                     <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-sm">
-                        <span class="text-gray-400 line-through decoration-gray-300 dark:text-gray-500 dark:decoration-gray-600">To do</span>
-                        <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-gray-500" aria-hidden="true"/>
+                        <span class="text-gray-400 line-through decoration-gray-300 dark:text-zinc-500 dark:decoration-zinc-600">To do</span>
+                        <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-zinc-500" aria-hidden="true"/>
                         <span class="font-medium text-gray-900 dark:text-white">Done</span>
                     </span>
                 </div>
             </div>
 
             <div class="mt-4 flex items-center justify-end gap-2 border-t border-gray-100 pt-3 dark:border-white/5">
-                <button type="button" tabindex="-1" class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300">
+                <button type="button" tabindex="-1" class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium text-gray-600 dark:text-zinc-300">
                     Discard
                 </button>
                 <button id="hero-approve-btn" type="button" tabindex="-1" class="inline-flex items-center gap-1.5 rounded-lg bg-primary-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm">
@@ -44,11 +44,11 @@
     </div>
 
     <div class="mcp-el mcp-input mx-auto w-full max-w-3xl">
-        <div class="relative rounded-2xl border border-gray-200 bg-white transition-colors focus-within:border-primary-500 dark:border-gray-700 dark:bg-gray-800">
+        <div class="relative rounded-2xl border border-gray-200 bg-white transition-colors focus-within:border-primary-500 dark:border-zinc-700 dark:bg-zinc-800">
             {{-- Editor row — placeholder anchored top-left; remaining space mimics a multi-line text input. --}}
             <div class="px-4 pt-3.5 pb-1.5 min-h-[60px] text-sm leading-snug">
-                <span id="hero-composer-placeholder" class="hero-composer-placeholder text-gray-400 dark:text-gray-500">Ask anything…</span>
-                <span id="hero-composer-typed" class="hero-composer-typed text-gray-900 dark:text-gray-100"></span>
+                <span id="hero-composer-placeholder" class="hero-composer-placeholder text-gray-400 dark:text-zinc-500">Ask anything…</span>
+                <span id="hero-composer-typed" class="hero-composer-typed text-gray-900 dark:text-zinc-100"></span>
                 <span id="hero-composer-cursor" class="hero-composer-cursor inline-block w-px h-4 align-middle bg-primary/60 dark:bg-primary/80 ml-px" aria-hidden="true"></span>
             </div>
 
@@ -57,7 +57,7 @@
             <div class="flex items-center justify-between gap-2 px-3 pb-2.5">
                 <div class="flex-1"></div>
                 <div class="flex items-center gap-2">
-                    <button type="button" tabindex="-1" class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-pico font-medium text-gray-500 dark:text-gray-400">
+                    <button type="button" tabindex="-1" class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-pico font-medium text-gray-500 dark:text-zinc-400">
                         <span>Auto</span>
                         <x-heroicon-o-chevron-down class="w-3 h-3"/>
                     </button>

--- a/resources/views/home/partials/hero-agent-composer.blade.php
+++ b/resources/views/home/partials/hero-agent-composer.blade.php
@@ -1,5 +1,48 @@
 {{-- Composer — card-style 2-row layout, mirrors real chat-interface composer --}}
 <div class="border-t border-gray-200 bg-white px-4 py-4 dark:border-gray-700 dark:bg-gray-900">
+    {{-- Docked proposal — mirrors the real pending-proposal dock that replaces the
+         composer while a write awaits review. Display is toggled by the heroChat
+         script (swap with .mcp-input); opacity is animated separately. --}}
+    <div id="hero-dock" class="mcp-dock mx-auto w-full max-w-3xl" style="display: none; opacity: 0;">
+        <div class="mb-2 flex items-center gap-1.5 text-micro font-medium text-gray-500 dark:text-gray-400">
+            <x-heroicon-o-sparkles class="h-3.5 w-3.5 text-primary-500 dark:text-primary-400"/>
+            <span>Review before continuing</span>
+        </div>
+
+        <div class="rounded-2xl border border-gray-200/80 bg-white p-4 shadow-lg shadow-gray-900/[0.04] dark:border-white/10 dark:bg-gray-900 dark:shadow-black/20">
+            <div class="flex items-start gap-3">
+                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400" aria-hidden="true">
+                    <x-heroicon-o-pencil-square class="h-4 w-4"/>
+                </div>
+                <div class="min-w-0 flex-1 pt-1">
+                    <p class="text-sm font-semibold leading-5 text-gray-900 dark:text-white">Update task "Schedule demo with Kovra Systems"</p>
+                </div>
+            </div>
+
+            <div class="mt-3 space-y-1.5 ps-11">
+                <div class="flex items-start gap-3">
+                    <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-gray-400">Status</span>
+                    <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-sm">
+                        <span class="text-gray-400 line-through decoration-gray-300 dark:text-gray-500 dark:decoration-gray-600">To do</span>
+                        <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-gray-500" aria-hidden="true"/>
+                        <span class="font-medium text-gray-900 dark:text-white">Done</span>
+                    </span>
+                </div>
+            </div>
+
+            <div class="mt-4 flex items-center justify-end gap-2 border-t border-gray-100 pt-3 dark:border-white/5">
+                <button type="button" tabindex="-1" class="inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300">
+                    Discard
+                </button>
+                <button id="hero-approve-btn" type="button" tabindex="-1" class="inline-flex items-center gap-1.5 rounded-lg bg-primary-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm">
+                    <x-heroicon-o-check class="h-3.5 w-3.5" aria-hidden="true"/>
+                    <span>Save changes</span>
+                    <kbd class="hidden rounded bg-white/20 px-1 font-sans text-[10px] sm:inline">&#8984;&#9166;</kbd>
+                </button>
+            </div>
+        </div>
+    </div>
+
     <div class="mcp-el mcp-input mx-auto w-full max-w-3xl">
         <div class="relative rounded-2xl border border-gray-200 bg-white transition-colors focus-within:border-primary-500 dark:border-gray-700 dark:bg-gray-800">
             {{-- Editor row — placeholder anchored top-left; remaining space mimics a multi-line text input. --}}

--- a/resources/views/home/partials/hero-agent-conversation.blade.php
+++ b/resources/views/home/partials/hero-agent-conversation.blade.php
@@ -85,23 +85,24 @@
     </div>
 
     {{-- Audit card — appears once the docked proposal is saved, exactly like the
-         real transcript's finalized proposal card. --}}
-    <div class="mcp-el mcp-audit-card w-full max-w-[85%] rounded-xl border border-gray-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900" aria-hidden="true">
-        <div class="flex items-start gap-3">
-            <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400">
-                <x-heroicon-o-pencil-square class="h-4 w-4"/>
+         real transcript's finalized proposal card. Internals compacted one notch
+         to the frame's scale, matching the docked card in hero-agent-composer. --}}
+    <div class="mcp-el mcp-audit-card w-full max-w-[85%] rounded-xl border border-gray-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900" aria-hidden="true">
+        <div class="flex items-start gap-2.5">
+            <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400">
+                <x-heroicon-o-pencil-square class="h-3.5 w-3.5"/>
             </div>
             <div class="min-w-0 flex-1 pt-1">
-                <p class="text-sm font-semibold leading-5 text-gray-900 dark:text-white">Update task "Schedule demo with Kovra Systems"</p>
+                <p class="text-xs font-semibold leading-5 text-gray-900 dark:text-white">Update task "Schedule demo with Kovra Systems"</p>
             </div>
-            <span class="mt-0.5 inline-flex shrink-0 items-center rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-400/10 dark:text-green-400">Approved</span>
+            <span class="mt-0.5 inline-flex shrink-0 items-center rounded-full bg-green-50 px-1.5 py-0.5 text-micro font-medium text-green-700 dark:bg-green-400/10 dark:text-green-400">Approved</span>
         </div>
-        <div class="mt-3 space-y-1.5 ps-11">
-            <div class="flex items-start gap-3">
-                <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-zinc-400">Status</span>
-                <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-sm">
+        <div class="mt-2.5 space-y-1 ps-9">
+            <div class="flex items-start gap-2.5">
+                <span class="w-24 shrink-0 text-micro font-medium text-gray-500 dark:text-zinc-400">Status</span>
+                <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-xs">
                     <span class="text-gray-400 line-through decoration-gray-300 dark:text-zinc-500 dark:decoration-zinc-600">To do</span>
-                    <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-zinc-500"/>
+                    <x-heroicon-m-arrow-right class="h-2.5 w-2.5 text-gray-400 dark:text-zinc-500"/>
                     <span class="font-medium text-gray-900 dark:text-white">Done</span>
                 </span>
             </div>

--- a/resources/views/home/partials/hero-agent-conversation.blade.php
+++ b/resources/views/home/partials/hero-agent-conversation.blade.php
@@ -66,55 +66,54 @@
     </div>
 </div>
 
-{{-- Exchange 2: destructive op gated by approval (climax) --}}
+{{-- Exchange 2: a write gated by review (climax). The proposal docks at the
+     composer (see hero-agent-composer.blade.php); once "saved", the audit card
+     and the agent outcome land here — mirroring the real transcript. --}}
 <div class="mcp-el mcp-user mcp-user-2 flex justify-end">
     <div class="max-w-[80%] rounded-2xl rounded-br-md bg-primary-600 px-4 py-3 text-sm text-white">
-        Mark them all as done.
+        Mark the Kovra demo as done.
     </div>
 </div>
 
-<div class="flex flex-col items-start gap-3">
+<div class="flex w-full flex-col items-start gap-3">
     <div class="mcp-el mcp-avatar mcp-avatar-2 max-w-[85%] rounded-2xl rounded-bl-md bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700">
         <span class="mcp-el mcp-label mcp-label-2 sr-only">Assistant</span>
 
         <div class="mcp-el mcp-text mcp-text-2 leading-relaxed text-gray-700 dark:text-gray-200">
-            I'll mark 3 tasks complete. Confirm to proceed.
+            Review the proposal below to update the task.
         </div>
     </div>
 
-    {{-- Pending action card — sibling of the bubble (matches real app pattern) --}}
-    <div class="mcp-el mcp-action-card max-w-[85%] rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900" aria-hidden="true">
-        <div class="flex items-center gap-2">
-            <span class="inline-flex items-center rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 dark:bg-amber-900/20 dark:text-amber-400">Update</span>
-            <span class="text-sm font-medium text-gray-900 dark:text-white">Mark 3 tasks complete</span>
+    {{-- Audit card — appears once the docked proposal is saved, exactly like the
+         real transcript's finalized proposal card. --}}
+    <div class="mcp-el mcp-audit-card w-full max-w-[85%] rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900" aria-hidden="true">
+        <div class="flex items-start gap-3">
+            <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400">
+                <x-heroicon-o-pencil-square class="h-4 w-4"/>
+            </div>
+            <div class="min-w-0 flex-1 pt-1">
+                <p class="text-sm font-semibold leading-5 text-gray-900 dark:text-white">Update task "Schedule demo with Kovra Systems"</p>
+            </div>
+            <span class="mt-0.5 inline-flex shrink-0 items-center rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-400/10 dark:text-green-400">Approved</span>
         </div>
-        <div class="mt-2 space-y-1">
-            <div class="flex gap-2 text-sm">
-                <span class="font-medium text-gray-500 dark:text-gray-400">Tasks:</span>
-                <span class="text-gray-900 dark:text-white">Call Sarah Chen · Send proposal · Schedule demo</span>
+        <div class="mt-3 space-y-1.5 ps-11">
+            <div class="flex items-start gap-3">
+                <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-gray-400">Status</span>
+                <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-sm">
+                    <span class="text-gray-400 line-through decoration-gray-300 dark:text-gray-500 dark:decoration-gray-600">To do</span>
+                    <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-gray-500"/>
+                    <span class="font-medium text-gray-900 dark:text-white">Done</span>
+                </span>
             </div>
         </div>
-        {{-- Grid-stack the pending buttons and the confirmed state in one cell
-             so the row sizes to whichever is taller (the confirmation can wrap
-             on narrow widths) and the two cross-fade without overlap. --}}
-        <div class="mt-3 grid">
-            <div class="mcp-approve-actions col-start-1 row-start-1 flex items-center gap-2">
-                <button id="hero-approve-btn" type="button" tabindex="-1" class="inline-flex items-center gap-1 rounded-lg bg-green-600 px-3 py-1.5 text-xs font-medium text-white">
-                    <x-heroicon-o-check class="w-3.5 h-3.5"/>
-                    Approve
-                </button>
-                <button type="button" tabindex="-1" class="inline-flex items-center gap-1 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white">
-                    <x-heroicon-o-x-mark class="w-3.5 h-3.5"/>
-                    Reject
-                </button>
-            </div>
-            {{-- Confirmed state — cross-fades in over the buttons once the
-                 approval resolves, so the safe-approval flow reads end-to-end
-                 instead of leaving a pending card behind. --}}
-            <div class="mcp-el mcp-approve-done col-start-1 row-start-1 flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400" aria-hidden="true">
-                <x-heroicon-o-check-circle class="w-4 h-4 shrink-0"/>
-                <span>Approved · 3 tasks marked complete</span>
-            </div>
+    </div>
+
+    {{-- Agent outcome — the sparkle summary bubble the real app renders below
+         a finalized proposal. --}}
+    <div class="mcp-el mcp-approve-done flex justify-start" aria-hidden="true">
+        <div class="inline-flex max-w-full items-start gap-1.5 rounded-2xl rounded-bl-md bg-white px-3 py-2 text-sm text-gray-700 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-700">
+            <x-heroicon-o-sparkles class="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary-500"/>
+            <span>Updated Schedule demo with Kovra Systems.</span>
         </div>
     </div>
 </div>

--- a/resources/views/home/partials/hero-agent-conversation.blade.php
+++ b/resources/views/home/partials/hero-agent-conversation.blade.php
@@ -11,17 +11,17 @@
      paywall cards render as SIBLINGS of the assistant bubble, not nested
      inside it. Avoids the card-in-card feel. --}}
 <div class="flex flex-col items-start gap-3">
-    <div class="mcp-el mcp-avatar mcp-avatar-1 max-w-[85%] rounded-2xl rounded-bl-md bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700">
+    <div class="mcp-el mcp-avatar mcp-avatar-1 max-w-[85%] rounded-2xl rounded-bl-md bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:text-zinc-100 dark:ring-zinc-700">
         {{-- Empty label spacer so existing animation target stays valid --}}
         <span class="mcp-el mcp-label mcp-label-1 sr-only">Assistant</span>
 
         <div class="mcp-el mcp-tool mcp-tool-1 flex items-center gap-2 text-micro">
-            <span class="h-1.5 w-1.5 rounded-full bg-gray-400 motion-safe:animate-pulse dark:bg-gray-500" aria-hidden="true"></span>
-            <span class="font-medium text-gray-600 dark:text-gray-300">Searching tasks…</span>
+            <span class="h-1.5 w-1.5 rounded-full bg-gray-400 motion-safe:animate-pulse dark:bg-zinc-500" aria-hidden="true"></span>
+            <span class="font-medium text-gray-600 dark:text-zinc-300">Searching tasks…</span>
             <span class="mcp-el mcp-tool-done text-emerald-600 dark:text-emerald-400 font-medium">done</span>
         </div>
 
-        <div class="mcp-el mcp-text mcp-text-1 mt-2 leading-relaxed text-gray-700 dark:text-gray-200">
+        <div class="mcp-el mcp-text mcp-text-1 mt-2 leading-relaxed text-gray-700 dark:text-zinc-200">
             You have 3 overdue tasks:
         </div>
     </div>
@@ -30,34 +30,34 @@
          one container, rows separated by a hairline divider.
          mcp-el keeps the container hidden during reset so its outline doesn't
          ghost through before exchange 1 begins. --}}
-    <div class="mcp-el mcp-tasks-table max-w-[85%] overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-        <div class="divide-y divide-gray-100 dark:divide-gray-700">
+    <div class="mcp-el mcp-tasks-table max-w-[85%] overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-zinc-700 dark:bg-zinc-800">
+        <div class="divide-y divide-gray-100 dark:divide-zinc-700">
             <div class="mcp-el mcp-task-card mcp-task-1 flex items-center justify-between gap-3 px-3 py-2.5">
                 <div class="flex items-center gap-2.5 min-w-0">
-                    <x-heroicon-o-stop-circle class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 shrink-0"/>
+                    <x-heroicon-o-stop-circle class="w-3.5 h-3.5 text-gray-400 dark:text-zinc-500 shrink-0"/>
                     <div>
                         <div class="text-sm font-medium text-gray-900 dark:text-white">Call Sarah Chen</div>
-                        <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Due yesterday · Kovra Systems</div>
+                        <div class="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">Due yesterday · Kovra Systems</div>
                     </div>
                 </div>
                 <span class="shrink-0 text-pico font-medium text-rose-600 dark:text-rose-400 uppercase tracking-wider">Overdue</span>
             </div>
             <div class="mcp-el mcp-task-card mcp-task-2 flex items-center justify-between gap-3 px-3 py-2.5">
                 <div class="flex items-center gap-2.5 min-w-0">
-                    <x-heroicon-o-stop-circle class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 shrink-0"/>
+                    <x-heroicon-o-stop-circle class="w-3.5 h-3.5 text-gray-400 dark:text-zinc-500 shrink-0"/>
                     <div>
                         <div class="text-sm font-medium text-gray-900 dark:text-white">Send proposal to Trellis Labs</div>
-                        <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Due 2 days ago · Trellis Labs</div>
+                        <div class="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">Due 2 days ago · Trellis Labs</div>
                     </div>
                 </div>
                 <span class="shrink-0 text-pico font-medium text-rose-600 dark:text-rose-400 uppercase tracking-wider">Overdue</span>
             </div>
             <div class="mcp-el mcp-task-card mcp-task-3 flex items-center justify-between gap-3 px-3 py-2.5">
                 <div class="flex items-center gap-2.5 min-w-0">
-                    <x-heroicon-o-stop-circle class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 shrink-0"/>
+                    <x-heroicon-o-stop-circle class="w-3.5 h-3.5 text-gray-400 dark:text-zinc-500 shrink-0"/>
                     <div>
                         <div class="text-sm font-medium text-gray-900 dark:text-white">Schedule demo with Kovra Systems</div>
-                        <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Due 3 days ago · Kovra Systems</div>
+                        <div class="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">Due 3 days ago · Kovra Systems</div>
                     </div>
                 </div>
                 <span class="shrink-0 text-pico font-medium text-rose-600 dark:text-rose-400 uppercase tracking-wider">Overdue</span>
@@ -76,17 +76,17 @@
 </div>
 
 <div class="flex w-full flex-col items-start gap-3">
-    <div class="mcp-el mcp-avatar mcp-avatar-2 max-w-[85%] rounded-2xl rounded-bl-md bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700">
+    <div class="mcp-el mcp-avatar mcp-avatar-2 max-w-[85%] rounded-2xl rounded-bl-md bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:text-zinc-100 dark:ring-zinc-700">
         <span class="mcp-el mcp-label mcp-label-2 sr-only">Assistant</span>
 
-        <div class="mcp-el mcp-text mcp-text-2 leading-relaxed text-gray-700 dark:text-gray-200">
+        <div class="mcp-el mcp-text mcp-text-2 leading-relaxed text-gray-700 dark:text-zinc-200">
             Review the proposal below to update the task.
         </div>
     </div>
 
     {{-- Audit card — appears once the docked proposal is saved, exactly like the
          real transcript's finalized proposal card. --}}
-    <div class="mcp-el mcp-audit-card w-full max-w-[85%] rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900" aria-hidden="true">
+    <div class="mcp-el mcp-audit-card w-full max-w-[85%] rounded-xl border border-gray-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900" aria-hidden="true">
         <div class="flex items-start gap-3">
             <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400">
                 <x-heroicon-o-pencil-square class="h-4 w-4"/>
@@ -98,10 +98,10 @@
         </div>
         <div class="mt-3 space-y-1.5 ps-11">
             <div class="flex items-start gap-3">
-                <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-gray-400">Status</span>
+                <span class="w-28 shrink-0 pt-0.5 text-xs font-medium leading-5 text-gray-500 sm:w-32 dark:text-zinc-400">Status</span>
                 <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 text-sm">
-                    <span class="text-gray-400 line-through decoration-gray-300 dark:text-gray-500 dark:decoration-gray-600">To do</span>
-                    <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-gray-500"/>
+                    <span class="text-gray-400 line-through decoration-gray-300 dark:text-zinc-500 dark:decoration-zinc-600">To do</span>
+                    <x-heroicon-m-arrow-right class="h-3 w-3 text-gray-400 dark:text-zinc-500"/>
                     <span class="font-medium text-gray-900 dark:text-white">Done</span>
                 </span>
             </div>
@@ -111,7 +111,7 @@
     {{-- Agent outcome — the sparkle summary bubble the real app renders below
          a finalized proposal. --}}
     <div class="mcp-el mcp-approve-done flex justify-start" aria-hidden="true">
-        <div class="inline-flex max-w-full items-start gap-1.5 rounded-2xl rounded-bl-md bg-white px-3 py-2 text-sm text-gray-700 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-700">
+        <div class="inline-flex max-w-full items-start gap-1.5 rounded-2xl rounded-bl-md bg-white px-3 py-2 text-sm text-gray-700 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-700">
             <x-heroicon-o-sparkles class="mt-0.5 h-3.5 w-3.5 shrink-0 text-primary-500"/>
             <span>Updated Schedule demo with Kovra Systems.</span>
         </div>
@@ -126,26 +126,26 @@
 </div>
 
 <div class="flex flex-col items-start gap-3">
-    <div class="mcp-el mcp-avatar mcp-avatar-3 max-w-[85%] rounded-2xl rounded-bl-md bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700">
+    <div class="mcp-el mcp-avatar mcp-avatar-3 max-w-[85%] rounded-2xl rounded-bl-md bg-white px-4 py-3 text-sm text-gray-900 shadow-sm ring-1 ring-gray-200 dark:bg-zinc-800 dark:text-zinc-100 dark:ring-zinc-700">
         <span class="mcp-el mcp-label mcp-label-3 sr-only">Assistant</span>
 
         <div class="mcp-el mcp-tool mcp-tool-3 flex items-center gap-2 text-micro">
-            <span class="h-1.5 w-1.5 rounded-full bg-gray-400 motion-safe:animate-pulse dark:bg-gray-500" aria-hidden="true"></span>
-            <span class="font-medium text-gray-600 dark:text-gray-300">Creating contact…</span>
+            <span class="h-1.5 w-1.5 rounded-full bg-gray-400 motion-safe:animate-pulse dark:bg-zinc-500" aria-hidden="true"></span>
+            <span class="font-medium text-gray-600 dark:text-zinc-300">Creating contact…</span>
             <span class="mcp-el mcp-tool-done text-emerald-600 dark:text-emerald-400 font-medium">done</span>
         </div>
 
-        <div class="mcp-el mcp-text mcp-text-3 mt-2 leading-relaxed text-gray-700 dark:text-gray-200">
+        <div class="mcp-el mcp-text mcp-text-3 mt-2 leading-relaxed text-gray-700 dark:text-zinc-200">
             Added Sarah and linked her to Kovra Systems.
         </div>
     </div>
 
     {{-- Created record card — sibling of the bubble --}}
-    <div class="mcp-el mcp-card max-w-[85%] rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-900">
+    <div class="mcp-el mcp-card max-w-[85%] rounded-xl border border-gray-200 bg-white p-3 dark:border-zinc-700 dark:bg-zinc-900">
         <div class="flex items-center justify-between">
             <div>
                 <div class="text-sm font-semibold text-gray-900 dark:text-white">Sarah Chen</div>
-                <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">VP of Engineering · Kovra Systems</div>
+                <div class="text-xs text-gray-500 dark:text-zinc-400 mt-0.5">VP of Engineering · Kovra Systems</div>
             </div>
             <div class="flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-rose-400 to-orange-300 dark:from-rose-500 dark:to-orange-400 shrink-0">
                 <span class="text-pico font-bold text-white">SC</span>

--- a/resources/views/home/partials/hero-agent-entry.blade.php
+++ b/resources/views/home/partials/hero-agent-entry.blade.php
@@ -5,7 +5,7 @@
      Visibility is driven by .mcp-el rule (opacity: 0 at rest) and the
      heroChat factory; no x-show so the markup is also visible to the SEO
      crawler and to no-JS users alongside the conversation. --}}
-<div class="hero-agent-entry mcp-el absolute inset-0 z-20 flex items-start justify-center bg-gray-50 dark:bg-gray-950 px-4 sm:px-6 md:px-8 overflow-hidden">
+<div class="hero-agent-entry mcp-el absolute inset-x-0 bottom-0 top-10 z-20 flex items-start justify-center bg-gray-50 dark:bg-gray-950 px-4 sm:px-6 md:px-8 overflow-hidden">
     {{-- pt-12/pt-20 mirrors the real dashboard's `py-16` while leaving headroom
          on the shorter mobile panel (h-[520px]). max-w-2xl keeps the composer
          readable without dominating the panel. --}}
@@ -47,18 +47,14 @@
             </div>
         </div>
 
-        {{-- Example prompts — three chips spotlighting what users can ask.
-             Stack on the smallest widths so they don't crowd. --}}
+        {{-- Starter chips — the real dashboard's four starter prompts, same
+             pill recipe as chat-interface's starters. --}}
         <div class="mcp-el mcp-entry-chips mt-5 flex flex-wrap justify-center gap-2 text-xs">
-            <span class="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                What's overdue this week?
-            </span>
-            <span class="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                Show this week's pipeline
-            </span>
-            <span class="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                Add a new contact
-            </span>
+            @foreach (['CRM overview', 'Overdue tasks', 'Recent companies', 'Pipeline summary'] as $heroStarterChip)
+                <span class="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                    {{ $heroStarterChip }}
+                </span>
+            @endforeach
         </div>
 
         {{-- My Tasks (empty state) — mirrors chat::filament.pages.partials.my-tasks,

--- a/resources/views/home/partials/hero-agent-entry.blade.php
+++ b/resources/views/home/partials/hero-agent-entry.blade.php
@@ -5,7 +5,7 @@
      Visibility is driven by .mcp-el rule (opacity: 0 at rest) and the
      heroChat factory; no x-show so the markup is also visible to the SEO
      crawler and to no-JS users alongside the conversation. --}}
-<div class="hero-agent-entry mcp-el absolute inset-x-0 bottom-0 top-10 z-20 flex items-start justify-center bg-gray-50 dark:bg-gray-950 px-4 sm:px-6 md:px-8 overflow-hidden">
+<div class="hero-agent-entry mcp-el absolute inset-x-0 bottom-0 top-10 z-20 flex items-start justify-center bg-gray-50 dark:bg-zinc-950 px-4 sm:px-6 md:px-8 overflow-hidden">
     {{-- pt-12/pt-20 mirrors the real dashboard's `py-16` while leaving headroom
          on the shorter mobile panel (h-[520px]). max-w-2xl keeps the composer
          readable without dominating the panel. --}}
@@ -16,7 +16,7 @@
                 Good morning, Marcus.
             </h2>
 
-            <div class="mcp-el mcp-entry-recent mt-2 inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+            <div class="mcp-el mcp-entry-recent mt-2 inline-flex items-center gap-1.5 text-xs sm:text-sm text-gray-500 dark:text-zinc-400">
                 <x-heroicon-o-arrow-path class="h-3.5 w-3.5"/>
                 <span>Recent chat · This week's pipeline review</span>
             </div>
@@ -25,17 +25,17 @@
         {{-- Composer twin — identical to hero-agent-composer.blade.php but
              with entry-scoped IDs so the JS factory can target it independently. --}}
         <div class="mcp-el mcp-entry-composer mt-8 sm:mt-10">
-            <div class="relative rounded-2xl border border-gray-200 bg-white transition-colors focus-within:border-primary-500 dark:border-gray-700 dark:bg-gray-800">
+            <div class="relative rounded-2xl border border-gray-200 bg-white transition-colors focus-within:border-primary-500 dark:border-zinc-700 dark:bg-zinc-800">
                 <div class="px-4 pt-3.5 pb-1.5 min-h-[60px] text-sm leading-snug">
-                    <span id="hero-entry-placeholder" class="hero-composer-placeholder text-gray-400 dark:text-gray-500">Ask anything…</span>
-                    <span id="hero-entry-typed" class="hero-composer-typed text-gray-900 dark:text-gray-100"></span>
+                    <span id="hero-entry-placeholder" class="hero-composer-placeholder text-gray-400 dark:text-zinc-500">Ask anything…</span>
+                    <span id="hero-entry-typed" class="hero-composer-typed text-gray-900 dark:text-zinc-100"></span>
                     <span class="hero-composer-cursor inline-block w-px h-4 align-middle bg-primary/60 dark:bg-primary/80 ml-px" aria-hidden="true"></span>
                 </div>
 
                 <div class="flex items-center justify-between gap-2 px-3 pb-2.5">
                     <div class="flex-1"></div>
                     <div class="flex items-center gap-2">
-                        <button type="button" tabindex="-1" class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-pico font-medium text-gray-500 dark:text-gray-400">
+                        <button type="button" tabindex="-1" class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-pico font-medium text-gray-500 dark:text-zinc-400">
                             <span>Auto</span>
                             <x-heroicon-o-chevron-down class="w-3 h-3"/>
                         </button>
@@ -51,7 +51,7 @@
              pill recipe as chat-interface's starters. --}}
         <div class="mcp-el mcp-entry-chips mt-5 flex flex-wrap justify-center gap-2 text-xs">
             @foreach (['CRM overview', 'Overdue tasks', 'Recent companies', 'Pipeline summary'] as $heroStarterChip)
-                <span class="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                <span class="inline-flex items-center rounded-full border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
                     {{ $heroStarterChip }}
                 </span>
             @endforeach
@@ -62,16 +62,16 @@
              the whole preview is non-interactive. --}}
         <div class="mcp-el mcp-entry-tasks mt-10 text-start">
             <div class="mb-3 flex items-center justify-between">
-                <h3 class="flex items-baseline gap-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                <h3 class="flex items-baseline gap-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-zinc-400">
                     <span>Tasks</span>
-                    <span class="text-gray-400 dark:text-gray-500">0</span>
+                    <span class="text-gray-400 dark:text-zinc-500">0</span>
                 </h3>
-                <span class="text-xs text-gray-500 dark:text-gray-400">View all</span>
+                <span class="text-xs text-gray-500 dark:text-zinc-400">View all</span>
             </div>
 
-            <div class="rounded-xl border border-dashed border-gray-200 bg-white px-6 py-8 text-center dark:border-gray-700 dark:bg-gray-800">
+            <div class="rounded-xl border border-dashed border-gray-200 bg-white px-6 py-8 text-center dark:border-zinc-700 dark:bg-zinc-800">
                 <p class="text-sm font-medium text-gray-900 dark:text-white">Stay on top of work</p>
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Create tasks for yourself or your team to track next steps</p>
+                <p class="mt-1 text-xs text-gray-500 dark:text-zinc-400">Create tasks for yourself or your team to track next steps</p>
                 <div class="mt-4 flex justify-center">
                     <span class="inline-flex items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-1.5 text-xs font-medium text-white">
                         <x-heroicon-o-plus class="h-3.5 w-3.5"/>

--- a/resources/views/home/partials/hero-agent-preview.blade.php
+++ b/resources/views/home/partials/hero-agent-preview.blade.php
@@ -27,7 +27,7 @@
 <div x-data="heroChat()"
      @hero-chat-reset.window="cancelInflight(); resetChat()"
      @hero-chat-animate.window="animateChat()"
-     class="hero-agent-preview relative bg-gray-50 dark:bg-gray-950 flex h-[520px] sm:h-[580px] md:h-[640px]">
+     class="hero-agent-preview relative bg-gray-50 dark:bg-zinc-950 flex h-[520px] sm:h-[580px] md:h-[640px]">
 
     {{-- Non-interactive overlay: blocks clicks, right-click, and drag.
          z-30 puts it above all panel content. --}}
@@ -48,11 +48,11 @@
              fades it out during the entry → conversation transition. Sits above
              the entry overlay (which starts at top-10) so it stays visible in
              both phases, exactly like the real shell. --}}
-        <div class="relative z-30 flex h-10 shrink-0 items-center justify-between border-b border-gray-200/60 bg-white px-3 dark:border-white/[0.06] dark:bg-gray-900">
-            <x-heroicon-o-bars-3 class="w-4 h-4 text-gray-400 md:hidden dark:text-gray-500"/>
-            <x-heroicon-o-chevron-left class="hidden w-4 h-4 text-gray-400 md:block dark:text-gray-500"/>
+        <div class="relative z-30 flex h-10 shrink-0 items-center justify-between border-b border-gray-200/60 bg-white px-3 dark:border-white/[0.06] dark:bg-zinc-900">
+            <x-heroicon-o-bars-3 class="w-4 h-4 text-gray-400 md:hidden dark:text-zinc-500"/>
+            <x-heroicon-o-chevron-left class="hidden w-4 h-4 text-gray-400 md:block dark:text-zinc-500"/>
             <div class="flex items-center gap-2">
-                <span class="mcp-topbar-ask inline-flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium text-gray-700 ring-1 ring-gray-200 dark:text-gray-200 dark:ring-white/10">
+                <span class="mcp-topbar-ask inline-flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium text-gray-700 ring-1 ring-gray-200 dark:text-zinc-200 dark:ring-white/10">
                     <x-heroicon-o-chat-bubble-left-ellipsis class="w-3.5 h-3.5" aria-hidden="true"/>
                     <span>Ask Relaticle</span>
                 </span>
@@ -136,10 +136,22 @@
                     el.style.opacity = '0';
                     el.style.transform = '';
                 });
-                var ask = this.$root.querySelector('.mcp-topbar-ask');
-                if (ask) ask.style.opacity = '';
-                this.setShellActive('home');
                 this.clearEntryComposer();
+            },
+
+            // Restore the shell chrome to its dashboard state (Home active,
+            // Ask pill back). Runs once the entry curtain is opaque over the
+            // chat column, so the sidebar/topbar change lands at the same
+            // moment the "page" changes — like a real navigation.
+            restoreShellToDashboard() {
+                this.setShellActive('home');
+                var ask = this.$root.querySelector('.mcp-topbar-ask');
+                if (!ask) return;
+                if (getComputedStyle(ask).opacity !== '1' && typeof animate === 'function') {
+                    animate(ask, { opacity: [0, 1] }, { duration: 0.3, ease: this.ease });
+                } else {
+                    ask.style.opacity = '';
+                }
             },
 
             // Swap the sidebar's active item between Home (dashboard phase) and
@@ -149,10 +161,10 @@
                 var home = this.$root.querySelector('#hero-shell-nav-home');
                 var chat = this.$root.querySelector('#hero-shell-nav-chat');
                 if (!home || !chat) return;
-                var itemOn = ['bg-gray-100', 'dark:bg-white/[0.06]', 'font-medium', 'text-primary-700', 'dark:text-primary-400'];
-                var itemOff = ['text-gray-700', 'dark:text-gray-300'];
+                var itemOn = ['bg-gray-100', 'dark:bg-zinc-800', 'font-medium', 'text-primary-700', 'dark:text-primary-400'];
+                var itemOff = ['text-gray-700', 'dark:text-zinc-200'];
                 var iconOn = ['text-primary-700', 'dark:text-primary-400'];
-                var iconOff = ['text-gray-400', 'dark:text-gray-500'];
+                var iconOff = ['text-gray-400', 'dark:text-zinc-500'];
                 var apply = function(el, active) {
                     el.classList.remove.apply(el.classList, active ? itemOff : itemOn);
                     el.classList.add.apply(el.classList, active ? itemOn : itemOff);
@@ -469,8 +481,10 @@
                 // Loop restart: the entry curtain (above) has now faded in over
                 // the previous conversation. Clear that conversation underneath
                 // once the curtain is opaque so the next cycle starts clean — no
-                // blank-panel flash. No-op on first load.
-                this.pendingTimers.push(setTimeout(function() { self.resetConversationOnly(); }, 420));
+                // blank-panel flash — and flip the shell chrome back to its
+                // dashboard state at the same "navigation" moment. No-op on
+                // first load.
+                this.pendingTimers.push(setTimeout(function() { self.resetConversationOnly(); self.restoreShellToDashboard(); }, 420));
 
                 // Type prompt 1 into the entry composer, then send.
                 var p1 = this.prompts[0];

--- a/resources/views/home/partials/hero-agent-preview.blade.php
+++ b/resources/views/home/partials/hero-agent-preview.blade.php
@@ -74,7 +74,7 @@
             // before the loop restarts.
             prompts: [
                 { text: "What's overdue this week?", charMs: 55 },
-                { text: 'Mark them all as done.', charMs: 38 },
+                { text: 'Mark the Kovra demo as done.', charMs: 38 },
                 { text: "Add Sarah Chen as a contact at @Kovra Systems. She's VP of Engineering.", charMs: 28 }
             ],
             // Entry phase budget — first prompt is typed into the centered
@@ -100,10 +100,7 @@
                     el.style.opacity = '';
                     el.style.transform = '';
                 });
-                this.$root.querySelectorAll('.mcp-approve-actions').forEach(function(el) {
-                    el.style.opacity = '';
-                    el.style.transform = '';
-                });
+                this.resetDock();
                 if (this.$refs.messagesScroll) {
                     this.$refs.messagesScroll.scrollTop = 0;
                 }
@@ -135,14 +132,69 @@
                     el.style.opacity = '';
                     el.style.transform = '';
                 });
-                this.$root.querySelectorAll('.mcp-approve-actions').forEach(function(el) {
-                    el.style.opacity = '';
-                    el.style.transform = '';
-                });
+                this.resetDock();
                 if (this.$refs.messagesScroll) {
                     this.$refs.messagesScroll.scrollTop = 0;
                 }
                 this.clearComposer();
+            },
+
+            // Restore the composer/dock swap to its rest state: dock hidden,
+            // composer input back in the flow (its opacity is owned by the
+            // .mcp-el reset/animation cycle).
+            resetDock() {
+                var dock = this.$root.querySelector('.mcp-dock');
+                if (dock) {
+                    dock.style.display = 'none';
+                    dock.style.opacity = '0';
+                    dock.style.transform = '';
+                }
+                var input = this.$root.querySelector('.mcp-input');
+                if (input) {
+                    input.style.display = '';
+                }
+            },
+
+            // Swap the composer input for the docked proposal, like the real
+            // chat does while a write awaits review.
+            showDock() {
+                var input = this.$root.querySelector('.mcp-input');
+                var dock = this.$root.querySelector('.mcp-dock');
+                if (!input || !dock) return;
+                var self = this;
+                if (typeof animate === 'function') {
+                    animate(input, { opacity: [1, 0] }, { duration: 0.18, ease: this.ease });
+                }
+                this.pendingTimers.push(setTimeout(function() {
+                    input.style.display = 'none';
+                    dock.style.display = '';
+                    if (typeof animate === 'function') {
+                        animate(dock, { opacity: [0, 1], transform: ['translateY(10px)', 'translateY(0px)'] }, { duration: 0.35, ease: self.ease });
+                    } else {
+                        dock.style.opacity = '1';
+                    }
+                }, 190));
+            },
+
+            // Resolve the review: dock slides away, composer returns.
+            hideDock() {
+                var input = this.$root.querySelector('.mcp-input');
+                var dock = this.$root.querySelector('.mcp-dock');
+                if (!input || !dock) return;
+                var self = this;
+                if (typeof animate === 'function') {
+                    animate(dock, { opacity: [1, 0], transform: ['translateY(0px)', 'translateY(4px)'] }, { duration: 0.22, ease: self.ease });
+                }
+                this.pendingTimers.push(setTimeout(function() {
+                    dock.style.display = 'none';
+                    dock.style.opacity = '0';
+                    input.style.display = '';
+                    if (typeof animate === 'function') {
+                        animate(input, { opacity: [0, 1] }, { duration: 0.25, ease: self.ease });
+                    } else {
+                        input.style.opacity = '1';
+                    }
+                }, 230));
             },
 
             clearComposer() {
@@ -233,11 +285,11 @@
             },
 
             cancelInflight() {
-                // .mcp-approve-actions isn't an .mcp-el but is animated (the
-                // approve cross-fade), so include it — otherwise its in-flight /
-                // delayed animation keeps holding opacity and overrides a static
-                // reset (e.g. the reduced-motion view after a tab switch).
-                this.$root.querySelectorAll('.mcp-el, .mcp-approve-actions').forEach(function(el) {
+                // .mcp-dock isn't an .mcp-el but is animated (the composer/dock
+                // swap), so include it — otherwise its in-flight / delayed
+                // animation keeps holding opacity and overrides a static reset
+                // (e.g. the reduced-motion view after a tab switch).
+                this.$root.querySelectorAll('.mcp-el, .mcp-dock').forEach(function(el) {
                     if (el.getAnimations) {
                         el.getAnimations().forEach(function(a) { a.cancel(); });
                     }
@@ -261,12 +313,10 @@
                 this.$root.querySelectorAll('.hero-agent-title').forEach(function(el) {
                     el.style.opacity = '1';
                 });
-                // Static view shows the resolved approval (the confirmed overlay
-                // is an .mcp-el shown above); hide the pending buttons so they
-                // don't stack underneath it.
-                this.$root.querySelectorAll('.mcp-approve-actions').forEach(function(el) {
-                    el.style.opacity = '0';
-                });
+                // Static view shows the resolved review (audit card + outcome
+                // are .mcp-el, shown above); the dock stays hidden and the
+                // composer stays in the flow.
+                this.resetDock();
                 var entry = this.$root.querySelector('.hero-agent-entry');
                 if (entry) entry.style.opacity = '0';
                 this.clearComposer();
@@ -393,10 +443,12 @@
                 // (e.g. the shorter mobile panel); a no-op when it already fits.
                 this.pendingTimers.push(setTimeout(function() { self.scrollToShow('.mcp-tasks-table'); }, conversationStart + 1300));
 
-                // ── Exchange 2: bulk approval ──
-                // The composer types while the view stays on exchange 1; the new
-                // message and its response then reveal at the bottom and the view
-                // follows each one down, leaving exchange 1 visible above.
+                // ── Exchange 2: a write gated by review ──
+                // The composer types while the view stays on exchange 1. The
+                // response then docks a proposal where the composer was — the
+                // same swap the real chat performs — and after a beat the "Save
+                // changes" press resolves it into the transcript audit card and
+                // the agent outcome bubble.
                 var p2 = this.prompts[1];
                 var typeStart2 = conversationStart + 2700;
                 this.pendingTimers.push(setTimeout(function() { self.typeIntoComposer(p2.text, p2.charMs); }, typeStart2));
@@ -408,20 +460,27 @@
                 animate(root.querySelector('.mcp-label-2'),  { opacity: [0, 1] }, { delay: (send2At + 300) / 1000, duration: 0.25, ease: ease });
                 this.pendingTimers.push(setTimeout(function() { self.scrollToShow('.mcp-avatar-2'); }, send2At + 320));
                 this.pendingTimers.push(setTimeout(function() { self.streamText('.mcp-text-2', 90); }, send2At + 300));
-                animate(root.querySelector('.mcp-action-card'), { opacity: [0, 1], transform: ['translateY(8px) scale(0.98)', 'translateY(0px) scale(1)'] }, { delay: (send2At + 750) / 1000, duration: 0.4, ease: ease });
-                this.pendingTimers.push(setTimeout(function() { self.scrollToShow('.mcp-action-card'); }, send2At + 780));
 
-                // Resolve the approval: press Approve, then cross-fade the
-                // buttons to a confirmed state. Completes the safe-approval
-                // story before the next prompt rather than leaving it pending.
-                var approveAt = send2At + 1300;
+                // The proposal docks at the composer. The dock is taller than
+                // the composer it replaces, so re-anchor the scroll once the
+                // swap lands — otherwise the assistant bubble gets clipped.
+                var dockAt = send2At + 850;
+                this.pendingTimers.push(setTimeout(function() { self.showDock(); }, dockAt));
+                this.pendingTimers.push(setTimeout(function() { self.scrollToShow('.mcp-avatar-2'); }, dockAt + 580));
+
+                // Resolve the review: press "Save changes", the dock hands back
+                // to the composer, and the audit card + outcome land inline.
+                var approveAt = dockAt + 1900;
                 this.pendingTimers.push(setTimeout(function() { self.flashButton('#hero-approve-btn'); }, approveAt));
-                animate(root.querySelector('.mcp-approve-actions'), { opacity: [1, 0] }, { delay: (approveAt + 200) / 1000, duration: 0.25, ease: ease });
-                animate(root.querySelector('.mcp-approve-done'),    { opacity: [0, 1], transform: ['translateY(3px)', 'translateY(0px)'] }, { delay: (approveAt + 340) / 1000, duration: 0.3, ease: ease });
+                this.pendingTimers.push(setTimeout(function() { self.hideDock(); }, approveAt + 220));
+                animate(root.querySelector('.mcp-audit-card'),   { opacity: [0, 1], transform: ['translateY(8px) scale(0.98)', 'translateY(0px) scale(1)'] }, { delay: (approveAt + 500) / 1000, duration: 0.4, ease: ease });
+                this.pendingTimers.push(setTimeout(function() { self.scrollToShow('.mcp-audit-card'); }, approveAt + 530));
+                animate(root.querySelector('.mcp-approve-done'), { opacity: [0, 1], transform: ['translateY(4px)', 'translateY(0px)'] }, { delay: (approveAt + 750) / 1000, duration: 0.3, ease: ease });
+                this.pendingTimers.push(setTimeout(function() { self.scrollToShow('.mcp-approve-done'); }, approveAt + 780));
 
                 // ── Exchange 3: create contact (longest prompt) ──
                 var p3 = this.prompts[2];
-                var typeStart3 = send2At + 2500;
+                var typeStart3 = approveAt + 2100;
                 this.pendingTimers.push(setTimeout(function() { self.typeIntoComposer(p3.text, p3.charMs); }, typeStart3));
                 var send3At = typeStart3 + p3.charMs * p3.text.length + 50;
                 this.pendingTimers.push(setTimeout(function() { self.flashSend(); self.clearComposer(); }, send3At));

--- a/resources/views/home/partials/hero-agent-preview.blade.php
+++ b/resources/views/home/partials/hero-agent-preview.blade.php
@@ -42,6 +42,24 @@
          keeps the sidebar visible during the entry phase too. --}}
     <div class="relative flex-1 flex flex-col min-w-0">
 
+        {{-- Topbar — mirrors the real fi-topbar: sidebar toggle on the left,
+             "Ask Relaticle" outlined trigger + user avatar on the right. The Ask
+             pill only exists on the dashboard in the real app, so the script
+             fades it out during the entry → conversation transition. Sits above
+             the entry overlay (which starts at top-10) so it stays visible in
+             both phases, exactly like the real shell. --}}
+        <div class="relative z-30 flex h-10 shrink-0 items-center justify-between border-b border-gray-200/60 bg-white px-3 dark:border-white/[0.06] dark:bg-gray-900">
+            <x-heroicon-o-bars-3 class="w-4 h-4 text-gray-400 md:hidden dark:text-gray-500"/>
+            <x-heroicon-o-chevron-left class="hidden w-4 h-4 text-gray-400 md:block dark:text-gray-500"/>
+            <div class="flex items-center gap-2">
+                <span class="mcp-topbar-ask inline-flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-xs font-medium text-gray-700 ring-1 ring-gray-200 dark:text-gray-200 dark:ring-white/10">
+                    <x-heroicon-o-chat-bubble-left-ellipsis class="w-3.5 h-3.5" aria-hidden="true"/>
+                    <span>Ask Relaticle</span>
+                </span>
+                <span class="flex h-6 w-6 items-center justify-center rounded-full bg-sky-600 text-pico font-bold text-white">MR</span>
+            </div>
+        </div>
+
         {{-- Conversation title — mirrors app chat-page H1: large, bold, left-aligned, no chrome --}}
         <div class="hero-agent-title px-4 sm:px-6 md:px-8 pt-5 pb-3">
             <h2 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white truncate">Overdue tasks this week</h2>
@@ -101,6 +119,9 @@
                     el.style.transform = '';
                 });
                 this.resetDock();
+                var ask = this.$root.querySelector('.mcp-topbar-ask');
+                if (ask) ask.style.opacity = '';
+                this.setShellActive('home');
                 if (this.$refs.messagesScroll) {
                     this.$refs.messagesScroll.scrollTop = 0;
                 }
@@ -115,7 +136,34 @@
                     el.style.opacity = '0';
                     el.style.transform = '';
                 });
+                var ask = this.$root.querySelector('.mcp-topbar-ask');
+                if (ask) ask.style.opacity = '';
+                this.setShellActive('home');
                 this.clearEntryComposer();
+            },
+
+            // Swap the sidebar's active item between Home (dashboard phase) and
+            // the demo conversation, mirroring how the real shell highlights the
+            // current page. Labels and icons both carry the active primary tone.
+            setShellActive(which) {
+                var home = this.$root.querySelector('#hero-shell-nav-home');
+                var chat = this.$root.querySelector('#hero-shell-nav-chat');
+                if (!home || !chat) return;
+                var itemOn = ['bg-gray-100', 'dark:bg-white/[0.06]', 'font-medium', 'text-primary-700', 'dark:text-primary-400'];
+                var itemOff = ['text-gray-700', 'dark:text-gray-300'];
+                var iconOn = ['text-primary-700', 'dark:text-primary-400'];
+                var iconOff = ['text-gray-400', 'dark:text-gray-500'];
+                var apply = function(el, active) {
+                    el.classList.remove.apply(el.classList, active ? itemOff : itemOn);
+                    el.classList.add.apply(el.classList, active ? itemOn : itemOff);
+                    var icon = el.querySelector('svg');
+                    if (icon) {
+                        icon.classList.remove.apply(icon.classList, active ? iconOff : iconOn);
+                        icon.classList.add.apply(icon.classList, active ? iconOn : iconOff);
+                    }
+                };
+                apply(home, which === 'home');
+                apply(chat, which === 'chat');
             },
 
             // Reset only the conversation layer (messages, cards, title, scroll,
@@ -285,11 +333,12 @@
             },
 
             cancelInflight() {
-                // .mcp-dock isn't an .mcp-el but is animated (the composer/dock
-                // swap), so include it — otherwise its in-flight / delayed
-                // animation keeps holding opacity and overrides a static reset
-                // (e.g. the reduced-motion view after a tab switch).
-                this.$root.querySelectorAll('.mcp-el, .mcp-dock').forEach(function(el) {
+                // .mcp-dock and .mcp-topbar-ask aren't .mcp-el but are animated
+                // (the composer/dock swap and the Ask-pill fade), so include
+                // them — otherwise an in-flight / delayed animation keeps
+                // holding opacity and overrides a static reset (e.g. the
+                // reduced-motion view after a tab switch).
+                this.$root.querySelectorAll('.mcp-el, .mcp-dock, .mcp-topbar-ask').forEach(function(el) {
                     if (el.getAnimations) {
                         el.getAnimations().forEach(function(a) { a.cancel(); });
                     }
@@ -315,8 +364,12 @@
                 });
                 // Static view shows the resolved review (audit card + outcome
                 // are .mcp-el, shown above); the dock stays hidden and the
-                // composer stays in the flow.
+                // composer stays in the flow. The shell reflects the final
+                // conversation state: Ask pill hidden, chat item highlighted.
                 this.resetDock();
+                var ask = this.$root.querySelector('.mcp-topbar-ask');
+                if (ask) ask.style.opacity = '0';
+                this.setShellActive('chat');
                 var entry = this.$root.querySelector('.hero-agent-entry');
                 if (entry) entry.style.opacity = '0';
                 this.clearComposer();
@@ -342,6 +395,16 @@
                         transform: ['translateY(-4px)', 'translateY(0px)']
                     }, { duration: d * 0.85, delay: d * 0.15, ease: ease });
                 }
+
+                // The real app only shows the "Ask Relaticle" trigger on the
+                // dashboard; the sidebar highlight moves to the conversation.
+                var ask = this.$root.querySelector('.mcp-topbar-ask');
+                if (ask && typeof animate === 'function') {
+                    animate(ask, { opacity: [1, 0] }, { duration: d * 0.6, ease: ease });
+                } else if (ask) {
+                    ask.style.opacity = '0';
+                }
+                this.setShellActive('chat');
             },
 
             // Keep the conversation anchored to the bottom like a real chat:

--- a/resources/views/home/partials/hero-agent-shell.blade.php
+++ b/resources/views/home/partials/hero-agent-shell.blade.php
@@ -4,7 +4,7 @@
      at the bottom containing the active conversation.
      Icons use Heroicon outline to match the real Filament app exactly (the rest of
      the marketing site uses Remix Icon per project convention). --}}
-<aside class="hero-agent-shell hidden md:flex md:w-48 lg:w-56 shrink-0 flex-col border-r border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
+<aside class="hero-agent-shell hidden md:flex md:w-48 lg:w-56 shrink-0 flex-col border-r border-gray-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
     {{-- Workspace switcher.
          The mark is a pixel-art "N" constructed from 13 discrete <rect>
          squares on a 5×5 grid: two full vertical columns plus three diagonal
@@ -35,18 +35,18 @@
         <div class="flex-1 min-w-0">
             <div class="text-sm font-semibold text-gray-900 dark:text-white truncate">Northwind</div>
         </div>
-        <x-heroicon-o-chevron-down class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500"/>
+        <x-heroicon-o-chevron-down class="w-3.5 h-3.5 text-gray-400 dark:text-zinc-500"/>
     </div>
 
     {{-- Global search + notifications row — mirrors the real sidebar's
          fi-sidebar-search-ctn (GlobalSearch pill + inbox trigger). --}}
     <div class="flex items-center gap-1.5 px-2 pb-1.5">
         <div class="flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-full bg-gray-100 px-2.5 dark:bg-white/[0.06]">
-            <x-heroicon-o-magnifying-glass class="w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-gray-500"/>
-            <span class="min-w-0 flex-1 truncate text-xs text-gray-400 dark:text-gray-500">Search</span>
-            <kbd class="rounded border border-gray-200 bg-white px-1 font-sans text-pico font-medium text-gray-400 dark:border-white/10 dark:bg-white/[0.06] dark:text-gray-500">&#8984;K</kbd>
+            <x-heroicon-o-magnifying-glass class="w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-zinc-500"/>
+            <span class="min-w-0 flex-1 truncate text-xs text-gray-400 dark:text-zinc-500">Search</span>
+            <kbd class="rounded border border-gray-200 bg-white px-1 font-sans text-pico font-medium text-gray-400 dark:border-white/10 dark:bg-white/[0.06] dark:text-zinc-500">&#8984;K</kbd>
         </div>
-        <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-gray-200 text-gray-400 dark:border-white/10 dark:text-gray-500">
+        <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-gray-200 text-gray-400 dark:border-white/10 dark:text-zinc-500">
             <x-heroicon-o-inbox class="w-3.5 h-3.5"/>
         </div>
     </div>
@@ -57,28 +57,28 @@
          Which item is active is swapped by heroChat.setShellActive() as the demo moves
          from the dashboard (Home) into the conversation (first chat), like the real app. --}}
     <nav class="flex-1 overflow-hidden px-2 py-1 space-y-px text-sm">
-        <div id="hero-shell-nav-home" class="flex items-center gap-2 rounded-lg px-2 py-1.5 bg-gray-100 font-medium text-primary-700 dark:bg-white/[0.06] dark:text-primary-400">
+        <div id="hero-shell-nav-home" class="flex items-center gap-2 rounded-lg px-2 py-1.5 bg-gray-100 font-medium text-primary-700 dark:bg-zinc-800 dark:text-primary-400">
             <x-heroicon-o-home class="w-4 h-4 shrink-0 text-primary-700 dark:text-primary-400"/>
             <span>Home</span>
         </div>
-        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-user class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-zinc-200">
+            <x-heroicon-o-user class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500"/>
             <span>People</span>
         </div>
-        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-home-modern class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-zinc-200">
+            <x-heroicon-o-home-modern class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500"/>
             <span>Companies</span>
         </div>
-        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-trophy class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-zinc-200">
+            <x-heroicon-o-trophy class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500"/>
             <span>Opportunities</span>
         </div>
-        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-check-circle class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-zinc-200">
+            <x-heroicon-o-check-circle class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500"/>
             <span>Tasks</span>
         </div>
-        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-document-text class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-zinc-200">
+            <x-heroicon-o-document-text class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500"/>
             <span>Notes</span>
         </div>
 
@@ -86,12 +86,12 @@
              None is active here because Home is the current page. --}}
         <div class="pt-3">
             <div class="flex items-center justify-between px-2 pb-1">
-                <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Chats</span>
-                <x-heroicon-o-chevron-up class="w-3 h-3 text-gray-400 dark:text-gray-500"/>
+                <span class="text-sm font-medium text-gray-500 dark:text-zinc-400">Chats</span>
+                <x-heroicon-o-chevron-up class="w-3 h-3 text-gray-400 dark:text-zinc-500"/>
             </div>
 
-            <div id="hero-shell-nav-chat" class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
-                <x-heroicon-o-chat-bubble-left class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+            <div id="hero-shell-nav-chat" class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-zinc-200">
+                <x-heroicon-o-chat-bubble-left class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500"/>
                 <span class="truncate">Overdue tasks this week</span>
             </div>
 
@@ -100,14 +100,14 @@
                 'Follow up with Priya Nair',
                 'Renewal prep — Daniel Okafor',
             ] as $heroChatTitle)
-                <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
-                    <x-heroicon-o-chat-bubble-left class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+                <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-zinc-200">
+                    <x-heroicon-o-chat-bubble-left class="w-4 h-4 shrink-0 text-gray-400 dark:text-zinc-500"/>
                     <span class="truncate">{{ $heroChatTitle }}</span>
                 </div>
             @endforeach
 
             {{-- All chats trigger — mirrors the "All chats" footer item in chat-sidebar-nav.blade.php --}}
-            <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-500 opacity-60 dark:text-gray-400">
+            <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-500 opacity-60 dark:text-zinc-400">
                 <x-heroicon-o-ellipsis-horizontal class="w-4 h-4 shrink-0"/>
                 <span>All chats</span>
             </div>

--- a/resources/views/home/partials/hero-agent-shell.blade.php
+++ b/resources/views/home/partials/hero-agent-shell.blade.php
@@ -11,7 +11,7 @@
          stair-step squares between them. Each cell is 4 units wide with a
          1-unit gap on a 24×24 viewBox, so the squares read as separate
          pixels rather than a solid letter. --}}
-    <div class="flex items-center gap-2 px-3 py-2.5">
+    <div class="flex items-center gap-2 px-3 pt-2.5 pb-2">
         <div class="flex h-6 w-6 items-center justify-center rounded bg-gray-900 shrink-0 dark:bg-white/[0.1]">
             <svg viewBox="0 0 24 24" class="h-3 w-3 text-white" fill="currentColor" aria-hidden="true" shape-rendering="crispEdges">
                 {{-- Left column --}}
@@ -38,32 +38,47 @@
         <x-heroicon-o-chevron-down class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500"/>
     </div>
 
+    {{-- Global search + notifications row — mirrors the real sidebar's
+         fi-sidebar-search-ctn (GlobalSearch pill + inbox trigger). --}}
+    <div class="flex items-center gap-1.5 px-2 pb-1.5">
+        <div class="flex h-7 min-w-0 flex-1 items-center gap-1.5 rounded-full bg-gray-100 px-2.5 dark:bg-white/[0.06]">
+            <x-heroicon-o-magnifying-glass class="w-3.5 h-3.5 shrink-0 text-gray-400 dark:text-gray-500"/>
+            <span class="min-w-0 flex-1 truncate text-xs text-gray-400 dark:text-gray-500">Search</span>
+            <kbd class="rounded border border-gray-200 bg-white px-1 font-sans text-pico font-medium text-gray-400 dark:border-white/10 dark:bg-white/[0.06] dark:text-gray-500">&#8984;K</kbd>
+        </div>
+        <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-gray-200 text-gray-400 dark:border-white/10 dark:text-gray-500">
+            <x-heroicon-o-inbox class="w-3.5 h-3.5"/>
+        </div>
+    </div>
+
     {{-- Top-level nav items — icons match app/Filament/Resources/*Resource.php $navigationIcon.
-         Home is the active page (mirrors the dashboard greeting "Good morning, …"); fi-active
-         renders as a light-gray bg + primary icon, matching the real Filament sidebar. --}}
+         The active item renders as gray-100 bg + primary-700 label AND icon (measured from
+         the live Filament sidebar); inactive icons are a step lighter than their labels.
+         Which item is active is swapped by heroChat.setShellActive() as the demo moves
+         from the dashboard (Home) into the conversation (first chat), like the real app. --}}
     <nav class="flex-1 overflow-hidden px-2 py-1 space-y-px text-sm">
-        <div id="hero-shell-nav-home" class="flex items-center gap-2 rounded-md bg-gray-100 px-2 py-1.5 font-medium text-gray-900 dark:bg-white/[0.06] dark:text-white">
-            <x-heroicon-o-home class="w-4 h-4 shrink-0 text-primary dark:text-primary-400"/>
+        <div id="hero-shell-nav-home" class="flex items-center gap-2 rounded-lg px-2 py-1.5 bg-gray-100 font-medium text-primary-700 dark:bg-white/[0.06] dark:text-primary-400">
+            <x-heroicon-o-home class="w-4 h-4 shrink-0 text-primary-700 dark:text-primary-400"/>
             <span>Home</span>
         </div>
-        <div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-user class="w-4 h-4 shrink-0"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
+            <x-heroicon-o-user class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
             <span>People</span>
         </div>
-        <div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-home-modern class="w-4 h-4 shrink-0"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
+            <x-heroicon-o-home-modern class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
             <span>Companies</span>
         </div>
-        <div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-trophy class="w-4 h-4 shrink-0"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
+            <x-heroicon-o-trophy class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
             <span>Opportunities</span>
         </div>
-        <div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-check-circle class="w-4 h-4 shrink-0"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
+            <x-heroicon-o-check-circle class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
             <span>Tasks</span>
         </div>
-        <div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 dark:text-gray-300">
-            <x-heroicon-o-document-text class="w-4 h-4 shrink-0"/>
+        <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
+            <x-heroicon-o-document-text class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
             <span>Notes</span>
         </div>
 
@@ -71,24 +86,28 @@
              None is active here because Home is the current page. --}}
         <div class="pt-3">
             <div class="flex items-center justify-between px-2 pb-1">
-                <span class="text-pico font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">Chats</span>
+                <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Chats</span>
                 <x-heroicon-o-chevron-up class="w-3 h-3 text-gray-400 dark:text-gray-500"/>
             </div>
 
+            <div id="hero-shell-nav-chat" class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
+                <x-heroicon-o-chat-bubble-left class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
+                <span class="truncate">Overdue tasks this week</span>
+            </div>
+
             @foreach ([
-                'Overdue tasks this week',
                 "This week's pipeline review",
                 'Follow up with Priya Nair',
                 'Renewal prep — Daniel Okafor',
             ] as $heroChatTitle)
-                <div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-gray-700 dark:text-gray-300">
-                    <x-heroicon-o-chat-bubble-left class="w-4 h-4 shrink-0"/>
+                <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-700 dark:text-gray-300">
+                    <x-heroicon-o-chat-bubble-left class="w-4 h-4 shrink-0 text-gray-400 dark:text-gray-500"/>
                     <span class="truncate">{{ $heroChatTitle }}</span>
                 </div>
             @endforeach
 
             {{-- All chats trigger — mirrors the "All chats" footer item in chat-sidebar-nav.blade.php --}}
-            <div class="flex items-center gap-2 rounded-md px-2 py-1.5 text-gray-500 opacity-60 dark:text-gray-400">
+            <div class="flex items-center gap-2 rounded-lg px-2 py-1.5 text-gray-500 opacity-60 dark:text-gray-400">
                 <x-heroicon-o-ellipsis-horizontal class="w-4 h-4 shrink-0"/>
                 <span>All chats</span>
             </div>

--- a/tests/Browser/Chat/FollowUpChipTest.php
+++ b/tests/Browser/Chat/FollowUpChipTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Tests\Helpers\ChatBrowser;
+
+/**
+ * Follow-up chips arrive over the `.follow_ups` broadcast and render below the
+ * assistant bubble. Clicking one must send its prompt as a new user message.
+ * sendMessage() reads the composer via localEditor().getText(), so the chip
+ * handler has to write the prompt into the TipTap editor — setting the Alpine
+ * `input` mirror alone is silently dropped (a mounted empty editor returns ''
+ * which short-circuits the `?? this.input` fallback).
+ */
+it('sends the follow-up prompt as a user message when a chip is clicked', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = $this->visit('/app/login')
+        ->type('[id="form.email"]', $user->email)
+        ->type('[id="form.password"]', 'password')
+        ->click('button.fi-btn')
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/chats")
+        ->assertSourceHas('placeholder="Ask anything..."');
+
+    $resolveInterface = ChatBrowser::resolveInterface();
+
+    $result = json_decode((string) $page->script(<<<JS
+        (async () => {
+            {$resolveInterface}
+
+            // A finished assistant turn whose follow-up chips came in over the
+            // .follow_ups broadcast.
+            data.messages.push({
+                role: 'assistant',
+                content: 'Here are the companies added this week.',
+                rendered: true,
+                prerendered: false,
+                editing: false,
+                editText: '',
+                copiedAt: 0,
+                follow_ups: [{ label: 'Filter by industry', prompt: 'Filter these companies by industry' }],
+            });
+
+            await new Promise((r) => setTimeout(r, 50));
+
+            const chip = Array.from(host.querySelectorAll('button'))
+                .find((b) => b.textContent.trim() === 'Filter by industry');
+            if (! chip) {
+                return JSON.stringify({ error: 'chip not rendered' });
+            }
+
+            // Keep sendMessage() away from the real /chat endpoint; the
+            // optimistic user-message push happens before the fetch.
+            window.fetch = () => new Promise(() => {});
+
+            chip.click();
+
+            await new Promise((r) => setTimeout(r, 100));
+
+            return JSON.stringify({
+                userMessages: data.messages
+                    .filter((m) => m.role === 'user')
+                    .map((m) => m.content),
+            });
+        })();
+    JS), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($result)->not->toHaveKey('error')
+        ->and($result['userMessages'])->toBe(['Filter these companies by industry']);
+});

--- a/tests/Feature/Chat/BatchResolvedActionsTest.php
+++ b/tests/Feature/Chat/BatchResolvedActionsTest.php
@@ -38,7 +38,7 @@ beforeEach(function (): void {
     ]);
 });
 
-it('returns record_ids for a batch-approved action in resolvedSinceLastAssistantMessage', function (): void {
+it('returns record_ids for a batch-approved action in resolvedForConversation', function (): void {
     PendingAction::query()->create([
         'team_id' => $this->user->currentTeam->getKey(),
         'user_id' => $this->user->getKey(),
@@ -54,7 +54,7 @@ it('returns record_ids for a batch-approved action in resolvedSinceLastAssistant
         'result_data' => ['ids' => ['01aa0000000000000000000000', '01bb0000000000000000000000'], 'type' => 'task', 'count' => 2],
     ]);
 
-    $results = resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage($this->convId);
+    $results = resolve(PendingActionService::class)->resolvedForConversation($this->convId);
 
     expect($results)->toHaveCount(1)
         ->and($results[0]['record_ids'])->toContain('01aa0000000000000000000000')
@@ -78,7 +78,7 @@ it('includes both batch ids in the resolved block of agent instructions', functi
         'result_data' => ['ids' => ['01aa0000000000000000000000', '01bb0000000000000000000000'], 'type' => 'task', 'count' => 2],
     ]);
 
-    $resolved = resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage($this->convId);
+    $resolved = resolve(PendingActionService::class)->resolvedForConversation($this->convId);
 
     $agent = resolve(CrmAssistant::class)->withResolvedActions($resolved);
 
@@ -105,7 +105,7 @@ it('returns an empty record_ids list and still emits record_id for a flat approv
         'result_data' => ['id' => '01cc0000000000000000000000', 'type' => 'task'],
     ]);
 
-    $results = resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage($this->convId);
+    $results = resolve(PendingActionService::class)->resolvedForConversation($this->convId);
 
     expect($results)->toHaveCount(1)
         ->and($results[0]['record_id'])->toBe('01cc0000000000000000000000')

--- a/tests/Feature/Chat/CrmAssistantResolvedBlockTest.php
+++ b/tests/Feature/Chat/CrmAssistantResolvedBlockTest.php
@@ -15,14 +15,16 @@ it('renders a resolved_actions block when set', function (): void {
     expect($instructions)->toContain('<resolved_actions>')
         ->and($instructions)->toContain('approved: create task "Review Q3" (id: 01ABC)')
         ->and($instructions)->toContain('rejected: create person "Sarah"')
-        ->and($instructions)->not->toContain('rejected: create person "Sarah" (id:');
+        ->and($instructions)->not->toContain('rejected: create person "Sarah" (id:')
+        ->and($instructions)->toContain('NEVER describe a decided proposal as pending')
+        ->and($instructions)->toContain('when the user explicitly asks for the action again (including after rejecting it), call the tool to create a FRESH proposal');
 });
 
 it('omits the resolved_actions block when empty', function (): void {
     // The prose mentions the <resolved_actions> tag; the rendered block has a
     // unique content marker that must be absent when there are no resolved actions.
     expect((new CrmAssistant)->instructions())
-        ->not->toContain('These proposals were already decided by the user.');
+        ->not->toContain('These proposals were already decided by the user');
 });
 
 it('static instructions forbid enumerating proposal data in prose', function (): void {

--- a/tests/Feature/Chat/ResolvedActionsContextTest.php
+++ b/tests/Feature/Chat/ResolvedActionsContextTest.php
@@ -48,7 +48,11 @@ function seedResolvedAssistantMsg(string $conversationId, User $user, DateTimeIn
     ]);
 }
 
-it('surfaces only actions resolved after the last assistant message', function (): void {
+it('keeps actions resolved before the last assistant message in context', function (): void {
+    // Regression: a rejection followed by any later assistant turn used to fall
+    // out of the resolved window, leaving only the stale "pending approval"
+    // tool result in the replayed transcript — the model then told the user the
+    // proposal was still awaiting approval instead of proposing again.
     $user = User::factory()->withPersonalTeam()->create();
     $this->actingAs($user);
     seedResolvedConv('conv-1', $user);
@@ -58,10 +62,10 @@ it('surfaces only actions resolved after the last assistant message', function (
     PendingAction::query()->create([
         'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
         'conversation_id' => 'conv-1', 'action_class' => CreateTask::class,
-        'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
-        'action_data' => ['title' => 'Stale'], 'display_data' => [],
-        'status' => PendingActionStatus::Approved, 'expires_at' => now(),
-        'resolved_at' => now()->subMinutes(10), 'result_data' => ['id' => 'old-id'],
+        'operation' => PendingActionOperation::Delete, 'entity_type' => 'task',
+        'action_data' => ['title' => 'Rejected before last turn'], 'display_data' => [],
+        'status' => PendingActionStatus::Rejected, 'expires_at' => now(),
+        'resolved_at' => now()->subMinutes(10),
     ]);
 
     PendingAction::query()->create([
@@ -73,14 +77,37 @@ it('surfaces only actions resolved after the last assistant message', function (
         'resolved_at' => now()->subMinute(), 'result_data' => ['id' => 'new-id'],
     ]);
 
-    $resolved = resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage('conv-1');
+    $resolved = resolve(PendingActionService::class)->resolvedForConversation('conv-1');
 
-    expect($resolved)->toHaveCount(1)
-        ->and($resolved[0]['label'])->toBe('Fresh Task')
-        ->and($resolved[0]['status'])->toBe('approved')
-        ->and($resolved[0]['record_id'])->toBe('new-id')
-        ->and($resolved[0]['operation'])->toBe('create')
-        ->and($resolved[0]['entity_type'])->toBe('task');
+    expect($resolved)->toHaveCount(2)
+        ->and($resolved[0]['label'])->toBe('Rejected before last turn')
+        ->and($resolved[0]['status'])->toBe('rejected')
+        ->and($resolved[1]['label'])->toBe('Fresh Task')
+        ->and($resolved[1]['status'])->toBe('approved')
+        ->and($resolved[1]['record_id'])->toBe('new-id');
+});
+
+it('caps the context at the 20 newest resolutions, oldest first', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    seedResolvedConv('conv-1', $user);
+
+    foreach (range(1, 21) as $i) {
+        PendingAction::query()->create([
+            'team_id' => $user->currentTeam->getKey(), 'user_id' => $user->getKey(),
+            'conversation_id' => 'conv-1', 'action_class' => CreateTask::class,
+            'operation' => PendingActionOperation::Create, 'entity_type' => 'task',
+            'action_data' => ['title' => "Task {$i}"], 'display_data' => [],
+            'status' => PendingActionStatus::Approved, 'expires_at' => now(),
+            'resolved_at' => now()->subMinutes(30 - $i), 'result_data' => ['id' => "id-{$i}"],
+        ]);
+    }
+
+    $resolved = resolve(PendingActionService::class)->resolvedForConversation('conv-1');
+
+    expect($resolved)->toHaveCount(20)
+        ->and($resolved[0]['label'])->toBe('Task 2')
+        ->and($resolved[19]['label'])->toBe('Task 21');
 });
 
 it('returns an empty list for another conversation', function (): void {
@@ -97,7 +124,7 @@ it('returns an empty list for another conversation', function (): void {
         'resolved_at' => now(), 'result_data' => ['id' => 'x'],
     ]);
 
-    expect(resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage('other-conv'))->toBe([]);
+    expect(resolve(PendingActionService::class)->resolvedForConversation('other-conv'))->toBe([]);
 });
 
 it('surfaces an approval even when the continuation never journals it (Bug A)', function (): void {
@@ -118,7 +145,7 @@ it('surfaces an approval even when the continuation never journals it (Bug A)', 
 
     resolve(PendingActionService::class)->approve($pending, $user);
 
-    $resolved = resolve(PendingActionService::class)->resolvedSinceLastAssistantMessage('conv-A');
+    $resolved = resolve(PendingActionService::class)->resolvedForConversation('conv-A');
 
     expect($resolved)->toHaveCount(1)
         ->and($resolved[0]['status'])->toBe('approved')

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -729,13 +729,14 @@ describe('Hero AI tab — entry phase', function () {
         $response->assertSee("This week's pipeline review", false);
     });
 
-    it('shows three example prompt chips to anchor the demo', function () {
+    it('shows the four real dashboard starter chips to anchor the demo', function () {
         $response = $this->get('/');
         $response->assertSuccessful();
 
-        $response->assertSee("What's overdue this week?", false);
-        $response->assertSee("Show this week's pipeline", false);
-        $response->assertSee('Add a new contact');
+        $response->assertSee('CRM overview');
+        $response->assertSee('Overdue tasks');
+        $response->assertSee('Recent companies');
+        $response->assertSee('Pipeline summary');
     });
 
     it('renders the empty My Tasks section mirroring the dashboard', function () {

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -212,9 +212,11 @@ describe('Hero AI tab — conversation', function () {
         $response->assertSee('Call Sarah Chen');
         $response->assertSee('Send proposal to Trellis Labs');
         $response->assertSee('Schedule demo with Kovra Systems');
-        $response->assertSee('Mark them all as done');
-        // Approval action card shows the operation badge ("Update") + summary.
-        $response->assertSee('Update');
+        $response->assertSee('Mark the Kovra demo as done');
+        // The proposal docks at the composer and resolves into the audit card.
+        $response->assertSee('Review before continuing');
+        $response->assertSee('Update task');
+        $response->assertSee('Save changes');
         $response->assertSee('Add Sarah Chen');
         $response->assertSee('VP of Engineering');
     });
@@ -226,8 +228,8 @@ describe('Hero AI tab — conversation', function () {
         // Exchange 1
         $response->assertSee('You have 3 overdue tasks');
         // Exchange 2 climax
-        $response->assertSee('Mark 3 tasks complete');
-        $response->assertSee('Call Sarah Chen · Send proposal · Schedule demo');
+        $response->assertSee('Review the proposal below to update the task');
+        $response->assertSee('Updated Schedule demo with Kovra Systems');
         // Exchange 3
         $response->assertSee('Added Sarah and linked her to Kovra Systems');
     });
@@ -695,7 +697,7 @@ describe('Hero AI tab — animation timeline', function () {
             ->toContain('scrollToShow')
             ->toContain("scrollToShow('.mcp-user-2')")
             ->toContain("scrollToShow('.mcp-user-3')")
-            ->toContain("scrollToShow('.mcp-action-card')")
+            ->toContain("scrollToShow('.mcp-audit-card')")
             ->not->toContain('scrollMessageIntoView')
             ->not->toContain('typeStart2 - 100')
             ->not->toContain('typeStart3 - 100');


### PR DESCRIPTION
Fixes follow-up suggestion chips silently doing nothing: the click handler now writes the prompt into the TipTap editor before `sendMessage()` (which reads editor text, not the Alpine `input` mirror), covered by a new browser test that failed before the fix. Redesigns the proposal review UI across the docked card, transcript audit card, and shared field rows: operation icon tile with a single human headline, aligned label column with old→new diffs and boolean/badge pills (fixing a dock/transcript rendering drift), separated footer with the batch pager moved into the header, and a smooth dock entrance transition. Rebuilds the homepage "Ask Relaticle" hero mockup as a measured 1:1 mirror of the app — the proposal docks over the composer and resolves into the audit card plus outcome bubble, the shell gains the real topbar, sidebar search row, measured active-nav colors with the highlight moving to the conversation, the real starter chips, the app's zinc dark palette, and proposal cards scaled to the frame's proportion. Fixes the agent treating rejected proposals as still pending: terminal proposals now stay in the model's `<resolved_actions>` context on every turn (the old since-last-assistant-message window dropped them after one turn while replayed tool results kept claiming "pending"), and the block now permits a fresh proposal when the user explicitly asks again. Also hardens the Conductor workspace setup (per-workspace Redis prefixes so foreign workers can't consume this workspace's queues, Passport key generation, horizon/vite run scripts) and records an agent-browser stale-frame hazard in the repo-tracked skill.

Test plan: walked the full loop against the production-shaped stack (redis queue worker + Reverb) — create, update-with-diffs, discard, batch with pager and mixed Created/Skipped results, inline field editing, light/dark/mobile — reproduced the rejected-proposal dead end in a real conversation and re-verified the same conversation now yields a fresh proposal after the fix; hero mirrored against computed styles measured from the live app in both themes; pint, PHPStan, 100% type coverage, and the full parallel Pest suite (2,792 passing incl. new `FollowUpChipTest` and resolved-context regression tests) all pass.