### PR TITLE
fix: restore missing team_user unique constraint and race-safe member attach

### DIFF
--- a/app/Actions/Jetstream/AddTeamMember.php
+++ b/app/Actions/Jetstream/AddTeamMember.php
@@ -8,6 +8,8 @@ use App\Models\Team;
 use App\Models\User;
 use Closure;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Jetstream\Contracts\AddsTeamMembers;
@@ -31,9 +33,14 @@ final readonly class AddTeamMember implements AddsTeamMembers
 
         event(new AddingTeamMember($team, $newTeamMember));
 
-        $team->users()->attach(
-            $newTeamMember, ['role' => $role]
-        );
+        try {
+            DB::transaction(fn () => $team->users()->attach(
+                $newTeamMember, ['role' => $role]
+            ));
+        } catch (UniqueConstraintViolationException) {
+            // A concurrent request already attached this member and fired the event.
+            return;
+        }
 
         event(new TeamMemberAdded($team, $newTeamMember));
     }

--- a/database/migrations/2026_08_18_111736_restore_team_user_unique_constraint.php
+++ b/database/migrations/2026_08_18_111736_restore_team_user_unique_constraint.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The team_user (team_id, user_id) unique constraint was verified missing
+     * in production (pg_constraint check, 2026-08-18): prod executed an early
+     * version of the ULID migration that dropped it without the later-added
+     * recreation phase. No duplicate pairs existed at verification time; the
+     * dedupe is defensive so the constraint creation cannot fail on rows that
+     * land before this deploys. Idempotent: a no-op when the constraint
+     * already exists.
+     */
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+            DELETE FROM team_user a
+            USING team_user b
+            WHERE a.team_id = b.team_id
+              AND a.user_id = b.user_id
+              AND a.id > b.id
+        SQL);
+
+        $constraintExists = DB::selectOne(
+            "SELECT 1 FROM pg_constraint WHERE conname = 'team_user_team_id_user_id_unique' AND conrelid = 'team_user'::regclass"
+        ) !== null;
+
+        if ($constraintExists) {
+            return;
+        }
+
+        DB::statement('DROP INDEX IF EXISTS team_user_team_id_user_id_unique');
+
+        Schema::table('team_user', function (Blueprint $table): void {
+            $table->unique(['team_id', 'user_id']);
+        });
+    }
+};

--- a/tests/Feature/Migrations/RestoreTeamUserUniqueConstraintTest.php
+++ b/tests/Feature/Migrations/RestoreTeamUserUniqueConstraintTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+
+function runRestoreTeamUserUniqueConstraintMigration(): void
+{
+    $migration = require database_path('migrations/2026_08_18_111736_restore_team_user_unique_constraint.php');
+    $migration->up();
+}
+
+function teamUserUniqueConstraintExists(): bool
+{
+    return DB::selectOne(
+        "SELECT 1 FROM pg_constraint WHERE conname = 'team_user_team_id_user_id_unique' AND conrelid = 'team_user'::regclass"
+    ) !== null;
+}
+
+test('removes duplicate memberships keeping the earliest row and restores the unique constraint', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+    $member = User::factory()->create();
+
+    DB::statement('ALTER TABLE team_user DROP CONSTRAINT team_user_team_id_user_id_unique');
+
+    foreach (['admin', 'editor', 'editor', 'editor'] as $role) {
+        DB::table('team_user')->insert([
+            'team_id' => $team->id,
+            'user_id' => $member->id,
+            'role' => $role,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    expect($team->users()->count())->toBe(4);
+
+    runRestoreTeamUserUniqueConstraintMigration();
+
+    $memberships = DB::table('team_user')->where('team_id', $team->id)->where('user_id', $member->id)->get();
+
+    expect($memberships)->toHaveCount(1)
+        ->and($memberships->first()->role)->toBe('admin')
+        ->and(teamUserUniqueConstraintExists())->toBeTrue();
+
+    $violation = false;
+
+    try {
+        DB::transaction(fn () => DB::table('team_user')->insert([
+            'team_id' => $team->id,
+            'user_id' => $member->id,
+            'role' => 'editor',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]));
+    } catch (UniqueConstraintViolationException) {
+        $violation = true;
+    }
+
+    expect($violation)->toBeTrue();
+});
+
+test('is a no-op on a healthy database', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+    $member = User::factory()->create();
+
+    $team->users()->attach($member, ['role' => 'editor']);
+
+    runRestoreTeamUserUniqueConstraintMigration();
+
+    expect($team->users()->count())->toBe(1)
+        ->and(teamUserUniqueConstraintExists())->toBeTrue();
+});

--- a/tests/Feature/Teams/InviteLinkTokenTest.php
+++ b/tests/Feature/Teams/InviteLinkTokenTest.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
+use App\Actions\Jetstream\AddTeamMember;
 use App\Actions\Jetstream\CreateTeam;
+use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Laravel\Jetstream\Events\AddingTeamMember;
 
-mutates(Team::class);
+mutates(Team::class, AddTeamMember::class);
 
 test('creating a team auto-generates a 40-char invite_link_token', function (): void {
     $user = User::factory()->create();
@@ -71,6 +76,28 @@ test('POST on a valid token attaches the user and redirects', function (): void 
         ->assertRedirect(config('fortify.home'));
 
     expect($team->fresh()->users()->where('users.id', $joiner->id)->exists())->toBeTrue()
+        ->and($joiner->fresh()->current_team_id)->toBe($team->id);
+});
+
+test('a join request racing an identical concurrent request does not duplicate the membership', function (): void {
+    $owner = User::factory()->create();
+    $team = resolve(CreateTeam::class)->create($owner, [
+        'name' => 'Acme',
+        'slug' => 'acme-race',
+        'onboarding_use_case' => 'other',
+    ]);
+
+    $joiner = User::factory()->create(['email_verified_at' => now()]);
+
+    Event::listen(AddingTeamMember::class, function (AddingTeamMember $event): void {
+        $event->team->users()->attach($event->user, ['role' => TeamRole::Editor->value]);
+    });
+
+    $this->actingAs($joiner)
+        ->post(route('teams.join.confirm', ['token' => $team->invite_link_token]))
+        ->assertRedirect(config('fortify.home'));
+
+    expect(DB::table('team_user')->where('team_id', $team->id)->where('user_id', $joiner->id)->count())->toBe(1)
         ->and($joiner->fresh()->current_team_id)->toBe($team->id);
 });
 


### PR DESCRIPTION
## Summary

A read-only check on production (2026-08-18) confirmed the `team_user (team_id, user_id)` unique constraint is missing there — prod executed an early version of the ULID migration that dropped it without the later-added recreation phase. This PR adds an idempotent migration that defensively dedupes `team_user` (zero violating rows existed at verification time) and restores the constraint, and hardens `AddTeamMember` so a double-submitted join/invitation attach is treated as an already-completed concurrent add instead of an unhandled unique-violation 500. Investigation context: the "duplicated members" screenshot that triggered this turned out to be the pivot-cast rendering bug fixed separately in #481; this PR fixes the real integrity gap found along the way. The remaining missing prod constraints/FKs from the same ULID-migration fallout are deliberately out of scope pending violating-row counts.

## Test plan

- New feature test: concurrent join race (via `AddingTeamMember` listener) no longer 500s and leaves exactly one membership — failed before the fix, passes after.
- New migration tests: dedupe keeps the earliest row and restores an enforcing constraint from the broken-prod state; no-op on a healthy schema.
- Pint, Rector, PHPStan, 100% type coverage, and the Teams/Migrations/SystemAdmin/Email suites all pass.