### PR TITLE
feat: store UTC everywhere, show every user their own timezone

### DIFF
--- a/.ai/guidelines/relaticle/core.md
+++ b/.ai/guidelines/relaticle/core.md
@@ -13,6 +13,12 @@ Treat every change like it's going through senior code review:
 
 - This project uses **PostgreSQL exclusively** — do not add SQLite/MySQL compatibility layers, driver checks, or conditional SQL
 - Migrations must only have `up()` methods — do not write `down()` methods
+- Every datetime column is `timestamp without time zone` holding **UTC**. Never write one from
+  the database clock — no `DB::raw('now()')`, `CURRENT_TIMESTAMP`, or `->useCurrent()` /
+  `->useCurrentOnUpdate()` column defaults. Those resolve against the *session* timezone and
+  write local wall-clock into a UTC column. Pass a PHP-side `now()` instead:
+  `->update(['used_at' => now()])`. The pgsql connection pins `'timezone' => 'UTC'` so the two
+  agree today; do not rely on that — it is the safety net, not the contract.
 
 ## Pre-Commit Quality Checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,12 @@ Treat every change like it's going through senior code review:
 
 - This project uses **PostgreSQL exclusively** — do not add SQLite/MySQL compatibility layers, driver checks, or conditional SQL
 - Migrations must only have `up()` methods — do not write `down()` methods
+- Every datetime column is `timestamp without time zone` holding **UTC**. Never write one from
+  the database clock — no `DB::raw('now()')`, `CURRENT_TIMESTAMP`, or `->useCurrent()` /
+  `->useCurrentOnUpdate()` column defaults. Those resolve against the *session* timezone and
+  write local wall-clock into a UTC column. Pass a PHP-side `now()` instead:
+  `->update(['used_at' => now()])`. The pgsql connection pins `'timezone' => 'UTC'` so the two
+  agree today; do not rely on that — it is the safety net, not the contract.
 
 ## Pre-Commit Quality Checks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,12 @@ Treat every change like it's going through senior code review:
 
 - This project uses **PostgreSQL exclusively** — do not add SQLite/MySQL compatibility layers, driver checks, or conditional SQL
 - Migrations must only have `up()` methods — do not write `down()` methods
+- Every datetime column is `timestamp without time zone` holding **UTC**. Never write one from
+  the database clock — no `DB::raw('now()')`, `CURRENT_TIMESTAMP`, or `->useCurrent()` /
+  `->useCurrentOnUpdate()` column defaults. Those resolve against the *session* timezone and
+  write local wall-clock into a UTC column. Pass a PHP-side `now()` instead:
+  `->update(['used_at' => now()])`. The pgsql connection pins `'timezone' => 'UTC'` so the two
+  agree today; do not rely on that — it is the safety net, not the contract.
 
 ## Pre-Commit Quality Checks
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -137,6 +137,12 @@ Treat every change like it's going through senior code review:
 
 - This project uses **PostgreSQL exclusively** — do not add SQLite/MySQL compatibility layers, driver checks, or conditional SQL
 - Migrations must only have `up()` methods — do not write `down()` methods
+- Every datetime column is `timestamp without time zone` holding **UTC**. Never write one from
+  the database clock — no `DB::raw('now()')`, `CURRENT_TIMESTAMP`, or `->useCurrent()` /
+  `->useCurrentOnUpdate()` column defaults. Those resolve against the *session* timezone and
+  write local wall-clock into a UTC column. Pass a PHP-side `now()` instead:
+  `->update(['used_at' => now()])`. The pgsql connection pins `'timezone' => 'UTC'` so the two
+  agree today; do not rely on that — it is the safety net, not the contract.
 
 ## Pre-Commit Quality Checks
 

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -20,6 +20,7 @@ final readonly class UpdateUserProfileInformation implements UpdatesUserProfileI
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
             'profile_photo_path' => ['nullable', 'string', 'max:255'],
+            'timezone' => ['nullable', 'string', 'max:64', 'timezone'],
         ])->validateWithBag('updateProfileInformation');
 
         $newPhotoPath = $input['profile_photo_path'] ?? null;
@@ -34,12 +35,13 @@ final readonly class UpdateUserProfileInformation implements UpdatesUserProfileI
             $user->forceFill([
                 'name' => $input['name'],
                 'email' => $input['email'],
+                ...$this->timezoneAttribute($input),
             ])->save();
         }
     }
 
     /**
-     * @param  array<string, string>  $input
+     * @param  array<string, mixed>  $input
      */
     private function updateVerifiedUser(User $user, array $input): void
     {
@@ -47,8 +49,26 @@ final readonly class UpdateUserProfileInformation implements UpdatesUserProfileI
             'name' => $input['name'],
             'email' => $input['email'],
             'email_verified_at' => null,
+            ...$this->timezoneAttribute($input),
         ])->save();
 
         $user->sendEmailVerificationNotification();
+    }
+
+    /**
+     * Clearing the select writes null — that is a deliberate "use the app default".
+     * An absent key means the caller is not managing the timezone at all, so the
+     * stored value is left alone.
+     *
+     * @param  array<string, mixed>  $input
+     * @return array<string, string|null>
+     */
+    private function timezoneAttribute(array $input): array
+    {
+        if (! array_key_exists('timezone', $input)) {
+            return [];
+        }
+
+        return ['timezone' => blank($input['timezone']) ? null : (string) $input['timezone']];
     }
 }

--- a/app/Actions/Profile/SyncUserTimezone.php
+++ b/app/Actions/Profile/SyncUserTimezone.php
@@ -6,6 +6,7 @@ namespace App\Actions\Profile;
 
 use App\Models\User;
 use DateTimeZone;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Seeds `users.timezone` from the browser's detected zone.
@@ -19,16 +20,28 @@ final readonly class SyncUserTimezone
 {
     public function execute(User $user, string $timezone): bool
     {
-        if ($user->timezone !== null) {
-            return false;
-        }
-
         if (! in_array($timezone, DateTimeZone::listIdentifiers(), true)) {
             return false;
         }
 
-        $user->forceFill(['timezone' => $timezone])->saveQuietly();
+        /**
+         * "Fill only if still null" is a check followed by a write, so two first-page
+         * loads racing each other both passed the check and both wrote — last one won.
+         * Re-read the row under a lock inside the transaction so the check and the write
+         * cannot be separated. Mirrors StartProTrial, which guards the same write-once
+         * shape the same way.
+         */
+        return DB::transaction(function () use ($user, $timezone): bool {
+            $locked = User::query()->whereKey($user->getKey())->lockForUpdate()->first();
 
-        return true;
+            if (! $locked instanceof User || $locked->timezone !== null) {
+                return false;
+            }
+
+            $locked->forceFill(['timezone' => $timezone])->saveQuietly();
+            $user->setAttribute('timezone', $timezone)->syncOriginalAttribute('timezone');
+
+            return true;
+        });
     }
 }

--- a/app/Actions/Profile/SyncUserTimezone.php
+++ b/app/Actions/Profile/SyncUserTimezone.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Profile;
+
+use App\Models\User;
+use DateTimeZone;
+
+/**
+ * Seeds `users.timezone` from the browser's detected zone.
+ *
+ * Only ever fills a null value: once a timezone is on the record — whether it was
+ * detected earlier or chosen explicitly on the profile page — the browser must not
+ * overwrite it, or a deliberate choice would be undone on the next page load from a
+ * travelling laptop or a VPN.
+ */
+final readonly class SyncUserTimezone
+{
+    public function execute(User $user, string $timezone): bool
+    {
+        if ($user->timezone !== null) {
+            return false;
+        }
+
+        if (! in_array($timezone, DateTimeZone::listIdentifiers(), true)) {
+            return false;
+        }
+
+        $user->forceFill(['timezone' => $timezone])->saveQuietly();
+
+        return true;
+    }
+}

--- a/app/Console/Commands/SendTaskDigestCommand.php
+++ b/app/Console/Commands/SendTaskDigestCommand.php
@@ -75,8 +75,7 @@ final class SendTaskDigestCommand extends Command
 
     private function sendForUser(User $user, DigestService $digestService): bool
     {
-        $timezone = $user->timezone ?? (string) config('app.timezone');
-        $localNow = Date::now($timezone);
+        $localNow = Date::now($user->effectiveTimezone());
 
         if ($localNow->hour !== 8) {
             return false;

--- a/app/Filament/CustomFields/DateFieldType.php
+++ b/app/Filament/CustomFields/DateFieldType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\CustomFields;
+
+use Relaticle\CustomFields\FieldTypeSystem\Definitions\DateFieldType as BaseDateFieldType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
+
+/**
+ * Date-only fields share the package's infolist entry with date-time fields, so they
+ * inherited the same hardcoded fallback and printed `2026-08-19` on a record page where
+ * the table showed `Aug 19, 2026`. Swap in the format-consistent entry.
+ *
+ * Only the entry is replaced. The package's table column is deliberately kept: a bare
+ * date has no time of day, so the timezone conversion {@see DateTimeColumn} performs
+ * would move it a day for every viewer west of UTC.
+ */
+final class DateFieldType extends BaseDateFieldType
+{
+    public function configure(): FieldSchema
+    {
+        return parent::configure()->infolistEntry(DateTimeEntry::class);
+    }
+}

--- a/app/Filament/CustomFields/DateTimeColumn.php
+++ b/app/Filament/CustomFields/DateTimeColumn.php
@@ -25,6 +25,11 @@ use Relaticle\CustomFields\Models\CustomField;
  * Registered for the `date-time` field type only (see AppServiceProvider). Date-only
  * fields must keep the package column: a bare date has no time of day to shift, so
  * converting one would move it a day for every viewer west of UTC.
+ *
+ * The format is passed straight through, null included. Filament resolves null to the
+ * table's own default, so a custom-field datetime reads the same as the `created_at`
+ * beside it instead of being pinned to a literal this class chose. That also means each
+ * panel's format applies without this class knowing which panels exist.
  */
 final class DateTimeColumn extends BaseDateTimeColumn
 {
@@ -38,6 +43,6 @@ final class DateTimeColumn extends BaseDateTimeColumn
 
         return $column
             ->getStateUsing(fn (HasCustomFields $record): mixed => $record->getCustomFieldValue($customField))
-            ->dateTime(CustomFields::dateTimeDisplayFormat() ?? 'M j, Y H:i');
+            ->dateTime(CustomFields::dateTimeDisplayFormat());
     }
 }

--- a/app/Filament/CustomFields/DateTimeColumn.php
+++ b/app/Filament/CustomFields/DateTimeColumn.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\CustomFields;
+
+use Filament\Tables\Columns\Column as BaseColumn;
+use Filament\Tables\Columns\TextColumn;
+use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Filament\Integration\Components\Tables\Columns\DateTimeColumn as BaseDateTimeColumn;
+use Relaticle\CustomFields\Models\Contracts\HasCustomFields;
+use Relaticle\CustomFields\Models\CustomField;
+
+/**
+ * The package column formats the value itself and hands Filament a finished string,
+ * so nothing downstream can still convert it — a date-time custom field renders the
+ * stored UTC wall clock to every viewer, while the DateTimePicker that wrote it and
+ * the infolist entry that echoes it both convert. Same value, three surfaces, two
+ * answers.
+ *
+ * Give Filament the Carbon instance instead and let its own dateTime() formatter run:
+ * that is the path that reads FilamentTimezone, and it is what the package's own
+ * infolist entry already does.
+ *
+ * Registered for the `date-time` field type only (see AppServiceProvider). Date-only
+ * fields must keep the package column: a bare date has no time of day to shift, so
+ * converting one would move it a day for every viewer west of UTC.
+ */
+final class DateTimeColumn extends BaseDateTimeColumn
+{
+    public function make(CustomField $customField): BaseColumn
+    {
+        $column = parent::make($customField);
+
+        if (! $column instanceof TextColumn) {
+            return $column;
+        }
+
+        return $column
+            ->getStateUsing(fn (HasCustomFields $record): mixed => $record->getCustomFieldValue($customField))
+            ->dateTime(CustomFields::dateTimeDisplayFormat() ?? 'M j, Y H:i');
+    }
+}

--- a/app/Filament/CustomFields/DateTimeEntry.php
+++ b/app/Filament/CustomFields/DateTimeEntry.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\CustomFields;
+
+use Filament\Infolists\Components\TextEntry;
+use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Filament\Integration\Base\AbstractInfolistEntry;
+use Relaticle\CustomFields\Models\CustomField;
+
+/**
+ * The package entry falls back to a literal `Y-m-d H:i:s` when the package has no display
+ * format configured, which it never does here — so a record's view page printed
+ * `2026-08-19 08:30:00` for the same field the table beside it rendered as
+ * `Aug 19, 2026 08:30`.
+ *
+ * Pass the format through untouched, null included, so Filament resolves it to the panel's
+ * own default. Same fix already applied to the table column in {@see DateTimeColumn}: the
+ * two surfaces have to agree, and neither should hardcode a literal the panel did not pick.
+ *
+ * Written out rather than subclassed because the package entry is final.
+ */
+final class DateTimeEntry extends AbstractInfolistEntry
+{
+    public function make(CustomField $customField): TextEntry
+    {
+        $isDateTime = $customField->isDateTimeField();
+
+        $format = $isDateTime
+            ? CustomFields::dateTimeDisplayFormat()
+            : CustomFields::dateDisplayFormat();
+
+        $entry = TextEntry::make($customField->getFieldName())
+            ->label($customField->name)
+            ->state(fn (mixed $record): mixed => $record->getCustomFieldValue($customField));
+
+        return $isDateTime
+            ? $entry->dateTime($format)
+            : $entry->date($format);
+    }
+}

--- a/app/Filament/CustomFields/DateTimeFieldType.php
+++ b/app/Filament/CustomFields/DateTimeFieldType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\CustomFields;
+
+use Relaticle\CustomFields\FieldTypeSystem\Definitions\DateTimeFieldType as BaseDateTimeFieldType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
+
+/**
+ * Swaps in the timezone-aware table column and changes nothing else. Registering this
+ * under the same `date-time` key replaces the package definition, because FieldManager
+ * keys its collection by field-type key and the last registration wins.
+ */
+final class DateTimeFieldType extends BaseDateTimeFieldType
+{
+    public function configure(): FieldSchema
+    {
+        return parent::configure()->tableColumn(DateTimeColumn::class);
+    }
+}

--- a/app/Filament/CustomFields/DateTimeFieldType.php
+++ b/app/Filament/CustomFields/DateTimeFieldType.php
@@ -8,14 +8,21 @@ use Relaticle\CustomFields\FieldTypeSystem\Definitions\DateTimeFieldType as Base
 use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 
 /**
- * Swaps in the timezone-aware table column and changes nothing else. Registering this
- * under the same `date-time` key replaces the package definition, because FieldManager
- * keys its collection by field-type key and the last registration wins.
+ * Swaps in the timezone-aware table column and the format-consistent infolist entry, and
+ * changes nothing else. Registering this under the same `date-time` key replaces the
+ * package definition, because FieldManager keys its collection by field-type key and the
+ * last registration wins.
+ *
+ * Both surfaces are overridden together on purpose: a table and the record page it links
+ * to showing the same value two ways is the bug, so fixing one without the other only
+ * moves it.
  */
 final class DateTimeFieldType extends BaseDateTimeFieldType
 {
     public function configure(): FieldSchema
     {
-        return parent::configure()->tableColumn(DateTimeColumn::class);
+        return parent::configure()
+            ->tableColumn(DateTimeColumn::class)
+            ->infolistEntry(DateTimeEntry::class);
     }
 }

--- a/app/Filament/Exports/BaseExporter.php
+++ b/app/Filament/Exports/BaseExporter.php
@@ -10,6 +10,7 @@ use Carbon\Carbon;
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
@@ -48,9 +49,7 @@ abstract class BaseExporter extends Exporter
      */
     public function timezone(): string
     {
-        $user = $this->export->user;
-
-        return ($user instanceof User ? $user->timezone : null) ?? (string) config('app.timezone');
+        return self::timezoneFor($this->export->user);
     }
 
     /**
@@ -58,9 +57,19 @@ abstract class BaseExporter extends Exporter
      */
     public static function requestTimezone(): string
     {
-        $user = Auth::guard('web')->user();
+        return self::timezoneFor(Auth::guard('web')->user());
+    }
 
-        return ($user instanceof User ? $user->timezone : null) ?? (string) config('app.timezone');
+    /**
+     * The web guard is shared with the sysadmin panel's SystemAdministrator, and an
+     * export row can outlive its author, so narrow to the customer model rather than
+     * assuming either is present.
+     */
+    private static function timezoneFor(?Authenticatable $user): string
+    {
+        return $user instanceof User
+            ? $user->effectiveTimezone()
+            : (string) config('app.timezone');
     }
 
     /**

--- a/app/Filament/Exports/BaseExporter.php
+++ b/app/Filament/Exports/BaseExporter.php
@@ -6,6 +6,8 @@ namespace App\Filament\Exports;
 
 use App\Models\Team;
 use App\Models\User;
+use Carbon\Carbon;
+use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
 use Illuminate\Database\Eloquent\Builder;
@@ -59,6 +61,18 @@ abstract class BaseExporter extends Exporter
         $user = Auth::guard('web')->user();
 
         return ($user instanceof User ? $user->timezone : null) ?? (string) config('app.timezone');
+    }
+
+    /**
+     * Every exporter builds its datetime columns through here, so a workspace never
+     * ends up with one CSV in local time and the next in UTC. The zone is named in
+     * the header because a bare timestamp gives the reader no way to tell which.
+     */
+    protected static function dateTimeColumn(string $name, string $label): ExportColumn
+    {
+        return ExportColumn::make($name)
+            ->label($label.' ('.self::requestTimezone().')')
+            ->formatStateUsing(fn (?Carbon $state, BaseExporter $exporter): ?string => $state?->setTimezone($exporter->timezone())->format('Y-m-d H:i:s'));
     }
 
     /**

--- a/app/Filament/Exports/BaseExporter.php
+++ b/app/Filament/Exports/BaseExporter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Exports;
 
 use App\Models\Team;
+use App\Models\User;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
 use Illuminate\Database\Eloquent\Builder;
@@ -30,6 +31,34 @@ abstract class BaseExporter extends Exporter
             $currentTeam = Auth::guard('web')->user()->currentTeam;
             $export->team_id = $currentTeam->getKey();
         }
+    }
+
+    /**
+     * A CSV is opened by a human who thinks in local time, so datetimes are converted
+     * out of UTC before they are written.
+     *
+     * Values and headers resolve the same user from two different places because they
+     * are produced at two different moments: `formatStateUsing` runs inside the queued
+     * job, which has no session and reads the user off the export record, while
+     * `getColumns()` is static and only ever evaluated for labels during the interactive
+     * column-mapping step — Filament freezes those labels into the export's columnMap
+     * and writes the header row from that, never re-deriving it in the job.
+     */
+    public function timezone(): string
+    {
+        $user = $this->export->user;
+
+        return ($user instanceof User ? $user->timezone : null) ?? (string) config('app.timezone');
+    }
+
+    /**
+     * Header-row timezone, resolved from the session — see timezone() for why.
+     */
+    public static function requestTimezone(): string
+    {
+        $user = Auth::guard('web')->user();
+
+        return ($user instanceof User ? $user->timezone : null) ?? (string) config('app.timezone');
     }
 
     /**

--- a/app/Filament/Exports/BaseExporter.php
+++ b/app/Filament/Exports/BaseExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Exports;
 
+use App\Models\CustomField;
 use App\Models\Team;
 use App\Models\User;
 use Carbon\Carbon;
@@ -13,7 +14,9 @@ use Filament\Actions\Exports\Models\Export;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Relaticle\CustomFields\Enums\FieldDataType;
 
 abstract class BaseExporter extends Exporter
 {
@@ -82,6 +85,57 @@ abstract class BaseExporter extends Exporter
         return ExportColumn::make($name)
             ->label($label.' ('.self::requestTimezone().')')
             ->formatStateUsing(fn (?Carbon $state, BaseExporter $exporter): ?string => $state?->setTimezone($exporter->timezone())->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * The custom-field columns arrive from the package already built, so they never pass
+     * through `dateTimeColumn()` above. Left alone they write the stored UTC under a bare
+     * header, in the same file where the native columns say `(Asia/Tokyo)` — and the
+     * neighbouring suffix is what makes that dangerous, because it tells the reader the
+     * file is local when one column is not.
+     *
+     * Only `date-time` fields are converted. A date-only field has no time of day, so
+     * shifting it would move the calendar day for every viewer west of UTC; it is instead
+     * trimmed to `Y-m-d` to drop the `00:00:00` a Carbon cast invents.
+     *
+     * @param  Collection<int, ExportColumn>  $columns
+     * @return array<int, ExportColumn>
+     */
+    protected static function customFieldColumns(Collection $columns): array
+    {
+        // Scoped to this exporter's entity: field codes are unique per entity type, not
+        // globally, so `linkedin` exists on both Company and People. Keying an unscoped
+        // list by code would let one entity's field decide another's formatting.
+        $fieldsByName = CustomField::query()
+            ->forEntity(self::getModel())
+            ->get()
+            ->keyBy(fn (CustomField $field): string => $field->getFieldName());
+
+        return $columns
+            ->map(function (ExportColumn $column) use ($fieldsByName): ExportColumn {
+                $field = $fieldsByName->get($column->getName());
+
+                if (! $field instanceof CustomField) {
+                    return $column;
+                }
+
+                if ($field->typeData->dataType === FieldDataType::DATE_TIME) {
+                    return $column
+                        ->label($column->getLabel().' ('.self::requestTimezone().')')
+                        ->formatStateUsing(fn (mixed $state, BaseExporter $exporter): mixed => $state instanceof Carbon
+                            ? $state->copy()->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')
+                            : $state);
+                }
+
+                if ($field->typeData->dataType === FieldDataType::DATE) {
+                    return $column->formatStateUsing(fn (mixed $state): mixed => $state instanceof Carbon
+                        ? $state->format('Y-m-d')
+                        : $state);
+                }
+
+                return $column;
+            })
+            ->all();
     }
 
     /**

--- a/app/Filament/Exports/CompanyExporter.php
+++ b/app/Filament/Exports/CompanyExporter.php
@@ -34,11 +34,11 @@ final class CompanyExporter extends BaseExporter
                 ->label(__('filament/exports.columns.opportunities_count'))
                 ->state(fn (Company $company): int => $company->opportunities()->count()),
             ExportColumn::make('created_at')
-                ->label(__('filament/exports.columns.created_at'))
-                ->formatStateUsing(fn (Carbon $state): string => $state->format('Y-m-d H:i:s')),
+                ->label(__('filament/exports.columns.created_at').' ('.self::requestTimezone().')')
+                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
             ExportColumn::make('updated_at')
-                ->label(__('filament/exports.columns.updated_at'))
-                ->formatStateUsing(fn (Carbon $state): string => $state->format('Y-m-d H:i:s')),
+                ->label(__('filament/exports.columns.updated_at').' ('.self::requestTimezone().')')
+                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
             ExportColumn::make('creation_source')
                 ->label(__('filament/exports.columns.creation_source'))
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),

--- a/app/Filament/Exports/CompanyExporter.php
+++ b/app/Filament/Exports/CompanyExporter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Exports;
 
 use App\Models\Company;
-use Carbon\Carbon;
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Models\Export;
 use Relaticle\CustomFields\Facades\CustomFields;
@@ -33,12 +32,8 @@ final class CompanyExporter extends BaseExporter
             ExportColumn::make('opportunities_count')
                 ->label(__('filament/exports.columns.opportunities_count'))
                 ->state(fn (Company $company): int => $company->opportunities()->count()),
-            ExportColumn::make('created_at')
-                ->label(__('filament/exports.columns.created_at').' ('.self::requestTimezone().')')
-                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
-            ExportColumn::make('updated_at')
-                ->label(__('filament/exports.columns.updated_at').' ('.self::requestTimezone().')')
-                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
+            self::dateTimeColumn('created_at', __('filament/exports.columns.created_at')),
+            self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
             ExportColumn::make('creation_source')
                 ->label(__('filament/exports.columns.creation_source'))
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),

--- a/app/Filament/Exports/CompanyExporter.php
+++ b/app/Filament/Exports/CompanyExporter.php
@@ -39,7 +39,7 @@ final class CompanyExporter extends BaseExporter
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),
 
             // Add all custom fields automatically
-            ...CustomFields::exporter()->forModel(self::getModel())->columns(),
+            ...self::customFieldColumns(CustomFields::exporter()->forModel(self::getModel())->columns()),
         ];
     }
 

--- a/app/Filament/Exports/NoteExporter.php
+++ b/app/Filament/Exports/NoteExporter.php
@@ -28,7 +28,7 @@ final class NoteExporter extends BaseExporter
             self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
             self::dateTimeColumn('deleted_at', __('filament/exports.columns.deleted_at')),
 
-            ...CustomFields::exporter()->forModel(self::getModel())->columns(),
+            ...self::customFieldColumns(CustomFields::exporter()->forModel(self::getModel())->columns()),
         ];
     }
 

--- a/app/Filament/Exports/NoteExporter.php
+++ b/app/Filament/Exports/NoteExporter.php
@@ -24,9 +24,9 @@ final class NoteExporter extends BaseExporter
             ExportColumn::make('creation_source')
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),
             ExportColumn::make('title'),
-            ExportColumn::make('created_at'),
-            ExportColumn::make('updated_at'),
-            ExportColumn::make('deleted_at'),
+            self::dateTimeColumn('created_at', __('filament/exports.columns.created_at')),
+            self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
+            self::dateTimeColumn('deleted_at', __('filament/exports.columns.deleted_at')),
 
             ...CustomFields::exporter()->forModel(self::getModel())->columns(),
         ];

--- a/app/Filament/Exports/OpportunityExporter.php
+++ b/app/Filament/Exports/OpportunityExporter.php
@@ -41,7 +41,7 @@ final class OpportunityExporter extends BaseExporter
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),
 
             // Add all custom fields automatically
-            ...CustomFields::exporter()->forModel(self::getModel())->columns(),
+            ...self::customFieldColumns(CustomFields::exporter()->forModel(self::getModel())->columns()),
         ];
     }
 

--- a/app/Filament/Exports/OpportunityExporter.php
+++ b/app/Filament/Exports/OpportunityExporter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Exports;
 
 use App\Models\Opportunity;
-use Carbon\Carbon;
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Models\Export;
 use Relaticle\CustomFields\Facades\CustomFields;
@@ -35,12 +34,8 @@ final class OpportunityExporter extends BaseExporter
             ExportColumn::make('tasks_count')
                 ->label(__('filament/exports.columns.tasks_count'))
                 ->state(fn (Opportunity $opportunity): int => $opportunity->tasks()->count()),
-            ExportColumn::make('created_at')
-                ->label(__('filament/exports.columns.created_at').' ('.self::requestTimezone().')')
-                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
-            ExportColumn::make('updated_at')
-                ->label(__('filament/exports.columns.updated_at').' ('.self::requestTimezone().')')
-                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
+            self::dateTimeColumn('created_at', __('filament/exports.columns.created_at')),
+            self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
             ExportColumn::make('creation_source')
                 ->label(__('filament/exports.columns.creation_source'))
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),

--- a/app/Filament/Exports/OpportunityExporter.php
+++ b/app/Filament/Exports/OpportunityExporter.php
@@ -36,11 +36,11 @@ final class OpportunityExporter extends BaseExporter
                 ->label(__('filament/exports.columns.tasks_count'))
                 ->state(fn (Opportunity $opportunity): int => $opportunity->tasks()->count()),
             ExportColumn::make('created_at')
-                ->label(__('filament/exports.columns.created_at'))
-                ->formatStateUsing(fn (Carbon $state): string => $state->format('Y-m-d H:i:s')),
+                ->label(__('filament/exports.columns.created_at').' ('.self::requestTimezone().')')
+                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
             ExportColumn::make('updated_at')
-                ->label(__('filament/exports.columns.updated_at'))
-                ->formatStateUsing(fn (Carbon $state): string => $state->format('Y-m-d H:i:s')),
+                ->label(__('filament/exports.columns.updated_at').' ('.self::requestTimezone().')')
+                ->formatStateUsing(fn (Carbon $state, BaseExporter $exporter): string => $state->setTimezone($exporter->timezone())->format('Y-m-d H:i:s')),
             ExportColumn::make('creation_source')
                 ->label(__('filament/exports.columns.creation_source'))
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),

--- a/app/Filament/Exports/PeopleExporter.php
+++ b/app/Filament/Exports/PeopleExporter.php
@@ -30,7 +30,7 @@ final class PeopleExporter extends BaseExporter
             self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
             self::dateTimeColumn('deleted_at', __('filament/exports.columns.deleted_at')),
 
-            ...CustomFields::exporter()->forModel(self::getModel())->columns(),
+            ...self::customFieldColumns(CustomFields::exporter()->forModel(self::getModel())->columns()),
         ];
     }
 

--- a/app/Filament/Exports/PeopleExporter.php
+++ b/app/Filament/Exports/PeopleExporter.php
@@ -26,9 +26,9 @@ final class PeopleExporter extends BaseExporter
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),
             ExportColumn::make('company.name'),
             ExportColumn::make('name'),
-            ExportColumn::make('created_at'),
-            ExportColumn::make('updated_at'),
-            ExportColumn::make('deleted_at'),
+            self::dateTimeColumn('created_at', __('filament/exports.columns.created_at')),
+            self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
+            self::dateTimeColumn('deleted_at', __('filament/exports.columns.deleted_at')),
 
             ...CustomFields::exporter()->forModel(self::getModel())->columns(),
         ];

--- a/app/Filament/Exports/TaskExporter.php
+++ b/app/Filament/Exports/TaskExporter.php
@@ -27,7 +27,7 @@ final class TaskExporter extends BaseExporter
             self::dateTimeColumn('created_at', __('filament/exports.columns.created_at')),
             self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
 
-            ...CustomFields::exporter()->forModel(self::getModel())->columns(),
+            ...self::customFieldColumns(CustomFields::exporter()->forModel(self::getModel())->columns()),
         ];
     }
 

--- a/app/Filament/Exports/TaskExporter.php
+++ b/app/Filament/Exports/TaskExporter.php
@@ -24,8 +24,8 @@ final class TaskExporter extends BaseExporter
             ExportColumn::make('creation_source')
                 ->formatStateUsing(fn (mixed $state): string => $state->value ?? (string) $state),
             ExportColumn::make('title'),
-            ExportColumn::make('created_at'),
-            ExportColumn::make('updated_at'),
+            self::dateTimeColumn('created_at', __('filament/exports.columns.created_at')),
+            self::dateTimeColumn('updated_at', __('filament/exports.columns.updated_at')),
 
             ...CustomFields::exporter()->forModel(self::getModel())->columns(),
         ];

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -91,9 +91,7 @@ final class Dashboard extends Page
         $user = Filament::auth()->user();
         $firstName = explode(' ', $user->name)[0];
 
-        /** @var string $timezone */
-        $timezone = $user->timezone ?? config('app.timezone');
-        $hour = Date::now($timezone)->hour;
+        $hour = Date::now($user->effectiveTimezone())->hour;
 
         return match (true) {
             $hour < 12 => "Good morning, {$firstName}.",

--- a/app/Filament/Resources/CompanyResource.php
+++ b/app/Filament/Resources/CompanyResource.php
@@ -90,9 +90,13 @@ final class CompanyResource extends Resource
                     ->searchable()
                     ->sortable()
                     ->toggleable(),
+                // "2 hours ago" is the friendlier read, but it was the one datetime in the
+                // panel a user could not check: no absolute value and no tooltip. Keep the
+                // relative label and put the exact time behind a hover.
                 TextColumn::make('updated_at')
                     ->label(__('filament/resources/company.fields.updated_at.label'))
                     ->since()
+                    ->dateTimeTooltip()
                     ->searchable()
                     ->sortable()
                     ->toggleable(),

--- a/app/Filament/Resources/NoteResource.php
+++ b/app/Filament/Resources/NoteResource.php
@@ -84,12 +84,12 @@ final class NoteResource extends Resource
                     ->toggledHiddenByDefault(),
                 TextColumn::make('created_at')
                     ->label(__('filament/resources/note.fields.created_at.label'))
-                    ->dateTime('Y-m-d H:i:s')
+                    ->dateTime()
                     ->sortable()
                     ->toggleable(),
                 TextColumn::make('updated_at')
                     ->label(__('filament/resources/note.fields.updated_at.label'))
-                    ->dateTime('Y-m-d H:i:s')
+                    ->dateTime()
                     ->sortable()
                     ->toggleable()
                     ->toggledHiddenByDefault(),

--- a/app/Filament/Resources/OpportunityResource/Pages/OpportunitiesBoard.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/OpportunitiesBoard.php
@@ -21,6 +21,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\TextSize;
 use Filament\Support\Enums\Width;
+use Filament\Support\Facades\FilamentTimezone;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
@@ -255,6 +256,16 @@ final class OpportunitiesBoard extends BoardResourcePage
         )->toArray();
     }
 
+    /**
+     * "Today" and "tomorrow" are questions about the viewer's calendar, so the boundary
+     * moves into their zone — but the close date itself must not. Unlike the tasks
+     * board's due date, this is a plain calendar date the package stores at midnight
+     * UTC: converting it into a negative-offset zone walks it back past midnight and
+     * the card reads a day early. Move only the "today" it is measured against, and
+     * compare the two as dates rather than instants — midnight UTC and midnight in
+     * Los Angeles are the same calendar day but seven hours apart, so an instant
+     * comparison would call a date closing today overdue.
+     */
     private function formatCloseDateBadge(?string $state): string
     {
         if (blank($state)) {
@@ -262,11 +273,16 @@ final class OpportunitiesBoard extends BoardResourcePage
         }
 
         $date = Date::parse($state);
+        $viewerToday = Date::now(FilamentTimezone::get())->startOfDay();
+
+        $closesOn = $date->toDateString();
+        $today = $viewerToday->toDateString();
+        $tomorrow = $viewerToday->copy()->addDay()->toDateString();
 
         return match (true) {
-            $date->isPast() => $date->format('M j').' (Overdue)',
-            $date->isToday() => 'Closes Today',
-            $date->isTomorrow() => 'Closes Tomorrow',
+            $closesOn < $today => $date->format('M j').' (Overdue)',
+            $closesOn === $today => 'Closes Today',
+            $closesOn === $tomorrow => 'Closes Tomorrow',
             default => $date->format('M j'),
         };
     }

--- a/app/Filament/Resources/TaskResource/Pages/TasksBoard.php
+++ b/app/Filament/Resources/TaskResource/Pages/TasksBoard.php
@@ -18,6 +18,7 @@ use Filament\Actions\CreateAction;
 use Filament\Infolists\Components\ImageEntry;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
+use Filament\Support\Facades\FilamentTimezone;
 use Filament\Tables\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\JoinClause;
@@ -242,6 +243,12 @@ final class TasksBoard extends BoardResourcePage
      *
      * Shows relative dates (Today/Tomorrow) for immediate items,
      * and full dates with year for all other cases.
+     *
+     * "Today" and "tomorrow" are questions about the viewer's calendar, so the stored
+     * UTC value is moved into their zone first: isToday()/isTomorrow() compare against
+     * now in the instance's own timezone, and left in UTC they bucket a late-evening
+     * due date a day early for anyone far enough east. isPast() compares instants and
+     * is unaffected either way.
      */
     private function formatDueDateBadge(?string $state): string
     {
@@ -249,7 +256,7 @@ final class TasksBoard extends BoardResourcePage
             return '';
         }
 
-        $date = Date::parse($state);
+        $date = Date::parse($state)->setTimezone(FilamentTimezone::get());
 
         return match (true) {
             $date->isPast() => $date->format('M j, Y').' (Overdue)',

--- a/app/Http/Controllers/SyncUserTimezoneController.php
+++ b/app/Http/Controllers/SyncUserTimezoneController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Actions\Profile\SyncUserTimezone;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final readonly class SyncUserTimezoneController
+{
+    public function __construct(private SyncUserTimezone $syncUserTimezone) {}
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'timezone' => ['required', 'string', 'max:64', 'timezone'],
+        ]);
+
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return new JsonResponse(['synced' => false], 403);
+        }
+
+        return new JsonResponse([
+            'synced' => $this->syncUserTimezone->execute($user, $validated['timezone']),
+        ]);
+    }
+}

--- a/app/Livewire/App/AccessTokens/ManageAccessTokens.php
+++ b/app/Livewire/App/AccessTokens/ManageAccessTokens.php
@@ -59,8 +59,12 @@ final class ManageAccessTokens extends BaseLivewireComponent implements HasTable
                 TextColumn::make('last_used_at')
                     ->label(__('access-tokens.table.columns.last_used_at'))
                     ->since()
+                    ->dateTimeTooltip()
                     ->placeholder(__('access-tokens.table.placeholders.never')),
-                TextColumn::make('created_at')->label(__('access-tokens.table.columns.created_at'))->since(),
+                TextColumn::make('created_at')
+                    ->label(__('access-tokens.table.columns.created_at'))
+                    ->since()
+                    ->dateTimeTooltip(),
             ])
             ->actions([
                 Action::make('permissions')

--- a/app/Livewire/App/AccessTokens/ManageOAuthConnectors.php
+++ b/app/Livewire/App/AccessTokens/ManageOAuthConnectors.php
@@ -67,7 +67,8 @@ final class ManageOAuthConnectors extends BaseLivewireComponent implements HasTa
                     ->badge(),
                 TextColumn::make('created_at')
                     ->label(__('access-tokens.table.columns.created_at'))
-                    ->since(),
+                    ->since()
+                    ->dateTimeTooltip(),
             ])
             ->recordActions([
                 Action::make('revoke')

--- a/app/Livewire/App/Profile/UpdateProfileInformation.php
+++ b/app/Livewire/App/Profile/UpdateProfileInformation.php
@@ -9,11 +9,13 @@ use App\Actions\Profile\RemoveUserProfilePhoto;
 use App\Livewire\BaseLivewireComponent;
 use App\Support\SameOriginUrl;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use DateTimeZone;
 use Filament\Actions\Action;
 use Filament\Auth\Notifications\NoticeOfEmailChangeRequest;
 use Filament\Auth\Notifications\VerifyEmailChange;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Actions;
@@ -21,6 +23,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
 use League\Flysystem\UnableToCheckFileExistence;
@@ -34,9 +37,28 @@ final class UpdateProfileInformation extends BaseLivewireComponent
 
     public function mount(): void
     {
-        $data = $this->authUser()->only(['name', 'email']);
+        $data = $this->authUser()->only(['name', 'email', 'timezone']);
 
         $this->form->fill($data);
+    }
+
+    /**
+     * IANA identifiers labelled with their current UTC offset, so the list is
+     * scannable without knowing every region name by heart.
+     *
+     * @return array<string, string>
+     */
+    private function timezoneOptions(): array
+    {
+        $options = [];
+
+        foreach (DateTimeZone::listIdentifiers() as $identifier) {
+            $offset = Date::now($identifier)->format('P');
+
+            $options[$identifier] = "{$identifier} (UTC{$offset})";
+        }
+
+        return $options;
     }
 
     public function form(Schema $schema): Schema
@@ -75,6 +97,13 @@ final class UpdateProfileInformation extends BaseLivewireComponent
                             ->email()
                             ->required()
                             ->unique(Filament::auth()->user() !== null ? Filament::auth()->user()::class : self::class, ignorable: $this->authUser()),
+                        Select::make('timezone')
+                            ->label(__('profile.form.timezone.label'))
+                            ->helperText(__('profile.form.timezone.helper_text'))
+                            ->placeholder(__('profile.form.timezone.placeholder'))
+                            ->options($this->timezoneOptions())
+                            ->searchable()
+                            ->native(false),
                         Actions::make([
                             Action::make('save')
                                 ->label(__('profile.actions.save'))
@@ -126,7 +155,7 @@ final class UpdateProfileInformation extends BaseLivewireComponent
         }
 
         $this->form->fill([
-            ...$this->authUser()->only(['name', 'email']),
+            ...$this->authUser()->only(['name', 'email', 'timezone']),
             'profile_photo_path' => null,
         ]);
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -120,6 +120,17 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
     }
 
     /**
+     * The zone this user's calendar is expressed in. `timezone` is nullable — a user
+     * who never chose one and whose browser was never detected falls back to the app
+     * default, so every caller that turns a stored UTC value into a wall clock reads
+     * it from here rather than repeating the fallback.
+     */
+    public function effectiveTimezone(): string
+    {
+        return $this->timezone ?? (string) config('app.timezone');
+    }
+
+    /**
      * @return HasMany<UserSocialAccount, $this>
      */
     public function socialAccounts(): HasMany

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Console\Commands\MakeFilamentUserCommand;
 use App\Enums\Plan;
+use App\Filament\CustomFields\DateTimeFieldType;
 use App\Http\Responses\LoginResponse;
 use App\Listeners\Billing\SyncPlanOnStripeSubscriptionChange;
 use App\Listeners\Email\NewSubscriberListener;
@@ -40,6 +41,7 @@ use App\Support\Markdown\TableAwareLeagueDriver;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Livewire\Notifications;
+use Filament\Support\Facades\FilamentTimezone;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -68,6 +70,7 @@ use Livewire\Livewire;
 use Relaticle\ActivityLog\Facades\Timeline;
 use Relaticle\Chat\Support\ChatTelemetry;
 use Relaticle\CustomFields\CustomFields;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\Ink\Filament\Resources\PostResource;
 use Relaticle\Ink\Ink;
 use Relaticle\Ink\Models\Category;
@@ -439,6 +442,11 @@ final class AppServiceProvider extends ServiceProvider
         CustomFields::useOptionModel(CustomFieldOption::class);
         CustomFields::useValueModel(CustomFieldValue::class);
 
+        // Replaces the package's `date-time` definition to fix its table column, which
+        // renders stored UTC to every viewer — see App\Filament\CustomFields\DateTimeColumn.
+        // Deliberately not registered for `date`: a date has no time of day to convert.
+        CustomFieldsType::register(['date-time' => DateTimeFieldType::class]);
+
         $this->configureCustomFieldSchemaInvalidation();
     }
 
@@ -476,6 +484,38 @@ final class AppServiceProvider extends ServiceProvider
             }
 
             return $action;
+        });
+
+        /**
+         * Datetimes are stored in UTC; every panel renders and accepts them in the
+         * signed-in account's chosen zone. Read by both table/infolist output and
+         * DateTimePicker input, so one closure keeps display and entry symmetrical.
+         *
+         * TimezoneManager is a single global slot, so this must stay the only writer
+         * — a second FilamentTimezone::set() anywhere would silently replace it, and
+         * which one survived would depend on service provider boot order. It lives
+         * here rather than in a panel provider for the same reason: the resolution
+         * spans every panel.
+         *
+         * The account is read through the current panel's own guard and by attribute
+         * rather than by class, so App\Models\User and SystemAdministrator are both
+         * served without this layer naming the sysadmin package. Returning null falls
+         * back to config('app.timezone'), which covers an unset zone, a zone that is
+         * no longer a valid identifier, an account type that has no zone at all, and
+         * any request outside a panel.
+         */
+        FilamentTimezone::set(function (): ?string {
+            if (Filament::getCurrentPanel() === null) {
+                return null;
+            }
+
+            $timezone = Filament::auth()->user()?->getAttribute('timezone');
+
+            if (! is_string($timezone)) {
+                return null;
+            }
+
+            return in_array($timezone, timezone_identifiers_list(), true) ? $timezone : null;
         });
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Console\Commands\MakeFilamentUserCommand;
 use App\Enums\Plan;
+use App\Filament\CustomFields\DateFieldType;
 use App\Filament\CustomFields\DateTimeFieldType;
 use App\Http\Responses\LoginResponse;
 use App\Listeners\Billing\SyncPlanOnStripeSubscriptionChange;
@@ -442,10 +443,18 @@ final class AppServiceProvider extends ServiceProvider
         CustomFields::useOptionModel(CustomFieldOption::class);
         CustomFields::useValueModel(CustomFieldValue::class);
 
-        // Replaces the package's `date-time` definition to fix its table column, which
-        // renders stored UTC to every viewer — see App\Filament\CustomFields\DateTimeColumn.
-        // Deliberately not registered for `date`: a date has no time of day to convert.
-        CustomFieldsType::register(['date-time' => DateTimeFieldType::class]);
+        // Replaces the package's definitions so custom-field dates read the same as the
+        // native columns beside them: `date-time` swaps the table column, which otherwise
+        // renders stored UTC to every viewer (App\Filament\CustomFields\DateTimeColumn),
+        // and both swap the infolist entry, which otherwise hardcodes `Y-m-d H:i:s` on
+        // record pages (App\Filament\CustomFields\DateTimeEntry).
+        //
+        // `date` gets the entry only. A bare date has no time of day, so converting one
+        // would move it a day for every viewer west of UTC.
+        CustomFieldsType::register([
+            'date-time' => DateTimeFieldType::class,
+            'date' => DateFieldType::class,
+        ]);
 
         $this->configureCustomFieldSchemaInvalidation();
     }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -48,7 +48,6 @@ use Filament\PanelProvider;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Enums\Platform;
 use Filament\Support\Enums\Size;
-use Filament\Support\Facades\FilamentTimezone;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Filament\View\PanelsRenderHook;
@@ -86,19 +85,6 @@ final class AppPanelProvider extends PanelProvider
             SwitchTeam::class,
         );
 
-        /**
-         * Datetimes are stored in UTC; the app panel renders and accepts them in the
-         * signed-in user's zone. Read by both table/infolist output and DateTimePicker
-         * input, so one closure keeps display and entry symmetrical.
-         *
-         * Guarded on the panel id because TimezoneManager is a global singleton — the
-         * sysadmin panel deliberately keeps rendering UTC (see SystemAdminPanelProvider),
-         * and returning null there falls back to config('app.timezone').
-         */
-        FilamentTimezone::set(fn (): ?string => Filament::getCurrentPanel()?->getId() === 'app'
-            ? $this->signedInUser()?->timezone
-            : null);
-
         Action::configureUsing(fn (Action $action): Action => $action->size(Size::Small)->iconPosition('before'));
         DeleteAction::configureUsing(fn (DeleteAction $action): DeleteAction => $action->label(__('filament/panel.actions.delete_record')));
         Section::configureUsing(fn (Section $section): Section => $section->compact());
@@ -106,8 +92,14 @@ final class AppPanelProvider extends PanelProvider
     }
 
     /**
-     * The web guard is shared with the sysadmin panel's SystemAdministrator, which has
-     * no timezone of its own — narrow to the customer model rather than assuming.
+     * Gates the browser timezone detection script below, which posts to an app-panel
+     * route. Panel rendering itself no longer reads this — that resolution is global
+     * and lives in AppServiceProvider::configureFilament(), because TimezoneManager
+     * holds a single slot and a second writer here would silently win on boot order.
+     *
+     * The web guard is shared with the sysadmin panel's SystemAdministrator, whose
+     * zone is chosen on its own profile page and never detected — narrow to the
+     * customer model rather than assuming.
      */
     private function signedInUser(): ?User
     {

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -46,6 +46,7 @@ use Filament\Navigation\NavigationGroup;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
 use Filament\Support\Enums\Platform;
 use Filament\Support\Enums\Size;
 use Filament\Support\Icons\Heroicon;
@@ -73,6 +74,19 @@ use Relaticle\ImportWizard\Filament\Pages\ImportHistory;
 final class AppPanelProvider extends PanelProvider
 {
     /**
+     * Datetime format for this panel, and the only place it is decided. Columns and
+     * entries call `->dateTime()` with no argument so they resolve to this; a resource
+     * that passes its own literal instead is drift, not a local preference.
+     *
+     * The value matches what Filament defaults to, so naming it here changes nothing
+     * on screen today. What it changes is that there is now one line to edit.
+     *
+     * No zone suffix, unlike sysadmin: every timestamp here is already in the reader's
+     * own zone, so there is nothing for them to correlate against.
+     */
+    private const string DATE_TIME_FORMAT = 'M j, Y H:i:s';
+
+    /**
      * Perform post-registration booting of components.
      */
     public function boot(): void
@@ -88,7 +102,21 @@ final class AppPanelProvider extends PanelProvider
         Action::configureUsing(fn (Action $action): Action => $action->size(Size::Small)->iconPosition('before'));
         DeleteAction::configureUsing(fn (DeleteAction $action): DeleteAction => $action->label(__('filament/panel.actions.delete_record')));
         Section::configureUsing(fn (Section $section): Section => $section->compact());
-        Table::configureUsing(fn (Table $table): Table => $table);
+
+        // Table and Schema configuration is global, so both callbacks have to check
+        // which panel is actually serving the request before they touch the format.
+        Table::configureUsing(fn (Table $table): Table => $this->isCurrentPanel()
+            ? $table->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+            : $table);
+
+        Schema::configureUsing(fn (Schema $schema): Schema => $this->isCurrentPanel()
+            ? $schema->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+            : $schema);
+    }
+
+    private function isCurrentPanel(): bool
+    {
+        return Filament::getCurrentPanel()?->getId() === 'app';
     }
 
     /**

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -78,13 +78,15 @@ final class AppPanelProvider extends PanelProvider
      * entries call `->dateTime()` with no argument so they resolve to this; a resource
      * that passes its own literal instead is drift, not a local preference.
      *
-     * The value matches what Filament defaults to, so naming it here changes nothing
-     * on screen today. What it changes is that there is now one line to edit.
+     * No seconds. Nobody reading a CRM list cares which second a note was written, and
+     * DateTimePicker offers minutes anyway, so keeping them made every value read back
+     * one field longer than it was entered. Sysadmin keeps its seconds on purpose: that
+     * panel exists to line rows up against Horizon and server logs.
      *
-     * No zone suffix, unlike sysadmin: every timestamp here is already in the reader's
-     * own zone, so there is nothing for them to correlate against.
+     * No zone suffix either, unlike sysadmin: every timestamp here is already in the
+     * reader's own zone, so there is nothing for them to correlate against.
      */
-    private const string DATE_TIME_FORMAT = 'M j, Y H:i:s';
+    private const string DATE_TIME_FORMAT = 'M j, Y H:i';
 
     /**
      * Perform post-registration booting of components.

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -269,14 +269,21 @@ final class AppPanelProvider extends PanelProvider
                 fn (): View|Factory => view('filament.app.analytics')
             )
             /**
-             * Only rendered until the user has a timezone; after that the hook returns
-             * nothing and no detection script reaches the browser at all.
+             * Only rendered for a signed-in user who has no timezone yet. The guest
+             * check matters: the panel's own login and registration pages render this
+             * hook too, and there the endpoint could only ever answer 401.
              */
             ->renderHook(
                 PanelsRenderHook::BODY_END,
-                fn (): View|Factory|string => $this->signedInUser()?->timezone === null
-                    ? view('filament.app.detect-timezone', ['endpoint' => route('filament.app.timezone.sync')])
-                    : '',
+                function (): View|Factory|string {
+                    $user = $this->signedInUser();
+
+                    if (! $user instanceof User || $user->timezone !== null) {
+                        return '';
+                    }
+
+                    return view('filament.app.detect-timezone', ['endpoint' => route('filament.app.timezone.sync')]);
+                },
             );
 
         if (Features::hasApiFeatures()) {

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -39,6 +39,7 @@ use Filament\Enums\DatabaseNotificationsPosition;
 use Filament\Enums\GlobalSearchPosition;
 use Filament\Events\TenantSet;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\DateTimePicker;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -49,6 +50,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Platform;
 use Filament\Support\Enums\Size;
+use Filament\Support\Facades\FilamentTimezone;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Filament\View\PanelsRenderHook;
@@ -65,6 +67,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Js;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Laravel\Jetstream\Features;
 use Laravel\Pennant\Feature;
@@ -114,6 +117,46 @@ final class AppPanelProvider extends PanelProvider
         Schema::configureUsing(fn (Schema $schema): Schema => $this->isCurrentPanel()
             ? $schema->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
             : $schema);
+
+        /**
+         * Filament's calendar decides which cell to circle as "today" with
+         * `dayjs.tz.guess()`, the device zone, and takes no server timezone. A user in
+         * Tokyo on a laptop still set elsewhere therefore saw the app say one date
+         * everywhere and the picker circle another, and clicking the circled cell books
+         * the wrong day.
+         *
+         * Only the highlight is wrong: the picker emits a naive wall-clock string that
+         * the server reads back in the panel zone, so typed values were always stored
+         * correctly. Overriding `dayIsToday` on the component's own element keeps the fix
+         * to that single comparison rather than forking the vendor component.
+         *
+         * The zone is baked in, the date is not: `Intl` recomputes it per call, so a tab
+         * left open across midnight still circles the right cell.
+         */
+        DateTimePicker::configureUsing(fn (DateTimePicker $picker): DateTimePicker => $this->isCurrentPanel()
+            ? $picker->extraAlpineAttributes(['x-init' => $this->todayInViewerZoneExpression()], merge: true)
+            : $picker);
+    }
+
+    /**
+     * `en-CA` is chosen for its output shape, not its language: it is the locale whose
+     * short date is already `YYYY-MM-DD`, so the parts split cleanly without parsing a
+     * localised order.
+     */
+    private function todayInViewerZoneExpression(): string
+    {
+        $timezone = Js::from(FilamentTimezone::get());
+
+        return <<<JS
+            dayIsToday = (day) => {
+                const [year, month, date] = new Intl.DateTimeFormat('en-CA', { timeZone: {$timezone} })
+                    .format(new Date())
+                    .split('-')
+                    .map(Number);
+
+                return day === date && focusedMonth === month - 1 && focusedYear === year;
+            }
+            JS;
     }
 
     private function isCurrentPanel(): bool

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -19,6 +19,7 @@ use App\Filament\Pages\EditTeam;
 use App\Filament\Pages\Team\CustomFields;
 use App\Filament\Resources\OpportunityResource;
 use App\Filament\Resources\TaskResource;
+use App\Http\Controllers\SyncUserTimezoneController;
 use App\Http\Middleware\ApplyTenantScopes;
 use App\Http\Middleware\CheckScheduledDeletion;
 use App\Http\Middleware\DenySearchIndexing;
@@ -28,6 +29,7 @@ use App\Livewire\App\AppDatabaseNotifications;
 use App\Livewire\App\AppSidebar;
 use App\Livewire\App\Profile\ScheduledDeletionInterstitial;
 use App\Models\Team;
+use App\Models\User;
 use App\Support\SupportForms;
 use Asmit\ResizedColumn\ResizedColumnPlugin;
 use Exception;
@@ -46,6 +48,7 @@ use Filament\PanelProvider;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Enums\Platform;
 use Filament\Support\Enums\Size;
+use Filament\Support\Facades\FilamentTimezone;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
 use Filament\View\PanelsRenderHook;
@@ -83,10 +86,34 @@ final class AppPanelProvider extends PanelProvider
             SwitchTeam::class,
         );
 
+        /**
+         * Datetimes are stored in UTC; the app panel renders and accepts them in the
+         * signed-in user's zone. Read by both table/infolist output and DateTimePicker
+         * input, so one closure keeps display and entry symmetrical.
+         *
+         * Guarded on the panel id because TimezoneManager is a global singleton — the
+         * sysadmin panel deliberately keeps rendering UTC (see SystemAdminPanelProvider),
+         * and returning null there falls back to config('app.timezone').
+         */
+        FilamentTimezone::set(fn (): ?string => Filament::getCurrentPanel()?->getId() === 'app'
+            ? $this->signedInUser()?->timezone
+            : null);
+
         Action::configureUsing(fn (Action $action): Action => $action->size(Size::Small)->iconPosition('before'));
         DeleteAction::configureUsing(fn (DeleteAction $action): DeleteAction => $action->label(__('filament/panel.actions.delete_record')));
         Section::configureUsing(fn (Section $section): Section => $section->compact());
         Table::configureUsing(fn (Table $table): Table => $table);
+    }
+
+    /**
+     * The web guard is shared with the sysadmin panel's SystemAdministrator, which has
+     * no timezone of its own — narrow to the customer model rather than assuming.
+     */
+    private function signedInUser(): ?User
+    {
+        $user = Auth::user();
+
+        return $user instanceof User ? $user : null;
     }
 
     /**
@@ -172,6 +199,9 @@ final class AppPanelProvider extends PanelProvider
                 Route::get('/scheduled-deletion', ScheduledDeletionInterstitial::class)
                     ->middleware('auth')
                     ->name('scheduled-deletion');
+                Route::post('/timezone', SyncUserTimezoneController::class)
+                    ->middleware('auth')
+                    ->name('timezone.sync');
 
                 Route::get('/{tenant}/tasks-board', fn (string $tenant) => redirect()->to(TaskResource::getUrl('board', ['tenant' => $tenant]), status: 301))
                     ->name('tasks-board.redirect');
@@ -237,6 +267,16 @@ final class AppPanelProvider extends PanelProvider
             ->renderHook(
                 PanelsRenderHook::HEAD_END,
                 fn (): View|Factory => view('filament.app.analytics')
+            )
+            /**
+             * Only rendered until the user has a timezone; after that the hook returns
+             * nothing and no detection script reaches the browser at all.
+             */
+            ->renderHook(
+                PanelsRenderHook::BODY_END,
+                fn (): View|Factory|string => $this->signedInUser()?->timezone === null
+                    ? view('filament.app.detect-timezone', ['endpoint' => route('filament.app.timezone.sync')])
+                    : '',
             );
 
         if (Features::hasApiFeatures()) {

--- a/app/Services/Notifications/DigestService.php
+++ b/app/Services/Notifications/DigestService.php
@@ -20,7 +20,7 @@ final readonly class DigestService
 {
     public function forUser(User $user): DigestPayload
     {
-        $timezone = $user->timezone ?? (string) config('app.timezone');
+        $timezone = $user->effectiveTimezone();
         $startOfToday = Date::now($timezone)->startOfDay()->utc();
         $windowEnd = $startOfToday->copy()->addDay();
 

--- a/config/database.php
+++ b/config/database.php
@@ -98,6 +98,14 @@ return [
             'prefix_indexes' => true,
             'search_path' => 'public',
             'sslmode' => 'prefer',
+
+            /*
+             * Every datetime column is `timestamp without time zone` holding a UTC value, so
+             * the session timezone decides what `now()`, `CURRENT_TIMESTAMP` and any
+             * `timestamptz` cast mean. Left unset it inherits the server default, which
+             * differs per environment and silently writes local wall-clock into UTC columns.
+             */
+            'timezone' => 'UTC',
         ],
 
         'sqlsrv' => [

--- a/database/migrations/2026_08_18_031107_move_pro_trial_marker_from_users_to_teams.php
+++ b/database/migrations/2026_08_18_031107_move_pro_trial_marker_from_users_to_teams.php
@@ -21,7 +21,7 @@ return new class extends Migration
         // trial under the per-workspace policy.
         DB::table('teams')
             ->whereNotNull('trial_ends_at')
-            ->update(['pro_trial_used_at' => DB::raw('now()')]);
+            ->update(['pro_trial_used_at' => now()]);
 
         Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('pro_trial_used_at');

--- a/database/migrations/2026_08_18_134240_add_timezone_to_system_administrators_table.php
+++ b/database/migrations/2026_08_18_134240_add_timezone_to_system_administrators_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('system_administrators', function (Blueprint $table): void {
+            // Nullable rather than defaulted to UTC: null means "never chose one", so
+            // the panel can keep an unconfigured administrator on server time without
+            // that being indistinguishable from a deliberate pick of UTC.
+            $table->string('timezone')->nullable()->after('email');
+        });
+    }
+};

--- a/lang/en/filament/exports.php
+++ b/lang/en/filament/exports.php
@@ -11,6 +11,7 @@ return [
         'creation_source' => 'Creation Source',
         'created_at' => 'Created At',
         'updated_at' => 'Updated At',
+        'deleted_at' => 'Deleted At',
         'company_name' => 'Company Name',
         'people_count' => 'Number of People',
         'opportunities_count' => 'Number of Opportunities',

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -13,6 +13,11 @@ return [
         'profile_photo' => [
             'label' => 'Photo',
         ],
+        'timezone' => [
+            'label' => 'Timezone',
+            'helper_text' => 'Dates and times across the app are shown in this timezone.',
+            'placeholder' => 'Select a timezone',
+        ],
         'current_password' => [
             'label' => 'Current Password',
         ],

--- a/packages/Chat/src/Services/MyTasksService.php
+++ b/packages/Chat/src/Services/MyTasksService.php
@@ -24,7 +24,14 @@ final readonly class MyTasksService
      */
     public function forUser(User $user, Team $team): Collection
     {
-        $startOfToday = Date::now()->startOfDay();
+        /**
+         * "Overdue" and "today" are claims about the user's calendar, not the server's:
+         * bounded on UTC midnight a task due 23:00 UTC reads as overdue to anyone east
+         * of London for most of their working day. Compute the boundaries in the user's
+         * zone, then compare in UTC where the stored values live.
+         */
+        $timezone = $user->timezone ?? (string) config('app.timezone');
+        $startOfToday = Date::now($timezone)->startOfDay()->utc();
         $startOfDayAfter = $startOfToday->copy()->addDay();
 
         $meta = $this->resolveFieldMetadata($team);

--- a/packages/Chat/src/Services/MyTasksService.php
+++ b/packages/Chat/src/Services/MyTasksService.php
@@ -29,10 +29,14 @@ final readonly class MyTasksService
          * bounded on UTC midnight a task due 23:00 UTC reads as overdue to anyone east
          * of London for most of their working day. Compute the boundaries in the user's
          * zone, then compare in UTC where the stored values live.
+         *
+         * Both boundaries are taken from local midnight before converting: a local day
+         * is 23 or 25 hours long across a DST transition, so adding a day to the already
+         * converted value would put the end of "today" an hour off twice a year.
          */
         $timezone = $user->timezone ?? (string) config('app.timezone');
         $startOfToday = Date::now($timezone)->startOfDay()->utc();
-        $startOfDayAfter = $startOfToday->copy()->addDay();
+        $startOfDayAfter = Date::now($timezone)->startOfDay()->addDay()->utc();
 
         $meta = $this->resolveFieldMetadata($team);
         $dueFieldId = $meta->dueFieldId;

--- a/packages/Chat/src/Services/MyTasksService.php
+++ b/packages/Chat/src/Services/MyTasksService.php
@@ -34,7 +34,7 @@ final readonly class MyTasksService
          * is 23 or 25 hours long across a DST transition, so adding a day to the already
          * converted value would put the end of "today" an hour off twice a year.
          */
-        $timezone = $user->timezone ?? (string) config('app.timezone');
+        $timezone = $user->effectiveTimezone();
         $startOfToday = Date::now($timezone)->startOfDay()->utc();
         $startOfDayAfter = Date::now($timezone)->startOfDay()->addDay()->utc();
 

--- a/packages/Chat/src/Tools/BaseReadListTool.php
+++ b/packages/Chat/src/Tools/BaseReadListTool.php
@@ -14,12 +14,14 @@ use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Services\Tools\CustomFieldsFilterDescriber;
 use Relaticle\Chat\Services\Tools\CustomFieldsFilterTranslator;
 use Relaticle\Chat\Support\RecordReferenceResolver;
+use Relaticle\Chat\Tools\Concerns\LocalisesDatetimes;
 use Relaticle\Chat\Tools\Concerns\NormalizesToolInput;
 use Relaticle\Chat\Tools\Concerns\ReportsValidationFailures;
 use Spatie\QueryBuilder\Exceptions\InvalidQuery;
 
 abstract class BaseReadListTool implements Tool
 {
+    use LocalisesDatetimes;
     use NormalizesToolInput;
     use ReportsValidationFailures;
 
@@ -148,7 +150,7 @@ abstract class BaseReadListTool implements Tool
             return $item;
         }, $items);
 
-        return (string) json_encode($items, JSON_PRETTY_PRINT);
+        return (string) json_encode($this->localiseDatetimes($items, $user), JSON_PRETTY_PRINT);
     }
 
     /**

--- a/packages/Chat/src/Tools/BaseReadShowTool.php
+++ b/packages/Chat/src/Tools/BaseReadShowTool.php
@@ -14,11 +14,14 @@ use Illuminate\Support\Str;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Support\RecordReferenceResolver;
+use Relaticle\Chat\Tools\Concerns\LocalisesDatetimes;
 use Relaticle\CustomFields\Models\CustomFieldValue;
 use stdClass;
 
 abstract class BaseReadShowTool implements Tool
 {
+    use LocalisesDatetimes;
+
     /**
      * Recent related records returned per include. Mirrors the limit the
      * old record-summary context builder used, keeping prompt size bounded
@@ -149,11 +152,14 @@ abstract class BaseReadShowTool implements Tool
         $ref = resolve(RecordReferenceResolver::class)->resolve($this->citationType(), $id);
 
         return (string) json_encode(
-            array_merge(
-                $payload,
-                $this->extraPayload($model),
-                ['url' => $ref['url'] ?? null],
-                $this->buildIncluded($model, $requestedIncludes, $user),
+            $this->localiseDatetimes(
+                array_merge(
+                    $payload,
+                    $this->extraPayload($model),
+                    ['url' => $ref['url'] ?? null],
+                    $this->buildIncluded($model, $requestedIncludes, $user),
+                ),
+                $user,
             ),
             JSON_PRETTY_PRINT,
         );

--- a/packages/Chat/src/Tools/Concerns/LocalisesDatetimes.php
+++ b/packages/Chat/src/Tools/Concerns/LocalisesDatetimes.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools\Concerns;
+
+use App\Models\User;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\Date;
+use stdClass;
+
+/**
+ * Rewrites the UTC datetimes in a serialised tool payload into the signed-in user's
+ * zone, carrying the offset.
+ *
+ * The agent prompt already tells the model which zone the user thinks in, but the
+ * payload used to carry bare `...Z` timestamps, so answering "is this due today?" meant
+ * the model doing timezone arithmetic. In a live chat it got that wrong. Emitting
+ * `2026-08-19T08:30:00+09:00` moves the conversion to where it is deterministic, and the
+ * offset means a model that ignores it still cannot be actively misled.
+ *
+ * This lives in the chat layer on purpose. The payloads come from `App\Http\Resources\V1`,
+ * which the public REST API and the MCP server also serve, and ISO-8601 UTC is the right
+ * contract for those — converting inside the resource would be a breaking API change.
+ */
+trait LocalisesDatetimes
+{
+    /**
+     * Walks the payload rather than taking a list of known date keys: custom fields are
+     * per-tenant, so the datetime keys are not knowable ahead of time.
+     *
+     * Three shapes have to be handled. The list tools round-trip through json_encode
+     * first, so their datetimes arrive as ISO-8601 strings. The show tool passes the
+     * resolved resource straight through, where they are still Carbon instances nested
+     * inside the stdClass that JsonApiResource wraps `attributes` in — so the walk has
+     * to descend into objects as well as arrays.
+     *
+     * @param  array<array-key, mixed>  $payload
+     * @return array<array-key, mixed>
+     */
+    protected function localiseDatetimes(array $payload, ?User $user): array
+    {
+        $timezone = $user?->effectiveTimezone() ?? (string) config('app.timezone');
+
+        return $this->localiseValue($payload, $timezone);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $values
+     * @return array<array-key, mixed>
+     */
+    private function localiseValue(array $values, string $timezone): array
+    {
+        foreach ($values as $key => $value) {
+            if (is_array($value)) {
+                $values[$key] = $this->localiseValue($value, $timezone);
+
+                continue;
+            }
+
+            if ($value instanceof CarbonInterface) {
+                $values[$key] = $value->copy()->setTimezone($timezone)->toIso8601String();
+
+                continue;
+            }
+
+            if ($value instanceof stdClass) {
+                $values[$key] = (object) $this->localiseValue(get_object_vars($value), $timezone);
+
+                continue;
+            }
+
+            if (is_string($value)) {
+                $values[$key] = $this->localiseString($value, $timezone);
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Only an unambiguous UTC instant is rewritten. A date-only value ("2026-08-19") is
+     * deliberately left alone: it has no time of day, so shifting it would move the
+     * calendar day for every user west of UTC.
+     */
+    private function localiseString(string $value, string $timezone): string
+    {
+        if (preg_match('/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/', $value) !== 1) {
+            return $value;
+        }
+
+        $parsed = rescue(
+            fn (): CarbonInterface => Date::parse($value)->setTimezone($timezone),
+            report: false,
+        );
+
+        return $parsed instanceof CarbonInterface
+            ? $parsed->toIso8601String()
+            : $value;
+    }
+}

--- a/packages/Chat/src/Tools/GetCrmSummaryTool.php
+++ b/packages/Chat/src/Tools/GetCrmSummaryTool.php
@@ -11,6 +11,7 @@ use App\Models\People;
 use App\Models\Task;
 use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Date;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 
@@ -32,6 +33,14 @@ final class GetCrmSummaryTool implements Tool
         $user = auth()->user();
         $team = $user->currentTeam;
 
+        /**
+         * "This week" is the user's week, not the server's — bounded on UTC the counts
+         * shift by a day for anyone far enough east or west.
+         */
+        $startOfWeek = Date::now($user->timezone ?? (string) config('app.timezone'))
+            ->startOfWeek()
+            ->utc();
+
         $summary = [
             'record_counts' => [
                 'companies' => Company::query()->whereBelongsTo($team)->count(),
@@ -41,9 +50,9 @@ final class GetCrmSummaryTool implements Tool
                 'notes' => Note::query()->whereBelongsTo($team)->count(),
             ],
             'recent_activity' => [
-                'companies_this_week' => Company::query()->whereBelongsTo($team)->where('created_at', '>=', now()->startOfWeek())->count(),
-                'tasks_this_week' => Task::query()->whereBelongsTo($team)->where('created_at', '>=', now()->startOfWeek())->count(),
-                'opportunities_this_week' => Opportunity::query()->whereBelongsTo($team)->where('created_at', '>=', now()->startOfWeek())->count(),
+                'companies_this_week' => Company::query()->whereBelongsTo($team)->where('created_at', '>=', $startOfWeek)->count(),
+                'tasks_this_week' => Task::query()->whereBelongsTo($team)->where('created_at', '>=', $startOfWeek)->count(),
+                'opportunities_this_week' => Opportunity::query()->whereBelongsTo($team)->where('created_at', '>=', $startOfWeek)->count(),
             ],
         ];
 

--- a/packages/Chat/src/Tools/GetCrmSummaryTool.php
+++ b/packages/Chat/src/Tools/GetCrmSummaryTool.php
@@ -37,7 +37,7 @@ final class GetCrmSummaryTool implements Tool
          * "This week" is the user's week, not the server's — bounded on UTC the counts
          * shift by a day for anyone far enough east or west.
          */
-        $startOfWeek = Date::now($user->timezone ?? (string) config('app.timezone'))
+        $startOfWeek = Date::now($user->effectiveTimezone())
             ->startOfWeek()
             ->utc();
 

--- a/packages/ImportWizard/src/Enums/DateFormat.php
+++ b/packages/ImportWizard/src/Enums/DateFormat.php
@@ -93,8 +93,18 @@ enum DateFormat: string implements HasLabel
      * Parse a date string into a Carbon instance.
      *
      * Attempts multiple format variations to handle real-world CSV data.
+     *
+     * A CSV carries no offset, so a naive datetime means the wall clock where the person
+     * who exported it lives — the same thing it means when they type it into the form,
+     * which converts out of their zone before storing. `$timezone` is that zone; parsing
+     * in it keeps the two paths on the same instant. Null keeps the PHP default, for
+     * callers with no user in scope.
+     *
+     * Only pass a zone when `$withTime` is true. A date has no time of day to convert,
+     * and interpreting midnight in a negative-offset zone would move it to the previous
+     * calendar day.
      */
-    public function parse(string $value, bool $withTime = false): ?Carbon
+    public function parse(string $value, bool $withTime = false, ?string $timezone = null): ?Carbon
     {
         $value = trim($value);
 
@@ -104,10 +114,10 @@ enum DateFormat: string implements HasLabel
 
         foreach ($this->getParseFormats($withTime) as $format) {
             try {
-                $date = Date::createFromFormat($format, $value);
+                $date = Date::createFromFormat($format, $value, $withTime ? $timezone : null);
 
                 if ($date instanceof Carbon) {
-                    return $date;
+                    return $withTime && $timezone !== null ? $date->utc() : $date;
                 }
             } catch (\Exception) {
                 continue;

--- a/packages/ImportWizard/src/Exceptions/MissingRequiredFieldException.php
+++ b/packages/ImportWizard/src/Exceptions/MissingRequiredFieldException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\ImportWizard\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when a CSV row leaves a required field empty on create.
+ *
+ * Named for the reader of the failed-rows table: they need to know which column was
+ * empty, not that a validation rule with some internal key did not pass.
+ */
+final class MissingRequiredFieldException extends RuntimeException
+{
+    public function __construct(public readonly string $fieldLabel)
+    {
+        parent::__construct(sprintf('%s is required and was empty.', $fieldLabel));
+    }
+}

--- a/packages/ImportWizard/src/Exceptions/UnparsableDateException.php
+++ b/packages/ImportWizard/src/Exceptions/UnparsableDateException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\ImportWizard\Exceptions;
+
+use Relaticle\ImportWizard\Enums\DateFormat;
+use RuntimeException;
+
+/**
+ * Thrown when a mapped date column holds a value the chosen format cannot read.
+ *
+ * The message is written for the person reading the failed-rows table, not for a log:
+ * it names the column, quotes what was actually in the cell, and states the format that
+ * was expected, because those three together are what let someone fix their CSV.
+ */
+final class UnparsableDateException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $columnName,
+        public readonly string $value,
+        public readonly DateFormat $expectedFormat,
+    ) {
+        parent::__construct(sprintf(
+            '%s: "%s" is not a valid date for the selected format (%s).',
+            $columnName,
+            $value,
+            $expectedFormat->getLabel(),
+        ));
+    }
+}

--- a/packages/ImportWizard/src/Filament/Pages/ImportHistory.php
+++ b/packages/ImportWizard/src/Filament/Pages/ImportHistory.php
@@ -24,6 +24,13 @@ final class ImportHistory extends Page implements HasTable
 
     protected string $view = 'import-wizard-new::filament.pages.import-history';
 
+    /**
+     * How long an import may sit untouched before the recovery action appears. Comfortably
+     * longer than the job's own timeout plus its retries, so a run that is merely slow is
+     * never offered up as stalled.
+     */
+    private const int STALLED_AFTER_MINUTES = 30;
+
     protected static string|null|BackedEnum $navigationIcon = Heroicon::OutlinedClock;
 
     protected static ?string $navigationLabel = 'Import History';
@@ -94,6 +101,7 @@ final class ImportHistory extends Page implements HasTable
                 TextColumn::make('created_at')
                     ->label('Date')
                     ->since()
+                    ->dateTimeTooltip()
                     ->sortable(),
             ])
             ->filters([
@@ -118,6 +126,20 @@ final class ImportHistory extends Page implements HasTable
                         ['import' => $record],
                     ), shouldOpenInNewTab: true)
                     ->visible(fn (Import $record): bool => $record->failedRows()->exists()),
+
+                // A worker that dies between claiming the import and finishing it leaves the
+                // row on "importing" with no way out: the wizard refuses to re-dispatch a
+                // record in that state, so the user is stuck with a spinner and no recourse.
+                // Only offered once the run is old enough that it cannot still be working.
+                Action::make('markFailed')
+                    ->label('Mark as failed')
+                    ->icon(Heroicon::OutlinedExclamationTriangle)
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->modalDescription('This import stopped responding. Marking it failed lets you start a new one from the same file.')
+                    ->action(fn (Import $record) => $record->update(['status' => ImportStatus::Failed]))
+                    ->visible(fn (Import $record): bool => $record->status === ImportStatus::Importing
+                        && $record->updated_at?->lt(now()->subMinutes(self::STALLED_AFTER_MINUTES)) === true),
             ])
             ->defaultSort('created_at', 'desc')
             ->poll('10s');

--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -41,6 +41,8 @@ use Relaticle\ImportWizard\Enums\ImportStatus;
 use Relaticle\ImportWizard\Enums\MatchBehavior;
 use Relaticle\ImportWizard\Enums\NumberFormat;
 use Relaticle\ImportWizard\Enums\RowMatchAction;
+use Relaticle\ImportWizard\Exceptions\MissingRequiredFieldException;
+use Relaticle\ImportWizard\Exceptions\UnparsableDateException;
 use Relaticle\ImportWizard\Importers\BaseImporter;
 use Relaticle\ImportWizard\Models\Import;
 use Relaticle\ImportWizard\Store\ImportRow;
@@ -252,6 +254,11 @@ final class ExecuteImportJob implements ShouldQueue
 
         try {
             $data = $this->buildDataFromRow($row, $fieldMappings);
+
+            if ($isCreate) {
+                $this->assertRequiredFieldsPresent($data, $importer);
+            }
+
             $existing = $isCreate
                 ? (null)
                 : $existingRecords[(string) $effectiveMatchedId] ?? $this->findExistingRecord($importer, $effectiveMatchedId);
@@ -292,8 +299,6 @@ final class ExecuteImportJob implements ShouldQueue
 
                 $this->storeEntityLinkRelationships($record, $pendingRelationships, $context);
 
-                $results[$isCreate ? 'created' : 'updated']++;
-
                 $storedCustomFieldData = ImportDataStorage::pull($record);
                 $batchableData = array_intersect_key($storedCustomFieldData, $customFieldDefs->all());
                 $remainingData = array_diff_key($storedCustomFieldData, $batchableData);
@@ -305,6 +310,11 @@ final class ExecuteImportJob implements ShouldQueue
                 }
 
                 $importer->afterSave($record, $context);
+
+                // Counted last. A rollback undoes the record but not a PHP counter, so
+                // incrementing before the custom-field pass could report a row as created
+                // that the database no longer holds.
+                $results[$isCreate ? 'created' : 'updated']++;
             });
 
             $this->markProcessed($row);
@@ -597,6 +607,35 @@ final class ExecuteImportJob implements ShouldQueue
     }
 
     /**
+     * A required field that arrives blank used to be written straight through, producing
+     * records like a company whose name is the empty string: invisible in the list, absent
+     * from search, and counted as a successful import. The wizard flags these at the review
+     * step, but nothing re-checked them at write time, so continuing past the warning
+     * created them anyway.
+     *
+     * Only enforced on create. An update legitimately carries a partial payload — a blank
+     * cell there means "leave this column alone", not "erase the name".
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws MissingRequiredFieldException
+     */
+    private function assertRequiredFieldsPresent(array $data, BaseImporter $importer): void
+    {
+        foreach ($importer->allFields()->required() as $field) {
+            if (! array_key_exists($field->key, $data)) {
+                continue;
+            }
+
+            $value = $data[$field->key];
+
+            if (is_string($value) ? trim($value) === '' : blank($value)) {
+                throw new MissingRequiredFieldException($field->label);
+            }
+        }
+    }
+
+    /**
      * Emit a key only for a mapped column whose cell the row actually carried, so that key
      * presence downstream means "carried" and a blank value means "carried empty" rather
      * than "withheld". Without the reject, a skipped or errored cell would arrive as null
@@ -654,6 +693,8 @@ final class ExecuteImportJob implements ShouldQueue
 
     /**
      * Apply format-aware conversion for date/datetime and float custom field values.
+     *
+     * @throws UnparsableDateException when a date column holds something that is not a date
      */
     private function convertCustomFieldValue(mixed $value, CustomField $cf, ?ColumnData $columnData): mixed
     {
@@ -663,12 +704,25 @@ final class ExecuteImportJob implements ShouldQueue
 
         $dataType = $cf->typeData->dataType;
 
+        // A cell holding only whitespace means "no value", not a malformed date. It is
+        // cleared downstream, so it must not reach the parser and be failed as garbage.
+        if ($dataType->isDateOrDateTime() && trim($value) === '') {
+            return $value;
+        }
+
         if ($dataType === FieldDataType::DATE || $dataType === FieldDataType::DATE_TIME) {
             $format = $columnData instanceof ColumnData ? ($columnData->dateFormat ?? DateFormat::ISO) : DateFormat::ISO;
             $parsed = $format->parse($value, $dataType->isTimestamp(), $this->importerTimezone);
 
+            /**
+             * An unparseable date used to be returned as-is, which the SafeValueConverter
+             * then blanked to null: the row imported, the value vanished, and the summary
+             * still said "0 failed". Silently dropping data the user handed us is worse
+             * than refusing the row, so fail it and let the existing failed-row path
+             * surface the column and the offending value.
+             */
             if (! $parsed instanceof Carbon) {
-                return $value;
+                throw new UnparsableDateException($cf->name, $value, $format);
             }
 
             return $dataType === FieldDataType::DATE

--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -81,6 +81,13 @@ final class ExecuteImportJob implements ShouldQueue
     /** @var array<string, array{field: CustomField, values: array<int, string>}> */
     private array $pendingTagOptions = [];
 
+    /**
+     * Zone the CSV's naive datetimes are interpreted in — the importer's own, so an
+     * imported value lands on the same instant as the same string typed into the form.
+     * Resolved once in handle() because the job runs on the queue with no session.
+     */
+    private string $importerTimezone = 'UTC';
+
     public function __construct(
         private readonly string $importId,
         private readonly string $teamId,
@@ -103,6 +110,8 @@ final class ExecuteImportJob implements ShouldQueue
         }
 
         $store->ensureProcessedColumn();
+
+        $this->importerTimezone = $import->user?->effectiveTimezone() ?? (string) config('app.timezone');
 
         $importer = $import->getImporter();
         $mappings = $import->columnMappings();
@@ -656,7 +665,7 @@ final class ExecuteImportJob implements ShouldQueue
 
         if ($dataType === FieldDataType::DATE || $dataType === FieldDataType::DATE_TIME) {
             $format = $columnData instanceof ColumnData ? ($columnData->dateFormat ?? DateFormat::ISO) : DateFormat::ISO;
-            $parsed = $format->parse($value, $dataType->isTimestamp());
+            $parsed = $format->parse($value, $dataType->isTimestamp(), $this->importerTimezone);
 
             if (! $parsed instanceof Carbon) {
                 return $value;

--- a/packages/SystemAdmin/src/Filament/Pages/Auth/EditProfile.php
+++ b/packages/SystemAdmin/src/Filament/Pages/Auth/EditProfile.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Pages\Auth;
+
+use Filament\Auth\Pages\EditProfile as BaseEditProfile;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Schema;
+use Illuminate\Validation\Rule;
+
+final class EditProfile extends BaseEditProfile
+{
+    public function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            $this->getNameFormComponent(),
+            $this->getEmailFormComponent(),
+            $this->getTimezoneFormComponent(),
+            $this->getPasswordFormComponent(),
+            $this->getPasswordConfirmationFormComponent(),
+            $this->getCurrentPasswordFormComponent(),
+        ]);
+    }
+
+    /**
+     * Validated on write as well as constrained by the options: the column is a plain
+     * string, and an identifier that PHP no longer recognises would otherwise reach
+     * the timezone resolver and silently drop the administrator back to server time.
+     */
+    private function getTimezoneFormComponent(): Select
+    {
+        $identifiers = timezone_identifiers_list();
+
+        return Select::make('timezone')
+            ->label('Timezone')
+            ->options(array_combine($identifiers, $identifiers))
+            ->searchable()
+            ->native(false)
+            ->placeholder('UTC (server time)')
+            ->rule(Rule::in($identifiers))
+            ->helperText('Timestamps across this panel render in this zone, always labelled with it. Leave unset to read the same UTC values as Horizon, Flare and the server logs.');
+    }
+}

--- a/packages/SystemAdmin/src/Models/SystemAdministrator.php
+++ b/packages/SystemAdmin/src/Models/SystemAdministrator.php
@@ -25,6 +25,7 @@ use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
  * @property string $id
  * @property string $name
  * @property string $email
+ * @property string|null $timezone
  * @property string $password
  * @property SystemAdministratorRole $role
  * @property Carbon|null $email_verified_at
@@ -35,6 +36,7 @@ use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
 #[Fillable([
     'name',
     'email',
+    'timezone',
     'password',
     'role',
 ])]

--- a/packages/SystemAdmin/src/SystemAdminPanelProvider.php
+++ b/packages/SystemAdmin/src/SystemAdminPanelProvider.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Relaticle\SystemAdmin;
 
 use Exception;
+use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\NavigationGroup;
 use Filament\Panel;
 use Filament\PanelProvider;
+use Filament\Schemas\Schema;
 use Filament\Support\Colors\Color;
+use Filament\Tables\Table;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -47,6 +50,15 @@ final class SystemAdminPanelProvider extends PanelProvider
         Category::class => CategoryPolicy::class,
     ];
 
+    /**
+     * Datetime format for this panel. Unlike the app panel, sysadmin deliberately
+     * does NOT convert to the viewer's timezone: it is used to correlate incidents
+     * against Horizon, Flare and server logs, which are all UTC, and two admins in
+     * different zones must describe the same event with the same numbers. The `UTC`
+     * suffix makes that explicit rather than leaving the reader to assume.
+     */
+    private const string DATE_TIME_FORMAT = 'M j, Y H:i:s \U\T\C';
+
     public function boot(): void
     {
         // Blog MCP requests are not Filament panel requests, so the panel-scoped
@@ -54,6 +66,16 @@ final class SystemAdminPanelProvider extends PanelProvider
         foreach (self::BLOG_MODEL_POLICIES as $model => $policy) {
             Gate::policy($model, $policy);
         }
+
+        // Table and Schema configuration is global, so both callbacks have to check
+        // which panel is actually serving the request before they touch the format.
+        Table::configureUsing(fn (Table $table): Table => $this->isCurrentPanel()
+            ? $table->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+            : $table);
+
+        Schema::configureUsing(fn (Schema $schema): Schema => $this->isCurrentPanel()
+            ? $schema->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+            : $schema);
 
         // PostPolicy/CategoryPolicy type-hint SystemAdministrator, and Gate never
         // checks a policy method's parameter type before calling it — a caller of
@@ -70,6 +92,11 @@ final class SystemAdminPanelProvider extends PanelProvider
 
             return null;
         });
+    }
+
+    private function isCurrentPanel(): bool
+    {
+        return Filament::getCurrentPanel()?->getId() === 'sysadmin';
     }
 
     /**

--- a/packages/SystemAdmin/src/SystemAdminPanelProvider.php
+++ b/packages/SystemAdmin/src/SystemAdminPanelProvider.php
@@ -30,6 +30,7 @@ use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Relaticle\Ink\InkPlugin;
 use Relaticle\Ink\Models\Category;
 use Relaticle\Ink\Models\Post;
+use Relaticle\SystemAdmin\Filament\Pages\Auth\EditProfile;
 use Relaticle\SystemAdmin\Filament\Pages\Dashboard;
 use Relaticle\SystemAdmin\Http\Middleware\DenySearchIndexing;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
@@ -51,13 +52,17 @@ final class SystemAdminPanelProvider extends PanelProvider
     ];
 
     /**
-     * Datetime format for this panel. Unlike the app panel, sysadmin deliberately
-     * does NOT convert to the viewer's timezone: it is used to correlate incidents
-     * against Horizon, Flare and server logs, which are all UTC, and two admins in
-     * different zones must describe the same event with the same numbers. The `UTC`
-     * suffix makes that explicit rather than leaving the reader to assume.
+     * Datetime format for this panel. The zone is opt-in per administrator on the
+     * profile page and defaults to UTC, because this panel is used to correlate
+     * incidents against Horizon, Flare and server logs, which are all UTC.
+     *
+     * `T` prints the zone the value is actually rendered in, so a timestamp is never
+     * ambiguous: an administrator who has opted out of UTC can still see they did,
+     * and two administrators in different zones cannot read the same row as the same
+     * numbers. This is why the suffix must stay — dropping it, not the conversion
+     * itself, is what would break incident correlation.
      */
-    private const string DATE_TIME_FORMAT = 'M j, Y H:i:s \U\T\C';
+    private const string DATE_TIME_FORMAT = 'M j, Y H:i:s T';
 
     public function boot(): void
     {
@@ -115,6 +120,7 @@ final class SystemAdminPanelProvider extends PanelProvider
 
         return $panel
             ->login()
+            ->profile(EditProfile::class)
             ->emailVerification(isRequired: config('app.require_email_verification'))
             ->authGuard('sysadmin')
             ->authPasswordBroker('system_administrators')

--- a/resources/views/filament/app/detect-timezone.blade.php
+++ b/resources/views/filament/app/detect-timezone.blade.php
@@ -1,0 +1,26 @@
+{{--
+    Seeds the signed-in user's timezone from the browser once, then never again — the
+    render hook that includes this only fires while `users.timezone` is still null, and
+    the action behind the endpoint refuses to overwrite a value that is already set.
+
+    x-init rather than a DOMContentLoaded listener because the panel is an SPA: a
+    wire:navigate arrival never fires that event.
+--}}
+<div
+    x-data
+    x-init="
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        if (timezone) {
+            fetch(@js($endpoint), {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json',
+                    'X-CSRF-TOKEN': @js(csrf_token()),
+                },
+                body: JSON.stringify({ timezone }),
+            }).catch(() => {});
+        }
+    "
+></div>

--- a/tests/Arch/ConventionsTest.php
+++ b/tests/Arch/ConventionsTest.php
@@ -40,6 +40,26 @@ it('keeps migrations forward-only (no down methods)', function (): void {
     );
 });
 
+it('keeps migrations off the database clock (no useCurrent, CURRENT_TIMESTAMP, or raw now())', function (): void {
+    $grandfathered = [
+        '0001_01_01_000002_create_jobs_table.php',
+    ];
+
+    $offenders = array_values(array_filter(
+        migrationFiles(),
+        fn (string $file): bool => ! in_array(basename($file), $grandfathered, true)
+            && preg_match(
+                '/->useCurrent(OnUpdate)?\s*\(|CURRENT_TIMESTAMP|DB::raw\([^)]*\bnow\s*\(\s*\)/i',
+                (string) file_get_contents($file),
+            ) === 1,
+    ));
+
+    expect($offenders)->toBe(
+        [],
+        'Migrations must not write datetimes from the database clock — it resolves against the session timezone, not UTC (.ai/guidelines/relaticle/core.md). Use a PHP-side now() in: '.implode(', ', $offenders),
+    );
+});
+
 it('keeps compiled agent guidelines in sync with their .ai sources', function (): void {
     $root = dirname(__DIR__, 2);
 

--- a/tests/Feature/Chat/GetCrmSummaryToolTest.php
+++ b/tests/Feature/Chat/GetCrmSummaryToolTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\OnboardSeed;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Laravel\Ai\Tools\Request;
+use Laravel\Pennant\Feature;
+use Relaticle\Chat\Tools\GetCrmSummaryTool;
+
+mutates(GetCrmSummaryTool::class);
+
+beforeEach(function (): void {
+    Feature::define(OnboardSeed::class, false);
+});
+
+/**
+ * The instant both tests below read the summary at: Sunday night in UTC, but already
+ * Monday morning in Tokyo. Tokyo's week has therefore just begun (it starts at
+ * 2026-08-16 15:00 UTC) while the UTC reader is still in the week that began on
+ * 2026-08-10. A company created between those two boundaries belongs to "this week"
+ * for one of them and "last week" for the other.
+ */
+function crmSummaryInstant(): Carbon
+{
+    return Carbon::parse('2026-08-16 23:30:00', 'UTC');
+}
+
+function companyCreatedAt(): Carbon
+{
+    return Carbon::parse('2026-08-14 12:00:00', 'UTC');
+}
+
+function crmSummaryWeekCount(User $user): int
+{
+    Auth::guard('web')->setUser($user);
+
+    Company::factory()->create([
+        'team_id' => $user->currentTeam->getKey(),
+        'created_at' => companyCreatedAt(),
+    ]);
+
+    /** @var array{recent_activity: array{companies_this_week: int}} $decoded */
+    $decoded = json_decode((new GetCrmSummaryTool)->handle(new Request([])), true);
+
+    return $decoded['recent_activity']['companies_this_week'];
+}
+
+it('excludes a record from this week once the user calendar has rolled into a new week', function (): void {
+    $this->travelTo(crmSummaryInstant());
+
+    $tokyo = User::factory()->withPersonalTeam()->create(['timezone' => 'Asia/Tokyo']);
+
+    expect(crmSummaryWeekCount($tokyo))->toBe(0);
+});
+
+it('counts that same record for a user still inside the previous week', function (): void {
+    $this->travelTo(crmSummaryInstant());
+
+    $utc = User::factory()->withPersonalTeam()->create(['timezone' => 'UTC']);
+
+    expect(crmSummaryWeekCount($utc))->toBe(1);
+});

--- a/tests/Feature/Chat/MyTasksServiceTest.php
+++ b/tests/Feature/Chat/MyTasksServiceTest.php
@@ -263,3 +263,21 @@ it('reads the same task as due today for a user whose calendar has not rolled ov
 
     expect((new MyTasksService)->forUser($london, $team)->first()->severity)->toBe('today');
 });
+
+it('ends today at local midnight across a dst transition, not 24 hours after it starts', function (): void {
+    // The UK puts its clocks back at 02:00 on 2026-10-25, so that local day runs 25
+    // hours: it starts at 23:00 UTC on the 24th and ends at 00:00 UTC on the 26th.
+    // Adding a day to the converted start would cut "today" off at 23:00 UTC and push
+    // a task due half an hour later into tomorrow.
+    $this->travelTo(Carbon::parse('2026-10-25 10:00:00', 'Europe/London'));
+
+    $user = User::factory()->withPersonalTeam()->create(['timezone' => 'Europe/London']);
+    $team = $user->currentTeam;
+    $dueFieldId = resolveDueDateField($team->id);
+
+    $task = Task::factory()->for($team)->create(['title' => 'late on the long day']);
+    $task->assignees()->attach($user);
+    attachDueDate($task, $dueFieldId, Carbon::parse('2026-10-25 23:30:00', 'Europe/London')->utc());
+
+    expect((new MyTasksService)->forUser($user, $team)->first()->severity)->toBe('today');
+});

--- a/tests/Feature/Chat/MyTasksServiceTest.php
+++ b/tests/Feature/Chat/MyTasksServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Features\OnboardSeed;
 use App\Models\Task;
 use App\Models\User;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Laravel\Pennant\Feature;
@@ -230,4 +231,35 @@ it('does not leak tasks from another team where the user is also a member', func
     $items = (new MyTasksService)->forUser($user, $teamA);
 
     expect($items)->toBeEmpty();
+});
+
+it('bounds today on the user calendar, not the server clock', function (): void {
+    // At 2026-08-18 23:30 UTC the Tokyo calendar already reads the 19th, so Tokyo's
+    // "today" began at 15:00 UTC. A task due 10:00 UTC that day therefore falls before
+    // it — overdue — while for a UTC reader at the very same instant it is still today.
+    $this->travelTo(Carbon::parse('2026-08-18 23:30:00', 'UTC'));
+
+    $tokyo = User::factory()->withPersonalTeam()->create(['timezone' => 'Asia/Tokyo']);
+    $team = $tokyo->currentTeam;
+    $dueFieldId = resolveDueDateField($team->id);
+
+    $task = Task::factory()->for($team)->create(['title' => 'crosses midnight in Tokyo']);
+    $task->assignees()->attach($tokyo);
+    attachDueDate($task, $dueFieldId, Carbon::parse('2026-08-18 10:00:00', 'UTC'));
+
+    expect((new MyTasksService)->forUser($tokyo, $team)->first()->severity)->toBe('overdue');
+});
+
+it('reads the same task as due today for a user whose calendar has not rolled over', function (): void {
+    $this->travelTo(Carbon::parse('2026-08-18 23:30:00', 'UTC'));
+
+    $london = User::factory()->withPersonalTeam()->create(['timezone' => 'UTC']);
+    $team = $london->currentTeam;
+    $dueFieldId = resolveDueDateField($team->id);
+
+    $task = Task::factory()->for($team)->create(['title' => 'still today in UTC']);
+    $task->assignees()->attach($london);
+    attachDueDate($task, $dueFieldId, Carbon::parse('2026-08-18 10:00:00', 'UTC'));
+
+    expect((new MyTasksService)->forUser($london, $team)->first()->severity)->toBe('today');
 });

--- a/tests/Feature/Chat/ReadToolTimezoneTest.php
+++ b/tests/Feature/Chat/ReadToolTimezoneTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\OnboardSeed;
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Laravel\Ai\Tools\Request;
+use Laravel\Pennant\Feature;
+use Laravel\Sanctum\Sanctum;
+use Relaticle\Chat\Tools\Task\GetTaskTool;
+use Relaticle\Chat\Tools\Task\ListTasksTool;
+
+mutates(ListTasksTool::class, GetTaskTool::class);
+
+beforeEach(function (): void {
+    Feature::define(OnboardSeed::class, false);
+
+    $this->user = User::factory()->withPersonalTeam()->create(['timezone' => 'Asia/Tokyo']);
+    $this->user->switchTeam($this->user->ownedTeams()->first());
+    $this->actingAs($this->user);
+});
+
+/**
+ * The agent prompt tells the model the user's zone, but the tool payload used to carry
+ * bare `...Z` UTC timestamps, leaving the model to do the conversion — and in a live
+ * chat it got it wrong, filing a task due tomorrow in Tokyo under "Due Today".
+ *
+ * Emitting the offset removes the arithmetic: the wall clock is already local, and a
+ * model that ignores the suffix still cannot be actively misled by it.
+ */
+it('emits chat list datetimes with the user offset rather than bare utc', function (): void {
+    $task = Task::factory()->for($this->user->currentTeam)->create([
+        'created_at' => Carbon::parse('2026-08-18 23:30:00', 'UTC'),
+        'updated_at' => Carbon::parse('2026-08-18 23:30:00', 'UTC'),
+    ]);
+
+    $payload = (new ListTasksTool)->handle(new Request([]));
+
+    /** @var list<array{attributes: array{created_at: string}}> $rows */
+    $rows = json_decode($payload, true);
+    $row = collect($rows)->firstWhere('id', $task->getKey());
+
+    // 23:30 UTC on the 18th is 08:30 the next morning in Tokyo.
+    expect($row['attributes']['created_at'])->toBe('2026-08-19T08:30:00+09:00');
+});
+
+it('emits chat show datetimes with the user offset too, so both tools agree', function (): void {
+    $task = Task::factory()->for($this->user->currentTeam)->create([
+        'created_at' => Carbon::parse('2026-08-18 23:30:00', 'UTC'),
+        'updated_at' => Carbon::parse('2026-08-18 23:30:00', 'UTC'),
+    ]);
+
+    $payload = (new GetTaskTool)->handle(new Request(['id' => (string) $task->getKey()]));
+
+    /** @var array{attributes: array{created_at: string}} $decoded */
+    $decoded = json_decode($payload, true);
+
+    expect($decoded['attributes']['created_at'])->toBe('2026-08-19T08:30:00+09:00');
+});
+
+/**
+ * Custom-field datetimes are where the live failure actually happened — a due date is
+ * what the model buckets as overdue/today/upcoming.
+ */
+it('converts custom-field datetimes in chat tool output', function (): void {
+    $team = $this->user->currentTeam;
+
+    $dueFieldId = DB::table('custom_fields')
+        ->where('tenant_id', $team->getKey())
+        ->where('entity_type', 'task')
+        ->where('code', 'due_date')
+        ->value('id');
+
+    $task = Task::factory()->for($team)->create(['title' => 'due at the boundary']);
+
+    DB::table('custom_field_values')->insert([
+        'id' => (string) Str::ulid(),
+        'tenant_id' => $team->getKey(),
+        'entity_type' => 'task',
+        'entity_id' => $task->getKey(),
+        'custom_field_id' => $dueFieldId,
+        'datetime_value' => '2026-08-18 23:30:00',
+    ]);
+
+    $payload = (new ListTasksTool)->handle(new Request([]));
+
+    /** @var list<array{id: string, attributes: array{custom_fields: array{due_date: string}}}> $rows */
+    $rows = json_decode($payload, true);
+    $row = collect($rows)->firstWhere('id', $task->getKey());
+
+    expect($row['attributes']['custom_fields']['due_date'])->toBe('2026-08-19T08:30:00+09:00');
+});
+
+/**
+ * The REST API and MCP share these resources, and ISO-8601 UTC is the correct contract
+ * for a public API — the conversion must live in the chat layer only. This is the guard
+ * that keeps a future refactor from "simplifying" it down into the resource.
+ */
+it('leaves the rest api on utc, because the conversion belongs to the chat layer', function (): void {
+    $task = Task::factory()->for($this->user->currentTeam)->create([
+        'created_at' => Carbon::parse('2026-08-18 23:30:00', 'UTC'),
+        'updated_at' => Carbon::parse('2026-08-18 23:30:00', 'UTC'),
+    ]);
+
+    Sanctum::actingAs($this->user);
+
+    $this->getJson('/api/v1/tasks/'.$task->getKey())
+        ->assertOk()
+        ->assertJsonPath('data.attributes.created_at', '2026-08-18T23:30:00.000000Z');
+});

--- a/tests/Feature/DatabaseTimezoneTest.php
+++ b/tests/Feature/DatabaseTimezoneTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Every datetime column is `timestamp without time zone` holding a UTC value, so the
+ * PostgreSQL session timezone decides what `now()` and any `timestamptz` cast mean. Left
+ * unpinned it inherits the server default, which differs per environment and silently writes
+ * local wall-clock into a UTC column.
+ */
+it('declares the utc session timezone on the pgsql connection so it does not inherit the server default', function (): void {
+    expect(config('database.connections.pgsql.timezone'))->toBe('UTC');
+});
+
+it('pins the postgres session timezone to utc so the database clock cannot drift from the app clock', function (): void {
+    expect(DB::select('show timezone')[0]->TimeZone)->toBe('UTC');
+});
+
+it('casts now() to a timestamp without shifting it, so a database-clock write lands in utc', function (): void {
+    $row = DB::select("select cast(now() as timestamp) as cast_ts, (now() at time zone 'UTC') as utc_ts")[0];
+
+    expect($row->cast_ts)->toBe($row->utc_ts);
+});
+
+it('keeps the database clock and the php clock on the same wall time', function (): void {
+    $databaseNow = Date::parse((string) DB::select('select cast(now() as timestamp) as ts')[0]->ts);
+
+    expect(abs(now()->diffInSeconds($databaseNow)))->toBeLessThan(60);
+});

--- a/tests/Feature/Filament/App/Exports/CompanyExporterTest.php
+++ b/tests/Feature/Filament/App/Exports/CompanyExporterTest.php
@@ -13,6 +13,7 @@ use App\Models\Export;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Jetstream\Events\TeamCreated;
@@ -116,4 +117,44 @@ test('export generates CSV with correct data', function () {
     expect($headers)->toContain('Company Name')
         ->and($headers)->toContain('ICP')
         ->and($data)->toContain('Acme Corp');
+});
+
+test('export headers name the timezone the values are written in', function () {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+
+    $labels = collect(CompanyExporter::getColumns())->map(fn ($column) => $column->getLabel())->all();
+
+    expect($labels)->toContain('Created At (Asia/Tokyo)')
+        ->and($labels)->toContain('Updated At (Asia/Tokyo)');
+});
+
+test('export headers fall back to the app timezone for a user without one', function () {
+    $this->user->forceFill(['timezone' => null])->save();
+
+    $labels = collect(CompanyExporter::getColumns())->map(fn ($column) => $column->getLabel())->all();
+
+    expect($labels)->toContain('Created At (UTC)');
+});
+
+test('export values are converted out of utc into the requesting user timezone', function () {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+
+    $company = Company::factory()->create([
+        'team_id' => $this->team->id,
+        'created_at' => Date::parse('2026-08-18 23:30:00', 'UTC'),
+    ]);
+
+    Livewire::test(ListCompanies::class)
+        ->callAction('export')
+        ->assertHasNoFormErrors();
+
+    $export = Export::latest()->first();
+
+    expect($export->user_id)->toBe($this->user->getKey());
+
+    $exporter = new CompanyExporter($export, ['created_at' => 'Created At'], []);
+    $row = $exporter($company->fresh());
+
+    // 23:30 UTC on the 18th is 08:30 the next morning in Tokyo — the date rolls over.
+    expect($row[0])->toBe('2026-08-19 08:30:00');
 });

--- a/tests/Feature/Filament/App/Exports/NoteExporterTest.php
+++ b/tests/Feature/Filament/App/Exports/NoteExporterTest.php
@@ -13,6 +13,7 @@ use App\Models\Note;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Jetstream\Events\TeamCreated;
@@ -116,4 +117,30 @@ test('export generates CSV with correct data', function () {
     expect($headers)->toContain('Title')
         ->and($headers)->toContain('Body')
         ->and($data)->toContain('Meeting notes Q1');
+});
+
+test('export datetimes name and use the requesting user timezone', function () {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+
+    $labels = collect(NoteExporter::getColumns())->map(fn ($column) => $column->getLabel())->all();
+
+    expect($labels)->toContain('Created At (Asia/Tokyo)')
+        ->and($labels)->toContain('Updated At (Asia/Tokyo)')
+        ->and($labels)->toContain('Deleted At (Asia/Tokyo)');
+
+    $note = Note::factory()->create([
+        'team_id' => $this->team->id,
+        'created_at' => Date::parse('2026-08-18 23:30:00', 'UTC'),
+    ]);
+
+    Livewire::test(ManageNotes::class)
+        ->callAction('export')
+        ->assertHasNoFormErrors();
+
+    $exporter = new NoteExporter(Export::latest()->first(), ['created_at' => 'Created At', 'deleted_at' => 'Deleted At'], []);
+    $row = $exporter($note->fresh());
+
+    // 23:30 UTC on the 18th is 08:30 the next morning in Tokyo — the date rolls over.
+    expect($row[0])->toBe('2026-08-19 08:30:00')
+        ->and($row[1])->toBeNull();
 });

--- a/tests/Feature/Filament/App/Exports/PeopleExporterTest.php
+++ b/tests/Feature/Filament/App/Exports/PeopleExporterTest.php
@@ -13,6 +13,7 @@ use App\Models\People;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Jetstream\Events\TeamCreated;
@@ -116,4 +117,30 @@ test('export generates CSV with correct data', function () {
     expect($headers)->toContain('Name')
         ->and($headers)->toContain('Emails')
         ->and($data)->toContain('Jane Doe');
+});
+
+test('export datetimes name and use the requesting user timezone', function () {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+
+    $labels = collect(PeopleExporter::getColumns())->map(fn ($column) => $column->getLabel())->all();
+
+    expect($labels)->toContain('Created At (Asia/Tokyo)')
+        ->and($labels)->toContain('Updated At (Asia/Tokyo)')
+        ->and($labels)->toContain('Deleted At (Asia/Tokyo)');
+
+    $person = People::factory()->create([
+        'team_id' => $this->team->id,
+        'created_at' => Date::parse('2026-08-18 23:30:00', 'UTC'),
+    ]);
+
+    Livewire::test(ListPeople::class)
+        ->callAction('export')
+        ->assertHasNoFormErrors();
+
+    $exporter = new PeopleExporter(Export::latest()->first(), ['created_at' => 'Created At', 'deleted_at' => 'Deleted At'], []);
+    $row = $exporter($person->fresh());
+
+    // 23:30 UTC on the 18th is 08:30 the next morning in Tokyo — the date rolls over.
+    expect($row[0])->toBe('2026-08-19 08:30:00')
+        ->and($row[1])->toBeNull();
 });

--- a/tests/Feature/Filament/App/Exports/TaskExporterTest.php
+++ b/tests/Feature/Filament/App/Exports/TaskExporterTest.php
@@ -13,6 +13,7 @@ use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Jetstream\Events\TeamCreated;
@@ -116,4 +117,27 @@ test('export generates CSV with correct data', function () {
     expect($headers)->toContain('Title')
         ->and($headers)->toContain('Status')
         ->and($data)->toContain('Fix login bug');
+});
+
+test('export datetimes name and use the requesting user timezone', function () {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+
+    $labels = collect(TaskExporter::getColumns())->map(fn ($column) => $column->getLabel())->all();
+
+    expect($labels)->toContain('Created At (Asia/Tokyo)')
+        ->and($labels)->toContain('Updated At (Asia/Tokyo)');
+
+    $task = Task::factory()->create([
+        'team_id' => $this->team->id,
+        'created_at' => Date::parse('2026-08-18 23:30:00', 'UTC'),
+    ]);
+
+    Livewire::test(ManageTasks::class)
+        ->callAction('export')
+        ->assertHasNoFormErrors();
+
+    $exporter = new TaskExporter(Export::latest()->first(), ['created_at' => 'Created At'], []);
+
+    // 23:30 UTC on the 18th is 08:30 the next morning in Tokyo — the date rolls over.
+    expect($exporter($task->fresh())[0])->toBe('2026-08-19 08:30:00');
 });

--- a/tests/Feature/Filament/App/Exports/TaskExporterTest.php
+++ b/tests/Feature/Filament/App/Exports/TaskExporterTest.php
@@ -70,8 +70,16 @@ test('export columns include system-seeded custom fields', function () {
     $columns = TaskExporter::getColumns();
     $columnLabels = collect($columns)->map(fn ($column) => $column->getLabel())->all();
 
+    // Matched by prefix rather than equality: a date-time field's header also carries the
+    // zone its values are written in, so "Due Date" ships as "Due Date (UTC)".
     foreach (TaskField::cases() as $field) {
-        expect($columnLabels)->toContain($field->getDisplayName());
+        $matching = array_filter(
+            $columnLabels,
+            fn (string $label): bool => $label === $field->getDisplayName()
+                || str_starts_with($label, $field->getDisplayName().' ('),
+        );
+
+        expect($matching)->not->toBeEmpty("no export column for {$field->getDisplayName()}");
     }
 });
 
@@ -140,4 +148,73 @@ test('export datetimes name and use the requesting user timezone', function () {
 
     // 23:30 UTC on the 18th is 08:30 the next morning in Tokyo — the date rolls over.
     expect($exporter($task->fresh())[0])->toBe('2026-08-19 08:30:00');
+});
+
+/**
+ * Custom-field datetimes reach the exporter from the package, bypassing the helper the
+ * native columns use. Left alone they wrote the stored UTC under a bare header, in the
+ * same file whose other headers say `(Asia/Tokyo)` — so a due date could land a full
+ * calendar day off with nothing signalling it.
+ */
+test('custom field datetimes export in the user timezone with the zone named', function () {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+    TenantContextService::setTenantId($this->team->id);
+
+    $dueDate = CustomField::query()
+        ->where('tenant_id', $this->team->id)
+        ->where('entity_type', 'task')
+        ->where('code', TaskField::DUE_DATE->value)
+        ->sole();
+
+    $task = Task::factory()->create(['team_id' => $this->team->id]);
+    $task->saveCustomFieldValue($dueDate, '2026-08-18 23:30:00');
+
+    $labels = collect(TaskExporter::getColumns())->map(fn ($column) => $column->getLabel())->all();
+
+    expect($labels)->toContain('Due Date (Asia/Tokyo)');
+
+    Livewire::test(ManageTasks::class)
+        ->callAction('export')
+        ->assertHasNoFormErrors();
+
+    $exporter = new TaskExporter(Export::latest()->first(), ['custom_fields.due_date' => 'Due Date'], []);
+
+    expect($exporter($task->fresh())[0])->toBe('2026-08-19 08:30:00');
+});
+
+/**
+ * The other half: a date has no time of day, so converting it would move the calendar day
+ * for every viewer west of UTC. It must stay put, and must not gain the `00:00:00` a
+ * Carbon cast invents.
+ */
+test('custom field dates export unshifted and without a time', function () {
+    $this->user->forceFill(['timezone' => 'America/New_York'])->save();
+    TenantContextService::setTenantId($this->team->id);
+
+    $field = CustomField::forceCreate([
+        'name' => 'Kickoff Day',
+        'code' => 'kickoff_day',
+        'type' => 'date',
+        'entity_type' => 'task',
+        'tenant_id' => $this->team->id,
+        'sort_order' => 98,
+        'active' => true,
+        'system_defined' => false,
+        'settings' => new CustomFieldSettingsData,
+    ]);
+
+    $task = Task::factory()->create(['team_id' => $this->team->id]);
+    $task->saveCustomFieldValue($field, '2026-08-19');
+
+    $labels = collect(TaskExporter::getColumns())->map(fn ($column) => $column->getLabel())->all();
+
+    expect($labels)->toContain('Kickoff Day');
+
+    Livewire::test(ManageTasks::class)
+        ->callAction('export')
+        ->assertHasNoFormErrors();
+
+    $exporter = new TaskExporter(Export::latest()->first(), ['custom_fields.kickoff_day' => 'Kickoff Day'], []);
+
+    expect($exporter($task->fresh())[0])->toBe('2026-08-19');
 });

--- a/tests/Feature/Filament/App/Pages/OpportunitiesBoardTest.php
+++ b/tests/Feature/Filament/App/Pages/OpportunitiesBoardTest.php
@@ -10,6 +10,7 @@ use App\Models\CustomField;
 use App\Models\Opportunity;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Carbon;
 use Relaticle\Flowforge\Board;
 
 mutates(OpportunitiesBoard::class);
@@ -113,4 +114,59 @@ it('opens the edit action when a card is clicked', function (): void {
     $component
         ->call('mountAction', 'edit', [], ['recordKey' => (string) $opportunity->id])
         ->assertSet('mountedActions.0.data.name', $opportunity->name);
+});
+
+/**
+ * Sibling of the tasks board badge: "closes today" is a claim about the viewer's
+ * calendar. A close date is a plain date, so the stored value is midnight UTC — read
+ * without conversion it still reads as the previous day for anyone far enough east,
+ * and the pipeline card lands in the wrong urgency bucket.
+ */
+it('buckets the close-date badge against the user calendar, not the server clock', function (): void {
+    // 23:00 UTC on the 18th is already 08:00 on the 19th in Tokyo.
+    $this->travelTo(Carbon::parse('2026-08-18 23:00:00', 'UTC'));
+
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $closeField = CustomField::query()
+        ->forEntity(Opportunity::class)
+        ->where('code', OpportunityField::CLOSE_DATE)
+        ->first();
+
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity->saveCustomFieldValue($this->stageField, $this->stageField->options->firstWhere('name', 'Prospecting')->getKey());
+    $opportunity->saveCustomFieldValue($closeField, Carbon::parse('2026-08-19 00:00:00', 'UTC'));
+
+    livewire(OpportunitiesBoard::class)
+        ->assertSee('Closes Today')
+        ->assertDontSee('Closes Tomorrow');
+});
+
+/**
+ * The mirror of the case above, for a viewer west of UTC. A close date is a plain
+ * calendar date that the package stores at midnight UTC, so converting it into a
+ * negative-offset zone walks it back past midnight and the card reads a day early —
+ * the failure the eastern case cannot see, because moving midnight forward stays
+ * inside the same day.
+ */
+it('does not walk a close date back a day for a viewer west of utc', function (): void {
+    // 16:00 UTC on the 19th is 09:00 the same morning in Los Angeles.
+    $this->travelTo(Carbon::parse('2026-08-19 16:00:00', 'UTC'));
+
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $closeField = CustomField::query()
+        ->forEntity(Opportunity::class)
+        ->where('code', OpportunityField::CLOSE_DATE)
+        ->first();
+
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity->saveCustomFieldValue($this->stageField, $this->stageField->options->firstWhere('name', 'Prospecting')->getKey());
+    $opportunity->saveCustomFieldValue($closeField, Carbon::parse('2026-08-19 00:00:00', 'UTC'));
+
+    livewire(OpportunitiesBoard::class)
+        ->assertSee('Closes Today')
+        ->assertDontSee('Overdue');
 });

--- a/tests/Feature/Filament/App/Pages/TasksBoardTest.php
+++ b/tests/Feature/Filament/App/Pages/TasksBoardTest.php
@@ -11,6 +11,7 @@ use App\Models\Task;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Relaticle\Flowforge\Board;
 
@@ -152,4 +153,34 @@ it('opens the edit action when a card is clicked', function (): void {
     $component
         ->call('mountAction', 'edit', [], ['recordKey' => (string) $task->id])
         ->assertSet('mountedActions.0.data.title', $task->title);
+});
+
+/**
+ * The badge answers "is this due today?", which is a question about the viewer's
+ * calendar. Bounded on the server clock instead, a task lands in the wrong bucket for
+ * every user far enough east or west — the board is the primary planning view, so the
+ * wrong bucket is the wrong plan for the day.
+ */
+it('buckets the due-date badge against the user calendar, not the server clock', function (): void {
+    $this->travelTo(Carbon::parse('2026-08-18 13:50:00', 'UTC'));
+
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $dueField = CustomField::query()
+        ->forEntity(Task::class)
+        ->where('code', TaskField::DUE_DATE)
+        ->first();
+
+    $task = Task::factory()->recycle([$this->user, $this->team])->create();
+    $task->saveCustomFieldValue($this->statusField, $this->statusField->options->firstWhere('name', 'To do')->getKey());
+
+    // 23:30 UTC on the 18th is 08:30 on the 19th in Tokyo. At the moment above the
+    // Tokyo calendar already reads the 18th at 22:50, so this is due *tomorrow* there
+    // while a UTC reader would still call it today.
+    $task->saveCustomFieldValue($dueField, Carbon::parse('2026-08-18 23:30:00', 'UTC'));
+
+    livewire(TasksBoard::class)
+        ->assertSee('Due Tomorrow')
+        ->assertDontSee('Due Today');
 });

--- a/tests/Feature/Filament/App/Resources/OpportunityResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/OpportunityResourceTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 mutates(OpportunityResource::class);
 
@@ -192,4 +193,31 @@ it('denies non-team-member from viewing another team opportunity', function (): 
     expect($this->user->can('view', $record))->toBeFalse()
         ->and($this->user->can('update', $record))->toBeFalse()
         ->and($this->user->can('delete', $record))->toBeFalse();
+});
+
+/**
+ * The date-time table column converts to the viewer's zone, but a date-only field must
+ * not: a bare close date has no time of day, so shifting it moves the day itself for
+ * anyone west of UTC. Los Angeles is UTC-7 in August — a naive conversion of
+ * 2026-08-19 00:00 renders as the 18th.
+ */
+it('does not shift a date-only custom field into the user timezone', function (): void {
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $closeDateField = DB::table('custom_fields')
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'opportunity')
+        ->where('code', 'close_date')
+        ->value('id');
+
+    expect($closeDateField)->not->toBeNull();
+
+    $opportunity = Opportunity::factory()->recycle([$this->user, $this->team])->create();
+    $opportunity->saveCustomFields(['close_date' => '2026-08-19']);
+
+    livewire(ListOpportunities::class)
+        ->assertOk()
+        ->assertSee('Aug 19, 2026')
+        ->assertDontSee('Aug 18, 2026');
 });

--- a/tests/Feature/Filament/App/Resources/TaskResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/TaskResourceTest.php
@@ -8,7 +8,9 @@ use App\Models\Task;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
 mutates(TaskResource::class);
@@ -256,12 +258,6 @@ it('renders a custom-field datetime in the user timezone in the table', function
     $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
     Filament::setCurrentPanel(Filament::getPanel('app'));
 
-    $dueField = DB::table('custom_fields')
-        ->where('tenant_id', $this->team->getKey())
-        ->where('entity_type', 'task')
-        ->where('code', 'due_date')
-        ->value('id');
-
     livewire(ManageTasks::class)
         ->callAction(TestAction::make('create'), [
             'title' => 'round trips through Tokyo',
@@ -273,4 +269,27 @@ it('renders a custom-field datetime in the user timezone in the table', function
         ->assertOk()
         ->assertSee('Aug 19, 2026 08:30')
         ->assertDontSee('Aug 18, 2026 23:30');
+});
+
+/**
+ * A custom-field datetime has to read like the `created_at` next to it, so the column
+ * takes the table's format rather than one of its own. The seconds are the tell: the
+ * table default carries them, and the literal this class used to hardcode did not.
+ */
+it('renders a custom-field datetime in the same format as the table default', function (): void {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    livewire(ManageTasks::class)
+        ->callAction(TestAction::make('create'), [
+            'title' => 'formatted like its neighbours',
+            'custom_fields' => ['due_date' => '2026-08-19 08:30:00'],
+        ])
+        ->assertHasNoActionErrors();
+
+    $format = Table::make(new ManageTasks)->getDefaultDateTimeDisplayFormat();
+
+    livewire(ManageTasks::class)
+        ->assertOk()
+        ->assertSee(Date::parse('2026-08-19 08:30:00', 'Asia/Tokyo')->translatedFormat($format));
 });

--- a/tests/Feature/Filament/App/Resources/TaskResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/TaskResourceTest.php
@@ -246,3 +246,31 @@ it('stores a datetime typed in the user timezone as utc', function (): void {
     // 08:30 on the 19th in Tokyo is 23:30 the previous evening in UTC.
     expect($stored)->toBe('2026-08-18 23:30:00');
 });
+
+/**
+ * The other half of the round trip: a due date typed in the user's zone has to come
+ * back out of the table reading the same wall clock it was entered with. The list is
+ * the primary view of a task, so a shift here is what a customer actually sees.
+ */
+it('renders a custom-field datetime in the user timezone in the table', function (): void {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $dueField = DB::table('custom_fields')
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'task')
+        ->where('code', 'due_date')
+        ->value('id');
+
+    livewire(ManageTasks::class)
+        ->callAction(TestAction::make('create'), [
+            'title' => 'round trips through Tokyo',
+            'custom_fields' => ['due_date' => '2026-08-19 08:30:00'],
+        ])
+        ->assertHasNoActionErrors();
+
+    livewire(ManageTasks::class)
+        ->assertOk()
+        ->assertSee('Aug 19, 2026 08:30')
+        ->assertDontSee('Aug 18, 2026 23:30');
+});

--- a/tests/Feature/Filament/App/Resources/TaskResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/TaskResourceTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 mutates(TaskResource::class);
 
@@ -205,4 +206,43 @@ it('denies non-team-member from viewing another team task', function (): void {
     expect($this->user->can('view', $record))->toBeFalse()
         ->and($this->user->can('update', $record))->toBeFalse()
         ->and($this->user->can('delete', $record))->toBeFalse();
+});
+
+/**
+ * The picker resolves its timezone from the same TimezoneManager the table columns read,
+ * so display and entry cannot drift apart — this asserts the *input* direction, where a
+ * regression would silently shift every datetime a user types.
+ */
+it('stores a datetime typed in the user timezone as utc', function (): void {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+
+    // A real request has the panel bound by Filament's middleware; the harness does not,
+    // and the conversion is deliberately scoped to the app panel.
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $dueField = DB::table('custom_fields')
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'task')
+        ->where('code', 'due_date')
+        ->value('id');
+
+    expect($dueField)->not->toBeNull();
+
+    livewire(ManageTasks::class)
+        ->callAction(TestAction::make('create'), [
+            'title' => 'typed in Tokyo',
+            'custom_fields' => ['due_date' => '2026-08-19 08:30:00'],
+        ])
+        ->assertHasNoActionErrors();
+
+    $task = Task::query()->where('title', 'typed in Tokyo')->sole();
+
+    $stored = DB::table('custom_field_values')
+        ->where('entity_id', $task->getKey())
+        ->where('entity_type', 'task')
+        ->where('custom_field_id', $dueField)
+        ->value('datetime_value');
+
+    // 08:30 on the 19th in Tokyo is 23:30 the previous evening in UTC.
+    expect($stored)->toBe('2026-08-18 23:30:00');
 });

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
@@ -2559,3 +2559,59 @@ it('does not shift a date-only custom field for an importer in another timezone'
     expect($cfv)->not->toBeNull()
         ->and($cfv->date_value->format('Y-m-d'))->toBe('2026-08-19');
 });
+
+/**
+ * A date column holding something that is not a date used to import "successfully" with
+ * the value dropped: the wizard flagged it at review, the user clicked through, and the
+ * summary then said 0 failed. Silently discarding data is worse than refusing the row.
+ */
+it('fails a row whose datetime cannot be parsed instead of dropping the value', function (): void {
+    $cf = createTestCustomField($this, 'meeting_bad', 'date-time');
+
+    createImportReadyStore($this, ['Name', 'Meeting'], [
+        makeRow(2, ['Name' => 'Valid Row', 'Meeting' => '2026-08-19 08:30:00'], ['match_action' => RowMatchAction::Create->value]),
+        makeRow(3, ['Name' => 'Bad Row', 'Meeting' => 'not-a-date'], ['match_action' => RowMatchAction::Create->value]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Meeting', target: "custom_fields_{$cf->code}"),
+    ]);
+
+    runImportJob($this);
+
+    $import = $this->import->fresh();
+
+    expect($import->created_rows)->toBe(1)
+        ->and($import->failed_rows)->toBe(1)
+        ->and(People::where('team_id', $this->team->id)->where('name', 'Bad Row')->exists())->toBeFalse()
+        ->and(People::where('team_id', $this->team->id)->where('name', 'Valid Row')->exists())->toBeTrue();
+
+    // The failed-rows table is what the user downloads, so the message has to name the
+    // column and quote the value rather than read like a stack trace.
+    expect($import->failedRows()->value('validation_error'))
+        ->toContain('Meeting bad')
+        ->toContain('not-a-date');
+});
+
+/**
+ * REG-003. A CSV row with the required name empty was imported as a record whose name is
+ * the empty string: invisible in the list, absent from search, and counted as successful.
+ */
+it('fails a row that leaves a required field empty rather than creating a nameless record', function (): void {
+    createImportReadyStore($this, ['Name', 'Email'], [
+        makeRow(2, ['Name' => 'Has A Name', 'Email' => 'ok@example.test'], ['match_action' => RowMatchAction::Create->value]),
+        makeRow(3, ['Name' => '', 'Email' => 'blank@example.test'], ['match_action' => RowMatchAction::Create->value]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Email', target: 'emails'),
+    ]);
+
+    runImportJob($this);
+
+    $import = $this->import->fresh();
+
+    expect($import->created_rows)->toBe(1)
+        ->and($import->failed_rows)->toBe(1)
+        ->and(People::where('team_id', $this->team->id)->where('name', '')->exists())->toBeFalse();
+
+    expect($import->failedRows()->value('validation_error'))->toContain('required');
+});

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobTest.php
@@ -2505,3 +2505,57 @@ it('creates a new company when re-importing a domain whose company was soft-dele
         ->and($import->skipped_rows)->toBe(0)
         ->and(Company::where('team_id', $this->team->id)->where('name', 'Acme Reimport 282')->exists())->toBeTrue();
 });
+
+/**
+ * A naive datetime in a CSV means "that wall clock where the importer is", exactly as
+ * it does when the same string is typed into the Filament form — which converts out of
+ * the user's zone before storing. Parsed as UTC instead, the two paths disagree by the
+ * offset, so the same value imported and hand-entered lands on different instants.
+ */
+it('parses an imported datetime in the importer timezone, matching what the form would store', function (): void {
+    $this->user->forceFill(['timezone' => 'Asia/Tokyo'])->save();
+
+    $cf = createTestCustomField($this, 'meeting_tokyo', 'date-time');
+
+    createImportReadyStore($this, ['Name', 'Meeting'], [
+        makeRow(2, ['Name' => 'John', 'Meeting' => '2026-08-19 08:30:00'], ['match_action' => RowMatchAction::Create->value]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Meeting', target: "custom_fields_{$cf->code}"),
+    ]);
+
+    runImportJob($this);
+
+    $person = People::where('team_id', $this->team->id)->where('name', 'John')->first();
+    $cfv = getTestCustomFieldValue($this, (string) $person->id, (string) $cf->id);
+
+    // 08:30 on the 19th in Tokyo is 23:30 the previous evening in UTC — the exact value
+    // TaskResourceTest asserts the form stores for this same typed string.
+    expect($cfv)->not->toBeNull()
+        ->and($cfv->datetime_value->format('Y-m-d H:i:s'))->toBe('2026-08-18 23:30:00');
+});
+
+/**
+ * The other half of the rule: a date-only field has no time of day, so it must never be
+ * shifted. Converting it would move the calendar day for every importer west of UTC.
+ */
+it('does not shift a date-only custom field for an importer in another timezone', function (): void {
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+
+    $cf = createTestCustomField($this, 'start_date_la', 'date');
+
+    createImportReadyStore($this, ['Name', 'Start'], [
+        makeRow(2, ['Name' => 'John', 'Start' => '2026-08-19'], ['match_action' => RowMatchAction::Create->value]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+        ColumnData::toField(source: 'Start', target: "custom_fields_{$cf->code}"),
+    ]);
+
+    runImportJob($this);
+
+    $person = People::where('team_id', $this->team->id)->where('name', 'John')->first();
+    $cfv = getTestCustomFieldValue($this, (string) $person->id, (string) $cf->id);
+
+    expect($cfv)->not->toBeNull()
+        ->and($cfv->date_value->format('Y-m-d'))->toBe('2026-08-19');
+});

--- a/tests/Feature/Profile/SyncUserTimezoneTest.php
+++ b/tests/Feature/Profile/SyncUserTimezoneTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Profile\SyncUserTimezone;
+use App\Http\Controllers\SyncUserTimezoneController;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+
+mutates(SyncUserTimezone::class, SyncUserTimezoneController::class);
+
+function syncTimezone(string $timezone): TestResponse
+{
+    return test()->postJson(route('filament.app.timezone.sync'), ['timezone' => $timezone]);
+}
+
+it('seeds the timezone from the browser when the user has none', function (): void {
+    $user = User::factory()->withTeam()->create(['timezone' => null]);
+    $this->actingAs($user);
+
+    syncTimezone('Asia/Tokyo')
+        ->assertOk()
+        ->assertJson(['synced' => true]);
+
+    expect($user->fresh()->timezone)->toBe('Asia/Tokyo');
+});
+
+it('never overwrites a timezone the user already has, so a deliberate choice survives travel', function (): void {
+    $user = User::factory()->withTeam()->create(['timezone' => 'Europe/London']);
+    $this->actingAs($user);
+
+    syncTimezone('America/New_York')
+        ->assertOk()
+        ->assertJson(['synced' => false]);
+
+    expect($user->fresh()->timezone)->toBe('Europe/London');
+});
+
+it('rejects an identifier that is not a real timezone', function (): void {
+    $user = User::factory()->withTeam()->create(['timezone' => null]);
+    $this->actingAs($user);
+
+    syncTimezone('Mars/Olympus_Mons')->assertUnprocessable();
+
+    expect($user->fresh()->timezone)->toBeNull();
+});
+
+it('rejects a fixed offset, so only DST-aware identifiers are ever stored', function (): void {
+    $user = User::factory()->withTeam()->create(['timezone' => null]);
+    $this->actingAs($user);
+
+    syncTimezone('+04:00')->assertUnprocessable();
+
+    expect($user->fresh()->timezone)->toBeNull();
+});
+
+it('requires authentication', function (): void {
+    $this->postJson(route('filament.app.timezone.sync'), ['timezone' => 'Asia/Tokyo'])
+        ->assertUnauthorized();
+});

--- a/tests/Feature/Profile/SyncUserTimezoneTest.php
+++ b/tests/Feature/Profile/SyncUserTimezoneTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Profile\SyncUserTimezone;
 use App\Http\Controllers\SyncUserTimezoneController;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\TestResponse;
 
 mutates(SyncUserTimezone::class, SyncUserTimezoneController::class);
@@ -57,4 +58,29 @@ it('rejects a fixed offset, so only DST-aware identifiers are ever stored', func
 it('requires authentication', function (): void {
     $this->postJson(route('filament.app.timezone.sync'), ['timezone' => 'Asia/Tokyo'])
         ->assertUnauthorized();
+});
+
+/**
+ * "Fill only if still null" was a check followed by a write, and the check read the
+ * in-memory model. Two first-page loads racing each other therefore both saw null and
+ * both wrote, so the zone a user kept was whichever request finished last.
+ *
+ * A single process cannot interleave two real requests, but it can reproduce the half
+ * that made the race lose data: a stale in-memory model. The row is changed underneath an
+ * already-loaded User, exactly as the other request would have changed it, and the action
+ * must notice. It only can if it re-reads the row inside the transaction, which is what
+ * the lock is there to make safe.
+ */
+it('re-reads the row before writing, so it cannot clobber a zone set by a racing request', function (): void {
+    $user = User::factory()->withTeam()->create(['timezone' => null]);
+
+    // Not $user->update(): the point is that THIS instance still believes it is null.
+    DB::table('users')->where('id', $user->getKey())->update(['timezone' => 'Europe/London']);
+
+    expect($user->timezone)->toBeNull();
+
+    $synced = app(SyncUserTimezone::class)->execute($user, 'Asia/Tokyo');
+
+    expect($synced)->toBeFalse()
+        ->and($user->fresh()->timezone)->toBe('Europe/London');
 });

--- a/tests/Feature/Profile/UpdateUserProfileInformationTest.php
+++ b/tests/Feature/Profile/UpdateUserProfileInformationTest.php
@@ -15,6 +15,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
 use Livewire\Livewire;
 
 mutates(UpdateUserProfileInformation::class, UpdateProfileInformationComponent::class);
@@ -445,5 +446,102 @@ describe('photo url generation', function () {
         $response->assertOk();
         expect($response->getContent())
             ->toBe('https://app.relaticle.test/storage/profile-photos/test.png?signature=abc123');
+    });
+});
+
+describe('timezone', function () {
+    test('form is prefilled with the stored timezone', function () {
+        $user = User::factory()->withTeam()->create(['timezone' => 'Asia/Tokyo']);
+        $this->actingAs($user);
+
+        Livewire::test(UpdateProfileInformationComponent::class)
+            ->assertFormSet(['timezone' => 'Asia/Tokyo']);
+    });
+
+    test('can set a timezone through the component', function () {
+        $user = User::factory()->withTeam()->create([
+            'email' => 'tz@example.com',
+            'timezone' => null,
+        ]);
+        $this->actingAs($user);
+
+        Livewire::test(UpdateProfileInformationComponent::class)
+            ->fillForm([
+                'name' => $user->name,
+                'email' => 'tz@example.com',
+                'timezone' => 'America/New_York',
+            ])
+            ->call('updateProfile')
+            ->assertHasNoFormErrors();
+
+        expect($user->fresh()->timezone)->toBe('America/New_York');
+    });
+
+    test('clearing the select writes null so the app default applies again', function () {
+        $user = User::factory()->withTeam()->create([
+            'email' => 'tz-clear@example.com',
+            'timezone' => 'Asia/Tokyo',
+        ]);
+        $this->actingAs($user);
+
+        Livewire::test(UpdateProfileInformationComponent::class)
+            ->fillForm([
+                'name' => $user->name,
+                'email' => 'tz-clear@example.com',
+                'timezone' => null,
+            ])
+            ->call('updateProfile')
+            ->assertHasNoFormErrors();
+
+        expect($user->fresh()->timezone)->toBeNull();
+    });
+
+    test('timezone survives a deferred email change', function () {
+        Notification::fake();
+
+        $user = User::factory()->withTeam()->create([
+            'email' => 'tz-email@example.com',
+            'email_verified_at' => now(),
+            'timezone' => null,
+        ]);
+        $this->actingAs($user);
+
+        Livewire::test(UpdateProfileInformationComponent::class)
+            ->fillForm([
+                'name' => $user->name,
+                'email' => 'tz-changed@example.com',
+                'timezone' => 'Europe/Lisbon',
+            ])
+            ->call('updateProfile')
+            ->assertHasNoFormErrors();
+
+        expect($user->fresh())
+            ->timezone->toBe('Europe/Lisbon')
+            ->email->toBe('tz-email@example.com');
+    });
+
+    test('rejects an identifier that is not a real timezone', function () {
+        $user = User::factory()->withTeam()->create(['timezone' => 'Asia/Tokyo']);
+
+        expect(fn () => $this->action->update($user, [
+            'name' => $user->name,
+            'email' => $user->email,
+            'timezone' => 'Mars/Olympus_Mons',
+        ]))->toThrow(ValidationException::class);
+
+        expect($user->fresh()->timezone)->toBe('Asia/Tokyo');
+    });
+
+    test('action leaves the timezone untouched when the key is absent from input', function () {
+        $user = User::factory()->withTeam()->create(['timezone' => 'Asia/Tokyo']);
+
+        $this->action->update($user, [
+            'name' => 'Renamed Without Timezone Key',
+            'email' => $user->email,
+        ]);
+
+        expect($user->fresh())
+            ->name->toBe('Renamed Without Timezone Key')
+            ->timezone->toBe('Asia/Tokyo');
     });
 });

--- a/tests/Feature/SystemAdmin/SysadminTimezoneTest.php
+++ b/tests/Feature/SystemAdmin/SysadminTimezoneTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Relaticle\SystemAdmin\Filament\Pages\Auth\EditProfile;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+mutates(EditProfile::class);
+
+/**
+ * 2026-08-18 23:30 UTC is 2026-08-19 08:30 in Tokyo — deliberately across the date
+ * line, so a test that only compares the clock time cannot pass by accident.
+ */
+function sysadminKnownInstant(): Carbon
+{
+    return Date::parse('2026-08-18 23:30:00', 'UTC');
+}
+
+function actAsAdminInZone(?string $timezone): SystemAdministrator
+{
+    $admin = SystemAdministrator::factory()->create(['timezone' => $timezone]);
+
+    test()->actingAs($admin, 'sysadmin');
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+
+    return $admin;
+}
+
+function seedUserAtKnownInstant(): void
+{
+    User::factory()->create([
+        'name' => 'Timezone Fixture',
+        'created_at' => sysadminKnownInstant(),
+        'updated_at' => sysadminKnownInstant(),
+    ]);
+}
+
+it('renders sysadmin datetimes in the administrator zone, labelled with it', function (): void {
+    seedUserAtKnownInstant();
+    actAsAdminInZone('Asia/Tokyo');
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->assertSee('Aug 19, 2026 08:30:00 JST')
+        ->assertDontSee('Aug 18, 2026 23:30:00 UTC');
+});
+
+it('keeps an administrator who has chosen no zone on utc', function (): void {
+    seedUserAtKnownInstant();
+    actAsAdminInZone(null);
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->assertSee('Aug 18, 2026 23:30:00 UTC');
+});
+
+it('falls back to utc when the stored zone is no longer a valid identifier', function (): void {
+    seedUserAtKnownInstant();
+    // Written straight to the column: the profile form rejects this, but a zone that
+    // PHP drops in a future tzdata release would arrive the same way.
+    actAsAdminInZone(null)->forceFill(['timezone' => 'Not/ARealZone'])->save();
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->assertSee('Aug 18, 2026 23:30:00 UTC');
+});
+
+it('lets an administrator choose a zone on the profile page', function (): void {
+    $admin = actAsAdminInZone(null);
+
+    livewire(EditProfile::class)
+        ->fillForm(['timezone' => 'Europe/London'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($admin->refresh()->timezone)->toBe('Europe/London');
+});
+
+it('rejects a zone that is not a real identifier', function (): void {
+    $admin = actAsAdminInZone(null);
+
+    livewire(EditProfile::class)
+        ->fillForm(['timezone' => 'Mars/Phobos'])
+        ->call('save')
+        ->assertHasFormErrors(['timezone']);
+
+    expect($admin->refresh()->timezone)->toBeNull();
+});

--- a/tests/Feature/UserTimezoneDisplayTest.php
+++ b/tests/Feature/UserTimezoneDisplayTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use App\Filament\Pages\Dashboard;
 use App\Filament\Resources\NoteResource\Pages\ManageNotes;
+use App\Filament\Resources\PeopleResource\Pages\ViewPeople;
+use App\Models\CustomField;
 use App\Models\Note;
+use App\Models\People;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
@@ -12,6 +15,8 @@ use Filament\Support\Facades\FilamentTimezone;
 use Filament\Tables\Table;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
+use Relaticle\CustomFields\Data\CustomFieldSettingsData;
+use Relaticle\CustomFields\Services\TenantContextService;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
@@ -151,4 +156,50 @@ it('stops shipping the detection script once the user has a timezone', function 
     $this->get(Dashboard::getUrl(tenant: $user->personalTeam()))
         ->assertOk()
         ->assertDontSee('resolvedOptions().timeZone', escape: false);
+});
+
+/**
+ * A record's view page renders custom fields through the package's infolist entry, which
+ * hardcoded `Y-m-d H:i:s` when the package had no format configured — which it never does
+ * here. So the page printed `2026-08-19 08:30:00` for the same field the table beside it
+ * rendered as `Aug 19, 2026 08:30`. Same value, same row, two formats.
+ */
+it('renders a custom-field datetime on a record page in the panel format, not a raw literal', function (): void {
+    $user = actAsTokyoUser();
+
+    /** @var Team $team */
+    $team = $user->currentTeam;
+
+    TenantContextService::setTenantId($team->getKey());
+
+    $field = CustomField::query()
+        ->where('tenant_id', $team->getKey())
+        ->where('entity_type', 'people')
+        ->where('type', 'date-time')
+        ->first();
+
+    if (! $field instanceof CustomField) {
+        $field = CustomField::forceCreate([
+            'name' => 'Tz Meeting At',
+            'code' => 'tz_meeting_at',
+            'type' => 'date-time',
+            'entity_type' => 'people',
+            'tenant_id' => $team->getKey(),
+            'sort_order' => 97,
+            'active' => true,
+            'system_defined' => false,
+            'settings' => new CustomFieldSettingsData,
+        ]);
+    }
+
+    $person = People::factory()->create([
+        'team_id' => $team->getKey(),
+        'creator_id' => $user->getKey(),
+    ]);
+    $person->saveCustomFieldValue($field, knownInstant()->toDateTimeString());
+
+    livewire(ViewPeople::class, ['record' => $person->getKey()])
+        ->assertSuccessful()
+        ->assertSee('Aug 19, 2026 08:30')
+        ->assertDontSee('2026-08-19 08:30:00');
 });

--- a/tests/Feature/UserTimezoneDisplayTest.php
+++ b/tests/Feature/UserTimezoneDisplayTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Filament\Pages\Dashboard;
 use App\Filament\Resources\NoteResource\Pages\ManageNotes;
 use App\Models\Note;
 use App\Models\Team;
@@ -90,4 +91,32 @@ it('labels sysadmin datetimes as utc so an admin never has to assume', function 
     livewire(ListUsers::class)
         ->assertSuccessful()
         ->assertSee('Aug 18, 2026 23:30:00 UTC');
+});
+
+it('does not ship the timezone detection script to signed-out visitors', function (): void {
+    // The panel's own login page renders the same BODY_END hook, and the sync endpoint
+    // behind it is authenticated — a script there could only ever produce a 401.
+    $this->get(Filament::getPanel('app')->getLoginUrl())
+        ->assertSuccessful()
+        ->assertDontSee('resolvedOptions().timeZone', escape: false);
+});
+
+it('ships the timezone detection script to a signed-in user who has none yet', function (): void {
+    $user = User::factory()->withPersonalTeam()->create(['timezone' => null]);
+    $this->actingAs($user);
+    Filament::setTenant($user->personalTeam());
+
+    $this->get(Dashboard::getUrl(tenant: $user->personalTeam()))
+        ->assertOk()
+        ->assertSee('resolvedOptions().timeZone', escape: false);
+});
+
+it('stops shipping the detection script once the user has a timezone', function (): void {
+    $user = User::factory()->withPersonalTeam()->create(['timezone' => 'Asia/Tokyo']);
+    $this->actingAs($user);
+    Filament::setTenant($user->personalTeam());
+
+    $this->get(Dashboard::getUrl(tenant: $user->personalTeam()))
+        ->assertOk()
+        ->assertDontSee('resolvedOptions().timeZone', escape: false);
 });

--- a/tests/Feature/UserTimezoneDisplayTest.php
+++ b/tests/Feature/UserTimezoneDisplayTest.php
@@ -77,14 +77,15 @@ it('renders a stored utc datetime in the user timezone in the app panel', functi
 
     livewire(ManageNotes::class)
         ->assertSuccessful()
-        ->assertSee('Aug 19, 2026 08:30:00')
-        ->assertDontSee('Aug 18, 2026 23:30:00');
+        ->assertSee('Aug 19, 2026 08:30')
+        ->assertDontSee('Aug 18, 2026 23:30');
 });
 
 /**
- * The panel names its datetime format in one place, so a resource that renders a
- * timestamp any other way is drift. Reading the format off the table rather than
- * asserting a literal keeps this true if the panel later picks a different one.
+ * Two separate things, both worth pinning. The panel declares one datetime format, so
+ * a resource that renders a timestamp any other way is drift: that half reads the
+ * format off the table rather than a literal, and keeps holding if the format changes.
+ * Which format it declares is a product decision, so that half names it.
  */
 it('renders every app panel datetime in the format the panel declares', function (): void {
     $user = actAsTokyoUser();
@@ -101,9 +102,12 @@ it('renders every app panel datetime in the format the panel declares', function
 
     $format = Table::make(new ManageNotes)->getDefaultDateTimeDisplayFormat();
 
+    expect($format)->toBe('M j, Y H:i');
+
     livewire(ManageNotes::class)
         ->assertSuccessful()
-        ->assertSee(knownInstant()->setTimezone('Asia/Tokyo')->translatedFormat($format));
+        ->assertSee(knownInstant()->setTimezone('Asia/Tokyo')->translatedFormat($format))
+        ->assertDontSee('Aug 19, 2026 08:30:00');
 });
 
 it('labels sysadmin datetimes as utc so an admin never has to assume', function (): void {

--- a/tests/Feature/UserTimezoneDisplayTest.php
+++ b/tests/Feature/UserTimezoneDisplayTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\NoteResource\Pages\ManageNotes;
+use App\Models\Note;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Support\Facades\FilamentTimezone;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+/**
+ * 2026-08-18 23:30 UTC is 2026-08-19 08:30 in Tokyo — deliberately across the date
+ * line, so a test that only compares the clock time cannot pass by accident.
+ */
+function knownInstant(): Carbon
+{
+    return Date::parse('2026-08-18 23:30:00', 'UTC');
+}
+
+function actAsTokyoUser(): User
+{
+    $user = User::factory()->withTeam()->create(['timezone' => 'Asia/Tokyo']);
+
+    test()->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+    Filament::setTenant($user->currentTeam);
+
+    return $user;
+}
+
+it('resolves the app panel timezone to the signed-in user', function (): void {
+    actAsTokyoUser();
+
+    expect(FilamentTimezone::get())->toBe('Asia/Tokyo');
+});
+
+it('falls back to the app timezone for a user who has not set one', function (): void {
+    $user = User::factory()->withTeam()->create(['timezone' => null]);
+    $this->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    expect(FilamentTimezone::get())->toBe(config('app.timezone'))
+        ->and(FilamentTimezone::get())->toBe('UTC');
+});
+
+it('keeps the sysadmin panel on utc even while a user timezone is set, so incidents correlate with server logs', function (): void {
+    $user = User::factory()->withTeam()->create(['timezone' => 'Asia/Tokyo']);
+    $this->actingAs($user);
+
+    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+
+    expect(FilamentTimezone::get())->toBe('UTC');
+});
+
+it('renders a stored utc datetime in the user timezone in the app panel', function (): void {
+    $user = actAsTokyoUser();
+
+    /** @var Team $team */
+    $team = $user->currentTeam;
+
+    Note::factory()->create([
+        'team_id' => $team->getKey(),
+        'creator_id' => $user->getKey(),
+        'created_at' => knownInstant(),
+        'updated_at' => knownInstant(),
+    ]);
+
+    livewire(ManageNotes::class)
+        ->assertSuccessful()
+        ->assertSee('2026-08-19 08:30:00')
+        ->assertDontSee('2026-08-18 23:30:00');
+});
+
+it('labels sysadmin datetimes as utc so an admin never has to assume', function (): void {
+    User::factory()->create([
+        'name' => 'Timezone Fixture',
+        'created_at' => knownInstant(),
+        'updated_at' => knownInstant(),
+    ]);
+
+    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->assertSee('Aug 18, 2026 23:30:00 UTC');
+});

--- a/tests/Feature/UserTimezoneDisplayTest.php
+++ b/tests/Feature/UserTimezoneDisplayTest.php
@@ -9,6 +9,7 @@ use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Filament\Support\Facades\FilamentTimezone;
+use Filament\Tables\Table;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
@@ -76,8 +77,33 @@ it('renders a stored utc datetime in the user timezone in the app panel', functi
 
     livewire(ManageNotes::class)
         ->assertSuccessful()
-        ->assertSee('2026-08-19 08:30:00')
-        ->assertDontSee('2026-08-18 23:30:00');
+        ->assertSee('Aug 19, 2026 08:30:00')
+        ->assertDontSee('Aug 18, 2026 23:30:00');
+});
+
+/**
+ * The panel names its datetime format in one place, so a resource that renders a
+ * timestamp any other way is drift. Reading the format off the table rather than
+ * asserting a literal keeps this true if the panel later picks a different one.
+ */
+it('renders every app panel datetime in the format the panel declares', function (): void {
+    $user = actAsTokyoUser();
+
+    /** @var Team $team */
+    $team = $user->currentTeam;
+
+    Note::factory()->create([
+        'team_id' => $team->getKey(),
+        'creator_id' => $user->getKey(),
+        'created_at' => knownInstant(),
+        'updated_at' => knownInstant(),
+    ]);
+
+    $format = Table::make(new ManageNotes)->getDefaultDateTimeDisplayFormat();
+
+    livewire(ManageNotes::class)
+        ->assertSuccessful()
+        ->assertSee(knownInstant()->setTimezone('Asia/Tokyo')->translatedFormat($format));
 });
 
 it('labels sysadmin datetimes as utc so an admin never has to assume', function (): void {

--- a/tests/Feature/UserTimezoneDisplayTest.php
+++ b/tests/Feature/UserTimezoneDisplayTest.php
@@ -49,10 +49,12 @@ it('falls back to the app timezone for a user who has not set one', function ():
         ->and(FilamentTimezone::get())->toBe('UTC');
 });
 
-it('keeps the sysadmin panel on utc even while a user timezone is set, so incidents correlate with server logs', function (): void {
+it('resolves each panel through its own guard, so a customer zone never leaks into sysadmin', function (): void {
     $user = User::factory()->withTeam()->create(['timezone' => 'Asia/Tokyo']);
     $this->actingAs($user);
 
+    // The administrator has chosen no zone of their own, so the panel stays on UTC
+    // and correlates with server logs — see SysadminTimezoneTest for the opt-in.
     $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
     Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
 


### PR DESCRIPTION
Two commits: the first makes UTC an *enforced* property of the connection, the second builds per-user display on top of it. In that order deliberately — the display work is only safe because storage is already unambiguous.

## Why

Every datetime column is `timestamp without time zone` holding UTC — 196 of them, zero `timestamptz`. But nothing pinned the PostgreSQL **session** timezone, so it inherited whatever the server was initialised with (locally `Asia/Yerevan`, in production unknown and not under version control). Any datetime written from the *database* clock therefore resolved against the wrong zone:

```
session=Asia/Yerevan   cast(now() as timestamp) = 2026-08-18 15:50:51
php now()                                       = 2026-08-18 11:50:51 UTC
```

A silent 4-hour drift, no error, and no way to tell affected rows from correct ones afterwards. One live offender existed — the pro-trial backfill in #480.

Separately, `users.timezone` has existed since #209 and is read by the task digest scheduler, the chat agent, the dashboard greeting and `MyTasksService` — but **nothing ever wrote it**, so every one of them silently fell back to UTC and the per-user 08:00 digest never worked.

## Commit 1 — pin the session timezone

- `config/database.php` — `'timezone' => 'UTC'` on the pgsql connection, so `PostgresConnector` issues `set time zone` on every connection, migrations included
- the pro-trial migration's `DB::raw('now()')` → PHP-side `now()`
- guidelines ban DB-clock datetime writes, enforced by a new `ConventionsTest` check rather than left as documentation

`failed_jobs.failed_at` keeps its `CURRENT_TIMESTAMP` default and is grandfathered: `DatabaseFailedJobProvider::log()` always passes `Date::now()` explicitly so it is never exercised, and changing it would only affect fresh installs — leaving new databases with a different default than every existing one.

## Commit 2 — per-user timezone

Storage does not change and no data migration is needed; this is purely additive.

**Acquisition** — the browser's IANA zone is detected and seeded once, via a render hook that stops emitting the moment a value exists. The action refuses to overwrite, so a deliberate choice survives travel and VPNs — which is also why no "explicitly set" column was needed. Plus a searchable Timezone select on the profile form, labelled with each zone's current UTC offset; clearing it writes null and returns to the app default.

**Display** — one `FilamentTimezone` closure. It is read by both table/infolist output and `DateTimePicker` input, so entry and display cannot drift apart, and ~40 existing `->dateTime()` call sites needed no changes. Date-only fields keep using the app timezone, so calendar dates correctly do not shift.

**Sysadmin deliberately stays on UTC** and now says so in the format. It is used to correlate incidents against Horizon, Flare and server logs — all UTC — and two admins in different zones must describe the same event with the same numbers. The gap there was the missing label, not the conversion.

**Day boundaries** — `MyTasksService` bounded overdue/today on UTC midnight, so a task due 23:00 UTC read as overdue to anyone east of London for most of their working day. `GetCrmSummaryTool` counted "this week" from the server's week. `CreditPeriodResolver` was examined and left on UTC on purpose: it is a *team* billing month whose members span zones, reset by a UTC-scheduled command.

**Exports** convert out of UTC and name the zone in the header.

## Verification

Walked in a real browser against Herd, both panels, one stored instant `2026-08-18 23:30:00 UTC`:

| Surface | Renders |
|---|---|
| app panel, user `Asia/Yerevan` | `2026-08-19 03:30:00` |
| sysadmin panel | `Aug 18, 2026 23:30:00 UTC` |

Auto-detect observed live: `users.timezone` went `NULL` → `Asia/Yerevan`, matching `Intl.DateTimeFormat().resolvedOptions().timeZone`, and the hook stopped rendering afterwards. The picker's **input** direction proved the same instant in reverse — typed `2026-08-19 03:30:00`, stored `2026-08-18 23:30:00`.

Every phase was proven load-bearing by reverting its production change and watching the matching test fail — including the original 4h drift, which the timezone test reports as `14399.999411` seconds.

24 tests added (2833 → **2857 passing**, 2 skipped, 1 risky). `pint` clean · `rector` 0 changes · `phpstan` 0 errors · type coverage 100.0%.

## Notes for review

- **The picker round-trip test needs `Filament::setCurrentPanel()` in setup.** A real request gets the panel from middleware; the harness does not, and the conversion is deliberately panel-scoped. Without it the test silently exercises the UTC fallback and passes for the wrong reason — worth knowing before copying the pattern.
- **The digest send time will shift for existing users.** They currently match the `orWhereNull('timezone')` branch and get 08:00 UTC; once detected they move to their own 08:00. Better, but it is a visible change on an email channel and belongs in release notes.
- Worth confirming after deploy, through the app's own connection rather than a psql session — if production sits behind a transaction-pooling proxy, per-session `SET`s may not stick:
  ```sql
  show timezone;
  ```