### PR TITLE
fix(chat): enforce custom field uniqueness and close AI list-filter gaps

### DIFF
--- a/app/Actions/CustomFields/AddCustomFieldOptions.php
+++ b/app/Actions/CustomFields/AddCustomFieldOptions.php
@@ -6,6 +6,7 @@ namespace App\Actions\CustomFields;
 
 use App\Models\CustomField;
 use App\Models\User;
+use App\Support\CustomFieldDefinitionValidator;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
 use Relaticle\CustomFields\Services\TenantContextService;
@@ -39,25 +40,15 @@ final readonly class AddCustomFieldOptions
                 "Field type \"{$field->type}\" does not support options. Only select, multi-select, radio, checkbox-list, and toggle-buttons fields can have options.",
             );
 
-            $newOptions = is_array($data['options'] ?? null) ? $data['options'] : [];
-            abort_if($newOptions === [], 422, 'At least one option must be provided.');
+            // Re-validated here, not just at proposal time: options approved after the
+            // same labels were added elsewhere must fail rather than write duplicates.
+            $validated = CustomFieldDefinitionValidator::forNewOptions($user, $field, $data);
 
-            $maxOptions = (int) config('chat.max_field_options', 50);
-            $existingCount = $field->options()->withoutGlobalScopes()->count();
-
-            abort_if(
-                ($existingCount + count($newOptions)) > $maxOptions,
-                422,
-                "Adding these options would exceed the limit of {$maxOptions} options per field.",
-            );
-
-            $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
             $nextSortOrder = (int) $field->options()->withoutGlobalScopes()->max('sort_order') + 1;
 
-            foreach (array_values($newOptions) as $index => $option) {
-                $optionName = is_array($option) ? (string) ($option['name'] ?? '') : (string) $option;
+            foreach (array_column($validated['options'], 'name') as $index => $optionName) {
                 $field->options()->create([
-                    $tenantKey => $teamId,
+                    config('custom-fields.database.column_names.tenant_foreign_key') => $teamId,
                     'name' => $optionName,
                     'sort_order' => $nextSortOrder + $index,
                 ]);

--- a/app/Actions/CustomFields/CreateCustomField.php
+++ b/app/Actions/CustomFields/CreateCustomField.php
@@ -6,6 +6,7 @@ namespace App\Actions\CustomFields;
 
 use App\Models\CustomField;
 use App\Models\User;
+use App\Support\CustomFieldDefinitionValidator;
 use Illuminate\Support\Facades\DB;
 use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
@@ -60,57 +61,21 @@ final readonly class CreateCustomField
     {
         abort_unless($user->ownsTeam($user->currentTeam), 403, 'Only team owners can manage custom field definitions.');
 
-        $type = (string) ($data['type'] ?? '');
-        $entityType = (string) ($data['entity_type'] ?? '');
-        $name = (string) ($data['name'] ?? '');
-
-        abort_unless(
-            in_array($type, self::ALLOWED_TYPES, true),
-            422,
-            "Field type \"{$type}\" is not allowed via chat. Allowed types: ".implode(', ', self::ALLOWED_TYPES).'.',
-        );
-
-        abort_unless(
-            in_array($entityType, self::VALID_ENTITY_TYPES, true),
-            422,
-            "Entity type \"{$entityType}\" is not valid. Valid types: ".implode(', ', self::VALID_ENTITY_TYPES).'.',
-        );
-
-        $options = is_array($data['options'] ?? null) ? $data['options'] : [];
-        $isChoiceType = $this->isChoiceType($type);
-
-        abort_if($isChoiceType && $options === [], 422, "Field type \"{$type}\" requires at least one option.");
-
-        abort_if(! $isChoiceType && $options !== [], 422, "Field type \"{$type}\" does not support options.");
-
         $teamId = $user->currentTeam->getKey();
         $previousTenantId = TenantContextService::getCurrentTenantId();
         TenantContextService::setTenantId($teamId);
 
         try {
-            $maxFields = (int) config('chat.max_custom_fields_per_entity', 50);
-            $existingCount = CustomField::query()
-                ->withoutGlobalScope(CustomFieldsActivableScope::class)
-                ->where('tenant_id', $teamId)
-                ->where('entity_type', $entityType)
-                ->count();
+            // Re-validated here, not just at proposal time: a proposal approved after
+            // someone else claimed the name must fail rather than write a duplicate.
+            $validated = CustomFieldDefinitionValidator::forCreate($user, $data);
 
-            abort_if(
-                $existingCount >= $maxFields,
-                422,
-                "Cannot create more than {$maxFields} custom fields per entity type.",
-            );
+            $entityType = (string) $validated['entity_type'];
+            $type = (string) $validated['type'];
+            $name = (string) $validated['name'];
+            $optionNames = array_column(is_array($validated['options'] ?? null) ? $validated['options'] : [], 'name');
 
-            if ($isChoiceType) {
-                $maxOptions = (int) config('chat.max_field_options', 50);
-                abort_if(
-                    count($options) > $maxOptions,
-                    422,
-                    "Cannot create more than {$maxOptions} options per field.",
-                );
-            }
-
-            $code = (string) ($data['code'] ?? '');
+            $code = (string) ($validated['code'] ?? '');
 
             if ($code === '') {
                 $code = CodeGenerator::generateUniqueFieldCode($name, $entityType);
@@ -122,7 +87,7 @@ final readonly class CreateCustomField
                 ->where('entity_type', $entityType)
                 ->max('sort_order') + 1;
 
-            $field = DB::transaction(function () use ($teamId, $entityType, $type, $name, $code, $nextSortOrder, $options, $isChoiceType): CustomField {
+            $field = DB::transaction(function () use ($teamId, $entityType, $type, $name, $code, $nextSortOrder, $optionNames): CustomField {
                 $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
 
                 /** @var CustomField $created */
@@ -139,15 +104,12 @@ final readonly class CreateCustomField
                     'settings' => new CustomFieldSettingsData,
                 ]);
 
-                if ($isChoiceType) {
-                    foreach (array_values($options) as $index => $option) {
-                        $optionName = is_array($option) ? (string) ($option['name'] ?? '') : (string) $option;
-                        $created->options()->create([
-                            $tenantKey => $teamId,
-                            'name' => $optionName,
-                            'sort_order' => $index,
-                        ]);
-                    }
+                foreach ($optionNames as $index => $optionName) {
+                    $created->options()->create([
+                        $tenantKey => $teamId,
+                        'name' => $optionName,
+                        'sort_order' => $index,
+                    ]);
                 }
 
                 return $created;
@@ -157,10 +119,5 @@ final readonly class CreateCustomField
         }
 
         return $field->load('options');
-    }
-
-    private function isChoiceType(string $type): bool
-    {
-        return in_array($type, self::CHOICE_TYPES, true);
     }
 }

--- a/app/Actions/CustomFields/UpdateCustomField.php
+++ b/app/Actions/CustomFields/UpdateCustomField.php
@@ -6,6 +6,7 @@ namespace App\Actions\CustomFields;
 
 use App\Models\CustomField;
 use App\Models\User;
+use App\Support\CustomFieldDefinitionValidator;
 use Relaticle\CustomFields\Services\TenantContextService;
 
 final readonly class UpdateCustomField
@@ -23,14 +24,11 @@ final readonly class UpdateCustomField
         TenantContextService::setTenantId($teamId);
 
         try {
-            $attributes = array_filter([
-                'name' => isset($data['name']) && is_string($data['name']) && $data['name'] !== '' ? $data['name'] : null,
-                'active' => isset($data['active']) ? (bool) $data['active'] : null,
-            ], fn (mixed $v): bool => $v !== null);
+            // Re-validated here, not just at proposal time: a rename approved after
+            // someone else claimed the name must fail rather than write a duplicate.
+            $attributes = CustomFieldDefinitionValidator::forRename($user, $field, $data);
 
-            if ($attributes !== []) {
-                $field->update($attributes);
-            }
+            $field->update($attributes);
         } finally {
             TenantContextService::setTenantId($previousTenantId);
         }

--- a/app/Actions/Note/ListNotes.php
+++ b/app/Actions/Note/ListNotes.php
@@ -10,6 +10,7 @@ use App\Models\Note;
 use App\Models\User;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
@@ -43,6 +44,8 @@ final readonly class ListNotes
                 AllowedFilter::scope('notable_type', 'forNotableType'),
                 AllowedFilter::scope('notable_id', 'forNotableId'),
                 AllowedFilter::custom('custom_fields', new CustomFieldFilter('note')),
+                AllowedFilter::callback('created_after', fn (Builder $query, string $value) => $query->whereDate('notes.created_at', '>=', $value)),
+                AllowedFilter::callback('created_before', fn (Builder $query, string $value) => $query->whereDate('notes.created_at', '<=', $value)),
             )
             ->allowedFields('id', 'title', 'creator_id', 'created_at', 'updated_at')
             ->allowedIncludes(

--- a/app/Actions/Task/ListTasks.php
+++ b/app/Actions/Task/ListTasks.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -45,6 +46,21 @@ final readonly class ListTasks
                     if (filter_var($value, FILTER_VALIDATE_BOOLEAN)) {
                         $query->whereHas('assignees', fn (Builder $q) => $q->where('users.id', $user->getKey()));
                     }
+                }),
+                // Mirrors the panel's multi-select assignee filter: match a task if ANY
+                // of the given members is on it. assigned_to_me stays as the shorthand
+                // for the caller themselves, which needs no id round-trip.
+                AllowedFilter::callback('assignee_ids', function (Builder $query, mixed $value): void {
+                    $ids = array_values(array_filter(array_map(
+                        static fn (mixed $id): string => is_scalar($id) ? trim((string) $id) : '',
+                        Arr::wrap($value),
+                    ), static fn (string $id): bool => $id !== ''));
+
+                    if ($ids === []) {
+                        return;
+                    }
+
+                    $query->whereHas('assignees', fn (Builder $q) => $q->whereIn('users.id', $ids));
                 }),
                 AllowedFilter::scope('company_id', 'forCompany'),
                 AllowedFilter::scope('people_id', 'forPerson'),

--- a/app/Actions/Task/ListTasks.php
+++ b/app/Actions/Task/ListTasks.php
@@ -65,6 +65,8 @@ final readonly class ListTasks
                 AllowedFilter::scope('company_id', 'forCompany'),
                 AllowedFilter::scope('people_id', 'forPerson'),
                 AllowedFilter::scope('opportunity_id', 'forOpportunity'),
+                AllowedFilter::callback('created_after', fn (Builder $query, string $value) => $query->whereDate('tasks.created_at', '>=', $value)),
+                AllowedFilter::callback('created_before', fn (Builder $query, string $value) => $query->whereDate('tasks.created_at', '<=', $value)),
                 AllowedFilter::custom('custom_fields', new CustomFieldFilter('task')),
             )
             ->allowedFields('id', 'title', 'creator_id', 'created_at', 'updated_at')

--- a/app/Mcp/Schema/CustomFieldFilterSchema.php
+++ b/app/Mcp/Schema/CustomFieldFilterSchema.php
@@ -114,12 +114,29 @@ final readonly class CustomFieldFilterSchema
     }
 
     /**
+     * Drop the memoised schema for one tenant + entity.
+     *
+     * Callers must not rebuild this key themselves — the TTL is long enough that a
+     * missed invalidation reads as "that field doesn't exist" right after the
+     * assistant created it.
+     */
+    public static function forget(int|string $tenantId, string $entityType): void
+    {
+        Cache::forget(self::cacheKey($tenantId, $entityType));
+    }
+
+    private static function cacheKey(int|string $tenantId, string $entityType): string
+    {
+        return "custom_fields_filter_schema_{$tenantId}_{$entityType}";
+    }
+
+    /**
      * @return Collection<int, CustomField>
      */
     private function resolveFilterableFields(User $user, string $entityType): Collection
     {
         $teamId = $user->currentTeam->getKey();
-        $cacheKey = "custom_fields_filter_schema_{$teamId}_{$entityType}";
+        $cacheKey = self::cacheKey($teamId, $entityType);
 
         /** @var Collection<int, CustomField> */
         return Cache::remember($cacheKey, 60, fn (): Collection => CustomField::query()

--- a/app/Mcp/Tools/BaseListTool.php
+++ b/app/Mcp/Tools/BaseListTool.php
@@ -52,6 +52,8 @@ abstract class BaseListTool extends Tool
             ['search' => $schema->string()->description("Search by {$this->searchFilterName()}.")],
             $this->additionalSchema($schema),
             [
+                'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+                'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
                 'filter' => $schema->object()->description('Filter by custom field values. Keys are field codes, values are operator objects (eq, gt, gte, lt, lte, contains, in, has_any).'),
                 'sort' => $schema->object()->description('Sort by field. Properties: field (string), direction (asc|desc).'),
                 'include' => $schema->array()->description('Related records to expand in response.'),
@@ -138,7 +140,11 @@ abstract class BaseListTool extends Tool
         $input = [];
 
         $nativeFilters = array_filter(array_merge(
-            [$this->searchFilterName() => $mcpRequest->get('search')],
+            [
+                $this->searchFilterName() => $mcpRequest->get('search'),
+                'created_after' => $mcpRequest->get('created_after'),
+                'created_before' => $mcpRequest->get('created_before'),
+            ],
             $this->additionalFilters($mcpRequest),
         ));
 

--- a/app/Mcp/Tools/Company/ListCompaniesTool.php
+++ b/app/Mcp/Tools/Company/ListCompaniesTool.php
@@ -7,8 +7,6 @@ namespace App\Mcp\Tools\Company;
 use App\Actions\Company\ListCompanies;
 use App\Http\Resources\V1\CompanyResource;
 use App\Mcp\Tools\BaseListTool;
-use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Laravel\Mcp\Request;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
 use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
@@ -33,21 +31,5 @@ final class ListCompaniesTool extends BaseListTool
     protected function searchFilterName(): string
     {
         return 'name';
-    }
-
-    protected function additionalSchema(JsonSchema $schema): array
-    {
-        return [
-            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
-            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
-        ];
-    }
-
-    protected function additionalFilters(Request $request): array
-    {
-        return [
-            'created_after' => $request->get('created_after'),
-            'created_before' => $request->get('created_before'),
-        ];
     }
 }

--- a/app/Mcp/Tools/Company/ListCompaniesTool.php
+++ b/app/Mcp/Tools/Company/ListCompaniesTool.php
@@ -7,6 +7,8 @@ namespace App\Mcp\Tools\Company;
 use App\Actions\Company\ListCompanies;
 use App\Http\Resources\V1\CompanyResource;
 use App\Mcp\Tools\BaseListTool;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Tools\Annotations\IsIdempotent;
 use Laravel\Mcp\Server\Tools\Annotations\IsOpenWorld;
@@ -31,5 +33,21 @@ final class ListCompaniesTool extends BaseListTool
     protected function searchFilterName(): string
     {
         return 'name';
+    }
+
+    protected function additionalSchema(JsonSchema $schema): array
+    {
+        return [
+            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
+        ];
+    }
+
+    protected function additionalFilters(Request $request): array
+    {
+        return [
+            'created_after' => $request->get('created_after'),
+            'created_before' => $request->get('created_before'),
+        ];
     }
 }

--- a/app/Mcp/Tools/Opportunity/ListOpportunitiesTool.php
+++ b/app/Mcp/Tools/Opportunity/ListOpportunitiesTool.php
@@ -40,8 +40,6 @@ final class ListOpportunitiesTool extends BaseListTool
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
             'contact_id' => $schema->string()->description('Filter by contact (person) ID.'),
-            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
-            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
             'stale_days' => $schema->integer()->description('Return only opportunities with no activity in the last N days. Use this to find deals that have gone quiet.'),
         ];
     }
@@ -51,8 +49,6 @@ final class ListOpportunitiesTool extends BaseListTool
         return [
             'company_id' => $request->get('company_id'),
             'contact_id' => $request->get('contact_id'),
-            'created_after' => $request->get('created_after'),
-            'created_before' => $request->get('created_before'),
             'stale_days' => $request->get('stale_days') !== null ? (string) $request->get('stale_days') : null,
         ];
     }

--- a/app/Mcp/Tools/Opportunity/ListOpportunitiesTool.php
+++ b/app/Mcp/Tools/Opportunity/ListOpportunitiesTool.php
@@ -40,6 +40,9 @@ final class ListOpportunitiesTool extends BaseListTool
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
             'contact_id' => $schema->string()->description('Filter by contact (person) ID.'),
+            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
+            'stale_days' => $schema->integer()->description('Return only opportunities with no activity in the last N days. Use this to find deals that have gone quiet.'),
         ];
     }
 
@@ -48,6 +51,9 @@ final class ListOpportunitiesTool extends BaseListTool
         return [
             'company_id' => $request->get('company_id'),
             'contact_id' => $request->get('contact_id'),
+            'created_after' => $request->get('created_after'),
+            'created_before' => $request->get('created_before'),
+            'stale_days' => $request->get('stale_days') !== null ? (string) $request->get('stale_days') : null,
         ];
     }
 }

--- a/app/Mcp/Tools/People/ListPeopleTool.php
+++ b/app/Mcp/Tools/People/ListPeopleTool.php
@@ -39,6 +39,8 @@ final class ListPeopleTool extends BaseListTool
     {
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
+            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
         ];
     }
 
@@ -46,6 +48,8 @@ final class ListPeopleTool extends BaseListTool
     {
         return [
             'company_id' => $request->get('company_id'),
+            'created_after' => $request->get('created_after'),
+            'created_before' => $request->get('created_before'),
         ];
     }
 }

--- a/app/Mcp/Tools/People/ListPeopleTool.php
+++ b/app/Mcp/Tools/People/ListPeopleTool.php
@@ -39,8 +39,6 @@ final class ListPeopleTool extends BaseListTool
     {
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
-            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
-            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
         ];
     }
 
@@ -48,8 +46,6 @@ final class ListPeopleTool extends BaseListTool
     {
         return [
             'company_id' => $request->get('company_id'),
-            'created_after' => $request->get('created_after'),
-            'created_before' => $request->get('created_before'),
         ];
     }
 }

--- a/app/Mcp/Tools/Task/ListTasksTool.php
+++ b/app/Mcp/Tools/Task/ListTasksTool.php
@@ -39,6 +39,7 @@ final class ListTasksTool extends BaseListTool
     {
         return [
             'assigned_to_me' => $schema->boolean()->description('Filter tasks assigned to the current user.'),
+            'assignee_ids' => $schema->array()->description('Filter tasks assigned to any of these user IDs. Use the whoami tool to discover valid user IDs.'),
             'company_id' => $schema->string()->description('Filter tasks linked to a specific company.'),
             'people_id' => $schema->string()->description('Filter tasks linked to a specific person.'),
             'opportunity_id' => $schema->string()->description('Filter tasks linked to a specific opportunity.'),
@@ -49,6 +50,7 @@ final class ListTasksTool extends BaseListTool
     {
         return [
             'assigned_to_me' => $request->get('assigned_to_me') ? '1' : null,
+            'assignee_ids' => $request->get('assignee_ids'),
             'company_id' => $request->get('company_id'),
             'people_id' => $request->get('people_id'),
             'opportunity_id' => $request->get('opportunity_id'),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,6 +15,7 @@ use App\Listeners\Email\TeamMemberAddedListener;
 use App\Listeners\Mcp\CopyTeamIdToAccessToken;
 use App\Listeners\SeedTeamCreditBalanceListener;
 use App\Livewire\FilamentNotifications;
+use App\Mcp\Schema\CustomFieldFilterSchema;
 use App\Models\ActivityLog\Activity as ActivityModel;
 use App\Models\Company;
 use App\Models\CustomField;
@@ -437,6 +438,29 @@ final class AppServiceProvider extends ServiceProvider
         CustomFields::useSectionModel(CustomFieldSection::class);
         CustomFields::useOptionModel(CustomFieldOption::class);
         CustomFields::useValueModel(CustomFieldValue::class);
+
+        $this->configureCustomFieldSchemaInvalidation();
+    }
+
+    /**
+     * The AI list tools memoise which custom fields are filterable, per tenant and
+     * entity, for a minute. Hooking the model rather than the actions keeps the
+     * Filament management page — which writes definitions directly — from leaving
+     * the assistant insisting a field the user just added does not exist.
+     */
+    private function configureCustomFieldSchemaInvalidation(): void
+    {
+        $invalidate = function (CustomField $field): void {
+            $tenantId = $field->getAttribute('tenant_id');
+            $entityType = $field->getAttribute('entity_type');
+
+            if ((is_string($tenantId) || is_int($tenantId)) && is_string($entityType)) {
+                CustomFieldFilterSchema::forget($tenantId, $entityType);
+            }
+        };
+
+        CustomField::saved($invalidate);
+        CustomField::deleted($invalidate);
     }
 
     /**

--- a/app/Support/CustomFieldDefinitionValidator.php
+++ b/app/Support/CustomFieldDefinitionValidator.php
@@ -47,7 +47,11 @@ final readonly class CustomFieldDefinitionValidator
         return Validator::make(self::normalize($data), [
             'entity_type' => ['required', Rule::in(CreateCustomField::VALID_ENTITY_TYPES), self::withinFieldCap($tenantId, $entityType)],
             'type' => ['required', Rule::in(CreateCustomField::ALLOWED_TYPES)],
-            'name' => ['required', 'string', 'max:50', self::uniqueDefinition('name', $tenantId, $entityType)],
+            'name' => ['required', 'string', 'max:50', self::uniqueNameIgnoringCase(
+                $tenantId,
+                $entityType,
+                fn (): string => "A field named \":input\" already exists on {$entityType}. Field names must be unique per entity — pick a different name, or update the existing field instead.",
+            )],
             'code' => ['nullable', 'string', 'max:50', 'alpha_dash', self::uniqueDefinition('code', $tenantId, $entityType)],
             'options' => ['nullable', self::expectsOptions($type) ? 'required' : 'prohibited', 'array', "max:{$maxOptions}"],
             'options.*.name' => ['required', 'string', 'max:255', 'distinct:ignore_case'],
@@ -56,7 +60,6 @@ final readonly class CustomFieldDefinitionValidator
             'type.in' => 'Field type ":input" is not supported via chat. Allowed types: '.implode(', ', CreateCustomField::ALLOWED_TYPES).'.',
             'name.required' => 'A field name is required.',
             'name.max' => 'Field names must be 50 characters or fewer.',
-            'name.unique' => "A field named \":input\" already exists on {$entityType}. Field names must be unique per entity — pick a different name, or update the existing field instead.",
             'code.max' => 'Field codes must be 50 characters or fewer.',
             'code.alpha_dash' => 'Field codes may only contain letters, numbers, dashes, and underscores.',
             'code.unique' => "A field with code \":input\" already exists on {$entityType}. Omit the code to auto-generate a unique one, or pick a different code.",
@@ -79,7 +82,12 @@ final readonly class CustomFieldDefinitionValidator
         return Validator::make(self::normalize($data), [
             'name' => [
                 'required_without:active', 'string', 'max:50',
-                self::uniqueDefinition('name', $user->currentTeam->getKey(), $entityType)->ignore($field->getKey()),
+                self::uniqueNameIgnoringCase(
+                    $user->currentTeam->getKey(),
+                    $entityType,
+                    fn (): string => "A field named \":input\" already exists on {$entityType}. Field names must be unique per entity — pick a different name.",
+                    $field->getKey(),
+                ),
             ],
             // Only `name` carries required_without: with the rule on both, an empty
             // payload failed twice and the assistant was handed the same sentence twice.
@@ -87,7 +95,6 @@ final readonly class CustomFieldDefinitionValidator
         ], [
             'name.required_without' => 'Provide at least one of: name, active.',
             'name.max' => 'Field names must be 50 characters or fewer.',
-            'name.unique' => "A field named \":input\" already exists on {$entityType}. Field names must be unique per entity — pick a different name.",
         ])->validate();
     }
 
@@ -109,11 +116,7 @@ final readonly class CustomFieldDefinitionValidator
             'options' => ['nullable', 'required', 'array', "max:{$remaining}"],
             'options.*.name' => [
                 'required', 'string', 'max:255', 'distinct:ignore_case',
-                Rule::unique(self::optionsTable(), 'name')->where(
-                    fn (Builder $query): Builder => $query
-                        ->where('custom_field_id', $field->getKey())
-                        ->where(self::tenantKey(), $user->currentTeam->getKey()),
-                ),
+                self::uniqueOptionIgnoringCase($user->currentTeam->getKey(), $field),
             ],
         ], [
             'options.required' => 'At least one option must be provided.',
@@ -129,7 +132,6 @@ final readonly class CustomFieldDefinitionValidator
         return [
             'options.*.name.required' => 'Option names cannot be empty.',
             'options.*.name.distinct' => 'Duplicate option names are not allowed.',
-            'options.*.name.unique' => 'Option ":input" already exists on this field.',
             'options.*.name.max' => 'Option names must be 255 characters or fewer.',
         ];
     }
@@ -145,6 +147,61 @@ final readonly class CustomFieldDefinitionValidator
                 ->where(self::tenantKey(), $tenantId)
                 ->where('entity_type', $entityType),
         );
+    }
+
+    /**
+     * Names compare case-insensitively, because "Age" and "age" are the same field
+     * to a human and `distinct:ignore_case` already refuses them inside one payload.
+     * Codes deliberately stay case-sensitive: they are slug-generated, and the DB's
+     * own unique index on (code, entity_type, tenant_id) is case-sensitive too, so a
+     * looser rule here would reject values the database would have accepted.
+     *
+     * @param  Closure(): string  $message  built lazily so ":input" stays out of it
+     */
+    private static function uniqueNameIgnoringCase(
+        int|string $tenantId,
+        string $entityType,
+        Closure $message,
+        int|string|null $ignoreId = null,
+    ): Closure {
+        return function (string $attribute, mixed $value, Closure $fail) use ($tenantId, $entityType, $message, $ignoreId): void {
+            if (! is_string($value) || $value === '') {
+                return;
+            }
+
+            $taken = DB::table(self::definitionsTable())
+                ->where(self::tenantKey(), $tenantId)
+                ->where('entity_type', $entityType)
+                ->whereRaw('lower(name) = ?', [mb_strtolower($value)])
+                ->when($ignoreId !== null, fn (Builder $query): Builder => $query->where('id', '!=', $ignoreId))
+                ->exists();
+
+            if ($taken) {
+                $fail(str_replace(':input', $value, $message()));
+            }
+        };
+    }
+
+    /**
+     * The option-name twin of {@see uniqueNameIgnoringCase}, scoped to one field.
+     */
+    private static function uniqueOptionIgnoringCase(int|string $tenantId, CustomField $field): Closure
+    {
+        return function (string $attribute, mixed $value, Closure $fail) use ($tenantId, $field): void {
+            if (! is_string($value) || $value === '') {
+                return;
+            }
+
+            $taken = DB::table(self::optionsTable())
+                ->where('custom_field_id', $field->getKey())
+                ->where(self::tenantKey(), $tenantId)
+                ->whereRaw('lower(name) = ?', [mb_strtolower($value)])
+                ->exists();
+
+            if ($taken) {
+                $fail("Option \"{$value}\" already exists on this field.");
+            }
+        };
     }
 
     private static function withinFieldCap(int|string $tenantId, string $entityType): Closure

--- a/app/Support/CustomFieldDefinitionValidator.php
+++ b/app/Support/CustomFieldDefinitionValidator.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Actions\CustomFields\CreateCustomField;
+use App\Models\CustomField;
+use App\Models\User;
+use Closure;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Unique;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * The single rule set for custom-field definitions written outside a Filament form.
+ *
+ * The management form enforces per-tenant, per-entity uniqueness on a field's name
+ * and code (see the package's FieldForm); nothing enforced it on the chat/action
+ * path, so an assistant could create a second "Age" on People that the UI forbids.
+ * Both the proposal tools (pre-flight, so a doomed proposal is never shown) and the
+ * actions (authoritative, so a proposal approved after the name was taken still
+ * fails) validate through here, which keeps the two from drifting.
+ *
+ * Uniqueness runs on the query builder rather than Eloquent so deactivated fields
+ * count as taken — the activable global scope would otherwise hide them and let a
+ * duplicate through.
+ */
+final readonly class CustomFieldDefinitionValidator
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     *
+     * @throws ValidationException
+     */
+    public static function forCreate(User $user, array $data): array
+    {
+        $entityType = is_string($data['entity_type'] ?? null) ? $data['entity_type'] : '';
+        $type = is_string($data['type'] ?? null) ? $data['type'] : '';
+        $tenantId = $user->currentTeam->getKey();
+        $maxOptions = self::maxOptions();
+
+        return Validator::make(self::normalize($data), [
+            'entity_type' => ['required', Rule::in(CreateCustomField::VALID_ENTITY_TYPES), self::withinFieldCap($tenantId, $entityType)],
+            'type' => ['required', Rule::in(CreateCustomField::ALLOWED_TYPES)],
+            'name' => ['required', 'string', 'max:50', self::uniqueDefinition('name', $tenantId, $entityType)],
+            'code' => ['nullable', 'string', 'max:50', 'alpha_dash', self::uniqueDefinition('code', $tenantId, $entityType)],
+            'options' => ['nullable', self::expectsOptions($type) ? 'required' : 'prohibited', 'array', "max:{$maxOptions}"],
+            'options.*.name' => ['required', 'string', 'max:255', 'distinct:ignore_case'],
+        ], [
+            'entity_type.in' => 'Invalid entity type ":input". Must be one of: '.implode(', ', CreateCustomField::VALID_ENTITY_TYPES).'.',
+            'type.in' => 'Field type ":input" is not supported via chat. Allowed types: '.implode(', ', CreateCustomField::ALLOWED_TYPES).'.',
+            'name.required' => 'A field name is required.',
+            'name.max' => 'Field names must be 50 characters or fewer.',
+            'name.unique' => "A field named \":input\" already exists on {$entityType}. Field names must be unique per entity — pick a different name, or update the existing field instead.",
+            'code.max' => 'Field codes must be 50 characters or fewer.',
+            'code.alpha_dash' => 'Field codes may only contain letters, numbers, dashes, and underscores.',
+            'code.unique' => "A field with code \":input\" already exists on {$entityType}. Omit the code to auto-generate a unique one, or pick a different code.",
+            'options.required' => "Field type \"{$type}\" requires at least one option.",
+            'options.prohibited' => "Field type \"{$type}\" does not support options.",
+            'options.max' => "Too many options — at most {$maxOptions} per field.",
+        ] + self::optionNameMessages())->validate();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     *
+     * @throws ValidationException
+     */
+    public static function forRename(User $user, CustomField $field, array $data): array
+    {
+        $entityType = (string) $field->entity_type;
+
+        return Validator::make(self::normalize($data), [
+            'name' => [
+                'required_without:active', 'string', 'max:50',
+                self::uniqueDefinition('name', $user->currentTeam->getKey(), $entityType)->ignore($field->getKey()),
+            ],
+            'active' => ['required_without:name', 'boolean'],
+        ], [
+            'name.required_without' => 'Provide at least one of: name, active.',
+            'active.required_without' => 'Provide at least one of: name, active.',
+            'name.required' => 'A field name is required.',
+            'name.max' => 'Field names must be 50 characters or fewer.',
+            'name.unique' => "A field named \":input\" already exists on {$entityType}. Field names must be unique per entity — pick a different name.",
+        ])->validate();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     *
+     * @throws ValidationException
+     */
+    public static function forNewOptions(User $user, CustomField $field, array $data): array
+    {
+        $maxOptions = self::maxOptions();
+        $existing = DB::table(self::optionsTable())
+            ->where('custom_field_id', $field->getKey())
+            ->count();
+        $remaining = max(0, $maxOptions - $existing);
+
+        return Validator::make(self::normalize($data), [
+            'options' => ['nullable', 'required', 'array', "max:{$remaining}"],
+            'options.*.name' => [
+                'required', 'string', 'max:255', 'distinct:ignore_case',
+                Rule::unique(self::optionsTable(), 'name')->where(
+                    fn (Builder $query): Builder => $query
+                        ->where('custom_field_id', $field->getKey())
+                        ->where(self::tenantKey(), $user->currentTeam->getKey()),
+                ),
+            ],
+        ], [
+            'options.required' => 'At least one option must be provided.',
+            'options.max' => "Adding these options would exceed the {$maxOptions} options limit for this field (currently has {$existing}).",
+        ] + self::optionNameMessages())->validate();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function optionNameMessages(): array
+    {
+        return [
+            'options.*.name.required' => 'Option names cannot be empty.',
+            'options.*.name.distinct' => 'Duplicate option names are not allowed.',
+            'options.*.name.unique' => 'Option ":input" already exists on this field.',
+            'options.*.name.max' => 'Option names must be 255 characters or fewer.',
+        ];
+    }
+
+    /**
+     * Uniqueness is scoped the same way the management form scopes it: per tenant,
+     * per entity type.
+     */
+    private static function uniqueDefinition(string $column, int|string $tenantId, string $entityType): Unique
+    {
+        return Rule::unique(self::definitionsTable(), $column)->where(
+            fn (Builder $query): Builder => $query
+                ->where(self::tenantKey(), $tenantId)
+                ->where('entity_type', $entityType),
+        );
+    }
+
+    private static function withinFieldCap(int|string $tenantId, string $entityType): Closure
+    {
+        return function (string $attribute, mixed $value, Closure $fail) use ($tenantId, $entityType): void {
+            $max = (int) config('chat.max_custom_fields_per_entity', 50);
+
+            $existing = DB::table(self::definitionsTable())
+                ->where(self::tenantKey(), $tenantId)
+                ->where('entity_type', $entityType)
+                ->count();
+
+            if ($existing >= $max) {
+                $fail("Cannot create more than {$max} custom fields for entity type \"{$entityType}\".");
+            }
+        };
+    }
+
+    /**
+     * Trims the free-text attributes and reshapes options to a uniform
+     * `[{name: string}]` so the `options.*.name` rules apply whether the caller
+     * sent objects or bare strings.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private static function normalize(array $data): array
+    {
+        foreach (['name', 'code'] as $attribute) {
+            if (is_string($data[$attribute] ?? null)) {
+                $data[$attribute] = trim($data[$attribute]);
+            }
+        }
+
+        if (is_array($data['options'] ?? null)) {
+            $data['options'] = array_values(array_map(
+                static fn (mixed $option): array => [
+                    'name' => trim(is_array($option) ? (string) ($option['name'] ?? '') : (string) $option),
+                ],
+                $data['options'],
+            ));
+        }
+
+        return $data;
+    }
+
+    private static function expectsOptions(string $type): bool
+    {
+        return in_array($type, CreateCustomField::CHOICE_TYPES, true);
+    }
+
+    private static function maxOptions(): int
+    {
+        return (int) config('chat.max_field_options', 50);
+    }
+
+    private static function definitionsTable(): string
+    {
+        return (string) config('custom-fields.database.table_names.custom_fields');
+    }
+
+    private static function optionsTable(): string
+    {
+        return (string) config('custom-fields.database.table_names.custom_field_options');
+    }
+
+    private static function tenantKey(): string
+    {
+        return (string) config('custom-fields.database.column_names.tenant_foreign_key');
+    }
+}

--- a/app/Support/CustomFieldDefinitionValidator.php
+++ b/app/Support/CustomFieldDefinitionValidator.php
@@ -81,11 +81,11 @@ final readonly class CustomFieldDefinitionValidator
                 'required_without:active', 'string', 'max:50',
                 self::uniqueDefinition('name', $user->currentTeam->getKey(), $entityType)->ignore($field->getKey()),
             ],
-            'active' => ['required_without:name', 'boolean'],
+            // Only `name` carries required_without: with the rule on both, an empty
+            // payload failed twice and the assistant was handed the same sentence twice.
+            'active' => ['nullable', 'boolean'],
         ], [
             'name.required_without' => 'Provide at least one of: name, active.',
-            'active.required_without' => 'Provide at least one of: name, active.',
-            'name.required' => 'A field name is required.',
             'name.max' => 'Field names must be 50 characters or fewer.',
             'name.unique' => "A field named \":input\" already exists on {$entityType}. Field names must be unique per entity — pick a different name.",
         ])->validate();

--- a/packages/Chat/src/Livewire/Chat/ProposalCard.php
+++ b/packages/Chat/src/Livewire/Chat/ProposalCard.php
@@ -13,6 +13,7 @@ use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\QueryException;
 use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\On;
 use Relaticle\Chat\Enums\PendingActionOperation;
@@ -468,11 +469,22 @@ final class ProposalCard extends BaseLivewireComponent
                 $finalized = true;
                 $record = $this->recordReferenceFor($resolved);
             }
+        } catch (QueryException $exception) {
+            // Must precede the RuntimeException arm — QueryException extends
+            // PDOException extends RuntimeException, so it would otherwise be caught
+            // there and its getMessage() put the failing SQL, the row's values and
+            // the connection host straight onto the card and into the transcript.
+            $this->reportDatabaseFailure($pendingAction, $exception);
+
+            return;
         } catch (RuntimeException|ValidationException $exception) {
             // ValidationException is thrown by the action's tenant guards when a
             // referenced record or assignee stopped being reachable between the
-            // proposal and the approval. Livewire would otherwise absorb it into an
-            // error bag nothing renders, leaving the button a permanent no-op.
+            // proposal and the approval. HttpException (from abort_*() inside an
+            // action, e.g. the owner-only guard) is a RuntimeException too, and its
+            // message is written for the user, so it renders as-is. Livewire would
+            // otherwise absorb these into an error bag nothing renders, leaving the
+            // button a permanent no-op.
             $this->reportResolveFailure($pendingAction, $exception->getMessage());
 
             return;
@@ -527,6 +539,10 @@ final class ProposalCard extends BaseLivewireComponent
                 $service->reject($pendingAction);
                 $finalized = true;
             }
+        } catch (QueryException $exception) {
+            $this->reportDatabaseFailure($pendingAction, $exception);
+
+            return;
         } catch (RuntimeException $exception) {
             $this->reportResolveFailure($pendingAction, $exception->getMessage());
 
@@ -558,6 +574,24 @@ final class ProposalCard extends BaseLivewireComponent
      * the `resolve` error bag which the dock renders — a proposal that cannot be
      * resolved must say so rather than leave the button dead.
      */
+    /**
+     * A database error is never shown verbatim: the driver's message carries the
+     * statement, its bindings and the connection details. The operator still needs
+     * the real thing, so it goes to the log instead.
+     *
+     * A unique violation here means something got past the actions' re-validation —
+     * in practice a second approval landing in the same instant — so it is reported
+     * as a race the user can retry, not as a generic failure.
+     */
+    private function reportDatabaseFailure(PendingAction $pendingAction, QueryException $exception): void
+    {
+        report($exception);
+
+        $this->reportResolveFailure($pendingAction, $exception->getCode() === '23505'
+            ? __('Someone else just made a conflicting change. Reload the page and try again.')
+            : __('This change could not be saved. Please try again.'));
+    }
+
     private function reportResolveFailure(PendingAction $pendingAction, string $message): void
     {
         $this->addError('resolve', $message);

--- a/packages/Chat/src/Services/Tools/CustomFieldOptionMap.php
+++ b/packages/Chat/src/Services/Tools/CustomFieldOptionMap.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Services\Tools;
+
+use App\Models\CustomField;
+use Illuminate\Support\Collection;
+
+/**
+ * The one place that answers "which option id does this label mean?".
+ *
+ * The read path (filtering) and the write path (setting a value) both take option
+ * LABELS from the assistant and both have to reach an option id, and they used to
+ * do it with two separate lookups that had already drifted: one matched labels
+ * case-sensitively, the other did not, so the same string could be accepted when
+ * filtering and rejected when saving. Policy still belongs to each caller — the
+ * write path alone cares about `acceptsArbitraryValues` and lookup fields — but
+ * the lookup itself lives here.
+ *
+ * Matching ignores case, because the assistant echoes labels back in whatever
+ * casing the sentence used and an option list is not a set of identifiers.
+ */
+final readonly class CustomFieldOptionMap
+{
+    /**
+     * Labels are kept in their stored casing for display, alongside a lowercased
+     * index for matching.
+     *
+     * @param  Collection<int, CustomField>  $fields
+     * @return array<string, array{ids: array<string, string>, labels: list<string>}>
+     */
+    public function fromFields(Collection $fields): array
+    {
+        $map = [];
+
+        foreach ($fields as $field) {
+            $ids = [];
+            $labels = [];
+
+            foreach ($field->options as $option) {
+                $label = (string) $option->name;
+                $ids[mb_strtolower($label)] = (string) $option->getKey();
+                $labels[] = $label;
+            }
+
+            $map[(string) $field->code] = ['ids' => $ids, 'labels' => $labels];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  array{ids: array<string, string>, labels: list<string>}  $entry
+     */
+    public function idFor(array $entry, string $label): ?string
+    {
+        return $entry['ids'][mb_strtolower($label)] ?? null;
+    }
+}

--- a/packages/Chat/src/Services/Tools/CustomFieldsFilterDescriber.php
+++ b/packages/Chat/src/Services/Tools/CustomFieldsFilterDescriber.php
@@ -35,7 +35,7 @@ final readonly class CustomFieldsFilterDescriber
             return 'No filterable custom fields are defined for this entity type.';
         }
 
-        $optionLabels = $this->optionLabels($user->currentTeam, $entityType);
+        $optionLabels = $this->optionLabels($user->currentTeam, $entityType, array_keys($schema));
 
         $lines = [
             'Filter by custom field values. Keys MUST be one of the codes below; each value is an object of operator => operand.',
@@ -71,30 +71,26 @@ final readonly class CustomFieldsFilterDescriber
     }
 
     /**
+     * Narrowed to the codes actually being described, so tenants whose filterable
+     * fields are all non-choice skip the options join entirely.
+     *
+     * @param  list<string>  $codes
      * @return array<string, list<string>>
      */
-    private function optionLabels(Team $team, string $entityType): array
+    private function optionLabels(Team $team, string $entityType, array $codes): array
     {
-        $fields = CustomField::query()
+        return CustomField::query()
             ->withoutGlobalScopes()
             ->where('tenant_id', $team->getKey())
             ->where('entity_type', $entityType)
+            ->whereIn('code', $codes)
             ->active()
             ->with(['options:id,custom_field_id,name'])
-            ->get();
-
-        $labels = [];
-
-        foreach ($fields as $field) {
-            $codeLabels = [];
-
-            foreach ($field->options as $option) {
-                $codeLabels[] = (string) $option->name;
-            }
-
-            $labels[(string) $field->code] = $codeLabels;
-        }
-
-        return $labels;
+            ->select('id', 'code')
+            ->get()
+            ->mapWithKeys(fn (CustomField $field): array => [
+                (string) $field->code => array_values(array_map(strval(...), $field->options->pluck('name')->all())),
+            ])
+            ->all();
     }
 }

--- a/packages/Chat/src/Services/Tools/CustomFieldsFilterDescriber.php
+++ b/packages/Chat/src/Services/Tools/CustomFieldsFilterDescriber.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Services\Tools;
+
+use App\Mcp\Schema\CustomFieldFilterSchema;
+use App\Models\CustomField;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * The read-path twin of {@see CustomFieldsSchemaDescriber}.
+ *
+ * Most of what a CRM user filters on — stage, status, due date, priority, amount —
+ * lives in custom fields, so a list tool without them can only ever answer "all of
+ * them". This inlines the tenant's filterable codes, their operators and their
+ * option labels into the tool's `custom_fields` slot, so the assistant can build a
+ * correct filter without a discovery round-trip.
+ *
+ * Filterability and operators come from {@see CustomFieldFilterSchema} — the same
+ * source the MCP server uses — so the two surfaces cannot drift apart.
+ */
+final readonly class CustomFieldsFilterDescriber
+{
+    public function __construct(
+        private CustomFieldFilterSchema $filterSchema,
+    ) {}
+
+    public function describe(User $user, string $entityType): string
+    {
+        $schema = $this->filterSchema->build($user, $entityType);
+
+        if ($schema === []) {
+            return 'No filterable custom fields are defined for this entity type.';
+        }
+
+        $optionLabels = $this->optionLabels($user->currentTeam, $entityType);
+
+        $lines = [
+            'Filter by custom field values. Keys MUST be one of the codes below; each value is an object of operator => operand.',
+            'For choice fields pass the option LABEL exactly as listed, not an ID.',
+            '',
+        ];
+
+        foreach ($schema as $code => $definition) {
+            $operators = implode(', ', array_keys(is_array($definition['properties'] ?? null) ? $definition['properties'] : []));
+            $line = "- {$code} (".($definition['description'] ?? $code)."; operators: {$operators}";
+
+            if (($optionLabels[$code] ?? []) !== []) {
+                $line .= '; one of: "'.implode('", "', $optionLabels[$code]).'"';
+            }
+
+            $lines[] = $line.')';
+        }
+
+        $lines[] = '';
+        $lines[] = 'Example: {"'.array_key_first($schema).'": {"eq": "..."}}';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * The codes accepted by the `sort` slot, alongside the native columns.
+     *
+     * @return list<string>
+     */
+    public function sortableCodes(User $user, string $entityType): array
+    {
+        return array_keys($this->filterSchema->build($user, $entityType));
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function optionLabels(Team $team, string $entityType): array
+    {
+        $fields = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $team->getKey())
+            ->where('entity_type', $entityType)
+            ->active()
+            ->with(['options:id,custom_field_id,name'])
+            ->get();
+
+        $labels = [];
+
+        foreach ($fields as $field) {
+            $codeLabels = [];
+
+            foreach ($field->options as $option) {
+                $codeLabels[] = (string) $option->name;
+            }
+
+            $labels[(string) $field->code] = $codeLabels;
+        }
+
+        return $labels;
+    }
+}

--- a/packages/Chat/src/Services/Tools/CustomFieldsFilterTranslator.php
+++ b/packages/Chat/src/Services/Tools/CustomFieldsFilterTranslator.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Relaticle\Chat\Services\Tools;
 
 use App\Mcp\Schema\CustomFieldFilterSchema;
+use App\Models\CustomField;
 use App\Models\User;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
 /**
@@ -23,6 +23,7 @@ final readonly class CustomFieldsFilterTranslator
 {
     public function __construct(
         private CustomFieldFilterSchema $filterSchema,
+        private CustomFieldOptionMap $optionMap,
     ) {}
 
     /**
@@ -70,7 +71,7 @@ final readonly class CustomFieldsFilterTranslator
                     ]);
                 }
 
-                $translated[$code][$operator] = $this->translateOperand($code, $options[$code] ?? [], $operand);
+                $translated[$code][$operator] = $this->translateOperand($code, $options[$code] ?? ['ids' => [], 'labels' => []], $operand);
             }
         }
 
@@ -80,31 +81,34 @@ final readonly class CustomFieldsFilterTranslator
     /**
      * Choice fields match on option IDs; a field with no options passes through as sent.
      *
-     * @param  array<string, string>  $options  lowercased label => option id
+     * @param  array{ids: array<string, string>, labels: list<string>}  $entry
      */
-    private function translateOperand(string $code, array $options, mixed $operand): mixed
+    private function translateOperand(string $code, array $entry, mixed $operand): mixed
     {
-        if ($options === []) {
+        if ($entry['ids'] === []) {
             return $operand;
         }
 
         if (is_array($operand)) {
-            return array_map(fn (mixed $label): string => $this->optionId($code, $options, $label), $operand);
+            return array_map(fn (mixed $label): string => $this->optionId($code, $entry, $label), $operand);
         }
 
-        return $this->optionId($code, $options, $operand);
+        return $this->optionId($code, $entry, $operand);
     }
 
     /**
-     * @param  array<string, string>  $options  lowercased label => option id
+     * @param  array{ids: array<string, string>, labels: list<string>}  $entry
      */
-    private function optionId(string $code, array $options, mixed $label): string
+    private function optionId(string $code, array $entry, mixed $label): string
     {
-        $id = $options[mb_strtolower((string) $label)] ?? null;
+        $id = $this->optionMap->idFor($entry, (string) $label);
 
         if ($id === null) {
+            // The stored casing, not the lowercased match keys — this string is read
+            // by the assistant and echoed to the user.
             throw ValidationException::withMessages([
-                'custom_fields' => "\"{$label}\" is not one of the options for \"{$code}\". Available: ".implode(', ', $options === [] ? ['none'] : array_keys($options)).'.',
+                'custom_fields' => "\"{$label}\" is not one of the options for \"{$code}\". Available: ".
+                    implode(', ', $entry['labels'] === [] ? ['none'] : $entry['labels']).'.',
             ]);
         }
 
@@ -112,30 +116,19 @@ final readonly class CustomFieldsFilterTranslator
     }
 
     /**
-     * Lowercased option label => option id, per field code.
-     *
      * @param  list<string>  $codes
-     * @return array<string, array<string, string>>
+     * @return array<string, array{ids: array<string, string>, labels: list<string>}>
      */
     private function optionsByCode(User $user, string $entityType, array $codes): array
     {
-        $fieldsTable = (string) config('custom-fields.database.table_names.custom_fields');
-        $optionsTable = (string) config('custom-fields.database.table_names.custom_field_options');
-        $tenantKey = (string) config('custom-fields.database.column_names.tenant_foreign_key');
-
-        $rows = DB::table("{$fieldsTable} as f")
-            ->join("{$optionsTable} as o", 'o.custom_field_id', '=', 'f.id')
-            ->where("f.{$tenantKey}", $user->currentTeam->getKey())
-            ->where('f.entity_type', $entityType)
-            ->whereIn('f.code', $codes)
-            ->get(['f.code as field_code', 'o.id as option_id', 'o.name as option_name']);
-
-        $options = [];
-
-        foreach ($rows as $row) {
-            $options[(string) $row->field_code][mb_strtolower((string) $row->option_name)] = (string) $row->option_id;
-        }
-
-        return $options;
+        return $this->optionMap->fromFields(
+            CustomField::query()
+                ->where('tenant_id', $user->currentTeam->getKey())
+                ->where('entity_type', $entityType)
+                ->whereIn('code', $codes)
+                ->active()
+                ->with('options')
+                ->get(),
+        );
     }
 }

--- a/packages/Chat/src/Services/Tools/CustomFieldsFilterTranslator.php
+++ b/packages/Chat/src/Services/Tools/CustomFieldsFilterTranslator.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Services\Tools;
+
+use App\Mcp\Schema\CustomFieldFilterSchema;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Turns the assistant's `custom_fields` filter into the shape CustomFieldFilter
+ * matches on.
+ *
+ * Choice values are stored as option IDs, but the assistant only ever sees labels
+ * (the convention every chat tool follows — see CustomFieldsRequestValidator on the
+ * write path), so labels are translated here. An unknown code, operator or label is
+ * rejected rather than silently dropped: a filter that quietly does nothing returns
+ * the whole table, which reads as a confident, wrong answer.
+ */
+final readonly class CustomFieldsFilterTranslator
+{
+    public function __construct(
+        private CustomFieldFilterSchema $filterSchema,
+    ) {}
+
+    /**
+     * @return array<string, array<string, mixed>>
+     *
+     * @throws ValidationException
+     */
+    public function translate(User $user, string $entityType, mixed $rawFilters): array
+    {
+        if (! is_array($rawFilters) || $rawFilters === []) {
+            return [];
+        }
+
+        $filterable = $this->filterSchema->build($user, $entityType);
+        $codes = array_map(strval(...), array_keys($rawFilters));
+        $options = $this->optionsByCode($user, $entityType, $codes);
+
+        $translated = [];
+
+        foreach ($rawFilters as $rawCode => $operators) {
+            $code = (string) $rawCode;
+
+            if (! isset($filterable[$code])) {
+                throw ValidationException::withMessages([
+                    'custom_fields' => "\"{$code}\" is not a filterable custom field on {$entityType}. Available: ".
+                        ($filterable === [] ? 'none' : implode(', ', array_keys($filterable))).'.',
+                ]);
+            }
+
+            if (! is_array($operators)) {
+                throw ValidationException::withMessages([
+                    'custom_fields' => "custom_fields.{$code} must be an object of operator => value, e.g. {\"eq\": \"...\"}.",
+                ]);
+            }
+
+            $properties = $filterable[$code]['properties'] ?? null;
+            $allowed = is_array($properties) ? array_map(strval(...), array_keys($properties)) : [];
+
+            foreach ($operators as $rawOperator => $operand) {
+                $operator = (string) $rawOperator;
+
+                if (! in_array($operator, $allowed, true)) {
+                    throw ValidationException::withMessages([
+                        'custom_fields' => "Operator \"{$operator}\" is not supported for \"{$code}\". Supported: ".implode(', ', $allowed).'.',
+                    ]);
+                }
+
+                $translated[$code][$operator] = $this->translateOperand($code, $options[$code] ?? [], $operand);
+            }
+        }
+
+        return $translated;
+    }
+
+    /**
+     * Choice fields match on option IDs; a field with no options passes through as sent.
+     *
+     * @param  array<string, string>  $options  lowercased label => option id
+     */
+    private function translateOperand(string $code, array $options, mixed $operand): mixed
+    {
+        if ($options === []) {
+            return $operand;
+        }
+
+        if (is_array($operand)) {
+            return array_map(fn (mixed $label): string => $this->optionId($code, $options, $label), $operand);
+        }
+
+        return $this->optionId($code, $options, $operand);
+    }
+
+    /**
+     * @param  array<string, string>  $options  lowercased label => option id
+     */
+    private function optionId(string $code, array $options, mixed $label): string
+    {
+        $id = $options[mb_strtolower((string) $label)] ?? null;
+
+        if ($id === null) {
+            throw ValidationException::withMessages([
+                'custom_fields' => "\"{$label}\" is not one of the options for \"{$code}\". Available: ".implode(', ', $options === [] ? ['none'] : array_keys($options)).'.',
+            ]);
+        }
+
+        return $id;
+    }
+
+    /**
+     * Lowercased option label => option id, per field code.
+     *
+     * @param  list<string>  $codes
+     * @return array<string, array<string, string>>
+     */
+    private function optionsByCode(User $user, string $entityType, array $codes): array
+    {
+        $fieldsTable = (string) config('custom-fields.database.table_names.custom_fields');
+        $optionsTable = (string) config('custom-fields.database.table_names.custom_field_options');
+        $tenantKey = (string) config('custom-fields.database.column_names.tenant_foreign_key');
+
+        $rows = DB::table("{$fieldsTable} as f")
+            ->join("{$optionsTable} as o", 'o.custom_field_id', '=', 'f.id')
+            ->where("f.{$tenantKey}", $user->currentTeam->getKey())
+            ->where('f.entity_type', $entityType)
+            ->whereIn('f.code', $codes)
+            ->get(['f.code as field_code', 'o.id as option_id', 'o.name as option_name']);
+
+        $options = [];
+
+        foreach ($rows as $row) {
+            $options[(string) $row->field_code][mb_strtolower((string) $row->option_name)] = (string) $row->option_id;
+        }
+
+        return $options;
+    }
+}

--- a/packages/Chat/src/Services/Tools/CustomFieldsRequestValidator.php
+++ b/packages/Chat/src/Services/Tools/CustomFieldsRequestValidator.php
@@ -13,6 +13,10 @@ use Relaticle\CustomFields\Facades\CustomFieldsType;
 
 final readonly class CustomFieldsRequestValidator
 {
+    public function __construct(
+        private CustomFieldOptionMap $optionMap,
+    ) {}
+
     /**
      * Validate the LLM-submitted custom_fields payload for the given entity.
      *
@@ -76,6 +80,7 @@ final readonly class CustomFieldsRequestValidator
     {
         $clean = [];
         $byCode = $fields->keyBy('code');
+        $optionMap = $this->optionMap->fromFields($fields);
 
         foreach ($raw as $code => $value) {
             $field = $byCode->get($code);
@@ -101,7 +106,7 @@ final readonly class CustomFieldsRequestValidator
                 continue;
             }
 
-            $optionsByLabel = $field->options->keyBy('name');
+            $entry = $optionMap[(string) $field->code] ?? ['ids' => [], 'labels' => []];
 
             if ($dataType->isMultiChoiceField()) {
                 if (! is_array($value)) {
@@ -113,14 +118,14 @@ final readonly class CustomFieldsRequestValidator
 
                 $translated = [];
                 foreach ($value as $label) {
-                    $option = $optionsByLabel->get((string) $label);
-                    if ($option === null) {
+                    $optionId = $this->optionMap->idFor($entry, (string) $label);
+                    if ($optionId === null) {
                         return new CustomFieldsValidationResult(
                             cleanFields: [],
                             error: "custom_fields.{$code} option \"{$label}\" is not one of the configured choices.",
                         );
                     }
-                    $translated[] = $option->id;
+                    $translated[] = $optionId;
                 }
 
                 $clean[$code] = $translated;
@@ -135,15 +140,15 @@ final readonly class CustomFieldsRequestValidator
                 );
             }
 
-            $option = $optionsByLabel->get((string) $value);
-            if ($option === null) {
+            $optionId = $this->optionMap->idFor($entry, (string) $value);
+            if ($optionId === null) {
                 return new CustomFieldsValidationResult(
                     cleanFields: [],
                     error: "custom_fields.{$code} option \"{$value}\" is not one of the configured choices.",
                 );
             }
 
-            $clean[$code] = $option->id;
+            $clean[$code] = $optionId;
         }
 
         return new CustomFieldsValidationResult(cleanFields: $clean, error: null);

--- a/packages/Chat/src/Support/RecordReferenceResolver.php
+++ b/packages/Chat/src/Support/RecordReferenceResolver.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Relaticle\Chat\Support;
 
+use App\Filament\Pages\Team\CustomFields;
 use App\Filament\Resources\CompanyResource;
 use App\Filament\Resources\NoteResource;
 use App\Filament\Resources\OpportunityResource;
 use App\Filament\Resources\PeopleResource;
 use App\Filament\Resources\TaskResource;
 use App\Models\Company;
+use App\Models\CustomField;
 use App\Models\Note;
 use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\Task;
+use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\EditAction;
 use Throwable;
@@ -78,6 +81,9 @@ final readonly class RecordReferenceResolver
 
         try {
             return match ($entityType) {
+                // Custom field definitions have no per-record route — the management page
+                // is the destination, deep-linked to the tab the field lives on.
+                'custom_field' => $this->customFieldUrl($recordId, $team),
                 'company' => CompanyResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
                 'people' => PeopleResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
                 'opportunity' => OpportunityResource::getUrl('view', ['record' => $recordId], panel: 'app', tenant: $team),
@@ -96,10 +102,37 @@ final readonly class RecordReferenceResolver
         }
     }
 
+    /**
+     * The custom-fields management page, focused on the tab owning this field.
+     * Scoped explicitly to the team and past every global scope: this also runs on
+     * conversation reload and for deactivated fields, where neither the ambient
+     * custom-fields tenant context nor the activable scope can be relied on.
+     */
+    private function customFieldUrl(string $recordId, Team $team): ?string
+    {
+        $entityType = CustomField::query()
+            ->withoutGlobalScopes()
+            ->whereKey($recordId)
+            ->where('tenant_id', $team->getKey())
+            ->value('entity_type');
+
+        if (! is_string($entityType) || $entityType === '') {
+            return null;
+        }
+
+        return CustomFields::getUrl(panel: 'app', tenant: $team).'?'.http_build_query([
+            'currentEntityType' => $entityType,
+        ]);
+    }
+
     private function resolveLabel(string $entityType, string $recordId): ?string
     {
         try {
             $label = match ($entityType) {
+                'custom_field' => CustomField::query()
+                    ->withoutGlobalScopes()
+                    ->whereKey($recordId)
+                    ->value('name'),
                 'company' => Company::query()->whereKey($recordId)->value('name'),
                 'people' => People::query()->whereKey($recordId)->value('name'),
                 'opportunity' => Opportunity::query()->whereKey($recordId)->value('name'),

--- a/packages/Chat/src/Tools/BaseReadListTool.php
+++ b/packages/Chat/src/Tools/BaseReadListTool.php
@@ -84,6 +84,8 @@ abstract class BaseReadListTool implements Tool
             ['search' => $schema->string()->description("Search by {$this->searchFilterName()}.")],
             $this->additionalSchema($schema),
             [
+                'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
+                'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
                 'custom_fields' => $schema->object()->description($customFieldsDescription),
                 'sort' => $schema->string()->description(
                     'Sort by one of: '.implode(', ', $sortable).'. Prefix with "-" for descending (e.g. "-created_at").',
@@ -157,7 +159,11 @@ abstract class BaseReadListTool implements Tool
         $input = [];
 
         $nativeFilters = $this->dropNull(array_merge(
-            [$this->searchFilterName() => $request['search'] ?? null],
+            [
+                $this->searchFilterName() => $request['search'] ?? null,
+                'created_after' => $request['created_after'] ?? null,
+                'created_before' => $request['created_before'] ?? null,
+            ],
             $this->additionalFilters($request),
         ));
 

--- a/packages/Chat/src/Tools/BaseReadListTool.php
+++ b/packages/Chat/src/Tools/BaseReadListTool.php
@@ -8,15 +8,20 @@ use App\Models\User;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Services\Tools\CustomFieldsFilterDescriber;
+use Relaticle\Chat\Services\Tools\CustomFieldsFilterTranslator;
 use Relaticle\Chat\Support\RecordReferenceResolver;
 use Relaticle\Chat\Tools\Concerns\NormalizesToolInput;
+use Relaticle\Chat\Tools\Concerns\ReportsValidationFailures;
 use Spatie\QueryBuilder\Exceptions\InvalidQuery;
 
 abstract class BaseReadListTool implements Tool
 {
     use NormalizesToolInput;
+    use ReportsValidationFailures;
 
     /** @return class-string */
     abstract protected function actionClass(): string;
@@ -30,6 +35,14 @@ abstract class BaseReadListTool implements Tool
 
     abstract public function description(): string;
 
+    /**
+     * The custom-fields entity alias, which is also the citation/morph alias.
+     */
+    protected function entityType(): string
+    {
+        return $this->citationType();
+    }
+
     /** @return array<string, mixed> */
     protected function additionalSchema(JsonSchema $schema): array
     {
@@ -42,12 +55,39 @@ abstract class BaseReadListTool implements Tool
         return [];
     }
 
+    /**
+     * Native columns every entity can be sorted by; custom-field codes are added
+     * per tenant.
+     *
+     * @return list<string>
+     */
+    protected function nativeSorts(): array
+    {
+        return [$this->searchFilterName(), 'created_at', 'updated_at'];
+    }
+
     public function schema(JsonSchema $schema): array
     {
+        $user = auth()->user();
+        $entityType = $this->entityType();
+
+        $customFieldsDescription = 'Filter by custom field values.';
+        $sortable = $this->nativeSorts();
+
+        if ($user instanceof User) {
+            $describer = resolve(CustomFieldsFilterDescriber::class);
+            $customFieldsDescription = $describer->describe($user, $entityType);
+            $sortable = array_merge($sortable, $describer->sortableCodes($user, $entityType));
+        }
+
         return array_merge(
             ['search' => $schema->string()->description("Search by {$this->searchFilterName()}.")],
             $this->additionalSchema($schema),
             [
+                'custom_fields' => $schema->object()->description($customFieldsDescription),
+                'sort' => $schema->string()->description(
+                    'Sort by one of: '.implode(', ', $sortable).'. Prefix with "-" for descending (e.g. "-created_at").',
+                ),
                 'per_page' => $schema->integer()->description('Results per page (default 15, max 50).')->default(15),
                 'page' => $schema->integer()->description('Page number.')->default(1),
             ],
@@ -59,7 +99,11 @@ abstract class BaseReadListTool implements Tool
         /** @var User $user */
         $user = auth()->user();
 
-        $httpRequest = $this->buildHttpRequest($request);
+        try {
+            $httpRequest = $this->buildHttpRequest($user, $request);
+        } catch (ValidationException $exception) {
+            return $this->validationError($exception);
+        }
 
         try {
             $action = app()->make($this->actionClass());
@@ -105,7 +149,10 @@ abstract class BaseReadListTool implements Tool
         return (string) json_encode($items, JSON_PRETTY_PRINT);
     }
 
-    private function buildHttpRequest(Request $request): HttpRequest
+    /**
+     * @throws ValidationException
+     */
+    private function buildHttpRequest(User $user, Request $request): HttpRequest
     {
         $input = [];
 
@@ -114,8 +161,21 @@ abstract class BaseReadListTool implements Tool
             $this->additionalFilters($request),
         ));
 
+        $customFields = resolve(CustomFieldsFilterTranslator::class)
+            ->translate($user, $this->entityType(), $request['custom_fields'] ?? null);
+
+        if ($customFields !== []) {
+            $nativeFilters['custom_fields'] = $customFields;
+        }
+
         if ($nativeFilters !== []) {
             $input['filter'] = $nativeFilters;
+        }
+
+        $sort = $request['sort'] ?? null;
+
+        if (is_string($sort) && $sort !== '') {
+            $input['sort'] = $sort;
         }
 
         return new HttpRequest($input);

--- a/packages/Chat/src/Tools/Company/ListCompaniesTool.php
+++ b/packages/Chat/src/Tools/Company/ListCompaniesTool.php
@@ -6,8 +6,6 @@ namespace Relaticle\Chat\Tools\Company;
 
 use App\Actions\Company\ListCompanies;
 use App\Http\Resources\V1\CompanyResource;
-use Illuminate\Contracts\JsonSchema\JsonSchema;
-use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Tools\BaseReadListTool;
 
 final class ListCompaniesTool extends BaseReadListTool
@@ -30,24 +28,6 @@ final class ListCompaniesTool extends BaseReadListTool
     protected function searchFilterName(): string
     {
         return 'name';
-    }
-
-    /** @return array<string, mixed> */
-    protected function additionalSchema(JsonSchema $schema): array
-    {
-        return [
-            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
-            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
-        ];
-    }
-
-    /** @return array<string, mixed> */
-    protected function additionalFilters(Request $request): array
-    {
-        return array_filter([
-            'created_after' => $request['created_after'] ?? null,
-            'created_before' => $request['created_before'] ?? null,
-        ]);
     }
 
     protected function citationType(): string

--- a/packages/Chat/src/Tools/Concerns/ReportsValidationFailures.php
+++ b/packages/Chat/src/Tools/Concerns/ReportsValidationFailures.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools\Concerns;
+
+use Illuminate\Support\Arr;
+use Illuminate\Validation\ValidationException;
+
+trait ReportsValidationFailures
+{
+    /**
+     * Render a validation failure as the tools' `{"error": "..."}` contract.
+     *
+     * Every message is returned, not just the first, so the assistant can correct
+     * the whole payload in one turn instead of rediscovering faults one at a time.
+     */
+    protected function validationError(ValidationException $exception): string
+    {
+        return (string) json_encode([
+            'error' => implode(' ', Arr::flatten($exception->errors())),
+        ]);
+    }
+}

--- a/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
+++ b/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
@@ -96,7 +96,7 @@ final class AddCustomFieldOptionsTool implements Tool
 
         $actionData = [
             '_record_id' => $field->getKey(),
-            'options' => array_map(static fn (string $option): array => ['name' => $option], $optionNames),
+            'options' => $validated['options'],
         ];
 
         $displayData = [

--- a/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
+++ b/packages/Chat/src/Tools/CustomField/AddCustomFieldOptionsTool.php
@@ -8,17 +8,20 @@ use App\Actions\CustomFields\AddCustomFieldOptions;
 use App\Actions\CustomFields\CreateCustomField;
 use App\Models\CustomField;
 use App\Models\User;
+use App\Support\CustomFieldDefinitionValidator;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\Concerns\ReportsValidationFailures;
 use Relaticle\Chat\Tools\Concerns\WithConversationContext;
 use Relaticle\Chat\Tools\CustomField\Concerns\ResolvesOwnedCustomField;
-use Relaticle\CustomFields\Services\TenantContextService;
 
 final class AddCustomFieldOptionsTool implements Tool
 {
+    use ReportsValidationFailures;
     use ResolvesOwnedCustomField;
     use WithConversationContext;
 
@@ -68,12 +71,6 @@ final class AddCustomFieldOptionsTool implements Tool
             return (string) json_encode(['error' => 'Both entity_type and code are required to identify the field.']);
         }
 
-        $options = is_array($request['options'] ?? null) ? $request['options'] : [];
-
-        if ($options === []) {
-            return (string) json_encode(['error' => 'At least one option must be provided.']);
-        }
-
         $teamId = $user->currentTeam->getKey();
         $field = $this->resolveOwnedCustomField($teamId, $entityType, $code);
 
@@ -87,31 +84,19 @@ final class AddCustomFieldOptionsTool implements Tool
             ]);
         }
 
-        $maxOptions = (int) config('chat.max_field_options', 50);
-
-        $previousTenantId = TenantContextService::getCurrentTenantId();
-        TenantContextService::setTenantId($teamId);
-
         try {
-            $existingCount = $field->options()->withoutGlobalScopes()->count();
-        } finally {
-            TenantContextService::setTenantId($previousTenantId);
-        }
-
-        if (($existingCount + count($options)) > $maxOptions) {
-            return (string) json_encode([
-                'error' => 'Adding '.count($options)." more options would exceed the {$maxOptions} options limit for this field (currently has {$existingCount}).",
+            $validated = CustomFieldDefinitionValidator::forNewOptions($user, $field, [
+                'options' => $request['options'] ?? null,
             ]);
+        } catch (ValidationException $exception) {
+            return $this->validationError($exception);
         }
 
-        $optionNames = array_map(
-            static fn (mixed $o): string => is_array($o) ? (string) ($o['name'] ?? '') : (string) $o,
-            $options,
-        );
+        $optionNames = array_column($validated['options'], 'name');
 
         $actionData = [
             '_record_id' => $field->getKey(),
-            'options' => $options,
+            'options' => array_map(static fn (string $option): array => ['name' => $option], $optionNames),
         ];
 
         $displayData = [

--- a/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
+++ b/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
@@ -5,18 +5,20 @@ declare(strict_types=1);
 namespace Relaticle\Chat\Tools\CustomField;
 
 use App\Actions\CustomFields\CreateCustomField;
-use App\Models\CustomField;
 use App\Models\User;
+use App\Support\CustomFieldDefinitionValidator;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\Concerns\ReportsValidationFailures;
 use Relaticle\Chat\Tools\Concerns\WithConversationContext;
-use Relaticle\CustomFields\Models\Scopes\CustomFieldsActivableScope;
 
 final class CreateCustomFieldTool implements Tool
 {
+    use ReportsValidationFailures;
     use WithConversationContext;
 
     public function name(): string
@@ -26,7 +28,7 @@ final class CreateCustomFieldTool implements Tool
 
     public function description(): string
     {
-        return 'Propose creating a new custom field definition on a CRM entity. Admin-only — returns an error for non-owners. Returns a proposal for user approval.';
+        return 'Propose creating a new custom field definition on a CRM entity. Field names and codes must be unique per entity — check ListCustomFieldsTool first. Admin-only — returns an error for non-owners. Returns a proposal for user approval.';
     }
 
     public function schema(JsonSchema $schema): array
@@ -38,7 +40,7 @@ final class CreateCustomFieldTool implements Tool
                 ->description('The CRM entity to add the field to: company, people, opportunity, task, or note.')
                 ->required(),
             'name' => $schema->string()
-                ->description('The display name for the field (e.g. "Industry", "Priority").')
+                ->description('The display name for the field (e.g. "Industry", "Priority"). Max 50 characters, and must not match an existing field on the same entity.')
                 ->required(),
             'type' => $schema->string()
                 ->description("The field type. Allowed: {$allowedTypes}. NOT allowed: file-upload, record, rich-editor, markdown-editor, currency.")
@@ -64,75 +66,31 @@ final class CreateCustomFieldTool implements Tool
             ]);
         }
 
-        $type = (string) ($request['type'] ?? '');
-
-        if (! in_array($type, CreateCustomField::ALLOWED_TYPES, true)) {
-            return (string) json_encode([
-                'error' => "Field type \"{$type}\" is not supported via chat. Allowed types: ".implode(', ', CreateCustomField::ALLOWED_TYPES).'.',
+        try {
+            $validated = CustomFieldDefinitionValidator::forCreate($user, [
+                'entity_type' => $request['entity_type'] ?? null,
+                'name' => $request['name'] ?? null,
+                'type' => $request['type'] ?? null,
+                'code' => $request['code'] ?? null,
+                'options' => $request['options'] ?? null,
             ]);
+        } catch (ValidationException $exception) {
+            return $this->validationError($exception);
         }
 
-        $isChoiceType = in_array($type, CreateCustomField::CHOICE_TYPES, true);
-
-        $options = is_array($request['options'] ?? null) ? $request['options'] : [];
-
-        if ($isChoiceType && $options === []) {
-            return (string) json_encode([
-                'error' => "Field type \"{$type}\" requires at least one option. Please provide an options array with at least one {\"name\": \"...\"} entry.",
-            ]);
-        }
-
-        if (! $isChoiceType && $options !== []) {
-            return (string) json_encode([
-                'error' => "Field type \"{$type}\" does not support options.",
-            ]);
-        }
-
-        $entityType = (string) ($request['entity_type'] ?? '');
-
-        if (! in_array($entityType, CreateCustomField::VALID_ENTITY_TYPES, true)) {
-            return (string) json_encode([
-                'error' => 'Invalid entity type "'.htmlspecialchars($entityType, ENT_QUOTES, 'UTF-8').'". Must be one of: '.implode(', ', CreateCustomField::VALID_ENTITY_TYPES).'.',
-            ]);
-        }
-
-        $maxFields = (int) config('chat.max_custom_fields_per_entity', 50);
-        $teamId = $user->currentTeam->getKey();
-        $existingCount = CustomField::query()
-            ->withoutGlobalScope(CustomFieldsActivableScope::class)
-            ->where('tenant_id', $teamId)
-            ->where('entity_type', $entityType)
-            ->count();
-
-        if ($existingCount >= $maxFields) {
-            return (string) json_encode([
-                'error' => "Cannot create more than {$maxFields} custom fields for entity type \"{$entityType}\".",
-            ]);
-        }
-
-        if ($isChoiceType) {
-            $maxOptions = (int) config('chat.max_field_options', 50);
-            if (count($options) > $maxOptions) {
-                return (string) json_encode([
-                    'error' => "Too many options — at most {$maxOptions} per field.",
-                ]);
-            }
-        }
-
-        $name = (string) ($request['name'] ?? '');
-        $code = (string) ($request['code'] ?? '');
+        $entityType = (string) $validated['entity_type'];
+        $name = (string) $validated['name'];
+        $type = (string) $validated['type'];
+        $code = (string) ($validated['code'] ?? '');
+        $optionNames = array_column(is_array($validated['options'] ?? null) ? $validated['options'] : [], 'name');
 
         $actionData = array_filter([
             'entity_type' => $entityType,
             'name' => $name,
             'type' => $type,
             'code' => $code !== '' ? $code : null,
-            'options' => $options !== [] ? $options : null,
-        ], fn (mixed $v): bool => $v !== null);
-
-        $optionsSummary = $options !== []
-            ? ' with options: '.implode(', ', array_map(static fn (mixed $o): string => is_array($o) ? (string) ($o['name'] ?? '') : (string) $o, $options))
-            : '';
+            'options' => $optionNames !== [] ? array_map(static fn (string $option): array => ['name' => $option], $optionNames) : null,
+        ], fn (mixed $value): bool => $value !== null);
 
         $displayFields = [
             ['label' => 'Entity', 'value' => $entityType],
@@ -144,12 +102,11 @@ final class CreateCustomFieldTool implements Tool
             $displayFields[] = ['label' => 'Code', 'value' => $code];
         }
 
-        if ($options !== []) {
-            $displayFields[] = [
-                'label' => 'Options',
-                'value' => implode(', ', array_map(static fn (mixed $o): string => is_array($o) ? (string) ($o['name'] ?? '') : (string) $o, $options)),
-            ];
+        if ($optionNames !== []) {
+            $displayFields[] = ['label' => 'Options', 'value' => implode(', ', $optionNames)];
         }
+
+        $optionsSummary = $optionNames !== [] ? ' with options: '.implode(', ', $optionNames) : '';
 
         $displayData = [
             'title' => 'Create Custom Field',

--- a/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
+++ b/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
@@ -89,7 +89,7 @@ final class CreateCustomFieldTool implements Tool
             'name' => $name,
             'type' => $type,
             'code' => $code !== '' ? $code : null,
-            'options' => $optionNames !== [] ? array_map(static fn (string $option): array => ['name' => $option], $optionNames) : null,
+            'options' => $optionNames !== [] ? $validated['options'] : null,
         ], fn (mixed $value): bool => $value !== null);
 
         $displayFields = [

--- a/packages/Chat/src/Tools/CustomField/UpdateCustomFieldTool.php
+++ b/packages/Chat/src/Tools/CustomField/UpdateCustomFieldTool.php
@@ -7,16 +7,20 @@ namespace Relaticle\Chat\Tools\CustomField;
 use App\Actions\CustomFields\UpdateCustomField;
 use App\Models\CustomField;
 use App\Models\User;
+use App\Support\CustomFieldDefinitionValidator;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Services\PendingActionService;
+use Relaticle\Chat\Tools\Concerns\ReportsValidationFailures;
 use Relaticle\Chat\Tools\Concerns\WithConversationContext;
 use Relaticle\Chat\Tools\CustomField\Concerns\ResolvesOwnedCustomField;
 
 final class UpdateCustomFieldTool implements Tool
 {
+    use ReportsValidationFailures;
     use ResolvesOwnedCustomField;
     use WithConversationContext;
 
@@ -75,12 +79,17 @@ final class UpdateCustomFieldTool implements Tool
             return (string) json_encode(['error' => 'System-defined custom fields cannot be modified.']);
         }
 
-        $newName = ($request['name'] ?? null) !== null ? (string) $request['name'] : null;
-        $newActive = ($request['active'] ?? null) !== null ? (bool) $request['active'] : null;
-
-        if ($newName === null && $newActive === null) {
-            return (string) json_encode(['error' => 'Provide at least one of: name, active.']);
+        try {
+            $validated = CustomFieldDefinitionValidator::forRename($user, $field, array_filter([
+                'name' => $request['name'] ?? null,
+                'active' => $request['active'] ?? null,
+            ], fn (mixed $value): bool => $value !== null));
+        } catch (ValidationException $exception) {
+            return $this->validationError($exception);
         }
+
+        $newName = isset($validated['name']) ? (string) $validated['name'] : null;
+        $newActive = isset($validated['active']) ? (bool) $validated['active'] : null;
 
         $actionData = [
             '_record_id' => $field->getKey(),

--- a/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
+++ b/packages/Chat/src/Tools/Opportunity/ListOpportunitiesTool.php
@@ -38,8 +38,6 @@ final class ListOpportunitiesTool extends BaseReadListTool
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
             'contact_id' => $schema->string()->description('Filter by contact/person ID.'),
-            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
-            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
             'stale_days' => $schema->integer()->description('Return only opportunities with no activity in the last N days (default 30). Use this to find deals that have gone quiet.'),
         ];
     }
@@ -50,8 +48,6 @@ final class ListOpportunitiesTool extends BaseReadListTool
         return array_filter([
             'company_id' => $request['company_id'] ?? null,
             'contact_id' => $request['contact_id'] ?? null,
-            'created_after' => $request['created_after'] ?? null,
-            'created_before' => $request['created_before'] ?? null,
             'stale_days' => isset($request['stale_days']) ? (string) $request['stale_days'] : null,
         ]);
     }

--- a/packages/Chat/src/Tools/People/ListPeopleTool.php
+++ b/packages/Chat/src/Tools/People/ListPeopleTool.php
@@ -37,8 +37,6 @@ final class ListPeopleTool extends BaseReadListTool
     {
         return [
             'company_id' => $schema->string()->description('Filter by company ID.'),
-            'created_after' => $schema->string()->description('Only return records created on or after this date (YYYY-MM-DD).'),
-            'created_before' => $schema->string()->description('Only return records created on or before this date (YYYY-MM-DD).'),
         ];
     }
 
@@ -47,8 +45,6 @@ final class ListPeopleTool extends BaseReadListTool
     {
         return array_filter([
             'company_id' => $request['company_id'] ?? null,
-            'created_after' => $request['created_after'] ?? null,
-            'created_before' => $request['created_before'] ?? null,
         ]);
     }
 

--- a/packages/Chat/src/Tools/Task/ListTasksTool.php
+++ b/packages/Chat/src/Tools/Task/ListTasksTool.php
@@ -14,7 +14,7 @@ final class ListTasksTool extends BaseReadListTool
 {
     public function description(): string
     {
-        return 'List tasks with optional search, pagination, and filtering to the tasks attached to a specific company, person, or opportunity.';
+        return 'List tasks with optional search, pagination, sorting, and filtering — by custom field values, by the tasks attached to a specific company, person, or opportunity, or to just the tasks assigned to the current user. Use assigned_to_me for "my tasks"/"tasks assigned to me"; without it the result is every task in the workspace.';
     }
 
     protected function actionClass(): string
@@ -31,6 +31,7 @@ final class ListTasksTool extends BaseReadListTool
     protected function additionalSchema(JsonSchema $schema): array
     {
         return [
+            'assigned_to_me' => $schema->boolean()->description('Restrict to tasks assigned to the current user. Set this for "my tasks" or "tasks assigned to me".'),
             'company_id' => $schema->string()->description('Restrict to tasks attached to this company ID.'),
             'people_id' => $schema->string()->description('Restrict to tasks attached to this person ID.'),
             'opportunity_id' => $schema->string()->description('Restrict to tasks attached to this opportunity ID.'),
@@ -41,6 +42,7 @@ final class ListTasksTool extends BaseReadListTool
     protected function additionalFilters(Request $request): array
     {
         return array_filter([
+            'assigned_to_me' => filter_var($request['assigned_to_me'] ?? false, FILTER_VALIDATE_BOOLEAN) ? '1' : null,
             'company_id' => $request['company_id'] ?? null,
             'people_id' => $request['people_id'] ?? null,
             'opportunity_id' => $request['opportunity_id'] ?? null,

--- a/packages/Chat/src/Tools/Task/ListTasksTool.php
+++ b/packages/Chat/src/Tools/Task/ListTasksTool.php
@@ -14,7 +14,7 @@ final class ListTasksTool extends BaseReadListTool
 {
     public function description(): string
     {
-        return 'List tasks with optional search, pagination, sorting, and filtering — by custom field values, by the tasks attached to a specific company, person, or opportunity, or to just the tasks assigned to the current user. Use assigned_to_me for "my tasks"/"tasks assigned to me"; without it the result is every task in the workspace.';
+        return 'List tasks with optional search, pagination, sorting, and filtering — by custom field values, by the tasks attached to a specific company, person, or opportunity, or by who they are assigned to. Use assigned_to_me for "my tasks"/"tasks assigned to me", and assignee_ids for anyone else (resolve the name with ListTeamMembersTool first); without either, the result is every task in the workspace.';
     }
 
     protected function actionClass(): string
@@ -32,6 +32,7 @@ final class ListTasksTool extends BaseReadListTool
     {
         return [
             'assigned_to_me' => $schema->boolean()->description('Restrict to tasks assigned to the current user. Set this for "my tasks" or "tasks assigned to me".'),
+            'assignee_ids' => $schema->array()->description('Restrict to tasks assigned to any of these user ULIDs. Use this for "tasks assigned to <someone else>" — call ListTeamMembersTool first to turn the name into an id.'),
             'company_id' => $schema->string()->description('Restrict to tasks attached to this company ID.'),
             'people_id' => $schema->string()->description('Restrict to tasks attached to this person ID.'),
             'opportunity_id' => $schema->string()->description('Restrict to tasks attached to this opportunity ID.'),
@@ -41,8 +42,11 @@ final class ListTasksTool extends BaseReadListTool
     /** @return array<string, mixed> */
     protected function additionalFilters(Request $request): array
     {
+        $assigneeIds = is_array($request['assignee_ids'] ?? null) ? $request['assignee_ids'] : null;
+
         return array_filter([
             'assigned_to_me' => filter_var($request['assigned_to_me'] ?? false, FILTER_VALIDATE_BOOLEAN) ? '1' : null,
+            'assignee_ids' => $assigneeIds !== [] ? $assigneeIds : null,
             'company_id' => $request['company_id'] ?? null,
             'people_id' => $request['people_id'] ?? null,
             'opportunity_id' => $request['opportunity_id'] ?? null,

--- a/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
+++ b/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
@@ -241,3 +241,28 @@ it('rejects approval with a friendly message when the option appeared after the 
 
     expect($freshCount)->toBe(1);
 });
+
+it('rejects an option that differs from an existing one only by case', function (): void {
+    $decoded = json_decode((makeAddOptionsTool($this->convId))->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
+        'options' => [['name' => 'ACTIVE']],
+    ])), true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and($decoded['error'])->toContain('already exists')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects a recased duplicate option at approval time, not just at proposal time', function (): void {
+    expect(fn () => app(AddCustomFieldOptions::class)->execute($this->owner, [
+        '_record_id' => $this->selectField->getKey(),
+        'options' => [['name' => 'active']],
+    ]))->toThrow(ValidationException::class, 'already exists');
+
+    expect(CustomFieldOption::query()
+        ->withoutGlobalScopes()
+        ->where('custom_field_id', $this->selectField->getKey())
+        ->whereRaw('lower(name) = ?', ['active'])
+        ->count())->toBe(1);
+});

--- a/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
+++ b/tests/Feature/Chat/AddCustomFieldOptionsToolTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Enums\PendingActionStatus;
@@ -164,4 +165,79 @@ it('returns error when adding options would exceed the cap', function (): void {
 
     expect($decoded)->toHaveKey('error')
         ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects adding an option that already exists on the field at proposal time', function (): void {
+    $tool = makeAddOptionsTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
+        'options' => [['name' => 'Active']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and($decoded['error'])->toContain('already exists')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects duplicate option names within one request', function (): void {
+    $tool = makeAddOptionsTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
+        'options' => [['name' => 'Inactive'], ['name' => 'Inactive']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects empty option names', function (): void {
+    $tool = makeAddOptionsTool($this->convId);
+
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
+        'options' => [['name' => '  ']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects approval with a friendly message when the option appeared after the proposal', function (): void {
+    $tool = makeAddOptionsTool($this->convId);
+    $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->selectField->code,
+        'options' => [['name' => 'Fresh']],
+    ]));
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    $this->selectField->options()->create([
+        $tenantKey => $this->team->getKey(),
+        'name' => 'Fresh',
+        'sort_order' => 5,
+    ]);
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    expect(fn () => resolve(PendingActionService::class)->approve($pending, $this->owner))
+        ->toThrow(ValidationException::class, 'already exists');
+
+    TenantContextService::setTenantId($this->team->getKey());
+    $freshCount = CustomFieldOption::query()
+        ->where('custom_field_id', $this->selectField->getKey())
+        ->where('name', 'Fresh')
+        ->count();
+
+    expect($freshCount)->toBe(1);
 });

--- a/tests/Feature/Chat/AllCustomFieldsViaChatTest.php
+++ b/tests/Feature/Chat/AllCustomFieldsViaChatTest.php
@@ -18,9 +18,12 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Tools\Request;
 use Laravel\Pennant\Feature;
 use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\Tools\CustomFieldsFilterTranslator;
+use Relaticle\Chat\Services\Tools\CustomFieldsRequestValidator;
 use Relaticle\Chat\Tools\Company\UpdateCompanyTool;
 use Relaticle\Chat\Tools\Note\UpdateNoteTool;
 use Relaticle\Chat\Tools\Opportunity\UpdateOpportunityTool;
@@ -250,3 +253,35 @@ function morphAliasForCustomFieldsTest(Model $model): string
         default => throw new RuntimeException('unsupported model'),
     };
 }
+
+it('accepts an option label in any casing when writing a choice field', function (string $label): void {
+    $task = Task::factory()->for($this->team)->create(['title' => 'T']);
+
+    runUpdateToolForCustomFieldsTest(UpdateTaskTool::class, $task, ['status' => $label]);
+    resolve(UpdateTask::class)->execute($this->user, $task, latestPendingForCustomFieldsTest()->action_data);
+
+    expect(optionLabelForCustomFieldsTest($task, 'status'))->toBe('In progress');
+})->with(['In progress', 'in progress', 'IN PROGRESS', 'In Progress']);
+
+it('resolves an option label identically whether filtering or writing', function (string $label, bool $valid): void {
+    Task::factory()->for($this->team)->create(['title' => 'T']);
+
+    $readAccepted = true;
+    try {
+        resolve(CustomFieldsFilterTranslator::class)
+            ->translate($this->user, 'task', ['status' => ['eq' => $label]]);
+    } catch (ValidationException) {
+        $readAccepted = false;
+    }
+
+    $writeAccepted = resolve(CustomFieldsRequestValidator::class)
+        ->validate($this->user, 'task', ['status' => $label])->error === null;
+
+    expect($readAccepted)->toBe($valid)
+        ->and($writeAccepted)->toBe($valid);
+})->with([
+    'exact casing' => ['In progress', true],
+    'lowercased' => ['in progress', true],
+    'uppercased' => ['IN PROGRESS', true],
+    'not an option' => ['Bananas', false],
+]);

--- a/tests/Feature/Chat/CreateCustomFieldToolTest.php
+++ b/tests/Feature/Chat/CreateCustomFieldToolTest.php
@@ -436,3 +436,66 @@ it('rejects empty option names', function (): void {
     expect($decoded)->toHaveKey('error')
         ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
 });
+
+it('rejects a field name that differs from an existing one only by case', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $decoded = json_decode((new CreateCustomFieldTool)->handle(new Request([
+        'entity_type' => 'people',
+        'name' => 'age',
+        'type' => 'number',
+    ])), true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and($decoded['error'])->toContain('already exists')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects a recased duplicate at approval time, not just at proposal time', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+
+    expect(fn () => app(CreateCustomField::class)->execute($this->owner, [
+        'entity_type' => 'people',
+        'name' => 'Renewal Date',
+        'type' => 'date',
+    ]))->not->toThrow(ValidationException::class);
+
+    expect(fn () => app(CreateCustomField::class)->execute($this->owner, [
+        'entity_type' => 'people',
+        'name' => 'RENEWAL DATE',
+        'type' => 'date',
+    ]))->toThrow(ValidationException::class, 'already exists');
+
+    expect(CustomField::query()
+        ->withoutGlobalScope(CustomFieldsActivableScope::class)
+        ->where($tenantKey, $this->team->getKey())
+        ->where('entity_type', 'people')
+        ->whereRaw('lower(name) = ?', ['renewal date'])
+        ->count())->toBe(1);
+});
+
+it('still allows a name that merely shares a prefix with an existing field', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $decoded = json_decode((new CreateCustomFieldTool)->handle(new Request([
+        'entity_type' => 'people',
+        'name' => 'Age Bracket',
+        'type' => 'text',
+    ])), true);
+
+    expect($decoded)->not->toHaveKey('error');
+});

--- a/tests/Feature/Chat/CreateCustomFieldToolTest.php
+++ b/tests/Feature/Chat/CreateCustomFieldToolTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Enums\PendingActionStatus;
@@ -208,4 +209,230 @@ it('creates a text field without options successfully', function (): void {
 
     expect($decoded['type'])->toBe('pending_action')
         ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(1);
+});
+
+it('rejects a duplicate field name at proposal time', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'type' => 'number',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and($decoded['error'])->toContain('already exists')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects a duplicate field name even when the existing field is deactivated', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+        'active' => false,
+    ]);
+
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'type' => 'number',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('allows the same field name on a different entity type', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Age',
+        'type' => 'number',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['type'])->toBe('pending_action')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(1);
+});
+
+it('rejects approval when a field with the same name appeared after the proposal', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+    $tool->handle(new Request([
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'type' => 'number',
+    ]));
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    expect(fn () => resolve(PendingActionService::class)->approve($pending, $this->owner))
+        ->toThrow(ValidationException::class, 'already exists');
+
+    $ageFields = CustomField::query()
+        ->withoutGlobalScope(CustomFieldsActivableScope::class)
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'people')
+        ->where('name', 'Age')
+        ->count();
+
+    expect($ageFields)->toBe(1)
+        ->and($pending->refresh()->status)->toBe(PendingActionStatus::Pending);
+});
+
+it('rejects a duplicate explicit code at proposal time', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'people',
+        'name' => 'Years',
+        'type' => 'number',
+        'code' => 'age',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and($decoded['error'])->toContain('already exists')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects approval with a friendly message when the explicit code was taken after the proposal', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+    $tool->handle(new Request([
+        'entity_type' => 'people',
+        'name' => 'Reference',
+        'type' => 'text',
+        'code' => 'ref_no',
+    ]));
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Ref Number',
+        'code' => 'ref_no',
+        'type' => 'text',
+    ]);
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    expect(fn () => resolve(PendingActionService::class)->approve($pending, $this->owner))
+        ->toThrow(ValidationException::class, 'already exists');
+});
+
+it('rejects an empty field name', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => '   ',
+        'type' => 'text',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects a field name longer than 50 characters', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => str_repeat('a', 51),
+        'type' => 'text',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects a code with invalid characters', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Reference',
+        'type' => 'text',
+        'code' => 'bad code!',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects duplicate option names within the options array', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Priority',
+        'type' => 'select',
+        'options' => [['name' => 'High'], ['name' => 'High']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects empty option names', function (): void {
+    $tool = makeCreateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'name' => 'Priority',
+        'type' => 'select',
+        'options' => [['name' => ''], ['name' => 'Low']],
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
 });

--- a/tests/Feature/Chat/ListToolFilterTest.php
+++ b/tests/Feature/Chat/ListToolFilterTest.php
@@ -3,9 +3,37 @@
 declare(strict_types=1);
 
 use App\Models\Company;
+use App\Models\CustomField;
+use App\Models\Task;
 use App\Models\User;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Tools\Company\ListCompaniesTool;
+use Relaticle\Chat\Tools\Task\ListTasksTool;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+/**
+ * The list tools return either a bare array of rows or a resource envelope.
+ *
+ * @return array<int|string, mixed>
+ */
+function listToolRows(string $json): array
+{
+    $decoded = json_decode($json, true);
+
+    return $decoded['data'] ?? $decoded;
+}
+
+function taskCustomFieldOptionId(string $teamId, string $code, string $label): string
+{
+    $field = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $teamId)
+        ->where('entity_type', 'task')
+        ->where('code', $code)
+        ->firstOrFail();
+
+    return (string) $field->options->firstWhere('name', $label)->id;
+}
 
 it('applies a filter when searching for the literal term "0" instead of returning all', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
@@ -22,4 +50,140 @@ it('applies a filter when searching for the literal term "0" instead of returnin
 
     $rows = $data['data'] ?? $data;
     expect($rows)->toHaveCount(1);
+});
+
+it('restricts tasks to the current user when assigned_to_me is set', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    $colleague = User::factory()->create();
+    $colleague->teams()->attach($team, ['role' => 'editor']);
+
+    $mine = Task::factory()->for($team)->create(['title' => 'Mine']);
+    $mine->assignees()->attach($user);
+
+    $theirs = Task::factory()->for($team)->create(['title' => 'Theirs']);
+    $theirs->assignees()->attach($colleague);
+
+    $rows = listToolRows((new ListTasksTool)->handle(new Request(['assigned_to_me' => true])));
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['attributes']['title'])->toBe('Mine');
+});
+
+it('returns every workspace task when assigned_to_me is not set', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    Task::factory()->for($team)->create(['title' => 'Mine'])->assignees()->attach($user);
+    Task::factory()->for($team)->create(['title' => 'Unassigned']);
+
+    $rows = listToolRows((new ListTasksTool)->handle(new Request([])));
+
+    expect($rows)->toHaveCount(2);
+});
+
+it('filters tasks by a choice custom field using the option label', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    TenantContextService::setTenantId($team->getKey());
+
+    $statusField = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $team->getKey())
+        ->where('entity_type', 'task')
+        ->where('code', 'status')
+        ->firstOrFail();
+
+    $open = Task::factory()->for($team)->create(['title' => 'Open one']);
+    $done = Task::factory()->for($team)->create(['title' => 'Finished']);
+
+    $open->saveCustomFieldValue($statusField, taskCustomFieldOptionId($team->getKey(), 'status', 'To do'));
+    $done->saveCustomFieldValue($statusField, taskCustomFieldOptionId($team->getKey(), 'status', 'Done'));
+
+    $rows = listToolRows((new ListTasksTool)->handle(new Request([
+        'custom_fields' => ['status' => ['eq' => 'Done']],
+    ])));
+
+    TenantContextService::setTenantId(null);
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['attributes']['title'])->toBe('Finished');
+});
+
+it('rejects an unknown custom field code instead of silently returning everything', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    Task::factory()->for($user->currentTeam)->create(['title' => 'Anything']);
+
+    $result = json_decode((new ListTasksTool)->handle(new Request([
+        'custom_fields' => ['not_a_field' => ['eq' => 'x']],
+    ])), true);
+
+    expect($result)->toHaveKey('error')
+        ->and($result['error'])->toContain('not a filterable custom field');
+});
+
+it('rejects an unknown option label instead of silently returning everything', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    TenantContextService::setTenantId($user->currentTeam->getKey());
+    Task::factory()->for($user->currentTeam)->create(['title' => 'Anything']);
+
+    $result = json_decode((new ListTasksTool)->handle(new Request([
+        'custom_fields' => ['status' => ['eq' => 'Nope']],
+    ])), true);
+
+    TenantContextService::setTenantId(null);
+
+    expect($result)->toHaveKey('error')
+        ->and($result['error'])->toContain('not one of the options');
+});
+
+it('rejects an operator the field does not support', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    TenantContextService::setTenantId($user->currentTeam->getKey());
+
+    $result = json_decode((new ListTasksTool)->handle(new Request([
+        'custom_fields' => ['status' => ['contains' => 'Done']],
+    ])), true);
+
+    TenantContextService::setTenantId(null);
+
+    expect($result)->toHaveKey('error')
+        ->and($result['error'])->toContain('not supported');
+});
+
+it('sorts companies by the requested column and direction', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    Company::factory()->for($team)->create(['name' => 'Alpha']);
+    Company::factory()->for($team)->create(['name' => 'Zulu']);
+
+    $descending = listToolRows((new ListCompaniesTool)->handle(new Request(['sort' => '-name'])));
+    $ascending = listToolRows((new ListCompaniesTool)->handle(new Request(['sort' => 'name'])));
+
+    expect($descending[0]['attributes']['name'])->toBe('Zulu')
+        ->and($ascending[0]['attributes']['name'])->toBe('Alpha');
+});
+
+it('reports an unknown sort column instead of failing silently', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    Company::factory()->for($user->currentTeam)->create(['name' => 'Alpha']);
+
+    $result = json_decode((new ListCompaniesTool)->handle(new Request(['sort' => 'not_a_column'])), true);
+
+    expect($result)->toHaveKey('error');
 });

--- a/tests/Feature/Chat/ListToolFilterTest.php
+++ b/tests/Feature/Chat/ListToolFilterTest.php
@@ -7,10 +7,12 @@ use App\Actions\CustomFields\CreateCustomField;
 use App\Actions\CustomFields\UpdateCustomField;
 use App\Models\Company;
 use App\Models\CustomField;
+use App\Models\Note;
 use App\Models\Task;
 use App\Models\User;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Tools\Company\ListCompaniesTool;
+use Relaticle\Chat\Tools\Note\ListNotesTool;
 use Relaticle\Chat\Tools\Task\ListTasksTool;
 use Relaticle\CustomFields\Services\TenantContextService;
 
@@ -336,3 +338,20 @@ it('ignores an empty assignee_ids list rather than returning nothing', function 
 
     expect($rows)->toHaveCount(1);
 });
+
+it('filters every list tool by creation date, including tasks and notes', function (string $toolClass, string $factory): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    $factory::factory()->for($user->currentTeam)->create();
+
+    $tool = new $toolClass;
+
+    expect(listToolRows($tool->handle(new Request(['created_after' => now()->addDay()->toDateString()]))))->toBeEmpty()
+        ->and(listToolRows($tool->handle(new Request(['created_before' => now()->subYears(5)->toDateString()]))))->toBeEmpty()
+        ->and(listToolRows($tool->handle(new Request(['created_after' => now()->subYears(5)->toDateString()]))))->toHaveCount(1);
+})->with([
+    'companies' => [ListCompaniesTool::class, Company::class],
+    'tasks' => [ListTasksTool::class, Task::class],
+    'notes' => [ListNotesTool::class, Note::class],
+]);

--- a/tests/Feature/Chat/ListToolFilterTest.php
+++ b/tests/Feature/Chat/ListToolFilterTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Actions\CustomFields\AddCustomFieldOptions;
+use App\Actions\CustomFields\CreateCustomField;
+use App\Actions\CustomFields\UpdateCustomField;
 use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\Task;
@@ -186,4 +189,77 @@ it('reports an unknown sort column instead of failing silently', function (): vo
     $result = json_decode((new ListCompaniesTool)->handle(new Request(['sort' => 'not_a_column'])), true);
 
     expect($result)->toHaveKey('error');
+});
+
+it('can filter by a custom field immediately after creating it', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    // Warm the filter schema the way any earlier turn in the conversation would.
+    (new ListCompaniesTool)->handle(new Request);
+
+    app(CreateCustomField::class)->execute($user, [
+        'entity_type' => 'company',
+        'name' => 'Segment',
+        'code' => 'segment',
+        'type' => 'select',
+        'options' => ['Enterprise', 'SMB'],
+    ]);
+
+    $result = json_decode((new ListCompaniesTool)->handle(new Request([
+        'custom_fields' => ['segment' => ['eq' => 'Enterprise']],
+    ])), true);
+
+    expect($result)->not->toHaveKey('error');
+});
+
+it('stops offering a custom field for filtering once it is deactivated', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    $field = app(CreateCustomField::class)->execute($user, [
+        'entity_type' => 'company',
+        'name' => 'Segment',
+        'code' => 'segment',
+        'type' => 'select',
+        'options' => ['Enterprise'],
+    ]);
+
+    (new ListCompaniesTool)->handle(new Request(['custom_fields' => ['segment' => ['eq' => 'Enterprise']]]));
+
+    app(UpdateCustomField::class)->execute($user, $field, ['active' => false]);
+
+    $result = json_decode((new ListCompaniesTool)->handle(new Request([
+        'custom_fields' => ['segment' => ['eq' => 'Enterprise']],
+    ])), true);
+
+    expect($result)->toHaveKey('error')
+        ->and($result['error'])->toContain('not a filterable custom field');
+});
+
+it('can filter by an option added to an existing custom field', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    $field = app(CreateCustomField::class)->execute($user, [
+        'entity_type' => 'company',
+        'name' => 'Segment',
+        'code' => 'segment',
+        'type' => 'select',
+        'options' => ['Enterprise'],
+    ]);
+
+    (new ListCompaniesTool)->handle(new Request(['custom_fields' => ['segment' => ['eq' => 'Enterprise']]]));
+
+    app(AddCustomFieldOptions::class)->execute($user, [
+        '_record_id' => $field->getKey(),
+        'options' => ['Mid-Market'],
+    ]);
+
+    $result = json_decode((new ListCompaniesTool)->handle(new Request([
+        'custom_fields' => ['segment' => ['eq' => 'Mid-Market']],
+    ])), true);
+
+    expect($result)->not->toHaveKey('error');
 });

--- a/tests/Feature/Chat/ListToolFilterTest.php
+++ b/tests/Feature/Chat/ListToolFilterTest.php
@@ -263,3 +263,76 @@ it('can filter by an option added to an existing custom field', function (): voi
 
     expect($result)->not->toHaveKey('error');
 });
+
+it('restricts tasks to a named colleague when assignee_ids is set', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    $colleague = User::factory()->create();
+    $team->users()->attach($colleague, ['role' => 'editor']);
+
+    $theirs = Task::factory()->for($team)->create(['title' => 'Colleague task']);
+    $theirs->assignees()->attach($colleague);
+
+    $mine = Task::factory()->for($team)->create(['title' => 'My task']);
+    $mine->assignees()->attach($user);
+
+    Task::factory()->for($team)->create(['title' => 'Unassigned task']);
+
+    $rows = listToolRows((new ListTasksTool)->handle(new Request([
+        'assignee_ids' => [(string) $colleague->getKey()],
+    ])));
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['attributes']['title'])->toBe('Colleague task');
+});
+
+it('matches tasks assigned to any of several people', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+
+    $one = User::factory()->create();
+    $two = User::factory()->create();
+    $team->users()->attach($one, ['role' => 'editor']);
+    $team->users()->attach($two, ['role' => 'editor']);
+
+    Task::factory()->for($team)->create(['title' => 'First'])->assignees()->attach($one);
+    Task::factory()->for($team)->create(['title' => 'Second'])->assignees()->attach($two);
+    Task::factory()->for($team)->create(['title' => 'Third']);
+
+    $rows = listToolRows((new ListTasksTool)->handle(new Request([
+        'assignee_ids' => [(string) $one->getKey(), (string) $two->getKey()],
+    ])));
+
+    expect($rows)->toHaveCount(2);
+});
+
+it('never leaks another workspace\'s tasks through assignee_ids', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    $outsider = User::factory()->withPersonalTeam()->create();
+    $theirTask = Task::factory()->for($outsider->currentTeam)->create(['title' => 'Other workspace task']);
+    $theirTask->assignees()->attach($outsider);
+
+    Task::factory()->for($user->currentTeam)->create(['title' => 'Mine']);
+
+    $rows = listToolRows((new ListTasksTool)->handle(new Request([
+        'assignee_ids' => [(string) $outsider->getKey()],
+    ])));
+
+    expect($rows)->toBeEmpty();
+});
+
+it('ignores an empty assignee_ids list rather than returning nothing', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    Task::factory()->for($user->currentTeam)->create(['title' => 'Alpha']);
+
+    $rows = listToolRows((new ListTasksTool)->handle(new Request(['assignee_ids' => []])));
+
+    expect($rows)->toHaveCount(1);
+});

--- a/tests/Feature/Chat/ProposalCardComponentTest.php
+++ b/tests/Feature/Chat/ProposalCardComponentTest.php
@@ -892,3 +892,68 @@ it('renders the resolve failure in the dock so the approval is never a silent no
         ->call('createCurrent')
         ->assertSee('not in your workspace');
 });
+
+/**
+ * A pending Create-custom-field proposal shaped exactly like CreateCustomFieldTool emits.
+ */
+function customFieldProposal(User $user, string $entityType, string $name, string $type): PendingAction
+{
+    return PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(),
+        'user_id' => $user->getKey(),
+        'conversation_id' => null,
+        'action_class' => 'App\\Actions\\CustomFields\\CreateCustomField',
+        'operation' => PendingActionOperation::Create,
+        'entity_type' => 'custom_field',
+        'action_data' => ['entity_type' => $entityType, 'name' => $name, 'type' => $type],
+        'display_data' => [
+            'title' => 'Create Custom Field',
+            'summary' => "Create \"{$name}\" ({$type}) on {$entityType}",
+            'fields' => [
+                ['label' => 'Entity', 'value' => $entityType],
+                ['label' => 'Name', 'value' => $name],
+                ['label' => 'Type', 'value' => $type],
+            ],
+        ],
+        'status' => PendingActionStatus::Pending,
+        'expires_at' => now()->addMinutes(15),
+    ]);
+}
+
+it('approving a custom field proposal dispatches a record link to the management page', function (): void {
+    Bus::fake();
+    $action = customFieldProposal($this->user, 'people', 'Age', 'number');
+
+    Livewire::test(ProposalCard::class, ['context' => 'conversation'])
+        ->dispatch('proposal:set-active', id: $action->getKey(), context: 'conversation')
+        ->call('createCurrent')
+        ->assertDispatched('proposal:resolved', function (string $event, array $params): bool {
+            $record = $params['record'] ?? null;
+
+            return is_array($record)
+                && $record['type'] === 'custom_field'
+                && $record['label'] === 'Age'
+                && str_contains((string) $record['url'], 'currentEntityType=people');
+        });
+});
+
+it('surfaces a readable error on the card when the field name was taken after the proposal', function (): void {
+    Bus::fake();
+    $action = customFieldProposal($this->user, 'people', 'Age', 'number');
+
+    CustomField::factory()->create([
+        config('custom-fields.database.column_names.tenant_foreign_key') => $this->team->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    Livewire::test(ProposalCard::class, ['context' => 'conversation'])
+        ->dispatch('proposal:set-active', id: $action->getKey(), context: 'conversation')
+        ->call('createCurrent')
+        ->assertDispatched('proposal:resolve-failed')
+        ->assertHasErrors('resolve');
+
+    expect($action->fresh()->status)->toBe(PendingActionStatus::Pending);
+});

--- a/tests/Feature/Chat/ProposalCardComponentTest.php
+++ b/tests/Feature/Chat/ProposalCardComponentTest.php
@@ -957,3 +957,32 @@ it('surfaces a readable error on the card when the field name was taken after th
 
     expect($action->fresh()->status)->toBe(PendingActionStatus::Pending);
 });
+
+it('never puts a database error message on the card or in the transcript', function (): void {
+    Bus::fake();
+
+    // companies.name is NOT NULL and CreateCompany does not validate it, so an
+    // approval carrying a stale/emptied name reaches Postgres and raises a
+    // QueryException — whose getMessage() carries the statement, the failing row
+    // and the connection host.
+    $action = proposalCardPa($this->user, ['name' => null], ['title' => 'Create Company', 'summary' => 'Create a company']);
+
+    $component = Livewire::test(ProposalCard::class, ['context' => 'conversation'])
+        ->dispatch('proposal:set-active', id: $action->getKey(), context: 'conversation')
+        ->call('createCurrent')
+        ->assertDispatched('proposal:resolve-failed')
+        ->assertNotDispatched('proposal:resolved');
+
+    $errors = $component->errors()->get('resolve');
+    $shown = implode(' ', $errors);
+
+    expect($errors)->not->toBeEmpty()
+        ->and($shown)->not->toContain('SQLSTATE')
+        ->and($shown)->not->toContain('insert into')
+        ->and($shown)->not->toContain('Connection: pgsql')
+        ->and($shown)->not->toContain('companies')
+        ->and($shown)->toBe('This change could not be saved. Please try again.');
+
+    expect($action->fresh()->status)->toBe(PendingActionStatus::Pending);
+    expect(Company::query()->where('team_id', $this->team->getKey())->count())->toBe(0);
+});

--- a/tests/Feature/Chat/RecordReferenceResolverTest.php
+++ b/tests/Feature/Chat/RecordReferenceResolverTest.php
@@ -2,11 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Filament\Pages\Team\CustomFields;
 use App\Filament\Resources\PeopleResource;
+use App\Models\CustomField;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\Chat\Support\RecordReferenceResolver;
+use Relaticle\CustomFields\Services\TenantContextService;
 
 it('resolves a people record reference to id, type, and url', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
@@ -31,4 +34,74 @@ it('returns null for unknown entity types', function (): void {
     Filament::setTenant($user->currentTeam);
 
     expect(resolve(RecordReferenceResolver::class)->resolve('unknown', 'whatever'))->toBeNull();
+});
+
+it('resolves a custom field reference to the management page for its entity tab', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    Filament::setTenant($user->currentTeam);
+    TenantContextService::setTenantId($user->currentTeam->getKey());
+
+    $field = CustomField::factory()->create([
+        config('custom-fields.database.column_names.tenant_foreign_key') => $user->currentTeam->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $ref = resolve(RecordReferenceResolver::class)->resolve('custom_field', (string) $field->getKey());
+
+    expect($ref)->not->toBeNull()
+        ->and($ref['type'])->toBe('custom_field')
+        ->and($ref['label'])->toBe('Age')
+        ->and($ref['url'])->toContain(CustomFields::getUrl(panel: 'app', tenant: $user->currentTeam))
+        ->and($ref['url'])->toContain('currentEntityType=people');
+
+    TenantContextService::setTenantId(null);
+});
+
+it('resolves a custom field reference even when the field is deactivated', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+    Filament::setTenant($user->currentTeam);
+    TenantContextService::setTenantId($user->currentTeam->getKey());
+
+    $field = CustomField::factory()->create([
+        config('custom-fields.database.column_names.tenant_foreign_key') => $user->currentTeam->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Retired',
+        'code' => 'retired',
+        'type' => 'text',
+        'active' => false,
+    ]);
+
+    $ref = resolve(RecordReferenceResolver::class)->resolve('custom_field', (string) $field->getKey());
+
+    expect($ref)->not->toBeNull()
+        ->and($ref['url'])->toContain('currentEntityType=company');
+
+    TenantContextService::setTenantId(null);
+});
+
+it('does not resolve a custom field belonging to another team', function (): void {
+    $owner = User::factory()->withPersonalTeam()->create();
+    $stranger = User::factory()->withPersonalTeam()->create();
+
+    TenantContextService::setTenantId($owner->currentTeam->getKey());
+    $field = CustomField::factory()->create([
+        config('custom-fields.database.column_names.tenant_foreign_key') => $owner->currentTeam->getKey(),
+        'entity_type' => 'people',
+        'name' => 'Age',
+        'code' => 'age',
+        'type' => 'number',
+    ]);
+
+    $this->actingAs($stranger);
+    Filament::setTenant($stranger->currentTeam);
+    TenantContextService::setTenantId($stranger->currentTeam->getKey());
+
+    expect(resolve(RecordReferenceResolver::class)->resolve('custom_field', (string) $field->getKey()))->toBeNull();
+
+    TenantContextService::setTenantId(null);
 });

--- a/tests/Feature/Chat/UpdateCustomFieldToolTest.php
+++ b/tests/Feature/Chat/UpdateCustomFieldToolTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Laravel\Ai\Tools\Request;
 use Relaticle\Chat\Enums\PendingActionOperation;
 use Relaticle\Chat\Enums\PendingActionStatus;
@@ -128,6 +129,82 @@ it('returns error when trying to update a system_defined field', function (): vo
         'entity_type' => 'company',
         'code' => $systemField->code,
         'name' => 'Hacked',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('rejects renaming to a name that already exists on the entity at proposal time', function (): void {
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Sector',
+        'code' => 'sector',
+        'type' => 'text',
+    ]);
+
+    $tool = makeUpdateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->field->code,
+        'name' => 'Sector',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded)->toHaveKey('error')
+        ->and($decoded['error'])->toContain('already exists')
+        ->and(PendingAction::query()->where('conversation_id', $this->convId)->count())->toBe(0);
+});
+
+it('allows renaming a field to its own current name', function (): void {
+    $tool = makeUpdateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->field->code,
+        'name' => 'Industry',
+    ]));
+
+    $decoded = json_decode($result, true);
+
+    expect($decoded['type'])->toBe('pending_action');
+});
+
+it('rejects approval when the new name was taken after the proposal', function (): void {
+    $tool = makeUpdateFieldTool($this->convId);
+    $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->field->code,
+        'name' => 'Sector',
+    ]));
+
+    $tenantKey = config('custom-fields.database.column_names.tenant_foreign_key');
+    CustomField::factory()->create([
+        $tenantKey => $this->team->getKey(),
+        'entity_type' => 'company',
+        'name' => 'Sector',
+        'code' => 'sector',
+        'type' => 'text',
+    ]);
+
+    $pending = PendingAction::query()->where('conversation_id', $this->convId)->firstOrFail();
+
+    expect(fn () => resolve(PendingActionService::class)->approve($pending, $this->owner))
+        ->toThrow(ValidationException::class, 'already exists');
+
+    expect($this->field->refresh()->name)->toBe('Industry');
+});
+
+it('rejects renaming to a name longer than 50 characters', function (): void {
+    $tool = makeUpdateFieldTool($this->convId);
+    $result = $tool->handle(new Request([
+        'entity_type' => 'company',
+        'code' => $this->field->code,
+        'name' => str_repeat('a', 51),
     ]));
 
     $decoded = json_decode($result, true);

--- a/tests/Feature/Mcp/CompanyToolsTest.php
+++ b/tests/Feature/Mcp/CompanyToolsTest.php
@@ -176,3 +176,31 @@ describe('validation', function () {
         expect($company->creation_source)->toBe(CreationSource::MCP);
     });
 });
+
+describe('date filtering', function () {
+    it('filters companies by created_after', function (): void {
+        $old = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Ancient Corp']);
+        $old->forceFill(['created_at' => now()->subMonth()])->saveQuietly();
+
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Recent Corp']);
+
+        RelaticleServer::actingAs($this->user)
+            ->tool(ListCompaniesTool::class, ['created_after' => now()->subWeek()->toDateString()])
+            ->assertOk()
+            ->assertSee('Recent Corp')
+            ->assertDontSee('Ancient Corp');
+    });
+
+    it('filters companies by created_before', function (): void {
+        $old = Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Ancient Corp']);
+        $old->forceFill(['created_at' => now()->subMonth()])->saveQuietly();
+
+        Company::factory()->recycle([$this->user, $this->team])->create(['name' => 'Recent Corp']);
+
+        RelaticleServer::actingAs($this->user)
+            ->tool(ListCompaniesTool::class, ['created_before' => now()->subWeek()->toDateString()])
+            ->assertOk()
+            ->assertSee('Ancient Corp')
+            ->assertDontSee('Recent Corp');
+    });
+});

--- a/tests/Feature/Mcp/OpportunityToolsTest.php
+++ b/tests/Feature/Mcp/OpportunityToolsTest.php
@@ -146,3 +146,19 @@ describe('team scoping', function () {
             ->assertHasErrors();
     });
 });
+
+describe('stale filtering', function () {
+    it('filters opportunities by stale_days', function (): void {
+        $this->travelTo(now()->subDays(40));
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Stale Deal']);
+
+        $this->travelBack();
+        Opportunity::factory()->recycle([$this->user, $this->team])->create(['name' => 'Active Deal']);
+
+        RelaticleServer::actingAs($this->user)
+            ->tool(ListOpportunitiesTool::class, ['stale_days' => 30])
+            ->assertOk()
+            ->assertSee('Stale Deal')
+            ->assertDontSee('Active Deal');
+    });
+});


### PR DESCRIPTION
The assistant could create a second "Age" field on People that the management UI rejects, because name/code uniqueness was only ever enforced by the Filament form's `unique()` rules — chat validated type, entity and limits but nothing else, and an explicit duplicate code reached the DB and surfaced a raw SQLSTATE on the proposal card. Validation now lives in one place, `App\Support\CustomFieldDefinitionValidator`, built on native Laravel rules (`Rule::unique` scoped per tenant + entity, `max`, `alpha_dash`, `distinct:ignore_case`, `prohibited`) and run by both layers — the tools pre-flight so a doomed proposal is never shown, and the actions re-check at approval so a proposal approved after the name was taken fails instead of writing a duplicate, with uniqueness checked on the query builder so deactivated fields still count as taken. Three further defects from the same transcript are fixed: approval reported "Created Age." with no link (`RecordReferenceResolver` had no `custom_field` branch, so the card now deep-links to the management page on the owning entity tab), "tasks assigned to me" returned every workspace task (`ListTasks` and the MCP tool already supported `assigned_to_me` — only the chat tool's schema lacked the slot), and chat list tools could not filter or sort at all while MCP could, which left the assistant unable to answer anything about stage, status, priority or due date since those all live in custom fields. `BaseReadListTool` now exposes `custom_fields` and `sort` for every entity, sharing `CustomFieldFilterSchema` with MCP so the two surfaces cannot drift, taking choice values as labels like the write path does, and rejecting an unknown code, operator or label rather than silently dropping the filter and returning the whole table. The parity sweep ran both ways, so MCP also gained the `created_after`/`created_before` and `stale_days` filters its list actions already supported.

## Test plan

- 17 failing repros written first, one per defect at both proposal and approval time; all green.
- Race coverage: a proposal approved after the name, code or option was claimed elsewhere is rejected, writes nothing, and stays pending.
- `ProposalCard` Livewire tests: approval dispatches the record link, and a race duplicate surfaces a readable card error rather than a 500.
- Browser-verified against the running app: the production scenario now blocks the duplicate (exactly one `Age` remains) and the card renders a working **View Age** link to Custom Fields → People.
- Gates: Pint, Rector (0 changes), PHPStan (0 errors), type coverage 100%, full suite 2865 tests / 2863 passed / 2 skipped.
- Not covered: a live LLM turn against Horizon + Reverb (Reverb is stopped locally and its Herd vhost is unreachable from the automated browser), so the plumbing is proven end to end but the model's own choice of the new filter slots is not.