### PR TITLE
fix(health): probe chat providers by model retrieval, not generation

### DIFF
--- a/app/Health/ChatProviderCheck.php
+++ b/app/Health/ChatProviderCheck.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Health;
 
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response as ClientResponse;
 use Illuminate\Support\Collection;
-use Prism\Prism\Exceptions\PrismProviderOverloadedException;
-use Prism\Prism\Exceptions\PrismRateLimitedException;
-use Prism\Prism\Facades\Prism;
+use Illuminate\Support\Facades\Http;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
-use Throwable;
 
 final class ChatProviderCheck extends Check
 {
@@ -42,9 +41,16 @@ final class ChatProviderCheck extends Check
     }
 
     /**
+     * Retrieving the model rather than generating from it: a generative probe
+     * has to pick a token budget, and a reasoning model spends that budget on
+     * thinking before it emits anything. OpenAI rejects a budget under 16 and
+     * returns an incomplete response when the budget runs out, so no value both
+     * stays free and stays green at an every-minute cadence. A revoked key and
+     * a retired model — the two persistent faults this check exists to catch —
+     * are precisely what this endpoint reports, as 401 and 404.
+     *
      * Provider overload and rate limiting are transient and nothing we can act
-     * on, so they only warn. Persistent faults — a revoked key, a retired
-     * model — are the ones worth failing the health report over.
+     * on, so they only warn.
      */
     public function run(): Result
     {
@@ -52,19 +58,69 @@ final class ChatProviderCheck extends Check
             ->meta(['provider' => $this->provider, 'model' => $this->model])
             ->shortSummary($this->model);
 
-        try {
-            Prism::text()
-                ->using($this->provider, $this->model)
-                ->withMaxTokens(1)
-                ->withPrompt('Hi')
-                ->generate();
+        $probe = $this->probe();
 
-            return $result->ok();
-        } catch (PrismRateLimitedException|PrismProviderOverloadedException|ConnectionException $e) {
-            return $result->warning("{$this->provider} is temporarily unavailable: {$e->getMessage()}");
-        } catch (Throwable $e) {
-            return $result->failed("{$this->provider} model '{$this->model}' is unavailable: {$e->getMessage()}");
+        if (! $probe instanceof PendingRequest) {
+            return $result->failed("no health probe is defined for chat provider '{$this->provider}'");
         }
+
+        try {
+            $response = $probe->get("models/{$this->model}");
+        } catch (ConnectionException $e) {
+            return $result->warning("{$this->provider} is unreachable: {$e->getMessage()}");
+        }
+
+        if ($response->successful()) {
+            return $result->ok();
+        }
+
+        if ($response->status() === 429 || $response->serverError()) {
+            return $result->warning("{$this->provider} is temporarily unavailable: {$this->describe($response)}");
+        }
+
+        return $result->failed("{$this->provider} model '{$this->model}' is unavailable: {$this->describe($response)}");
+    }
+
+    /**
+     * Mirrors how `laravel/ai` builds its client for the same provider, so the
+     * probe fails for the same reasons a real chat turn would. A provider the
+     * catalogue can register but this method does not know is left null on
+     * purpose: `run()` then fails loudly rather than reporting a provider as
+     * healthy without ever having contacted it.
+     */
+    private function probe(): ?PendingRequest
+    {
+        $key = (string) config("ai.providers.{$this->provider}.key");
+
+        $request = match ($this->provider) {
+            'anthropic' => Http::withHeaders([
+                'x-api-key' => $key,
+                'anthropic-version' => (string) config('ai.providers.anthropic.version', '2023-06-01'),
+            ])->baseUrl($this->baseUrl('https://api.anthropic.com/v1')),
+            'openai' => Http::withToken($key)
+                ->baseUrl($this->baseUrl('https://api.openai.com/v1')),
+            default => null,
+        };
+
+        return $request?->connectTimeout(5)->timeout(10);
+    }
+
+    private function baseUrl(string $default): string
+    {
+        $url = config("ai.providers.{$this->provider}.url");
+
+        return rtrim(is_string($url) && $url !== '' ? $url : $default, '/');
+    }
+
+    private function describe(ClientResponse $response): string
+    {
+        $message = $response->json('error.message');
+
+        if (! is_string($message) || $message === '') {
+            return "HTTP {$response->status()}";
+        }
+
+        return "HTTP {$response->status()} - {$message}";
     }
 
     /**

--- a/tests/Feature/HealthChecks/ChatProviderCheckTest.php
+++ b/tests/Feature/HealthChecks/ChatProviderCheckTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Health\ChatProviderCheck;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Enums\Status;
@@ -32,23 +34,66 @@ function chatProviderCatalogueEntry(
     ];
 }
 
-function configuredAnthropicCheck(): ChatProviderCheck
+function configuredCheck(string $provider, string $model): ChatProviderCheck
 {
-    config()->set('chat.models', [chatProviderCatalogueEntry('anthropic', 'claude-sonnet-4-6')]);
-    config()->set('ai.providers.anthropic.key', 'test-key');
+    config()->set('chat.models', [chatProviderCatalogueEntry($provider, $model)]);
+    config()->set("ai.providers.{$provider}.key", 'test-key');
 
     return ChatProviderCheck::forConfiguredProviders()[0];
 }
 
-it('only warns when a provider is overloaded', function (): void {
+function configuredAnthropicCheck(): ChatProviderCheck
+{
+    return configuredCheck('anthropic', 'claude-sonnet-4-6');
+}
+
+it('retrieves the model from anthropic with the credentials a chat turn uses', function (): void {
+    Http::fake();
+
+    configuredAnthropicCheck()->run();
+
+    Http::assertSent(fn (Request $request): bool => $request->method() === 'GET'
+        && $request->url() === 'https://api.anthropic.com/v1/models/claude-sonnet-4-6'
+        && $request->hasHeader('x-api-key', 'test-key')
+        && $request->hasHeader('anthropic-version', '2023-06-01'));
+});
+
+it('retrieves the model from openai with the credentials a chat turn uses', function (): void {
+    Http::fake();
+
+    configuredCheck('openai', 'gpt-5.5')->run();
+
+    Http::assertSent(fn (Request $request): bool => $request->method() === 'GET'
+        && $request->url() === 'https://api.openai.com/v1/models/gpt-5.5'
+        && $request->hasHeader('Authorization', 'Bearer test-key'));
+});
+
+it('never sends a generation request', function (): void {
+    Http::fake();
+
+    configuredCheck('openai', 'gpt-5.5')->run();
+
+    Http::assertNotSent(fn (Request $request): bool => $request->method() === 'POST'
+        || array_key_exists('max_output_tokens', $request->data())
+        || array_key_exists('max_tokens', $request->data()));
+});
+
+it('honours a provider base url override', function (): void {
+    Http::fake();
+
+    config()->set('ai.providers.openai.url', 'https://gateway.internal/openai/v1/');
+
+    configuredCheck('openai', 'gpt-5.5')->run();
+
+    Http::assertSent(fn (Request $request): bool => $request->url() === 'https://gateway.internal/openai/v1/models/gpt-5.5');
+});
+
+it('passes when the provider serves the model', function (): void {
     Http::fake([
-        'api.anthropic.com/*' => Http::response([
-            'type' => 'error',
-            'error' => ['type' => 'overloaded_error', 'message' => 'Overloaded'],
-        ], 529),
+        'api.openai.com/*' => Http::response(['id' => 'gpt-5.5', 'object' => 'model']),
     ]);
 
-    expect(configuredAnthropicCheck()->run()->status)->toBe(Status::warning());
+    expect(configuredCheck('openai', 'gpt-5.5')->run()->status)->toBe(Status::ok());
 });
 
 it('only warns when a provider rate limits us', function (): void {
@@ -62,42 +107,74 @@ it('only warns when a provider rate limits us', function (): void {
     expect(configuredAnthropicCheck()->run()->status)->toBe(Status::warning());
 });
 
-it('fails when the model is no longer available', function (): void {
+it('only warns when a provider is overloaded', function (): void {
     Http::fake([
         'api.anthropic.com/*' => Http::response([
             'type' => 'error',
-            'error' => ['type' => 'not_found_error', 'message' => 'model: claude-sonnet-4-6'],
+            'error' => ['type' => 'overloaded_error', 'message' => 'Overloaded'],
+        ], 529),
+    ]);
+
+    expect(configuredAnthropicCheck()->run()->status)->toBe(Status::warning());
+});
+
+it('only warns when a provider cannot be reached', function (): void {
+    Http::fake(fn (): never => throw new ConnectionException('cURL error 28: Operation timed out'));
+
+    expect(configuredAnthropicCheck()->run()->status)->toBe(Status::warning());
+});
+
+it('fails when the model is no longer available', function (): void {
+    Http::fake([
+        'api.openai.com/*' => Http::response([
+            'error' => ['type' => 'invalid_request_error', 'message' => "The model 'gpt-5.5' does not exist"],
         ], 404),
     ]);
 
-    expect(configuredAnthropicCheck()->run()->status)->toBe(Status::failed());
+    $result = configuredCheck('openai', 'gpt-5.5')->run();
+
+    expect($result->status)->toBe(Status::failed())
+        ->and($result->notificationMessage)->toContain("The model 'gpt-5.5' does not exist");
 });
 
 it('fails when the api key is rejected', function (): void {
     Http::fake([
-        'api.anthropic.com/*' => Http::response([
-            'type' => 'error',
-            'error' => ['type' => 'authentication_error', 'message' => 'invalid x-api-key'],
+        'api.openai.com/*' => Http::response([
+            'error' => ['type' => 'invalid_request_error', 'message' => 'Incorrect API key provided'],
         ], 401),
     ]);
 
-    expect(configuredAnthropicCheck()->run()->status)->toBe(Status::failed());
+    expect(configuredCheck('openai', 'gpt-5.5')->run()->status)->toBe(Status::failed());
 });
 
-it('passes when the provider responds', function (): void {
-    Http::fake([
-        'api.anthropic.com/*' => Http::response([
-            'id' => 'msg_test',
-            'type' => 'message',
-            'role' => 'assistant',
-            'model' => 'claude-sonnet-4-6',
-            'content' => [['type' => 'text', 'text' => 'Hi']],
-            'stop_reason' => 'max_tokens',
-            'usage' => ['input_tokens' => 10, 'output_tokens' => 1],
-        ]),
-    ]);
+it('fails loudly rather than silently passing a provider it cannot probe', function (): void {
+    Http::fake();
 
-    expect(configuredAnthropicCheck()->run()->status)->toBe(Status::ok());
+    $result = configuredCheck('groq', 'llama-4-scout')->run();
+
+    expect($result->status)->toBe(Status::failed())
+        ->and($result->notificationMessage)->toContain('no health probe is defined');
+
+    Http::assertNothingSent();
+});
+
+it('can probe every provider the real catalogue is able to register', function (): void {
+    Http::fake();
+
+    /** @var array<int, array<string, mixed>> $catalogue */
+    $catalogue = config('chat.models', []);
+
+    foreach ($catalogue as $entry) {
+        config()->set("ai.providers.{$entry['provider']}.key", 'test-key');
+    }
+
+    $checks = ChatProviderCheck::forConfiguredProviders();
+
+    expect($checks)->not->toBeEmpty();
+
+    foreach ($checks as $check) {
+        expect($check->run()->status)->toBe(Status::ok());
+    }
 });
 
 it('registers one check per provider that has a key configured', function (): void {


### PR DESCRIPTION
Fixes the Oh Dear alert `Chat Provider: Openai` → *"openai model 'gpt-5.5' is unavailable: OpenAI Error 400: Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 1 instead."*

## Root cause

#489 generalised the Anthropic health check to every reachable chat provider, probing each one with a real generation call capped at `->withMaxTokens(1)`. Anthropic accepts a 1-token cap; OpenAI's Responses API rejects `max_output_tokens` below 16, so the OpenAI check has failed on every run since that merge — every minute, per `RunHealthChecksCommand::everyMinute()`.

It shipped because `ChatProviderCheckTest` only ever faked `api.anthropic.com`. The OpenAI request shape was never exercised by a single test.

## Why not just raise the cap

Raising it to 16 trades one failure for another. `gpt-5.5` is a reasoning model and spends `max_output_tokens` on reasoning before emitting a message, so a small budget returns `status: incomplete`; Prism maps that to `FinishReason::Length` and throws (`Text.php:66`), which the check catches as a failure. The result would be a *flapping* check rather than a fixed one. A budget large enough to be reliable would bill real tokens 1440×/day/provider — for a liveness probe.

## The fix

The check now issues `GET {base}/models/{model}` instead of generating:

- **ok** — 2xx
- **warning** — 429, 5xx, `ConnectionException` (transients were already warn-only after #489)
- **failed** — 401, 404, anything else

That matches the check's own declared purpose from #489: fail on a revoked key or a retired model, warn on provider blips. Those are exactly 401 and 404 on this endpoint. There is no request body left to get wrong, and the probe costs nothing.

Two further fixes carried along:

- **Credential mismatch.** The check *registered* providers from `config('ai.providers.*.key')` but *authenticated* through Prism's separate `config('prism.providers.*')`. It only worked because both read the same env vars. Credentials and base URLs are now built exactly the way `laravel/ai` builds them for the same provider (`CreatesAnthropicClient`, `CreatesOpenAiClient`), so the probe fails for the same reasons a real chat turn would.
- **Silent gaps.** A provider the catalogue can register but the probe has no descriptor for now fails loudly instead of being skipped, and a test walks the real `chat.models` config to assert every registrable provider is probeable — so a future catalogue addition fails CI, not production.

Check names (`Chat provider: openai`) and the free-plan model preference are unchanged, keeping Oh Dear history continuous.

## Test plan

- Endpoint contract verified live before writing code: Anthropic valid model → **200**, retired model → **404**, OpenAI with a revoked key → **401**.
- The new tests were run against the **old** implementation first: **7 of 17 fail**, including `it never sends a generation request` ("Unexpected request was recorded"). The coverage is load-bearing, not decorative.
- With the fix: 17/17 pass. Both providers now have pinned request-shape assertions (method, URL, auth headers) — the gap that let this ship.
- Ran the real check against live providers: `Chat provider: anthropic => ok`, `Chat provider: openai => failed | HTTP 401 - Incorrect API key provided` (my local OpenAI key is revoked). The `max_output_tokens` error class is structurally gone — no request body is sent at all.
- Full suite: 2843 passed, 2 skipped, 0 failed. Pint, Rector, PHPStan (0 errors), type coverage 100%, Arch suite green.

**Not verified locally:** the OpenAI 200 path, because my local key is revoked. Production has a working key (its error was a 400 param rejection, not a 401), so this should clear on deploy — confirmable in Oh Dear.

**One caveat worth stating plainly:** the old 400 was a parameter rejection, which can precede model resolution, so it does *not* prove `gpt-5.5` is available to the production key. If the check comes back 404 after deploy, that is the check working correctly and the catalogue entry needing attention — not this fix failing.

## Follow-up (not in this PR)

`prism-php/prism` now has **zero** consumers — this check was the only one. Removing the dependency and `config/prism.php` is a dependency change, so I have left it alone; happy to open a separate PR if you want it dropped.