### PR TITLE
fix: keep workspace settings on the active tab after saving

### DIFF
--- a/app/Livewire/App/Teams/AddTeamMember.php
+++ b/app/Livewire/App/Teams/AddTeamMember.php
@@ -9,7 +9,6 @@ use App\Livewire\BaseLivewireComponent;
 use App\Models\Team;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use Filament\Actions\Action;
-use Filament\Facades\Filament;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\TextEntry;
@@ -109,7 +108,9 @@ final class AddTeamMember extends BaseLivewireComponent
 
         $this->sendNotification(__('teams.notifications.team_invitation_sent.success'));
 
-        $this->redirect(Filament::getTenantProfileUrl());
+        $this->form->fill($this->team->only(['name']));
+
+        $this->dispatch('teamInvitationSent');
     }
 
     public function render(): View

--- a/app/Livewire/App/Teams/PendingTeamInvitations.php
+++ b/app/Livewire/App/Teams/PendingTeamInvitations.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
+use Livewire\Attributes\On;
 
 final class PendingTeamInvitations extends BaseLivewireComponent implements Tables\Contracts\HasTable
 {
@@ -28,6 +29,12 @@ final class PendingTeamInvitations extends BaseLivewireComponent implements Tabl
     public function mount(Team $team): void
     {
         $this->team = $team;
+    }
+
+    #[On('teamInvitationSent')]
+    public function refreshInvitationList(): void
+    {
+        // Filament table auto-refreshes on Livewire re-render
     }
 
     public function table(Table $table): Table

--- a/app/Livewire/App/Teams/UpdateTeamName.php
+++ b/app/Livewire/App/Teams/UpdateTeamName.php
@@ -94,13 +94,11 @@ final class UpdateTeamName extends BaseLivewireComponent
 
         resolve(UpdateTeamNameAction::class)->update($this->authUser(), $team, $data);
 
+        $this->sendNotification();
+
         if ($team->slug !== $oldSlug) {
             $this->redirect(EditTeam::getUrl(tenant: $team));
-
-            return;
         }
-
-        $this->sendNotification();
     }
 
     public function render(): View

--- a/tests/Feature/Teams/TeamSettingsInvitationFlowTest.php
+++ b/tests/Feature/Teams/TeamSettingsInvitationFlowTest.php
@@ -75,6 +75,27 @@ test('admin invites by email and the invitation appears in the pending list', fu
     Mail::assertSent(TeamInvitationMail::class);
 });
 
+test('inviting keeps the admin on the members tab and refreshes the pending list', function () {
+    Mail::fake();
+
+    livewire(AddTeamMember::class, ['team' => $this->team])
+        ->fillForm([
+            'email' => 'invitee@example.com',
+            'role' => 'editor',
+        ])
+        ->call('addTeamMember', $this->team)
+        ->assertNoRedirect()
+        ->assertDispatched('teamInvitationSent')
+        ->assertSchemaStateSet([
+            'email' => null,
+            'role' => null,
+        ]);
+
+    livewire(PendingTeamInvitations::class, ['team' => $this->team])
+        ->dispatch('teamInvitationSent')
+        ->assertCanSeeTableRecords($this->team->fresh()->teamInvitations);
+});
+
 test('admin can resend a pending invitation', function () {
     Mail::fake();
 

--- a/tests/Feature/Teams/UpdateTeamNameTest.php
+++ b/tests/Feature/Teams/UpdateTeamNameTest.php
@@ -82,13 +82,14 @@ test('team can keep its own slug on update', function () {
         ->assertNotified();
 });
 
-test('slug change triggers redirect', function () {
+test('slug change triggers redirect and still notifies', function () {
     $this->actingAs($user = User::factory()->withTeam()->create());
 
     Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
         ->fillForm(['name' => 'New Name', 'slug' => 'completely-new-slug'])
         ->call('updateTeamName', $user->currentTeam)
         ->assertHasNoFormErrors()
+        ->assertNotified()
         ->assertRedirect();
 });
 


### PR DESCRIPTION
Inviting a member from **Workspace Settings → Members** redirected to `Filament::getTenantProfileUrl()` — which *is* the General tab — so the admin was thrown off Members on every invite. The redirect dates back to when the invite form lived on the General page and was a same-page refresh; splitting settings into tabs turned it into a bug. It now resets the form and dispatches `teamInvitationSent`, which the pending invitations table listens for, mirroring the existing `CreateAccessToken` → `ManageAccessTokens` pattern.

A sweep of every redirect in `app/Livewire` and `app/Filament` found one adjacent defect on the General tab: renaming the workspace slug saved correctly but showed no "Saved" toast, because the early `return` before `sendNotification()` meant no notification was ever queued for the redirect to carry over. Reordering the two fixes it — Filament notifications are session-flashed, so they survive the reload.

**Verification:** both fixes reproduced in the browser first and re-verified after (Members now stays put and the new invite appears live; the slug rename now shows its toast). Each new assertion was confirmed load-bearing by reverting its production change and watching it fail. Full suite green: 2837 passed / 2 skipped, with Pint, Rector, PHPStan and 100% type coverage clean.