### PR TITLE
chore: upgrade to php 8.5 and refresh dependencies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 Multi-tenant SaaS CRM with paying customers. Tenant isolation is the highest-priority concern — a single cross-tenant data leak is a critical security incident. The app uses Filament panels with a per-request `TeamScope` global scope applied via middleware, not in model boot. `Model::unguard()` is enabled globally.
 
-Stack: PHP 8.4, Laravel 13, Filament 5, Livewire 4, Pest 4, Tailwind CSS 4.
+Stack: PHP 8.5, Laravel 13, Filament 5, Livewire 4, Pest 4, Tailwind CSS 4.
 
 CI enforces: PHPStan level 7, Pint formatting, Rector, 99.9% type coverage, full test suite. CI does **not** enforce: code coverage percentage, mutation testing, or required reviewer count.
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,14 +22,14 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.5-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: json, dom, curl, libxml, mbstring, zip, intl
           tools: composer:v2
 
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4]
+        php: [8.5]
         shard: [1, 2, 3, 4, 5]
 
     name: Tests (Shard ${{ matrix.shard }}/5)
@@ -93,9 +93,9 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.5-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -179,14 +179,14 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.5-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: json, dom, curl, libxml, mbstring, zip, intl
           tools: composer:v2
           coverage: none

--- a/.github/workflows/filament-view-monitor-simple.yml
+++ b/.github/workflows/filament-view-monitor-simple.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -17,14 +17,14 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.5-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: json, dom, curl, libxml, mbstring, zip, intl
           tools: composer:v2
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,14 +23,14 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.5-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: json, dom, curl, libxml, mbstring, zip, intl
           tools: composer:v2
 
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4]
+        php: [8.5]
         shard: [1, 2, 3, 4, 5]
 
     name: Tests (Shard ${{ matrix.shard }}/5)
@@ -121,9 +121,9 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.5-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -190,14 +190,14 @@ jobs:
           path: |
             ~/.composer/cache
             vendor
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.5-composer-
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: 8.5
           extensions: json, dom, curl, libxml, mbstring, zip, intl
           tools: composer:v2
           coverage: none

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,7 +326,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 
 ## Foundational Context
 
-This application is a Laravel application running on PHP 8.4. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
+This application is a Laravel application running on PHP 8.5. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
 
 Before relying on a package's API, confirm its installed version:
 - PHP packages: run `composer show --direct` to list direct dependencies with versions, or `composer show <vendor/package>` for a single package.
@@ -377,7 +377,7 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 ## Searching Documentation (IMPORTANT)
 
-- Always use `search-docs` before making code changes. Do not skip this step. It returns version-specific docs based on installed packages automatically.
+- Use `search-docs` before changes that depend on Laravel ecosystem APIs, behavior, configuration, or version-specific syntax. Skip it for copy-only edits and other changes where package documentation is irrelevant. Reuse sufficient results already in context instead of searching again.
 - Pass a `packages` array to scope results when you know which packages are relevant.
 - Use multiple broad, topic-based queries: `['rate limiting', 'routing rate limiting', 'routing']`. Expect the most relevant results first.
 - Do not add package names to queries because package info is already shared. Use `test resource table`, not `filament 4 test resource table`.
@@ -742,6 +742,6 @@ livewire(ListUsers::class)
 - Always activate the `spatie-laravel-php` skill when writing, editing, reviewing, or formatting Laravel or PHP code.
 - Always activate the `spatie-javascript` skill when writing, editing, reviewing, or formatting JavaScript or TypeScript code.
 - Always activate the `spatie-version-control` skill when creating commits, branches, or managing Git operations.
-- Always activate the `spatie-security` skill when configuring security, reviewing authentication, or setting up servers and databases.
+- Always activate the `spatie-security` skill when configuring security, signing commits, reviewing authentication, or setting up servers and databases.
 
 </laravel-boost-guidelines>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 
 ## Foundational Context
 
-This application is a Laravel application running on PHP 8.4. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
+This application is a Laravel application running on PHP 8.5. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
 
 Before relying on a package's API, confirm its installed version:
 - PHP packages: run `composer show --direct` to list direct dependencies with versions, or `composer show <vendor/package>` for a single package.
@@ -377,7 +377,7 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 ## Searching Documentation (IMPORTANT)
 
-- Always use `search-docs` before making code changes. Do not skip this step. It returns version-specific docs based on installed packages automatically.
+- Use `search-docs` before changes that depend on Laravel ecosystem APIs, behavior, configuration, or version-specific syntax. Skip it for copy-only edits and other changes where package documentation is irrelevant. Reuse sufficient results already in context instead of searching again.
 - Pass a `packages` array to scope results when you know which packages are relevant.
 - Use multiple broad, topic-based queries: `['rate limiting', 'routing rate limiting', 'routing']`. Expect the most relevant results first.
 - Do not add package names to queries because package info is already shared. Use `test resource table`, not `filament 4 test resource table`.
@@ -742,6 +742,6 @@ livewire(ListUsers::class)
 - Always activate the `spatie-laravel-php` skill when writing, editing, reviewing, or formatting Laravel or PHP code.
 - Always activate the `spatie-javascript` skill when writing, editing, reviewing, or formatting JavaScript or TypeScript code.
 - Always activate the `spatie-version-control` skill when creating commits, branches, or managing Git operations.
-- Always activate the `spatie-security` skill when configuring security, reviewing authentication, or setting up servers and databases.
+- Always activate the `spatie-security` skill when configuring security, signing commits, reviewing authentication, or setting up servers and databases.
 
 </laravel-boost-guidelines>

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN npm run build
 ###########################################
 # Stage 3: Production image
 ###########################################
-FROM serversideup/php:8.4-fpm-nginx AS production
+FROM serversideup/php:8.5-fpm-nginx AS production
 
 LABEL org.opencontainers.image.title="Relaticle CRM"
 LABEL org.opencontainers.image.description="Modern, open-source CRM platform"

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -326,7 +326,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 
 ## Foundational Context
 
-This application is a Laravel application running on PHP 8.4. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
+This application is a Laravel application running on PHP 8.5. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
 
 Before relying on a package's API, confirm its installed version:
 - PHP packages: run `composer show --direct` to list direct dependencies with versions, or `composer show <vendor/package>` for a single package.
@@ -377,7 +377,7 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 ## Searching Documentation (IMPORTANT)
 
-- Always use `search-docs` before making code changes. Do not skip this step. It returns version-specific docs based on installed packages automatically.
+- Use `search-docs` before changes that depend on Laravel ecosystem APIs, behavior, configuration, or version-specific syntax. Skip it for copy-only edits and other changes where package documentation is irrelevant. Reuse sufficient results already in context instead of searching again.
 - Pass a `packages` array to scope results when you know which packages are relevant.
 - Use multiple broad, topic-based queries: `['rate limiting', 'routing rate limiting', 'routing']`. Expect the most relevant results first.
 - Do not add package names to queries because package info is already shared. Use `test resource table`, not `filament 4 test resource table`.
@@ -742,6 +742,6 @@ livewire(ListUsers::class)
 - Always activate the `spatie-laravel-php` skill when writing, editing, reviewing, or formatting Laravel or PHP code.
 - Always activate the `spatie-javascript` skill when writing, editing, reviewing, or formatting JavaScript or TypeScript code.
 - Always activate the `spatie-version-control` skill when creating commits, branches, or managing Git operations.
-- Always activate the `spatie-security` skill when configuring security, reviewing authentication, or setting up servers and databases.
+- Always activate the `spatie-security` skill when configuring security, signing commits, reviewing authentication, or setting up servers and databases.
 
 </laravel-boost-guidelines>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/Relaticle/relaticle/actions"><img src="https://img.shields.io/github/actions/workflow/status/Relaticle/relaticle/deploy.yml?style=for-the-badge&label=tests" alt="Tests"></a>
   <a href="https://relaticle.com/docs/mcp"><img src="https://img.shields.io/badge/MCP_Tools-32-8A2BE2?style=for-the-badge" alt="32 MCP Tools"></a>
   <a href="https://laravel.com/docs/13.x"><img src="https://img.shields.io/badge/Laravel-13.x-FF2D20?style=for-the-badge&logo=laravel" alt="Laravel 13"></a>
-  <a href="https://php.net"><img src="https://img.shields.io/badge/PHP-8.4-777BB4?style=for-the-badge&logo=php" alt="PHP 8.4"></a>
+  <a href="https://php.net"><img src="https://img.shields.io/badge/PHP-8.5-777BB4?style=for-the-badge&logo=php" alt="PHP 8.5"></a>
   <a href="https://github.com/Relaticle/relaticle/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg?style=for-the-badge" alt="License"></a>
 </p>
 
@@ -41,12 +41,12 @@ Relaticle is a self-hosted CRM with a production-grade MCP server. Connect any A
 - **Agent-Native Infrastructure** - MCP server with 32 tools, REST API with full CRUD, schema discovery for AI agents
 - **Customizable Data Model** - 22 field types including entity relationships, conditional visibility, and per-field encryption. No migrations needed.
 - **Multi-Team Isolation** - 5-layer authorization with team-scoped data and workspaces
-- **Modern Tech Stack** - Laravel 13, Filament 5, PHP 8.4, 2,000+ automated tests
+- **Modern Tech Stack** - Laravel 13, Filament 5, PHP 8.5, 2,000+ automated tests
 - **Privacy-First** - Self-hosted, AGPL-3.0, your data stays on your server
 
 # Requirements
 
-- PHP 8.4+
+- PHP 8.5+
 - PostgreSQL 17+
 - Composer 2 and Node.js 20+
 - Redis for queues (optional for development)

--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -167,7 +167,7 @@ final class InstallCommand extends Command
     private function checkSystemRequirements(): bool
     {
         $requirements = [
-            'PHP 8.4+' => version_compare(PHP_VERSION, '8.3.0', '>='),
+            'PHP 8.5+' => version_compare(PHP_VERSION, '8.5.0', '>='),
             'Composer' => $this->commandExists('composer'),
             'Node.js' => $this->commandExists('node'),
             'NPM' => $this->commandExists('npm'),

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,11 +1,11 @@
 services:
     laravel.test:
         build:
-            context: ./vendor/laravel/sail/runtimes/8.4
+            context: ./vendor/laravel/sail/runtimes/8.5
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'
-        image: sail-8.4/app
+        image: sail-8.5/app
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         ports:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "license": "AGPL-3.0",
     "require": {
-        "php": "^8.4",
+        "php": "^8.5",
         "ext-intl": "*",
         "andreiio/blade-remix-icon": "^3.9",
         "ashallendesign/favicon-fetcher": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b48b77ef7280b5c8a7f687be55df560",
+    "content-hash": "bd128d63100bb55c510164702d4cb176",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -3140,26 +3140,26 @@
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.10",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "f6c24c21f42b990e9a58912b332d0874df6ba839"
+                "reference": "516c3bf2af176c532d5b59b3430292f7e9ecccb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/f6c24c21f42b990e9a58912b332d0874df6ba839",
-                "reference": "f6c24c21f42b990e9a58912b332d0874df6ba839",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/516c3bf2af176c532d5b59b3430292f7e9ecccb1",
+                "reference": "516c3bf2af176c532d5b59b3430292f7e9ecccb1",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "symfony/polyfill-php80": "^1.25"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
-                "uri-template/tests": "1.0.0"
+                "phpunit/phpunit": "^9.6.34",
+                "uri-template/tests": "1.0.2"
             },
             "type": "library",
             "extra": {
@@ -3206,7 +3206,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.10"
+                "source": "https://github.com/guzzle/uri-template/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -3222,7 +3222,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-17T13:53:03+00:00"
+            "time": "2026-07-20T13:40:43+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -3670,16 +3670,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.25.0",
+            "version": "v13.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "ed36fe882bd4eed4e6ff75343cbad8dbda03fdba"
+                "reference": "17f6e626e014dd9b4a380ae2924b590a129a5307"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/ed36fe882bd4eed4e6ff75343cbad8dbda03fdba",
-                "reference": "ed36fe882bd4eed4e6ff75343cbad8dbda03fdba",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/17f6e626e014dd9b4a380ae2924b590a129a5307",
+                "reference": "17f6e626e014dd9b4a380ae2924b590a129a5307",
                 "shasum": ""
             },
             "require": {
@@ -3696,9 +3696,10 @@
                 "ext-session": "*",
                 "ext-tokenizer": "*",
                 "fruitcake/php-cors": "^1.3",
-                "guzzlehttp/guzzle": "^7.8.2",
-                "guzzlehttp/promises": "^2.0.3",
-                "guzzlehttp/uri-template": "^1.0",
+                "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+                "guzzlehttp/promises": "^2.0.3 || ^3.0",
+                "guzzlehttp/psr7": "^2.9 || ^3.0",
+                "guzzlehttp/uri-template": "^1.0 || ^2.0",
                 "laravel/prompts": "^0.3.11",
                 "laravel/serializable-closure": "^2.0.10",
                 "league/commonmark": "^2.8.1",
@@ -3710,6 +3711,7 @@
                 "nunomaduro/termwind": "^2.0",
                 "php": "^8.3",
                 "psr/container": "^1.1.1 || ^2.0.1",
+                "psr/http-message": "^1.0 || ^2.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
                 "ramsey/uuid": "^4.7",
@@ -3784,7 +3786,6 @@
                 "aws/aws-sdk-php": "^3.322.9",
                 "ext-gmp": "*",
                 "fakerphp/faker": "^1.24",
-                "guzzlehttp/psr7": "^2.9",
                 "intervention/image": "^4.0",
                 "laravel/pint": "^1.18",
                 "league/flysystem-aws-s3-v3": "^3.25.1",
@@ -3834,7 +3835,6 @@
                 "php-http/discovery": "Required to use PSR-7 bridging features (^1.15).",
                 "phpunit/phpunit": "Required to use assertions and run tests (^11.5.50 || ^12.5.8 || ^13.0.3).",
                 "predis/predis": "Required to use the predis connector (^2.3 || ^3.0).",
-                "psr/http-message": "Required to allow Storage::put to accept a StreamInterface (^1.0).",
                 "pusher/pusher-php-server": "Required to use the Pusher broadcast driver (^6.0 || ^7.0).",
                 "resend/resend-php": "Required to enable support for the Resend mail transport (^0.10.0 || ^1.0).",
                 "spatie/fork": "Required to use the 'fork' concurrency driver (^1.2).",
@@ -3893,7 +3893,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-08-11T13:56:22+00:00"
+            "time": "2026-08-18T12:30:10+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -4337,16 +4337,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.22",
+            "version": "v0.3.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4"
+                "reference": "b7b4c35e5bc47450f6b6238c6cc9c47ba19b2221"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/02b89b39e8972a998db4d5d4ad4719239dd4aee4",
-                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/b7b4c35e5bc47450f6b6238c6cc9c47ba19b2221",
+                "reference": "b7b4c35e5bc47450f6b6238c6cc9c47ba19b2221",
                 "shasum": ""
             },
             "require": {
@@ -4390,9 +4390,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.22"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.23"
             },
-            "time": "2026-08-04T14:50:50+00:00"
+            "time": "2026-08-11T18:58:24+00:00"
         },
         {
             "name": "laravel/reverb",
@@ -4655,16 +4655,16 @@
         },
         {
             "name": "laravel/socialite",
-            "version": "v5.29.0",
+            "version": "v5.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "cd343a5841f02292af119ee607edc71300c9ae4f"
+                "reference": "caf714f55d51ab0d914b40033d8b0f489d6219cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/cd343a5841f02292af119ee607edc71300c9ae4f",
-                "reference": "cd343a5841f02292af119ee607edc71300c9ae4f",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/caf714f55d51ab0d914b40033d8b0f489d6219cc",
+                "reference": "caf714f55d51ab0d914b40033d8b0f489d6219cc",
                 "shasum": ""
             },
             "require": {
@@ -4723,7 +4723,7 @@
                 "issues": "https://github.com/laravel/socialite/issues",
                 "source": "https://github.com/laravel/socialite"
             },
-            "time": "2026-07-01T13:50:23+00:00"
+            "time": "2026-08-13T23:01:33+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -5924,16 +5924,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.4.0",
+            "version": "v4.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "514b29d5a23594d4e4846494f580268b20c2f11e"
+                "reference": "0c925c55b4a5c134f2fb147efa4b9f53a837d866"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/514b29d5a23594d4e4846494f580268b20c2f11e",
-                "reference": "514b29d5a23594d4e4846494f580268b20c2f11e",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/0c925c55b4a5c134f2fb147efa4b9f53a837d866",
+                "reference": "0c925c55b4a5c134f2fb147efa4b9f53a837d866",
                 "shasum": ""
             },
             "require": {
@@ -5988,7 +5988,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.4.0"
+                "source": "https://github.com/livewire/livewire/tree/v4.4.1"
             },
             "funding": [
                 {
@@ -5996,7 +5996,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-10T15:24:22+00:00"
+            "time": "2026-08-18T11:39:06+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -21191,16 +21191,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.66.0",
+            "version": "v1.67.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "ebf286104306c50c8fd060cbc57de35b9dffa779"
+                "reference": "639e03ac12cf23def171770bcab05758045b2642"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/ebf286104306c50c8fd060cbc57de35b9dffa779",
-                "reference": "ebf286104306c50c8fd060cbc57de35b9dffa779",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/639e03ac12cf23def171770bcab05758045b2642",
+                "reference": "639e03ac12cf23def171770bcab05758045b2642",
                 "shasum": ""
             },
             "require": {
@@ -21250,7 +21250,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-08-10T13:09:27+00:00"
+            "time": "2026-08-12T13:55:56+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -24305,7 +24305,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.4",
+        "php": "^8.5",
         "ext-intl": "*"
     },
     "platform-dev": {},

--- a/config/database.php
+++ b/config/database.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Str;
+use Pdo\Mysql;
 
 return [
 
@@ -60,7 +61,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -80,7 +81,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/packages/Chat/src/Services/FollowUpService.php
+++ b/packages/Chat/src/Services/FollowUpService.php
@@ -28,7 +28,7 @@ final readonly class FollowUpService
             }
         }
 
-        $last = $toolCalls[array_key_last($toolCalls)];
+        $last = array_last($toolCalls);
         $name = $this->normalizeToolName($last['name']);
 
         $chips = match ($name) {

--- a/packages/Chat/src/Services/PendingActionService.php
+++ b/packages/Chat/src/Services/PendingActionService.php
@@ -697,7 +697,7 @@ final readonly class PendingActionService
             $existingLower = $this->proposedTitles($existing->action_data);
             $overlap = array_intersect($incomingLower, $existingLower);
             if ($overlap !== []) {
-                $matchedLower = array_values($overlap)[0];
+                $matchedLower = array_first($overlap);
                 $label = $titleMap[$matchedLower];
 
                 return "Heads up: \"{$label}\" was already proposed or created a moment ago — approving this may create a duplicate.";

--- a/packages/Documentation/resources/content/docs/guides/contributing.md
+++ b/packages/Documentation/resources/content/docs/guides/contributing.md
@@ -25,7 +25,7 @@ Visit `http://localhost:8000` to access the application.
 
 | Component | Technology                            |
 |-----------|---------------------------------------|
-| Backend | PHP 8.4, Laravel 13                   |
+| Backend | PHP 8.5, Laravel 13                   |
 | Admin UI | Filament 5                            |
 | Frontend | Livewire 4, Alpine.js, Tailwind CSS 4 |
 | Database | PostgreSQL                             |
@@ -67,7 +67,7 @@ All workspace data is isolated via the `HasTeam` trait. Every query automaticall
 
 ### Requirements
 
-- **PHP 8.4+** with extensions: pdo_pgsql, gd, bcmath, mbstring, xml
+- **PHP 8.5+** with extensions: pdo_pgsql, gd, bcmath, mbstring, xml
 - **PostgreSQL 17+**
 - **Node.js 20+**
 - **Composer 2+**

--- a/packages/Documentation/resources/content/docs/guides/self-hosting.md
+++ b/packages/Documentation/resources/content/docs/guides/self-hosting.md
@@ -428,7 +428,7 @@ If you prefer not to use Docker, you can deploy Relaticle directly on a server.
 
 ### Requirements
 
-- PHP 8.4+ with extensions: pdo_pgsql, gd, bcmath, mbstring, xml, redis
+- PHP 8.5+ with extensions: pdo_pgsql, gd, bcmath, mbstring, xml, redis
 - PostgreSQL 17+
 - Redis 7+
 - Node.js 20+
@@ -496,7 +496,7 @@ server {
     }
 
     location ~ \.php$ {
-        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
+        fastcgi_pass unix:/run/php/php8.5-fpm.sock;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         include fastcgi_params;
     }

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Php85\Rector\Property\AddOverrideAttributeToOverriddenPropertiesRector;
 use Rector\Privatization\Rector\ClassMethod\PrivatizeFinalClassMethodRector;
 use RectorLaravel\Rector\Class_\AddHasFactoryToModelsRector;
 use RectorLaravel\Rector\Class_\AppendsPropertyToAppendsAttributeRector;
@@ -39,6 +40,10 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,
+        // PHP 8.5 extends #[\Override] to properties. Skipped for the same reason as
+        // the method rule above: it would tag every Filament $navigationIcon/$slug
+        // override in the codebase without adding safety we rely on.
+        AddOverrideAttributeToOverriddenPropertiesRector::class,
         // Migrating model/job properties to their PHP-attribute equivalents and
         // tightening closure typehints in Eloquent where() calls is a codebase-wide
         // refactor best handled in dedicated PRs, not bundled into dependency updates.

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -7,7 +7,7 @@
         ['What AI agents can I connect from outside?', 'Any agent that speaks MCP (Model Context Protocol). Claude, ChatGPT, Gemini, open-source models, or your own custom agents. Relaticle\'s MCP server provides 32 tools for external AI agents to read, create, update, and delete CRM data — the same toolset the built-in chat uses internally.'],
         ['What is MCP?', 'MCP (Model Context Protocol) is an open standard that lets AI agents interact with tools and data sources. Relaticle\'s MCP server gives external agents 32 tools to work with your CRM data — listing companies, creating contacts, updating opportunities, and more.'],
         ['How is Relaticle different from HubSpot or Salesforce?', 'Relaticle is self-hosted (you own your data), open-source (AGPL-3.0), ships with both a built-in AI chat and 32 MCP tools for any external agent, and has no per-seat pricing. It\'s designed for teams who want AI built in and AI integration both — without vendor lock-in.'],
-        ['How do I deploy Relaticle?', 'Deploy with Docker Compose, Laravel Forge, or any PHP 8.4+ hosting with PostgreSQL. Self-hosted means your data never leaves your server. A managed hosting option is also available at app.relaticle.com.'],
+        ['How do I deploy Relaticle?', 'Deploy with Docker Compose, Laravel Forge, or any PHP 8.5+ hosting with PostgreSQL. Self-hosted means your data never leaves your server. A managed hosting option is also available at app.relaticle.com.'],
         ['Can I customize the data model?', 'Yes. Relaticle offers 22 custom field types including text, email, phone, currency, date, select, multiselect, entity relationships, conditional visibility, and per-field encryption. No migrations or code changes needed.'],
     ];
 @endphp


### PR DESCRIPTION
Moves the platform floor to PHP 8.5 across composer, the 4 CI workflows, the Docker image (`serversideup/php:8.5-fpm-nginx`), the Sail runtime, and the docs. The one real breakage was `config/database.php` using `PDO::MYSQL_ATTR_SSL_CA`, deprecated in 8.5: the notice printed to stdout on every boot, which corrupted `artisan route:list --json` and killed the Smoke suite's dataset resolution with `Pest\Exceptions\DatasetMissing`, so it is now `Pdo\Mysql::ATTR_SSL_CA`. Rector's 8.5 set ran automatically off the new constraint and produced two rewrites (`array_first()`/`array_last()`); its `AddOverrideAttributeToOverriddenPropertiesRector` is skipped in `rector.php` for the same reason the existing method-level `#[\Override]` rule is skipped, since it would tag 166 files. Dependency refresh: `laravel/framework` 13.26.0, `socialite` 5.30.0, `livewire` 4.4.1, `prompts` 0.3.23, `sail` 1.67.0, `guzzlehttp/uri-template` 2.0.0, and npm had nothing pending. Also corrects `InstallCommand`, which advertised "PHP 8.4+" while comparing against `8.3.0`.

## Before releasing

`vendor/composer/platform_check.php` now hard-requires `PHP_VERSION_ID >= 80500`, and `deploy.yml` fires the Forge webhook on release publish. **Switch the Forge server to PHP 8.5 first** (site PHP version, php-fpm, Horizon daemon, Reverb daemon, scheduler cron), otherwise the deploy fails at `composer install`. Merging this PR is safe; cutting a release before that step is not.

## Test plan

All run locally against PHP 8.5.8:

| Check | Result |
|---|---|
| `pint` | clean |
| `rector --dry-run` | 0 changed, 0 errors |
| `phpstan analyse` (level 7) | 0 errors |
| `pest --type-coverage --min=100` | 100.0% |
| `pest --parallel --exclude-testsuite=Browser` | 2846 tests, 2844 passed, 2 skipped, 1 risky |
| `pest tests/Browser/` | 35 tests, 34 passed, 1 skipped |

Deprecation notices emitted across the suite: 2 before, 0 after. `artisan route:list --json` parses cleanly again and returns 200 routes.

The Docker image build is not verified locally (no Docker on this machine); `docker-publish.yml` builds it on this PR, and the thing to watch is `install-php-extensions imagick` on 8.5.