### PR TITLE
chore: bump custom-fields to v3.7.0 for the record filter fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ralphjsmit/laravel-filament-seo": "^2.2",
         "ralphjsmit/laravel-seo": "^1.8",
         "relaticle/activity-log": "^1.2",
-        "relaticle/custom-fields": "^3.6.2",
+        "relaticle/custom-fields": "^3.7.0",
         "relaticle/flowforge": "^4.0",
         "relaticle/ink": "^2.3",
         "ryangjchandler/laravel-cloudflare-turnstile": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd128d63100bb55c510164702d4cb176",
+    "content-hash": "b5c476529e650d472d9b27f3a3c7e39b",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -10141,16 +10141,16 @@
         },
         {
             "name": "relaticle/custom-fields",
-            "version": "v3.6.3",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/relaticle/custom-fields.git",
-                "reference": "a7f58559ea9a81b95199450befe1b6c93a32ba64"
+                "reference": "a33e3a3801c64d11d2ca122d367bdf9dcdd60f94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/relaticle/custom-fields/zipball/a7f58559ea9a81b95199450befe1b6c93a32ba64",
-                "reference": "a7f58559ea9a81b95199450befe1b6c93a32ba64",
+                "url": "https://api.github.com/repos/relaticle/custom-fields/zipball/a33e3a3801c64d11d2ca122d367bdf9dcdd60f94",
+                "reference": "a33e3a3801c64d11d2ca122d367bdf9dcdd60f94",
                 "shasum": ""
             },
             "require": {
@@ -10236,7 +10236,7 @@
                 "issues": "https://github.com/relaticle/custom-fields/issues",
                 "source": "https://github.com/relaticle/custom-fields"
             },
-            "time": "2026-08-13T14:04:29+00:00"
+            "time": "2026-08-18T17:20:25+00:00"
         },
         {
             "name": "relaticle/flowforge",


### PR DESCRIPTION
Picks up [relaticle/custom-fields#202](https://github.com/relaticle/custom-fields/pull/202), released as v3.7.0.

## What was broken

Filtering the People (or any) table by a **single-value** Record custom field returned no rows, even with matching records. Multi-value Record fields filtered fine.

Found while answering [Discussion #469](https://github.com/orgs/relaticle/discussions/469), which asks whether custom fields can model people-to-people relationships. They can, via the Record field type, but the filter was broken.

`RecordFilter` branched on `allow_multiple` and queried `string_value` for single-value fields. Record fields always persist to `json_value` because `RecordFieldType` is a `multiChoice` schema, so that column is always NULL:

```
reports_to      string_value=NULL  json_value='["01m0aez6vjvbwnq6j46f2x53pn"]'
direct_reports  string_value=NULL  json_value='["01m0aez6v9ax794ngeenxen1mk", ...]'
```

The release also fixes filter option labels rendering as escaped HTML (`<div class="flex items-center gap-2"><img src="data:image/svg+xml;base64…`) instead of an avatar and name.

## Test plan

Browser-verified on `app.relaticle.test` with a `Reports To` Record field on People:

- Before: filter `Reports To = Tim Cook` → "No people", though Dylan Field reports to him
- After: same filter → 1 row, Dylan Field, with "Tim Cook" in the REPORTS TO column
- Dropdown label renders as the avatar + "Tim Cook", not raw markup

Upstream has a dataset-driven regression test covering both cardinalities; reverting the source change makes the single-value case fail and the multi-value case pass.

Local gate on this branch:

- `pest --parallel --exclude-testsuite=Browser` — 2844 passed, 0 failed
- `phpstan analyse` — 0 errors
- `pint --dirty` — passed
- `rector --dry-run` — 0 changes
- type coverage — 100.0%

Note for reviewers: the MCP OAuth tests fail in a fresh workspace until `php artisan passport:keys` is run (the keys are gitignored). Unrelated to this bump — verified identical failures on v3.6.3 before updating.