### PR TITLE
feat(sysadmin): link every relation to its record

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -26,7 +26,9 @@ use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamDeleted;
 use Laravel\Jetstream\Events\TeamUpdated;
 use Laravel\Jetstream\Team as JetstreamTeam;
+use Relaticle\Chat\Models\AgentConversation;
 use Relaticle\Chat\Models\AiCreditBalance;
+use Relaticle\ImportWizard\Models\Import;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -299,5 +301,21 @@ final class Team extends JetstreamTeam implements HasAvatar
     public function aiCreditBalance(): HasOne
     {
         return $this->hasOne(AiCreditBalance::class);
+    }
+
+    /**
+     * @return HasMany<AgentConversation, $this>
+     */
+    public function conversations(): HasMany
+    {
+        return $this->hasMany(AgentConversation::class);
+    }
+
+    /**
+     * @return HasMany<Import, $this>
+     */
+    public function imports(): HasMany
+    {
+        return $this->hasMany(Import::class);
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -22,6 +22,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Override;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActivities;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ViewActivity;
+use Relaticle\SystemAdmin\Filament\Resources\SystemAdministrators\SystemAdministratorResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class ActivityResource extends Resource
 {
@@ -62,6 +64,33 @@ final class ActivityResource extends Resource
         return false;
     }
 
+    /**
+     * @return array<string, class-string> Morph alias => Filament resource class
+     */
+    public static function causerResources(): array
+    {
+        return [
+            'user' => UserResource::class,
+            'system_administrator' => SystemAdministratorResource::class,
+        ];
+    }
+
+    /**
+     * @return array<string, class-string> Morph alias => Filament resource class
+     */
+    public static function subjectResources(): array
+    {
+        return [
+            'company' => CompanyResource::class,
+            'people' => PeopleResource::class,
+            'opportunity' => OpportunityResource::class,
+            'task' => TaskResource::class,
+            'note' => NoteResource::class,
+            'team' => TeamResource::class,
+            'user' => UserResource::class,
+        ];
+    }
+
     #[Override]
     public static function table(Table $table): Table
     {
@@ -75,15 +104,20 @@ final class ActivityResource extends Resource
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->placeholder('—')
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('causer.name')
                     ->label('User')
-                    ->placeholder('System'),
+                    ->placeholder('System')
+                    ->color('primary')
+                    ->url(RecordLink::toMorph(self::causerResources(), 'causer_type', 'causer_id')),
                 TextColumn::make('subject_type')
                     ->label('Subject')
                     ->badge()
                     ->color('gray')
-                    ->formatStateUsing(fn (?string $state): string => $state === null ? '—' : ucfirst($state)),
+                    ->formatStateUsing(fn (?string $state): string => $state === null ? '—' : ucfirst($state))
+                    ->url(RecordLink::toMorph(self::subjectResources(), 'subject_type', 'subject_id')),
                 TextColumn::make('event')
                     ->badge()
                     ->color(fn (?string $state): string => match ($state) {
@@ -159,13 +193,23 @@ final class ActivityResource extends Resource
                             'deleted' => 'danger',
                             default => 'gray',
                         }),
-                    TextEntry::make('team.name')->label('Team')->placeholder('—'),
-                    TextEntry::make('causer.name')->label('User')->placeholder('System'),
+                    TextEntry::make('team.name')
+                        ->label('Team')
+                        ->placeholder('—')
+                        ->color('primary')
+                        ->url(RecordLink::to(TeamResource::class, 'team')),
+                    TextEntry::make('causer.name')
+                        ->label('User')
+                        ->placeholder('System')
+                        ->color('primary')
+                        ->url(RecordLink::toMorph(self::causerResources(), 'causer_type', 'causer_id')),
                     TextEntry::make('subject_type')
                         ->label('Subject')
                         ->formatStateUsing(fn (?string $state, Activity $record): string => $state === null
                             ? '—'
-                            : ucfirst($state).' #'.$record->subject_id),
+                            : ucfirst($state).' #'.$record->subject_id)
+                        ->color('primary')
+                        ->url(RecordLink::toMorph(self::subjectResources(), 'subject_type', 'subject_id')),
                     TextEntry::make('description')->columnSpanFull(),
                 ])->columns(2)->columnSpanFull(),
                 Section::make('Changes')

--- a/packages/SystemAdmin/src/Filament/Resources/AgentConversationMessageResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AgentConversationMessageResource.php
@@ -19,6 +19,7 @@ use Override;
 use Relaticle\Chat\Models\AgentConversationMessage;
 use Relaticle\SystemAdmin\Filament\Resources\AgentConversationMessageResource\Pages\ListAgentConversationMessages;
 use Relaticle\SystemAdmin\Filament\Resources\AgentConversationMessageResource\Pages\ViewAgentConversationMessage;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 use UnitEnum;
 
 final class AgentConversationMessageResource extends Resource
@@ -50,9 +51,17 @@ final class AgentConversationMessageResource extends Resource
                 Section::make([
                     TextEntry::make('role')->badge()->color(fn (string $state): string => self::ROLE_COLORS[$state] ?? 'info'),
                     TextEntry::make('agent')->placeholder('—'),
-                    TextEntry::make('user.name')->label('User')->placeholder('—'),
+                    TextEntry::make('user.name')
+                        ->label('User')
+                        ->placeholder('—')
+                        ->color('primary')
+                        ->url(RecordLink::to(UserResource::class, 'user')),
                     TextEntry::make('superseded_at')->dateTime()->placeholder('Live'),
-                    TextEntry::make('conversation_id')->label('Conversation')->copyable(),
+                    TextEntry::make('conversation_id')
+                        ->label('Conversation')
+                        ->copyable()
+                        ->color('primary')
+                        ->url(RecordLink::to(AgentConversationResource::class, 'conversation')),
                     TextEntry::make('created_at')->dateTime(),
                     TextEntry::make('content')->placeholder('—')->columnSpanFull(),
                 ])->columnSpanFull()->columns(2),
@@ -83,7 +92,9 @@ final class AgentConversationMessageResource extends Resource
                     ->label('Conversation')
                     ->limit(8)
                     ->tooltip(fn (?string $state): ?string => $state)
-                    ->toggleable(isToggledHiddenByDefault: true),
+                    ->toggleable(isToggledHiddenByDefault: true)
+                    ->color('primary')
+                    ->url(RecordLink::to(AgentConversationResource::class, 'conversation')),
             ])
             ->filters([
                 SelectFilter::make('role')

--- a/packages/SystemAdmin/src/Filament/Resources/AgentConversationResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AgentConversationResource.php
@@ -17,6 +17,8 @@ use Override;
 use Relaticle\Chat\Models\AgentConversation;
 use Relaticle\SystemAdmin\Filament\Resources\AgentConversationResource\Pages\ListAgentConversations;
 use Relaticle\SystemAdmin\Filament\Resources\AgentConversationResource\Pages\ViewAgentConversation;
+use Relaticle\SystemAdmin\Filament\Resources\AgentConversationResource\RelationManagers\MessagesRelationManager;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 use UnitEnum;
 
 final class AgentConversationResource extends Resource
@@ -42,8 +44,16 @@ final class AgentConversationResource extends Resource
             ->components([
                 Section::make([
                     TextEntry::make('title'),
-                    TextEntry::make('team.name')->label('Team')->placeholder('—'),
-                    TextEntry::make('user.name')->label('User')->placeholder('—'),
+                    TextEntry::make('team.name')
+                        ->label('Team')
+                        ->placeholder('—')
+                        ->color('primary')
+                        ->url(RecordLink::to(TeamResource::class, 'team')),
+                    TextEntry::make('user.name')
+                        ->label('User')
+                        ->placeholder('—')
+                        ->color('primary')
+                        ->url(RecordLink::to(UserResource::class, 'user')),
                     TextEntry::make('messages_count')->label('Messages')->state(fn (AgentConversation $record): int => $record->messages()->count()),
                     TextEntry::make('id')->label('Conversation ID')->copyable(),
                     TextEntry::make('created_at')->dateTime(),
@@ -67,12 +77,16 @@ final class AgentConversationResource extends Resource
                     ->label('Team')
                     ->placeholder('—')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('user.name')
                     ->label('User')
                     ->placeholder('—')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'user')),
                 TextColumn::make('messages_count')
                     ->label('Messages')
                     ->counts('messages')
@@ -86,6 +100,14 @@ final class AgentConversationResource extends Resource
             ->recordActions([
                 ViewAction::make(),
             ]);
+    }
+
+    #[Override]
+    public static function getRelations(): array
+    {
+        return [
+            MessagesRelationManager::class,
+        ];
     }
 
     #[Override]

--- a/packages/SystemAdmin/src/Filament/Resources/AgentConversationResource/RelationManagers/MessagesRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AgentConversationResource/RelationManagers/MessagesRelationManager.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources\AgentConversationResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Relaticle\Chat\Models\AgentConversationMessage;
+use Relaticle\SystemAdmin\Filament\Resources\AgentConversationMessageResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+
+final class MessagesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'messages';
+
+    protected static string|\BackedEnum|null $icon = 'heroicon-o-chat-bubble-left-right';
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->messages()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->color('primary')
+                    ->url(fn (AgentConversationMessage $record): string => AgentConversationMessageResource::getUrl('view', ['record' => $record])),
+                TextColumn::make('role')
+                    ->badge(),
+                TextColumn::make('content')
+                    ->limit(80)
+                    ->placeholder('—')
+                    ->wrap(),
+                TextColumn::make('user.name')
+                    ->label('User')
+                    ->placeholder('—')
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'user')),
+                IconColumn::make('superseded_at')
+                    ->label('Superseded')
+                    ->boolean()
+                    ->state(fn (AgentConversationMessage $record): bool => $record->superseded_at !== null),
+            ])
+            ->defaultSort('created_at');
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
@@ -33,6 +33,7 @@ use Relaticle\Chat\Services\CreditService;
 use Relaticle\SystemAdmin\Filament\Resources\AiCreditBalanceResource\Pages\EditAiCreditBalance;
 use Relaticle\SystemAdmin\Filament\Resources\AiCreditBalanceResource\Pages\ListAiCreditBalances;
 use Relaticle\SystemAdmin\Filament\Resources\AiCreditBalanceResource\Pages\ViewAiCreditBalance;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class AiCreditBalanceResource extends Resource
 {
@@ -78,7 +79,10 @@ final class AiCreditBalanceResource extends Resource
         return $schema
             ->components([
                 Section::make([
-                    TextEntry::make('team.name')->label('Team'),
+                    TextEntry::make('team.name')
+                        ->label('Team')
+                        ->color('primary')
+                        ->url(RecordLink::to(TeamResource::class, 'team')),
                     TextEntry::make('credits_remaining')->numeric(),
                     TextEntry::make('credits_used')->numeric(),
                     TextEntry::make('purchased_credits')
@@ -101,7 +105,9 @@ final class AiCreditBalanceResource extends Resource
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('origin')
                     ->label('Origin')
                     ->state(function (AiCreditBalance $record): string {

--- a/packages/SystemAdmin/src/Filament/Resources/AiCreditTransactions/Schemas/AiCreditTransactionInfolist.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AiCreditTransactions/Schemas/AiCreditTransactionInfolist.php
@@ -8,6 +8,9 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Relaticle\Chat\Models\AiCreditTransaction;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class AiCreditTransactionInfolist
 {
@@ -20,8 +23,15 @@ final class AiCreditTransactionInfolist
                     ->schema([
                         TextEntry::make('created_at')->dateTime(),
                         TextEntry::make('type')->badge(),
-                        TextEntry::make('team.name')->label('Team'),
-                        TextEntry::make('user.name')->label('User')->placeholder('—'),
+                        TextEntry::make('team.name')
+                            ->label('Team')
+                            ->color('primary')
+                            ->url(RecordLink::to(TeamResource::class, 'team')),
+                        TextEntry::make('user.name')
+                            ->label('User')
+                            ->placeholder('—')
+                            ->color('primary')
+                            ->url(RecordLink::to(UserResource::class, 'user')),
                         TextEntry::make('model'),
                         TextEntry::make('credits_charged')->numeric(),
                         TextEntry::make('input_tokens')->numeric(),

--- a/packages/SystemAdmin/src/Filament/Resources/AiCreditTransactions/Tables/AiCreditTransactionsTable.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AiCreditTransactions/Tables/AiCreditTransactionsTable.php
@@ -13,6 +13,9 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Relaticle\Chat\Enums\AiCreditType;
 use Relaticle\Chat\Models\AiCreditTransaction;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class AiCreditTransactionsTable
 {
@@ -27,13 +30,17 @@ final class AiCreditTransactionsTable
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('user.name')
                     ->label('User')
                     ->placeholder('—')
                     ->searchable()
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'user')),
                 TextColumn::make('type')
                     ->badge(),
                 TextColumn::make('model')

--- a/packages/SystemAdmin/src/Filament/Resources/ChatMessageFeedbackResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ChatMessageFeedbackResource.php
@@ -16,6 +16,7 @@ use Override;
 use Relaticle\Chat\Models\ChatMessageFeedback;
 use Relaticle\SystemAdmin\Filament\Resources\ChatMessageFeedbackResource\Pages\ListChatMessageFeedback;
 use Relaticle\SystemAdmin\Filament\Resources\ChatMessageFeedbackResource\Pages\ViewChatMessageFeedback;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class ChatMessageFeedbackResource extends Resource
 {
@@ -39,12 +40,22 @@ final class ChatMessageFeedbackResource extends Resource
         return $schema
             ->components([
                 Section::make([
-                    TextEntry::make('team.name')->label('Team'),
-                    TextEntry::make('user.name')->label('User'),
+                    TextEntry::make('team.name')
+                        ->label('Team')
+                        ->color('primary')
+                        ->url(RecordLink::to(TeamResource::class, 'team')),
+                    TextEntry::make('user.name')
+                        ->label('User')
+                        ->color('primary')
+                        ->url(RecordLink::to(UserResource::class, 'user')),
                     TextEntry::make('rating')->badge()->color(fn (string $state): string => $state === ChatMessageFeedback::RATING_UP ? 'success' : 'danger'),
                     TextEntry::make('category')->placeholder('—'),
                     TextEntry::make('model')->placeholder('—'),
-                    TextEntry::make('conversation_id')->label('Conversation')->copyable(),
+                    TextEntry::make('conversation_id')
+                        ->label('Conversation')
+                        ->copyable()
+                        ->color('primary')
+                        ->url(RecordLink::to(AgentConversationResource::class, 'conversation')),
                     TextEntry::make('message_id')->label('Message')->copyable(),
                     TextEntry::make('comment')->placeholder('—')->columnSpanFull(),
                     TextEntry::make('created_at')->dateTime(),
@@ -64,7 +75,9 @@ final class ChatMessageFeedbackResource extends Resource
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('rating')
                     ->badge()
                     ->color(fn (string $state): string => $state === ChatMessageFeedback::RATING_UP ? 'success' : 'danger'),

--- a/packages/SystemAdmin/src/Filament/Resources/CompanyResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/CompanyResource.php
@@ -23,9 +23,15 @@ use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\Pages\CreateCompany
 use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\Pages\EditCompany;
 use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\Pages\ListCompanies;
 use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\Pages\ViewCompany;
+use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\RelationManagers\OpportunitiesRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\RelationManagers\PeopleRelationManager;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ResolvesTrashedRecords;
 
 final class CompanyResource extends Resource
 {
+    use ResolvesTrashedRecords;
+
     protected static ?string $model = Company::class;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-building-office';
@@ -80,15 +86,21 @@ final class CompanyResource extends Resource
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('accountOwner.name')
                     ->label('Account Owner')
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'accountOwner')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source')
@@ -129,7 +141,10 @@ final class CompanyResource extends Resource
     #[Override]
     public static function getRelations(): array
     {
-        return [];
+        return [
+            PeopleRelationManager::class,
+            OpportunitiesRelationManager::class,
+        ];
     }
 
     #[Override]

--- a/packages/SystemAdmin/src/Filament/Resources/CompanyResource/RelationManagers/OpportunitiesRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/CompanyResource/RelationManagers/OpportunitiesRelationManager.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
+namespace Relaticle\SystemAdmin\Filament\Resources\CompanyResource\RelationManagers;
 
 use App\Models\Opportunity;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
-use Relaticle\SystemAdmin\Filament\Resources\CompanyResource;
 use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource;
 use Relaticle\SystemAdmin\Filament\Resources\PeopleResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
@@ -38,12 +37,6 @@ final class OpportunitiesRelationManager extends RelationManager
                     ->sortable()
                     ->color('primary')
                     ->url(fn (Opportunity $record): string => OpportunityResource::getUrl('view', ['record' => $record])),
-                TextColumn::make('company.name')
-                    ->label('Company')
-                    ->searchable()
-                    ->sortable()
-                    ->color('primary')
-                    ->url(RecordLink::to(CompanyResource::class, 'company')),
                 TextColumn::make('contact.name')
                     ->label('Contact')
                     ->sortable()

--- a/packages/SystemAdmin/src/Filament/Resources/CompanyResource/RelationManagers/PeopleRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/CompanyResource/RelationManagers/PeopleRelationManager.php
@@ -2,28 +2,26 @@
 
 declare(strict_types=1);
 
-namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
+namespace Relaticle\SystemAdmin\Filament\Resources\CompanyResource\RelationManagers;
 
-use App\Models\Opportunity;
+use App\Models\People;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
-use Relaticle\SystemAdmin\Filament\Resources\CompanyResource;
-use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource;
 use Relaticle\SystemAdmin\Filament\Resources\PeopleResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
-final class OpportunitiesRelationManager extends RelationManager
+final class PeopleRelationManager extends RelationManager
 {
-    protected static string $relationship = 'opportunities';
+    protected static string $relationship = 'people';
 
-    protected static string|\BackedEnum|null $icon = 'heroicon-o-currency-dollar';
+    protected static string|\BackedEnum|null $icon = 'heroicon-o-users';
 
     public static function getBadge(Model $ownerRecord, string $pageClass): ?string
     {
-        $count = $ownerRecord->opportunities()->count();
+        $count = $ownerRecord->people()->count();
 
         return $count > 0 ? (string) $count : null;
     }
@@ -37,18 +35,7 @@ final class OpportunitiesRelationManager extends RelationManager
                     ->searchable()
                     ->sortable()
                     ->color('primary')
-                    ->url(fn (Opportunity $record): string => OpportunityResource::getUrl('view', ['record' => $record])),
-                TextColumn::make('company.name')
-                    ->label('Company')
-                    ->searchable()
-                    ->sortable()
-                    ->color('primary')
-                    ->url(RecordLink::to(CompanyResource::class, 'company')),
-                TextColumn::make('contact.name')
-                    ->label('Contact')
-                    ->sortable()
-                    ->color('primary')
-                    ->url(RecordLink::to(PeopleResource::class, 'contact')),
+                    ->url(fn (People $record): string => PeopleResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()

--- a/packages/SystemAdmin/src/Filament/Resources/ImportResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ImportResource.php
@@ -19,6 +19,7 @@ use Relaticle\ImportWizard\Models\Import;
 use Relaticle\SystemAdmin\Filament\Resources\ImportResource\Pages\ListImports;
 use Relaticle\SystemAdmin\Filament\Resources\ImportResource\Pages\ViewImport;
 use Relaticle\SystemAdmin\Filament\Resources\ImportResource\RelationManagers\FailedRowsRelationManager;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class ImportResource extends Resource
 {
@@ -56,9 +57,13 @@ final class ImportResource extends Resource
                     ->badge()
                     ->color(self::statusColor(...)),
                 TextEntry::make('team.name')
-                    ->label('Team'),
+                    ->label('Team')
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextEntry::make('user.name')
-                    ->label('User'),
+                    ->label('User')
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'user')),
                 TextEntry::make('total_rows'),
                 TextEntry::make('created_rows'),
                 TextEntry::make('updated_rows'),
@@ -90,11 +95,15 @@ final class ImportResource extends Resource
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('user.name')
                     ->label('User')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'user')),
                 TextColumn::make('total_rows')
                     ->numeric()
                     ->toggleable(),
@@ -146,7 +155,7 @@ final class ImportResource extends Resource
         ];
     }
 
-    private static function statusColor(ImportStatus $state): string
+    public static function statusColor(ImportStatus $state): string
     {
         return match ($state) {
             ImportStatus::Completed => 'success',

--- a/packages/SystemAdmin/src/Filament/Resources/NoteResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/NoteResource.php
@@ -23,9 +23,13 @@ use Relaticle\SystemAdmin\Filament\Resources\NoteResource\Pages\CreateNote;
 use Relaticle\SystemAdmin\Filament\Resources\NoteResource\Pages\EditNote;
 use Relaticle\SystemAdmin\Filament\Resources\NoteResource\Pages\ListNotes;
 use Relaticle\SystemAdmin\Filament\Resources\NoteResource\Pages\ViewNote;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ResolvesTrashedRecords;
 
 final class NoteResource extends Resource
 {
+    use ResolvesTrashedRecords;
+
     protected static ?string $model = Note::class;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
@@ -77,11 +81,15 @@ final class NoteResource extends Resource
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source')

--- a/packages/SystemAdmin/src/Filament/Resources/OpportunityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/OpportunityResource.php
@@ -23,9 +23,13 @@ use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource\Pages\CreateOpp
 use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource\Pages\EditOpportunity;
 use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource\Pages\ListOpportunities;
 use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource\Pages\ViewOpportunity;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ResolvesTrashedRecords;
 
 final class OpportunityResource extends Resource
 {
+    use ResolvesTrashedRecords;
+
     protected static ?string $model = Opportunity::class;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-currency-dollar';
@@ -83,18 +87,26 @@ final class OpportunityResource extends Resource
                 TextColumn::make('company.name')
                     ->label('Company')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(CompanyResource::class, 'company')),
                 TextColumn::make('contact.name')
                     ->label('Contact')
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(PeopleResource::class, 'contact')),
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source')

--- a/packages/SystemAdmin/src/Filament/Resources/PeopleResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/PeopleResource.php
@@ -23,9 +23,13 @@ use Relaticle\SystemAdmin\Filament\Resources\PeopleResource\Pages\CreatePeople;
 use Relaticle\SystemAdmin\Filament\Resources\PeopleResource\Pages\EditPeople;
 use Relaticle\SystemAdmin\Filament\Resources\PeopleResource\Pages\ListPeople;
 use Relaticle\SystemAdmin\Filament\Resources\PeopleResource\Pages\ViewPeople;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ResolvesTrashedRecords;
 
 final class PeopleResource extends Resource
 {
+    use ResolvesTrashedRecords;
+
     protected static ?string $model = People::class;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-users';
@@ -80,15 +84,21 @@ final class PeopleResource extends Resource
                 TextColumn::make('company.name')
                     ->label('Company')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(CompanyResource::class, 'company')),
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source')

--- a/packages/SystemAdmin/src/Filament/Resources/SubscriptionResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/SubscriptionResource.php
@@ -6,7 +6,11 @@ namespace Relaticle\SystemAdmin\Filament\Resources;
 
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\ViewAction;
+use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
@@ -14,6 +18,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Laravel\Cashier\Subscription;
 use Override;
 use Relaticle\SystemAdmin\Filament\Resources\SubscriptionResource\Pages\ListSubscriptions;
+use Relaticle\SystemAdmin\Filament\Resources\SubscriptionResource\Pages\ViewSubscription;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 use UnitEnum;
 
 final class SubscriptionResource extends Resource
@@ -32,10 +38,76 @@ final class SubscriptionResource extends Resource
 
     protected static ?string $slug = 'billing/subscriptions';
 
+    public static function getNavigationBadge(): ?string
+    {
+        $count = self::getModel()::query()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
     #[Override]
     public static function getEloquentQuery(): Builder
     {
         return parent::getEloquentQuery()->with('owner');
+    }
+
+    public static function planLabel(?string $state): string
+    {
+        return match (true) {
+            $state === config('services.stripe.prices.pro_monthly') => 'Pro · monthly',
+            $state === config('services.stripe.prices.pro_yearly') => 'Pro · yearly',
+            default => $state ?? '—',
+        };
+    }
+
+    public static function statusColor(string $state): string
+    {
+        return match ($state) {
+            'active', 'trialing' => 'success',
+            'past_due' => 'warning',
+            default => 'gray',
+        };
+    }
+
+    #[Override]
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make([
+                    TextEntry::make('owner.name')
+                        ->label('Team')
+                        ->placeholder('—')
+                        ->color('primary')
+                        ->url(RecordLink::to(TeamResource::class, 'owner')),
+                    TextEntry::make('type')
+                        ->label('Type'),
+                    TextEntry::make('stripe_price')
+                        ->label('Plan')
+                        ->formatStateUsing(self::planLabel(...)),
+                    TextEntry::make('stripe_status')
+                        ->label('Status')
+                        ->badge()
+                        ->color(self::statusColor(...)),
+                    TextEntry::make('quantity')
+                        ->numeric()
+                        ->placeholder('—'),
+                    TextEntry::make('stripe_id')
+                        ->label('Stripe ID')
+                        ->copyable(),
+                    TextEntry::make('trial_ends_at')
+                        ->label('Trial ends')
+                        ->dateTime()
+                        ->placeholder('—'),
+                    TextEntry::make('ends_at')
+                        ->label('Ends')
+                        ->dateTime()
+                        ->placeholder('—'),
+                    TextEntry::make('created_at')
+                        ->label('Started')
+                        ->dateTime(),
+                ])->columnSpanFull()->columns(2),
+            ]);
     }
 
     #[Override]
@@ -46,22 +118,16 @@ final class SubscriptionResource extends Resource
                 TextColumn::make('owner.name')
                     ->label('Team')
                     ->searchable()
-                    ->placeholder('—'),
+                    ->placeholder('—')
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'owner')),
                 TextColumn::make('stripe_price')
                     ->label('Plan')
-                    ->formatStateUsing(fn (?string $state): string => match (true) {
-                        $state === config('services.stripe.prices.pro_monthly') => 'Pro · monthly',
-                        $state === config('services.stripe.prices.pro_yearly') => 'Pro · yearly',
-                        default => $state ?? '—',
-                    }),
+                    ->formatStateUsing(self::planLabel(...)),
                 TextColumn::make('stripe_status')
                     ->label('Status')
                     ->badge()
-                    ->color(fn (string $state): string => match ($state) {
-                        'active', 'trialing' => 'success',
-                        'past_due' => 'warning',
-                        default => 'gray',
-                    }),
+                    ->color(self::statusColor(...)),
                 TextColumn::make('ends_at')
                     ->label('Ends')
                     ->dateTime()
@@ -83,6 +149,7 @@ final class SubscriptionResource extends Resource
                     ]),
             ])
             ->recordActions([
+                ViewAction::make(),
                 Action::make('stripe')
                     ->label('Open in Stripe')
                     ->icon('heroicon-o-arrow-top-right-on-square')
@@ -97,6 +164,7 @@ final class SubscriptionResource extends Resource
     {
         return [
             'index' => ListSubscriptions::route('/'),
+            'view' => ViewSubscription::route('/{record}'),
         ];
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/SubscriptionResource/Pages/ViewSubscription.php
+++ b/packages/SystemAdmin/src/Filament/Resources/SubscriptionResource/Pages/ViewSubscription.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources\SubscriptionResource\Pages;
+
+use Filament\Resources\Pages\ViewRecord;
+use Relaticle\SystemAdmin\Filament\Resources\SubscriptionResource;
+
+final class ViewSubscription extends ViewRecord
+{
+    protected static string $resource = SubscriptionResource::class;
+}

--- a/packages/SystemAdmin/src/Filament/Resources/TaskResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TaskResource.php
@@ -23,9 +23,13 @@ use Relaticle\SystemAdmin\Filament\Resources\TaskResource\Pages\CreateTask;
 use Relaticle\SystemAdmin\Filament\Resources\TaskResource\Pages\EditTask;
 use Relaticle\SystemAdmin\Filament\Resources\TaskResource\Pages\ListTasks;
 use Relaticle\SystemAdmin\Filament\Resources\TaskResource\Pages\ViewTask;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ResolvesTrashedRecords;
 
 final class TaskResource extends Resource
 {
+    use ResolvesTrashedRecords;
+
     protected static ?string $model = Task::class;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-check';
@@ -77,11 +81,15 @@ final class TaskResource extends Resource
                 TextColumn::make('team.name')
                     ->label('Team')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'team')),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source')

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
@@ -31,11 +31,15 @@ use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\EditTeam;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\ListTeams;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\ViewTeam;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\CompaniesRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\ConversationsRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\ImportsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\MembersRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\NotesRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\OpportunitiesRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\PeopleRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\SubscriptionsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\TasksRelationManager;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class TeamResource extends Resource
 {
@@ -93,7 +97,8 @@ final class TeamResource extends Resource
                     TextEntry::make('slug'),
                     TextEntry::make('owner.name')
                         ->label('Owner')
-                        ->url(fn (Team $record): ?string => $record->user_id === null ? null : UserResource::getUrl('view', ['record' => $record->user_id])),
+                        ->color('primary')
+                        ->url(RecordLink::to(UserResource::class, 'owner')),
                     IconEntry::make('personal_team')
                         ->label('Personal')
                         ->boolean(),
@@ -134,7 +139,8 @@ final class TeamResource extends Resource
                     ->label('Owner')
                     ->searchable()
                     ->sortable()
-                    ->url(fn (Team $record): ?string => $record->user_id === null ? null : UserResource::getUrl('view', ['record' => $record->user_id])),
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'owner')),
                 IconColumn::make('personal_team')
                     ->label('Personal')
                     ->boolean(),
@@ -188,6 +194,9 @@ final class TeamResource extends Resource
             TasksRelationManager::class,
             OpportunitiesRelationManager::class,
             NotesRelationManager::class,
+            ConversationsRelationManager::class,
+            ImportsRelationManager::class,
+            SubscriptionsRelationManager::class,
         ];
     }
 

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/CompaniesRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/CompaniesRelationManager.php
@@ -11,6 +11,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\SystemAdmin\Filament\Resources\CompanyResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class CompaniesRelationManager extends RelationManager
 {
@@ -33,11 +34,13 @@ final class CompaniesRelationManager extends RelationManager
                 TextColumn::make('name')
                     ->searchable()
                     ->sortable()
+                    ->color('primary')
                     ->url(fn (Company $record): string => CompanyResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->url(fn (Company $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/ConversationsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/ConversationsRelationManager.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Relaticle\Chat\Models\AgentConversation;
+use Relaticle\SystemAdmin\Filament\Resources\AgentConversationResource;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+
+final class ConversationsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'conversations';
+
+    protected static ?string $title = 'AI Conversations';
+
+    protected static string|\BackedEnum|null $icon = 'heroicon-o-chat-bubble-left-right';
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->conversations()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('title')
+            ->columns([
+                TextColumn::make('title')
+                    ->limit(50)
+                    ->placeholder('—')
+                    ->searchable()
+                    ->color('primary')
+                    ->url(fn (AgentConversation $record): string => AgentConversationResource::getUrl('view', ['record' => $record])),
+                TextColumn::make('user.name')
+                    ->label('User')
+                    ->placeholder('—')
+                    ->searchable()
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'user')),
+                TextColumn::make('messages_count')
+                    ->label('Messages')
+                    ->counts('messages')
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/ImportsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/ImportsRelationManager.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
 
-use App\Models\Note;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
-use Relaticle\SystemAdmin\Filament\Resources\NoteResource;
+use Relaticle\ImportWizard\Models\Import;
+use Relaticle\SystemAdmin\Filament\Resources\ImportResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
-final class NotesRelationManager extends RelationManager
+final class ImportsRelationManager extends RelationManager
 {
-    protected static string $relationship = 'notes';
+    protected static string $relationship = 'imports';
 
-    protected static string|\BackedEnum|null $icon = 'heroicon-o-document-text';
+    protected static string|\BackedEnum|null $icon = 'heroicon-o-arrow-up-tray';
 
     public static function getBadge(Model $ownerRecord, string $pageClass): ?string
     {
-        $count = $ownerRecord->notes()->count();
+        $count = $ownerRecord->imports()->count();
 
         return $count > 0 ? (string) $count : null;
     }
@@ -29,22 +29,23 @@ final class NotesRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
-            ->recordTitleAttribute('title')
+            ->recordTitleAttribute('file_name')
             ->columns([
-                TextColumn::make('title')
+                TextColumn::make('file_name')
                     ->searchable()
                     ->sortable()
-                    ->limit(50)
                     ->color('primary')
-                    ->url(fn (Note $record): string => NoteResource::getUrl('view', ['record' => $record])),
-                TextColumn::make('creator.name')
-                    ->label('Created by')
+                    ->url(fn (Import $record): string => ImportResource::getUrl('view', ['record' => $record])),
+                TextColumn::make('entity_type')
+                    ->badge(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(ImportResource::statusColor(...)),
+                TextColumn::make('user.name')
+                    ->label('User')
                     ->sortable()
                     ->color('primary')
-                    ->url(RecordLink::to(UserResource::class, 'creator')),
-                TextColumn::make('creation_source')
-                    ->badge()
-                    ->label('Source'),
+                    ->url(RecordLink::to(UserResource::class, 'user')),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable(),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/MembersRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/MembersRelationManager.php
@@ -37,6 +37,7 @@ final class MembersRelationManager extends RelationManager
                 TextColumn::make('name')
                     ->searchable()
                     ->sortable()
+                    ->color('primary')
                     ->url(fn (User $record): string => UserResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('email')
                     ->searchable()

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/PeopleRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/PeopleRelationManager.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Relaticle\SystemAdmin\Filament\Resources\CompanyResource;
 use Relaticle\SystemAdmin\Filament\Resources\PeopleResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class PeopleRelationManager extends RelationManager
 {
@@ -36,16 +37,19 @@ final class PeopleRelationManager extends RelationManager
                 TextColumn::make('name')
                     ->searchable()
                     ->sortable()
+                    ->color('primary')
                     ->url(fn (People $record): string => PeopleResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('company.name')
                     ->label('Company')
                     ->searchable()
                     ->sortable()
-                    ->url(fn (People $record): ?string => $record->company_id === null ? null : CompanyResource::getUrl('view', ['record' => $record->company_id])),
+                    ->color('primary')
+                    ->url(RecordLink::to(CompanyResource::class, 'company')),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->url(fn (People $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/SubscriptionsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/SubscriptionsRelationManager.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Cashier\Subscription;
+use Relaticle\SystemAdmin\Filament\Resources\SubscriptionResource;
+
+final class SubscriptionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'subscriptions';
+
+    protected static string|\BackedEnum|null $icon = 'heroicon-o-credit-card';
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->subscriptions()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('stripe_price')
+                    ->label('Plan')
+                    ->formatStateUsing(SubscriptionResource::planLabel(...))
+                    ->color('primary')
+                    ->url(fn (Subscription $record): string => SubscriptionResource::getUrl('view', ['record' => $record])),
+                TextColumn::make('stripe_status')
+                    ->label('Status')
+                    ->badge()
+                    ->color(SubscriptionResource::statusColor(...)),
+                TextColumn::make('ends_at')
+                    ->label('Ends')
+                    ->dateTime()
+                    ->placeholder('—'),
+                TextColumn::make('created_at')
+                    ->label('Started')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/TasksRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/TasksRelationManager.php
@@ -11,6 +11,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\SystemAdmin\Filament\Resources\TaskResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class TasksRelationManager extends RelationManager
 {
@@ -33,11 +34,13 @@ final class TasksRelationManager extends RelationManager
                 TextColumn::make('title')
                     ->searchable()
                     ->sortable()
+                    ->color('primary')
                     ->url(fn (Task $record): string => TaskResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('creator.name')
                     ->label('Created by')
                     ->sortable()
-                    ->url(fn (Task $record): ?string => $record->creator_id === null ? null : UserResource::getUrl('view', ['record' => $record->creator_id])),
+                    ->color('primary')
+                    ->url(RecordLink::to(UserResource::class, 'creator')),
                 TextColumn::make('creation_source')
                     ->badge()
                     ->label('Source'),

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource.php
@@ -35,6 +35,7 @@ use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ViewUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\OwnedTeamsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\TeamsRelationManager;
+use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 
 final class UserResource extends Resource
 {
@@ -122,7 +123,9 @@ final class UserResource extends Resource
                         ->label('Verified')
                         ->boolean(),
                     TextEntry::make('currentTeam.name')
-                        ->label('Current Team'),
+                        ->label('Current Team')
+                        ->color('primary')
+                        ->url(RecordLink::to(TeamResource::class, 'currentTeam')),
                     TextEntry::make('last_login_at')
                         ->label('Last Login')
                         ->dateTime()
@@ -159,7 +162,9 @@ final class UserResource extends Resource
                     ->falseIcon('heroicon-o-x-mark'),
                 TextColumn::make('currentTeam.name')
                     ->label('Current Team')
-                    ->sortable(),
+                    ->sortable()
+                    ->color('primary')
+                    ->url(RecordLink::to(TeamResource::class, 'currentTeam')),
                 TextColumn::make('last_login_at')
                     ->label('Last Login')
                     ->dateTime()

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/OwnedTeamsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/OwnedTeamsRelationManager.php
@@ -35,6 +35,7 @@ final class OwnedTeamsRelationManager extends RelationManager
                 TextColumn::make('name')
                     ->searchable()
                     ->sortable()
+                    ->color('primary')
                     ->url(fn (Team $record): string => TeamResource::getUrl('view', ['record' => $record])),
                 IconColumn::make('personal_team')
                     ->label('Personal')

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/TeamsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/TeamsRelationManager.php
@@ -37,6 +37,7 @@ final class TeamsRelationManager extends RelationManager
                 TextColumn::make('name')
                     ->searchable()
                     ->sortable()
+                    ->color('primary')
                     ->url(fn (Team $record): string => TeamResource::getUrl('view', ['record' => $record])),
                 TextColumn::make('membership.role')
                     ->label('Role')

--- a/packages/SystemAdmin/src/Filament/Support/RecordLink.php
+++ b/packages/SystemAdmin/src/Filament/Support/RecordLink.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Support;
+
+use Closure;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Builds deep links from a relation column or entry to the related record's own
+ * resource, so every relation shown in the panel is one click away from the
+ * record behind it.
+ */
+final readonly class RecordLink
+{
+    /**
+     * Prefers the loaded relation over the foreign key, so a dangling reference
+     * (a `creator_id` whose user was deleted) renders as plain text instead of a
+     * link to a missing record. Falls back to the foreign key when the relation
+     * was not eager-loaded, which keeps this free of lazy-loading violations.
+     *
+     * @param  class-string  $resource  A Filament resource class
+     */
+    public static function to(string $resource, string $relationship): Closure
+    {
+        return static function (Model $record) use ($resource, $relationship): ?string {
+            if ($record->relationLoaded($relationship)) {
+                $related = $record->getRelation($relationship);
+
+                return $related instanceof Model
+                    ? $resource::getUrl('view', ['record' => $related->getKey()])
+                    : null;
+            }
+
+            $relation = $record->{$relationship}();
+            $key = $relation instanceof BelongsTo
+                ? $record->getAttribute($relation->getForeignKeyName())
+                : null;
+
+            return blank($key) ? null : $resource::getUrl('view', ['record' => $key]);
+        };
+    }
+
+    /**
+     * Morph aliases are used as keys, matching what is stored in the type column.
+     * An unmapped alias yields no link rather than an error.
+     *
+     * @param  array<string, class-string>  $resources  Morph alias => Filament resource class
+     */
+    public static function toMorph(array $resources, string $typeColumn, string $keyColumn): Closure
+    {
+        return static function (Model $record) use ($resources, $typeColumn, $keyColumn): ?string {
+            $type = $record->getAttribute($typeColumn);
+            $key = $record->getAttribute($keyColumn);
+
+            if (! is_string($type) || blank($key)) {
+                return null;
+            }
+
+            $resource = $resources[$type] ?? null;
+
+            return $resource === null ? null : $resource::getUrl('view', ['record' => $key]);
+        };
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Support/ResolvesTrashedRecords.php
+++ b/packages/SystemAdmin/src/Filament/Support/ResolvesTrashedRecords.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Support;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+/**
+ * Filament resolves a record route against the resource's base query, which
+ * excludes soft-deleted rows. Support staff need the opposite: a trashed record
+ * is exactly the one worth inspecting, and every relation link pointing at it
+ * would otherwise 404. Only route binding is widened, not the list table.
+ */
+trait ResolvesTrashedRecords
+{
+    /**
+     * @return Builder<covariant \Illuminate\Database\Eloquent\Model>
+     */
+    public static function getRecordRouteBindingEloquentQuery(): Builder
+    {
+        return parent::getRecordRouteBindingEloquentQuery()
+            ->withoutGlobalScopes([SoftDeletingScope::class]);
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
@@ -39,11 +39,13 @@ final class TopTeamsTableWidget extends BaseWidget
                     ->searchable()
                     ->sortable()
                     ->weight('semibold')
+                    ->color('primary')
                     ->url(fn (Team $record): string => TeamResource::getUrl('view', ['record' => $record])),
 
                 TextColumn::make('owner.name')
                     ->label('Owner')
                     ->sortable()
+                    ->color('primary')
                     ->url(fn (Team $record): ?string => $record->owner ? UserResource::getUrl('view', ['record' => $record->owner]) : null),
 
                 TextColumn::make('members_count')

--- a/tests/Feature/SystemAdmin/SystemAdminResourceTest.php
+++ b/tests/Feature/SystemAdmin/SystemAdminResourceTest.php
@@ -14,12 +14,15 @@ use Relaticle\ImportWizard\Enums\ImportEntityType;
 use Relaticle\ImportWizard\Enums\ImportStatus;
 use Relaticle\ImportWizard\Models\Import;
 use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\Pages\ListCompanies;
+use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\Pages\ViewCompany;
 use Relaticle\SystemAdmin\Filament\Resources\ImportResource\Pages\ListImports;
 use Relaticle\SystemAdmin\Filament\Resources\NoteResource\Pages\ListNotes;
 use Relaticle\SystemAdmin\Filament\Resources\OpportunityResource\Pages\ListOpportunities;
 use Relaticle\SystemAdmin\Filament\Resources\PeopleResource\Pages\ListPeople;
 use Relaticle\SystemAdmin\Filament\Resources\TaskResource\Pages\ListTasks;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\ListTeams;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
@@ -129,3 +132,35 @@ it('has trashed filter on soft-deletable resources', function (string $listPageC
     'notes' => ListNotes::class,
     'opportunities' => ListOpportunities::class,
 ]);
+
+it('can open the view page of a soft deleted company', function () {
+    $company = Company::withoutEvents(fn (): Company => Company::factory()
+        ->for($this->team)
+        ->create(['creator_id' => $this->teamOwner->id]));
+
+    $company->delete();
+
+    livewire(ViewCompany::class, ['record' => $company->id])
+        ->assertOk();
+});
+
+it('links relation columns to the related record', function () {
+    Company::withoutEvents(fn (): Company => Company::factory()
+        ->for($this->team)
+        ->create(['creator_id' => $this->teamOwner->id]));
+
+    livewire(ListCompanies::class)
+        ->assertOk()
+        ->assertSee(TeamResource::getUrl('view', ['record' => $this->team->id]), escape: false)
+        ->assertSee(UserResource::getUrl('view', ['record' => $this->teamOwner->id]), escape: false);
+});
+
+it('does not link a relation column when the related record is missing', function () {
+    Company::withoutEvents(fn (): Company => Company::factory()
+        ->for($this->team)
+        ->create(['creator_id' => null]));
+
+    livewire(ListCompanies::class)
+        ->assertOk()
+        ->assertDontSee(UserResource::getUrl('view', ['record' => $this->teamOwner->id]), escape: false);
+});


### PR DESCRIPTION
Relation columns and infolist entries across all sysadmin resources now deep-link to the related record (team, creator, company, contact, user, conversation, and Activity's polymorphic causer/subject), via a shared `RecordLink` helper that resolves the target from the loaded relation and renders plain text when the reference is dangling.

Adds relation managers for Company (people, opportunities), AgentConversation (messages) and Team (conversations, imports, subscriptions), a Subscription view page, and a Subscriptions nav badge. Linked cells are styled as links so they read as clickable.

Also fixes soft-deleted records 404ing on their view page, which already broke the `ViewAction` on trashed rows and would have dead-ended the new links; route binding is widened for soft-deletable resources while the list query is unchanged.

**Test plan:** full suite green (2906 passed); new tests cover the trashed view page and assert relation columns link (and don't link a missing relation). Walked the sysadmin panel with agent-browser: verified links resolve on every list page, the new relation manager tabs render rows and links, and the Subscription view page loads.