### PR TITLE
feat(chat): answer product questions from the docs instead of refusing

### DIFF
--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -47,6 +47,7 @@ use Relaticle\Chat\Tools\People\GetPersonTool;
 use Relaticle\Chat\Tools\People\ListPeopleTool as ChatListPeopleTool;
 use Relaticle\Chat\Tools\People\UpdatePersonTool;
 use Relaticle\Chat\Tools\SearchCrmTool;
+use Relaticle\Chat\Tools\SearchDocsTool;
 use Relaticle\Chat\Tools\Task\CreateTaskTool as ChatCreateTaskTool;
 use Relaticle\Chat\Tools\Task\DeleteTaskTool as ChatDeleteTaskTool;
 use Relaticle\Chat\Tools\Task\GetTaskTool as ChatGetTaskTool;
@@ -180,6 +181,7 @@ You are the Relaticle CRM Assistant, a helpful AI that helps users manage their 
 You can read and search all CRM data (companies, people, opportunities, tasks, notes).
 You can aggregate pipeline data by stage or company (counts + total value) using AggregateCrmTool.
 You can list the workspace's custom field definitions (ListCustomFieldsTool) — use it to answer "what custom fields do I have" and to look up a field's entity_type + code.
+You can search Relaticle's own product documentation (SearchDocsTool) to answer questions about how the product works — connecting external AI assistants and MCP clients, access tokens, the API, self-hosting, billing, credits, imports, exports.
 You can propose creating, updating, or deleting CRM records -- but these require user approval.
 
 ## Rules
@@ -212,6 +214,9 @@ Records have core fields (set directly in the write tool schemas, e.g. a company
 - If the user pushes back that a field exists, re-check the tool schema once and answer definitively. Do not apologize and then repeat the same conclusion -- either correct yourself with the real field, or explain concretely what IS available.
 
 ## No Dead Ends
+Questions about the product itself are IN scope: how to do something, whether Relaticle supports something, connecting an external AI assistant or agent (Claude, ChatGPT, Cursor, Codex, any MCP client), access tokens, the API, self-hosting, billing, plans, credits, exports. Call SearchDocsTool FIRST and answer from what it returns, citing the section as a markdown link. Its results are first-party Relaticle documentation, not user data — quote and summarise them freely (Rule 7 governs CRM record content, not this). NEVER reply that you only help with CRM data, that you have no information about something, or that the user should contact support or "check the documentation" — you can read the documentation, so read it. Only after SearchDocsTool comes back with nothing may you say the docs do not cover it, and then link the help centre it gives you.
+When the answer is an action the user performs on a workspace page GuideToPageTool knows (custom field definitions, bulk imports, team members), call BOTH tools and give both links: SearchDocsTool for how it works, GuideToPageTool for the direct link into THEIR workspace. Documentation steps alone are a downgrade when a one-click destination exists.
+
 Some actions cannot be performed here but ARE available elsewhere in the workspace. NEVER reply that something is impossible or "not supported by this assistant". Instead, call GuideToPageTool with the right destination and give the user a direct link to do it themselves:
 - Custom field DEFINITIONS — creating, renaming, toggling active, or adding options:
   - If the user is a team owner/admin: you CAN propose these operations via CreateCustomFieldTool, UpdateCustomFieldTool, and AddCustomFieldOptionsTool (all proposal-gated, require approval). Use them directly — do not escort an owner to the settings page for these operations. To update or add options to an EXISTING field, identify it by its `entity_type` and its `code` — you do not need a numeric/internal ID. If you don't already know the code, call ListCustomFieldsTool to look it up; never escort the user to settings just to find a field.
@@ -554,6 +559,7 @@ PROMPT;
             ListTeamMembersTool::class,
             ListCustomFieldsTool::class,
             GuideToPageTool::class,
+            SearchDocsTool::class,
             AggregateCrmTool::class,
 
             // Write tools

--- a/packages/Chat/src/Tools/SearchDocsTool.php
+++ b/packages/Chat/src/Tools/SearchDocsTool.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Str;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Documentation\Support\BuildSearchIndex;
+use Relaticle\Documentation\Support\DocPage;
+use Relaticle\Documentation\Support\DocsRepository;
+
+/**
+ * Phase 2 of the No Dead Ends contract. GuideToPageTool escorts the user to a
+ * page they can act on; this answers the question outright from Relaticle's own
+ * help centre and developer guides, so "how do I connect my own agent" stops
+ * being a dead end for a capability the product ships.
+ *
+ * Ranking runs over the same section-level index the public docs search uses,
+ * so a hit lands on a heading rather than a whole page. The text handed back is
+ * the raw markdown under that heading, not the index's flattened copy: the
+ * index drops inline code, and the answer to that question is an inline-code
+ * URL.
+ */
+final readonly class SearchDocsTool implements Tool
+{
+    private const int MAX_RESULTS = 5;
+
+    private const int DEFAULT_RESULTS = 3;
+
+    private const int CONTENT_LIMIT = 1500;
+
+    /**
+     * One well-matched article otherwise wins every slot with its own
+     * sub-headings, burying the second article that answers the other half of
+     * the question — the help centre covers connecting Claude, the developer
+     * guide covers connecting anything else.
+     */
+    private const int MAX_SECTIONS_PER_PAGE = 2;
+
+    /** Below this, a term is punctuation noise rather than a word. */
+    private const int MIN_TERM_LENGTH = 2;
+
+    /** Matched whole-word rather than by prefix, so "ai" does not hit "aim". */
+    private const int PREFIX_MATCH_LENGTH = 4;
+
+    /**
+     * Two-letter words are listed rather than excluded by length, because "ai"
+     * is a real term here.
+     *
+     * @var list<string>
+     */
+    private const array STOP_WORDS = [
+        'about', 'all', 'am', 'an', 'and', 'any', 'are', 'as', 'at', 'be', 'but',
+        'by', 'can', 'do', 'does', 'for', 'from', 'get', 'got', 'has', 'have',
+        'help', 'here', 'how', 'if', 'in', 'into', 'is', 'it', 'its', 'me', 'my',
+        'need', 'no', 'not', 'of', 'on', 'or', 'out', 'own', 'please', 'so',
+        'that', 'the', 'them', 'there', 'they', 'this', 'to', 'up', 'use',
+        'using', 'want', 'was', 'we', 'what', 'when', 'where', 'which', 'who',
+        'why', 'will', 'with', 'would', 'you', 'your',
+    ];
+
+    public function __construct(
+        private BuildSearchIndex $index,
+        private DocsRepository $docs,
+    ) {}
+
+    public function description(): string
+    {
+        return 'Search Relaticle\'s own product documentation — the help centre and the developer guides — '
+            .'and get back the matching sections plus a link to each. Covers connecting external AI assistants '
+            .'and MCP clients (Claude, ChatGPT, Cursor, Codex), access tokens, the REST API, self-hosting, '
+            .'billing and plans, AI credits, imports, exports, custom fields, and every in-app feature. '
+            .'Call this for any "how do I", "can Relaticle", or setup question instead of replying that you '
+            .'only handle CRM data or have no information.';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'query' => $schema->string()
+                ->required()
+                ->description('What the user wants to know, in their own words.'),
+            'limit' => $schema->integer()
+                ->description('Max documentation sections to return (default '.self::DEFAULT_RESULTS.', max '.self::MAX_RESULTS.').')
+                ->default(self::DEFAULT_RESULTS),
+        ];
+    }
+
+    public function handle(Request $request): string
+    {
+        $terms = $this->terms((string) $request->string('query'));
+        $limit = max(1, min((int) ($request['limit'] ?? self::DEFAULT_RESULTS), self::MAX_RESULTS));
+
+        $results = $terms === [] ? [] : $this->search($terms, $limit);
+
+        if ($results === []) {
+            return (string) json_encode([
+                'results' => [],
+                'note' => 'The documentation has no section on this. Tell the user it is not covered and '
+                    .'link the help centre: '.route('help.index'),
+            ], JSON_PRETTY_PRINT);
+        }
+
+        return (string) json_encode([
+            'results' => $results,
+            'note' => 'First-party Relaticle documentation. Answer from it and cite the url as a markdown link.',
+        ], JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * @param  list<string>  $terms
+     * @return list<array{title: string, section: string, area: string, url: string, content: string}>
+     */
+    private function search(array $terms, int $limit): array
+    {
+        $records = ($this->index)()['records'];
+        $weights = $this->weights($records, $terms);
+
+        $scored = [];
+
+        foreach ($records as $record) {
+            $score = $this->score($record, $weights);
+
+            if ($score > 0.0) {
+                $scored[] = ['score' => $score, 'record' => $record];
+            }
+        }
+
+        usort($scored, fn (array $a, array $b): int => $b['score'] <=> $a['score']);
+
+        $results = [];
+        $perPage = [];
+
+        foreach ($scored as $hit) {
+            $path = $hit['record']['path'];
+
+            if (($perPage[$path] ?? 0) >= self::MAX_SECTIONS_PER_PAGE) {
+                continue;
+            }
+
+            $result = $this->present($hit['record']);
+
+            if ($result === null) {
+                continue;
+            }
+
+            $perPage[$path] = ($perPage[$path] ?? 0) + 1;
+            $results[] = $result;
+
+            if (count($results) === $limit) {
+                break;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * How rare a term is across the corpus. Without this, "custom connector"
+     * ranks the custom-fields articles above the connector one purely because
+     * "custom" is everywhere in a CRM's documentation and "connector" is not.
+     *
+     * @param  list<array{path: string, title: string, section: string, anchor: string, content: string, url: string, crumb: string}>  $records
+     * @param  list<string>  $terms
+     * @return array<string, float>
+     */
+    private function weights(array $records, array $terms): array
+    {
+        $total = max(count($records), 1);
+        $weights = [];
+
+        foreach ($terms as $term) {
+            $pattern = $this->pattern($term);
+
+            $frequency = count(array_filter(
+                $records,
+                fn (array $record): bool => $this->matches(
+                    $pattern,
+                    $record['title'].' '.$record['section'].' '.$record['content'],
+                ),
+            ));
+
+            $weights[$term] = max(log($total / (1 + $frequency)), 0.1);
+        }
+
+        return $weights;
+    }
+
+    /**
+     * Where a term matches counts for more than how often: a heading naming the
+     * user's word beats a body that mentions it in passing. Matching more of
+     * the query then beats matching one term loudly.
+     *
+     * @param  array{path: string, title: string, section: string, anchor: string, content: string, url: string, crumb: string}  $record
+     * @param  array<string, float>  $weights
+     */
+    private function score(array $record, array $weights): float
+    {
+        $score = 0.0;
+        $matched = 0;
+
+        foreach ($weights as $term => $weight) {
+            $pattern = $this->pattern((string) $term);
+
+            $hits = ($this->matches($pattern, $record['title']) ? 8 : 0)
+                + ($this->matches($pattern, $record['section']) ? 5 : 0)
+                + ($this->matches($pattern, $record['crumb']) ? 2 : 0)
+                + min((int) preg_match_all($pattern, $record['content']), 3);
+
+            if ($hits > 0) {
+                $matched++;
+            }
+
+            $score += $hits * $weight;
+        }
+
+        if ($score <= 0.0) {
+            return 0.0;
+        }
+
+        return $score * (1.0 + ($matched / count($weights)));
+    }
+
+    private function matches(string $pattern, string $haystack): bool
+    {
+        return preg_match($pattern, $haystack) === 1;
+    }
+
+    private function pattern(string $term): string
+    {
+        $quoted = preg_quote($this->stem($term), '/');
+
+        return mb_strlen($term) >= self::PREFIX_MATCH_LENGTH
+            ? '/\b'.$quoted.'/iu'
+            : '/\b'.$quoted.'\b/iu';
+    }
+
+    /**
+     * Prefix matching alone is one-directional: "connect" finds "connector",
+     * but a user who types "connector" would miss the heading "Connect it".
+     * Trimming the term back to a stem makes the common plural and agent-noun
+     * mismatches match in both directions.
+     */
+    private function stem(string $term): string
+    {
+        foreach (['ations', 'ation', 'ings', 'ing', 'ors', 'or', 'ers', 'er', 'es', 's'] as $suffix) {
+            if (! str_ends_with($term, $suffix)) {
+                continue;
+            }
+
+            $stem = mb_substr($term, 0, -mb_strlen($suffix));
+
+            if (mb_strlen($stem) >= self::PREFIX_MATCH_LENGTH) {
+                return $stem;
+            }
+        }
+
+        return $term;
+    }
+
+    /**
+     * @param  array{path: string, title: string, section: string, anchor: string, content: string, url: string, crumb: string}  $record
+     * @return array{title: string, section: string, area: string, url: string, content: string}|null
+     */
+    private function present(array $record): ?array
+    {
+        $content = $this->sectionMarkdown($record) ?? $record['content'];
+
+        if (trim($content) === '') {
+            return null;
+        }
+
+        return [
+            'title' => $record['title'],
+            'section' => $record['section'],
+            'area' => $record['crumb'],
+            'url' => $record['url'],
+            'content' => $this->readable($content),
+        ];
+    }
+
+    /**
+     * The slice of raw markdown the index record was flattened from. Splits on
+     * the same heading regex BuildSearchIndex uses, so the two stay aligned.
+     *
+     * @param  array{path: string, title: string, section: string, anchor: string, content: string, url: string, crumb: string}  $record
+     */
+    private function sectionMarkdown(array $record): ?string
+    {
+        $page = $this->docs->find($record['path']);
+
+        if (! $page instanceof DocPage) {
+            return null;
+        }
+
+        $chunks = preg_split('/^##[ \t]+(.+)$/m', $page->body, -1, PREG_SPLIT_DELIM_CAPTURE);
+
+        if ($chunks === false) {
+            return null;
+        }
+
+        if ($record['anchor'] === '') {
+            return $chunks[0] ?? null;
+        }
+
+        $counter = count($chunks);
+
+        for ($i = 1; $i < $counter; $i += 2) {
+            if (trim($chunks[$i]) === $record['section']) {
+                return $chunks[$i + 1] ?? null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Images carry nothing for a reader who cannot see them, and a doc's
+     * root-relative links would resolve against the app panel's host rather
+     * than the one serving the docs.
+     */
+    private function readable(string $markdown): string
+    {
+        $text = preg_replace('/!\[[^\]]*]\([^)]*\)/', '', $markdown) ?? $markdown;
+        $text = preg_replace('/]\(\/(?!\/)/', ']('.rtrim(url('/'), '/').'/', $text) ?? $text;
+        $text = preg_replace('/\n{3,}/', "\n\n", $text) ?? $text;
+
+        return Str::limit(trim($text), self::CONTENT_LIMIT);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function terms(string $query): array
+    {
+        $words = preg_split('/[^\p{L}\p{N}.]+/u', mb_strtolower(trim($query)), -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        $terms = array_filter(
+            array_map(fn (string $word): string => trim($word, '.'), $words),
+            fn (string $word): bool => mb_strlen($word) >= self::MIN_TERM_LENGTH
+                && ! in_array($word, self::STOP_WORDS, true),
+        );
+
+        return array_values(array_unique($terms));
+    }
+}

--- a/tests/Feature/Chat/SearchDocsToolTest.php
+++ b/tests/Feature/Chat/SearchDocsToolTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Ai\Tools\Request;
+use Relaticle\Chat\Agents\CrmAssistant;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Tools\SearchDocsTool;
+
+mutates(SearchDocsTool::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->user->switchTeam($this->user->ownedTeams()->first());
+    $this->actingAs($this->user);
+});
+
+function searchDocs(string $query, ?int $limit = null): array
+{
+    $payload = ['query' => $query];
+
+    if ($limit !== null) {
+        $payload['limit'] = $limit;
+    }
+
+    return json_decode(resolve(SearchDocsTool::class)->handle(new Request($payload)), true);
+}
+
+it('answers the connector question that used to be a dead end', function (): void {
+    $results = searchDocs('How can I connect my own agent (codex) to here?')['results'];
+
+    expect($results)->not->toBeEmpty();
+
+    $content = implode("\n", array_column($results, 'content'));
+
+    expect($content)->toContain('https://mcp.relaticle.com')
+        ->and(array_column($results, 'title'))->toContain('Connect Claude or ChatGPT to your workspace');
+});
+
+it('keeps inline code the flattened search index drops', function (): void {
+    $results = searchDocs('what url do I add as a custom connector')['results'];
+
+    expect(implode("\n", array_column($results, 'content')))->toContain('mcp.relaticle.com');
+});
+
+it('surfaces a second article instead of letting one page take every slot', function (): void {
+    $results = searchDocs('How can I connect my own agent (codex) to here?');
+
+    expect(array_unique(array_column($results['results'], 'title')))->toHaveCount(2);
+});
+
+it('matches a stemmed term in both directions', function (): void {
+    $sections = array_column(searchDocs('connectors')['results'], 'section');
+
+    expect($sections)->toContain('Connect it');
+});
+
+it('ranks a rare term above a term the whole corpus uses', function (): void {
+    $results = searchDocs('how do I add a custom connector')['results'];
+
+    expect($results[0]['title'])->toBe('Connect Claude or ChatGPT to your workspace');
+});
+
+it('cites route-derived urls so self-hosted installs link to themselves', function (): void {
+    $results = searchDocs('how do I export my data')['results'];
+
+    expect($results)->not->toBeEmpty();
+
+    foreach ($results as $result) {
+        expect($result['url'])->toStartWith(rtrim(url('/'), '/').'/help/');
+    }
+});
+
+it('rewrites root-relative doc links to absolute urls', function (): void {
+    $content = implode("\n", array_column(searchDocs('billing and plans')['results'], 'content'));
+
+    expect($content)->not->toMatch('/]\(\/[a-z]/');
+});
+
+it('reports no coverage and links the help centre when nothing matches', function (): void {
+    $payload = searchDocs('zzzqqxx unrelatedgibberish');
+
+    expect($payload['results'])->toBe([])
+        ->and($payload['note'])->toContain(route('help.index'));
+});
+
+it('returns nothing for a query that is only stop words', function (): void {
+    expect(searchDocs('how do you what the')['results'])->toBe([]);
+});
+
+it('caps the number of sections returned', function (): void {
+    expect(searchDocs('workspace', 99)['results'])->toHaveCount(5)
+        ->and(searchDocs('workspace', 1)['results'])->toHaveCount(1);
+});
+
+it('does not create a pending action because it is not a write', function (): void {
+    searchDocs('how do I invite my team');
+
+    expect(PendingAction::query()->count())->toBe(0);
+});
+
+it('is registered on the assistant', function (): void {
+    $tools = array_map(fn (object $tool): string => $tool::class, (new CrmAssistant)->tools());
+
+    expect($tools)->toContain(SearchDocsTool::class);
+});


### PR DESCRIPTION
Asked how to connect Codex, the assistant replied that it only handles CRM data, when Relaticle ships an MCP server and a help article covering exactly that. `SearchDocsTool` gives it a channel to the help centre and developer guides, ranking over the section-level index behind the public docs search and returning raw markdown so inline-code URLs survive the flattening the index applies.

Ranking is IDF-weighted so a rare term ("connector") outranks one the whole corpus uses ("custom"), and stemmed so a query matches a heading in both directions. The prompt keeps the Phase-1 escorts intact: when the answer is an action on a workspace page `GuideToPageTool` knows, both tools fire so the user still gets a direct link into their own workspace.

## Test plan

12 new tests in `tests/Feature/Chat/SearchDocsToolTest.php`; Chat suite 745/745, Chat + Documentation 801/801, Arch 25/25, Pint / Rector / PHPStan clean, type coverage 100%. Verified through the full stack (real composer, redis queue, Horizon, Reverb, streamed reply): the original question now answers with the MCP URL, the personal access token path, and a cited guide, while CRM questions still route to the CRM tools.