### PR TITLE
chore: bump relaticle/ink to v2.5.1 for blog slug support

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10328,16 +10328,16 @@
         },
         {
             "name": "relaticle/ink",
-            "version": "v2.5.0",
+            "version": "v2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/relaticle/ink.git",
-                "reference": "58f0c8a2ce276e1246c9ab4ebb393568bc34b04f"
+                "reference": "e12aad057ed2b77f26241d2dee12241471edbe36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/relaticle/ink/zipball/58f0c8a2ce276e1246c9ab4ebb393568bc34b04f",
-                "reference": "58f0c8a2ce276e1246c9ab4ebb393568bc34b04f",
+                "url": "https://api.github.com/repos/relaticle/ink/zipball/e12aad057ed2b77f26241d2dee12241471edbe36",
+                "reference": "e12aad057ed2b77f26241d2dee12241471edbe36",
                 "shasum": ""
             },
             "require": {
@@ -10399,7 +10399,7 @@
                 "issues": "https://github.com/relaticle/ink/issues",
                 "source": "https://github.com/relaticle/ink"
             },
-            "time": "2026-08-18T11:43:10+00:00"
+            "time": "2026-08-18T20:46:55+00:00"
         },
         {
             "name": "ryangjchandler/blade-capture-directive",


### PR DESCRIPTION
Bumps `relaticle/ink` from v2.5.0 to v2.5.1. Lock file only, 5 insertions and 5 deletions; the `^2.3` constraint in composer.json already allows it.

## Why

v2.5.1 adds a `slug` parameter to the blog MCP create/update tools and releases slugs held by soft-deleted posts (relaticle/ink#19). Three published posts currently carry collision suffixes from trashed twins:

| Post | Current slug | Target slug |
|---|---|---|
| 14 | `let-claude-code-run-your-sales-pipeline-2` | `let-claude-code-run-your-sales-pipeline` |
| 9 | `how-to-connect-claude-to-your-crm-with-mcp-1` | `how-to-connect-claude-to-your-crm-with-mcp` |
| 5 | `relaticle-vs-twenty-an-honest-comparison-1` | `relaticle-vs-twenty-an-honest-comparison` |

Post 5 is the Twenty comparison and publishes **2026-08-21 09:00 UTC**. Once it is public, renaming breaks any link already shared, so the suffix becomes permanent. This needs to be released and deployed before then.

Post 3 keeps its suffix deliberately; it is already public and there is no redirect layer.

## Verification

- `composer show relaticle/ink` reports v2.5.1 after the update.
- The installed package declares the new field: `vendor/relaticle/ink/src/Mcp/Tools/UpdatePostTool.php:142`, with a unique rule documented as "a slug held only by a deleted post is reusable".
- Upstream v2.5.0...v2.5.1 adds `ReclaimsTrashedSlugs`, `ReclaimsTrashedSlugsAction`, plus `SlugParameterTest` and `SlugReclaimTest`.
- Full suite on this branch: 3,004 tests, 3,001 passing, 15,753 assertions.

## Test plan

After release and deploy, set the three slugs above over the blog MCP `update-post-tool` and confirm each new URL returns 200.