### PR TITLE
refactor(settings): move access tokens under profile, drop all descriptions

### DIFF
--- a/app/Filament/Pages/AccessTokens.php
+++ b/app/Filament/Pages/AccessTokens.php
@@ -4,24 +4,39 @@ declare(strict_types=1);
 
 namespace App\Filament\Pages;
 
+use App\Filament\Clusters\Settings;
 use App\Livewire\App\AccessTokens\CreateAccessToken;
 use App\Livewire\App\AccessTokens\ManageAccessTokens;
 use App\Livewire\App\AccessTokens\ManageOAuthConnectors;
+use Filament\Clusters\Cluster;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Schema;
+use Laravel\Jetstream\Features;
 use Override;
 
 final class AccessTokens extends Page
 {
+    protected string $view = 'filament.pages.access-tokens';
+
+    protected static ?string $slug = 'access-tokens';
+
+    protected static ?int $navigationSort = 3;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-key';
 
-    protected string $view = 'filament.pages.access-tokens';
+    /** @var class-string<Cluster>|null */
+    protected static ?string $cluster = Settings::class;
 
     #[Override]
     public static function shouldRegisterNavigation(): bool
     {
-        return false;
+        return Features::hasApiFeatures();
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('access-tokens.title');
     }
 
     public function form(Schema $schema): Schema

--- a/app/Filament/Pages/Billing.php
+++ b/app/Filament/Pages/Billing.php
@@ -51,11 +51,6 @@ final class Billing extends Page
         return __('billing.title');
     }
 
-    public function getSubheading(): string
-    {
-        return __('billing.subtitle');
-    }
-
     public function mount(): void
     {
         abort_unless(Feature::active(BillingFeature::class), 403);

--- a/app/Filament/Pages/NotificationPreferences.php
+++ b/app/Filament/Pages/NotificationPreferences.php
@@ -7,8 +7,6 @@ namespace App\Filament\Pages;
 use App\Filament\Clusters\Settings;
 use Filament\Clusters\Cluster;
 use Filament\Pages\Page;
-use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HtmlString;
 
 final class NotificationPreferences extends Page
 {
@@ -31,11 +29,6 @@ final class NotificationPreferences extends Page
     public function getHeading(): string
     {
         return __('notifications.title');
-    }
-
-    public function getSubheading(): Htmlable
-    {
-        return new HtmlString(e(__('notifications.subtitle')));
     }
 
     public static function getLabel(): string

--- a/app/Filament/Pages/Team/CustomFields.php
+++ b/app/Filament/Pages/Team/CustomFields.php
@@ -23,4 +23,9 @@ final class CustomFields extends CustomFieldsManagementPage
     {
         return 'team/custom-fields';
     }
+
+    public function getSubheading(): ?string
+    {
+        return null;
+    }
 }

--- a/app/Http/Middleware/EnsureHostedWorkspaceAccess.php
+++ b/app/Http/Middleware/EnsureHostedWorkspaceAccess.php
@@ -18,7 +18,7 @@ final readonly class EnsureHostedWorkspaceAccess
     private const array SELF_SERVICE_ROUTES = [
         'filament.app.pages.billing',
         'filament.app.settings.pages.profile',
-        'filament.app.pages.access-tokens',
+        'filament.app.settings.pages.access-tokens',
         'filament.app.tenant.profile',
     ];
 

--- a/app/Livewire/App/AccessTokens/CreateAccessToken.php
+++ b/app/Livewire/App/AccessTokens/CreateAccessToken.php
@@ -41,9 +41,6 @@ final class CreateAccessToken extends BaseLivewireComponent
             ->schema([
                 Section::make(__('access-tokens.sections.create.title'))
                     ->aside()
-                    ->description(
-                        __('access-tokens.sections.create.description'),
-                    )
                     ->schema([
                         TextInput::make('name')
                             ->label(__('access-tokens.form.name'))

--- a/app/Livewire/App/Profile/DeleteAccount.php
+++ b/app/Livewire/App/Profile/DeleteAccount.php
@@ -28,7 +28,6 @@ final class DeleteAccount extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('profile.sections.delete_account.title'))
-                    ->description(__('profile.sections.delete_account.description'))
                     ->aside()
                     ->schema([
                         TextEntry::make('deleteAccountNotice')

--- a/app/Livewire/App/Profile/LogoutOtherBrowserSessions.php
+++ b/app/Livewire/App/Profile/LogoutOtherBrowserSessions.php
@@ -28,7 +28,6 @@ final class LogoutOtherBrowserSessions extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('profile.sections.browser_sessions.title'))
-                    ->description(__('profile.sections.browser_sessions.description'))
                     ->aside()
                     ->schema([
                         Forms\Components\ViewField::make('browserSessions')

--- a/app/Livewire/App/Profile/UpdatePassword.php
+++ b/app/Livewire/App/Profile/UpdatePassword.php
@@ -35,7 +35,6 @@ final class UpdatePassword extends BaseLivewireComponent
             ->schema([
                 Section::make($hasPassword ? __('profile.sections.update_password.title') : __('profile.sections.set_password.title'))
                     ->aside()
-                    ->description($hasPassword ? __('profile.sections.update_password.description') : __('profile.sections.set_password.description'))
                     ->schema([
                         TextInput::make('currentPassword')
                             ->label(__('profile.form.current_password.label'))

--- a/app/Livewire/App/Profile/UpdateProfileInformation.php
+++ b/app/Livewire/App/Profile/UpdateProfileInformation.php
@@ -67,7 +67,6 @@ final class UpdateProfileInformation extends BaseLivewireComponent
             ->schema([
                 Section::make(__('profile.sections.update_profile_information.title'))
                     ->aside()
-                    ->description(__('profile.sections.update_profile_information.description'))
                     ->schema([
                         FileUpload::make('profile_photo_path')
                             ->label(__('profile.form.profile_photo.label'))

--- a/app/Livewire/App/Teams/AddTeamMember.php
+++ b/app/Livewire/App/Teams/AddTeamMember.php
@@ -44,7 +44,6 @@ final class AddTeamMember extends BaseLivewireComponent
                 Section::make(__('teams.sections.add_team_member.title'))
                     ->aside()
                     ->visible(fn () => Gate::check('addTeamMember', $this->team))
-                    ->description(__('teams.sections.add_team_member.description'))
                     ->schema([
                         TextEntry::make('addTeamMemberNotice')
                             ->hiddenLabel()

--- a/app/Livewire/App/Teams/DeleteTeam.php
+++ b/app/Livewire/App/Teams/DeleteTeam.php
@@ -32,7 +32,6 @@ final class DeleteTeam extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('teams.sections.delete_team.title'))
-                    ->description(__('teams.sections.delete_team.description'))
                     ->aside()
                     ->visible(fn () => Gate::check('delete', $this->team))
                     ->schema([

--- a/app/Livewire/App/Teams/UpdateTeamName.php
+++ b/app/Livewire/App/Teams/UpdateTeamName.php
@@ -41,7 +41,6 @@ final class UpdateTeamName extends BaseLivewireComponent
             ->schema([
                 Section::make(__('teams.sections.update_team_name.title'))
                     ->aside()
-                    ->description(__('teams.sections.update_team_name.description'))
                     ->schema([
                         TextInput::make('name')
                             ->label(__('teams.form.team_name.label'))

--- a/lang/en/access-tokens.php
+++ b/lang/en/access-tokens.php
@@ -78,7 +78,6 @@ return [
 
     'connectors' => [
         'title' => 'AI Connectors',
-        'description' => 'Assistants such as Claude and ChatGPT that you connected through the consent screen. Revoking one immediately invalidates its access.',
         'columns' => [
             'name' => 'Connector',
             'team' => 'Workspace',

--- a/lang/en/billing.php
+++ b/lang/en/billing.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 return [
     'title' => 'Billing',
-    'subtitle' => 'Manage Cloud access, billing, and AI usage for this workspace.',
     'plans' => [
         'pro' => 'Pro',
         'cloud_pro' => 'Cloud Pro',

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 return [
     'title' => 'Notifications',
-    'subtitle' => 'Customize your notification settings to stay informed without being overwhelmed.',
 
     'digest' => [
         'heading' => 'Daily digest',

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -35,19 +35,15 @@ return [
     'sections' => [
         'update_profile_information' => [
             'title' => 'Profile Information',
-            'description' => 'Update your account\'s profile information and email address.',
         ],
         'update_password' => [
             'title' => 'Update Password',
-            'description' => 'Ensure your account is using a long, random password to stay secure.',
         ],
         'set_password' => [
             'title' => 'Set Password',
-            'description' => 'Add a password to your account so you can also sign in with your email and password.',
         ],
         'browser_sessions' => [
             'title' => 'Browser Sessions',
-            'description' => 'Manage and log out your active sessions on other browsers and devices.',
             'notice' => 'If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.',
             'labels' => [
                 'current_device' => 'This device',
@@ -57,7 +53,6 @@ return [
         ],
         'delete_account' => [
             'title' => 'Delete Account',
-            'description' => 'Schedule your account for deletion.',
             'notice' => 'Deleting your account will schedule it for permanent removal after a 30-day grace period. You can cancel the deletion by logging back in at any time before that. After the grace period, all your data will be permanently deleted.',
         ],
     ],

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -19,24 +19,19 @@ return [
     'sections' => [
         'update_team_name' => [
             'title' => 'Workspace Name',
-            'description' => 'The workspace\'s name and owner information.',
         ],
         'add_team_member' => [
             'title' => 'Add Member',
-            'description' => 'Add a new member to your workspace, allowing them to collaborate with you.',
             'notice' => 'Please provide the email address of the person you would like to add to this workspace.',
         ],
         'team_members' => [
             'title' => 'Members',
-            'description' => 'All of the people that are part of this workspace.',
         ],
         'pending_team_invitations' => [
             'title' => 'Pending Invitations',
-            'description' => 'These people have been invited to your workspace and have been sent an invitation email. They may join the workspace by accepting the email invitation.',
         ],
         'delete_team' => [
             'title' => 'Delete Workspace',
-            'description' => 'Schedule this workspace for deletion.',
             'notice' => 'Deleting this workspace will schedule it for permanent removal after a 30-day grace period. You can cancel the deletion at any time before that. After the grace period, all resources and data will be permanently deleted.',
             'scheduled_notice' => 'This workspace is scheduled for deletion on :date.',
         ],

--- a/resources/views/livewire/app/access-tokens/manage-access-tokens.blade.php
+++ b/resources/views/livewire/app/access-tokens/manage-access-tokens.blade.php
@@ -2,9 +2,6 @@
     <x-slot name="heading">
         {{ __('access-tokens.sections.manage.title') }}
     </x-slot>
-    <x-slot name="description">
-        {{ __('access-tokens.sections.manage.description') }}
-    </x-slot>
 
     {{ $this->table }}
 

--- a/resources/views/livewire/app/access-tokens/manage-oauth-connectors.blade.php
+++ b/resources/views/livewire/app/access-tokens/manage-oauth-connectors.blade.php
@@ -2,9 +2,6 @@
     <x-slot name="heading">
         {{ __('access-tokens.connectors.title') }}
     </x-slot>
-    <x-slot name="description">
-        {{ __('access-tokens.connectors.description') }}
-    </x-slot>
 
     {{ $this->table }}
 

--- a/resources/views/livewire/app/teams/pending-team-invitations.blade.php
+++ b/resources/views/livewire/app/teams/pending-team-invitations.blade.php
@@ -2,9 +2,6 @@
     <x-slot name="heading">
         {{ __('teams.sections.pending_team_invitations.title') }}
     </x-slot>
-    <x-slot name="description">
-        {{ __('teams.sections.pending_team_invitations.description') }}
-    </x-slot>
 
     {{ $this->table }}
 

--- a/resources/views/livewire/app/teams/team-members.blade.php
+++ b/resources/views/livewire/app/teams/team-members.blade.php
@@ -2,9 +2,6 @@
     <x-slot name="heading">
         {{ __('teams.sections.team_members.title') }}
     </x-slot>
-    <x-slot name="description">
-        {{ __('teams.sections.team_members.description') }}
-    </x-slot>
 
     {{ $this->table }}
 

--- a/tests/Feature/AccessTokens/AccessTokensPageTest.php
+++ b/tests/Feature/AccessTokens/AccessTokensPageTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 use App\Filament\Pages\AccessTokens;
 use App\Models\User;
+use Filament\Facades\Filament;
 use Laravel\Jetstream\Features;
 
 test('rest api integration link points to scribe docs', function (): void {
-    $this->actingAs(User::factory()->withTeam()->create());
+    $user = User::factory()->withTeam()->create();
+
+    $this->actingAs($user);
+    Filament::setTenant($user->currentTeam);
 
     livewire(AccessTokens::class)
         ->assertSee(route('scribe'), escape: false)

--- a/tests/Feature/Billing/HostedWorkspaceAccessTest.php
+++ b/tests/Feature/Billing/HostedWorkspaceAccessTest.php
@@ -39,7 +39,7 @@ it('keeps personal account controls available while paused', function (): void {
     $this->get(route('filament.app.settings.pages.profile', ['tenant' => $this->team->slug]))
         ->assertOk();
 
-    $this->get(route('filament.app.pages.access-tokens', ['tenant' => $this->team->slug]))
+    $this->get(route('filament.app.settings.pages.access-tokens', ['tenant' => $this->team->slug]))
         ->assertOk();
 });
 


### PR DESCRIPTION
Access Tokens was a standalone page reachable only from the user menu; it is now the third tab of the Settings cluster beside Profile and Notifications, moving from `/app/{tenant}/access-tokens` to `/app/{tenant}/settings/access-tokens`. `EnsureHostedWorkspaceAccess` follows the new route name so a paused workspace can still reach its own tokens, and `shouldRegisterNavigation()` now returns `Features::hasApiFeatures()` to keep the API-feature gate the old menu item carried. Separately, every workspace and profile settings page loses its grey section descriptions and page subheadings (Profile, Notifications, Access Tokens, Workspace General, Members, Custom Fields, Billing), along with the 13 lang keys left without a caller. Field helper text, role descriptions, and modal and empty-state copy stay, since those explain a control the user is about to operate.

## Test plan

- Full suite green: 2979 passed, 2 skipped. Pint, PHPStan (0 errors) and 100% type coverage all pass; Rector proposes nothing.
- Walked all seven settings tabs in the browser, plus dark mode and a 390px viewport on Access Tokens: the strip reads Profile | Notifications | Access Tokens, the workspace strip is unchanged, and no page renders description text.
- Verified the user-menu Access Tokens link resolves to the new URL, `/settings` still redirects to `/settings/profile`, and the old `/access-tokens` path returns 404.