### PR TITLE
feat(geo): deepen compare pages, fix Vary header, index marketing pages in llms.txt

### DIFF
--- a/app/Http/Middleware/AddVaryAcceptHeader.php
+++ b/app/Http/Middleware/AddVaryAcceptHeader.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * ProvideMarkdownResponse sets `Vary: Accept` only on the markdown variant;
+ * the HTML variant of the same URL leaves without it. That is latent while
+ * responses are `Cache-Control: private`, but the moment a shared cache (CDN)
+ * keys on the URL alone it will replay one variant to clients that asked for
+ * the other. Registered inside every content-negotiated group so the HTML
+ * variant declares the negotiation too; the markdown variant already does.
+ */
+final readonly class AddVaryAcceptHeader
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $response = $next($request);
+
+        if ($response instanceof Response && ! in_array('Accept', $response->getVary(), true)) {
+            $response->setVary('Accept', replace: false);
+        }
+
+        return $response;
+    }
+}

--- a/app/Support/CompetitorFacts.php
+++ b/app/Support/CompetitorFacts.php
@@ -27,6 +27,7 @@ final readonly class CompetitorFacts
      *     self_host: string,
      *     ai: string,
      *     extensibility: string,
+     *     source_urls: array{website: string, pricing: string, repository?: string},
      *     verified: string,
      * }>
      */
@@ -46,6 +47,7 @@ final readonly class CompetitorFacts
          *     self_host: string,
          *     ai: string,
          *     extensibility: string,
+         *     source_urls: array{website: string, pricing: string, repository?: string},
          *     verified: string,
          * }> $facts
          */

--- a/config/ink.php
+++ b/config/ink.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Middleware\AddVaryAcceptHeader;
 use App\Models\User;
 use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 
@@ -38,7 +39,7 @@ return [
         'feed' => 'blog.feed',
     ],
 
-    'middleware' => ['web', ProvideMarkdownResponse::class],
+    'middleware' => ['web', ProvideMarkdownResponse::class, AddVaryAcceptHeader::class],
 
     /*
      * ink's Mcp::web() route already carries ReorderJsonAccept and

--- a/packages/Documentation/routes/web.php
+++ b/packages/Documentation/routes/web.php
@@ -2,19 +2,20 @@
 
 declare(strict_types=1);
 
+use App\Http\Middleware\AddVaryAcceptHeader;
 use Illuminate\Support\Facades\Route;
 use Relaticle\Documentation\Http\Controllers\DocumentationController;
 use Relaticle\Documentation\Http\Controllers\HelpController;
 use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 
-Route::middleware([ProvideMarkdownResponse::class])->prefix('developers')->name('documentation.')->group(function (): void {
+Route::middleware([ProvideMarkdownResponse::class, AddVaryAcceptHeader::class])->prefix('developers')->name('documentation.')->group(function (): void {
     Route::get('/', [DocumentationController::class, 'index'])->name('index');
     Route::get('/{type}', [DocumentationController::class, 'show'])->name('show');
 });
 
 Route::get('/llms.txt', [HelpController::class, 'llmsTxt'])->name('llms-txt');
 
-Route::middleware([ProvideMarkdownResponse::class])->prefix('help')->name('help.')->group(function (): void {
+Route::middleware([ProvideMarkdownResponse::class, AddVaryAcceptHeader::class])->prefix('help')->name('help.')->group(function (): void {
     Route::get('/', [HelpController::class, 'index'])->name('index');
     Route::get('/search-index.json', [HelpController::class, 'searchIndex'])->name('search-index');
     Route::get('/{category}', [HelpController::class, 'category'])->name('category')->where('category', '[a-z0-9-]+');

--- a/packages/Documentation/src/Http/Controllers/HelpController.php
+++ b/packages/Documentation/src/Http/Controllers/HelpController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Relaticle\Documentation\Http\Controllers;
 
+use App\Support\CompetitorFacts;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Route;
 use Illuminate\View\View;
 use Relaticle\Documentation\Support\BuildSearchIndex;
 use Relaticle\Documentation\Support\DocCategory;
@@ -16,6 +18,7 @@ use Relaticle\Documentation\Support\DocsRepository;
 use Relaticle\Documentation\Support\DocUrl;
 use Relaticle\Documentation\Support\HeadingAnchors;
 use Relaticle\Documentation\Support\RenderDocMarkdown;
+use Relaticle\Ink\Models\Post;
 
 final readonly class HelpController
 {
@@ -125,7 +128,93 @@ final readonly class HelpController
             array_push($lines, '', '## '.__('Developer Documentation'), '', ...$docs);
         }
 
+        $comparisons = $this->llmsTxtComparisonEntries();
+
+        if ($comparisons !== []) {
+            array_push($lines, '', '## '.__('Comparisons & Alternatives'), '', ...$comparisons);
+        }
+        $lines[] = '';
+        $lines[] = '## '.__('Company');
+        $lines[] = '';
+        $lines[] = sprintf(
+            '- [%s](%s): %s',
+            __('Press Kit & Facts'),
+            route('press'),
+            __('Founding date, license, GitHub stars, pricing, tech stack, and product screenshots.'),
+        );
+
+        $blog = $this->llmsTxtBlogEntries();
+
+        if ($blog !== []) {
+            array_push($lines, '', '## '.__('Blog'), '', ...$blog);
+        }
+
         return implode("\n", $lines)."\n";
+    }
+
+    /** @return list<string> */
+    private function llmsTxtComparisonEntries(): array
+    {
+        $facts = CompetitorFacts::all();
+        $entries = [];
+
+        /** @var array<int, string> $compare */
+        $compare = config('comparisons.compare', []);
+
+        foreach ($compare as $slug) {
+            $entries[] = sprintf(
+                '- [%s](%s): %s',
+                __('Relaticle vs :name', ['name' => $facts[$slug]['name']]),
+                route('compare.show', ['competitor' => $slug]),
+                __('License, pricing, GitHub activity, tech stack, and AI/MCP support compared with dated, sourced facts.'),
+            );
+        }
+
+        /** @var array<int, string> $alternatives */
+        $alternatives = config('comparisons.alternatives', []);
+
+        foreach ($alternatives as $slug) {
+            $entries[] = sprintf(
+                '- [%s](%s): %s',
+                __(':name Alternative', ['name' => $facts[$slug]['name']]),
+                route('alternatives.show', ['competitor' => $slug]),
+                __('Why teams switch from :name to an open-source, self-hosted CRM, with the CSV migration path.', ['name' => $facts[$slug]['name']]),
+            );
+        }
+
+        return $entries;
+    }
+
+    /** @return list<string> */
+    private function llmsTxtBlogEntries(): array
+    {
+        if (! Route::has('blog.index')) {
+            return [];
+        }
+
+        $entries = [sprintf(
+            '- [%s](%s): %s',
+            __('Engineering Blog'),
+            route('blog.index'),
+            __('Engineering posts on building an open-source, AI-native CRM.'),
+        )];
+
+        $posts = Post::query()
+            ->published()
+            ->latest('published_at')
+            ->toBase()
+            ->get(['title', 'slug', 'excerpt']);
+
+        foreach ($posts as $post) {
+            $entries[] = sprintf(
+                '- [%s](%s): %s',
+                $post->title,
+                route('blog.show', ['slug' => $post->slug]),
+                $post->excerpt,
+            );
+        }
+
+        return $entries;
     }
 
     /** @return list<string> */

--- a/resources/data/competitor-facts.php
+++ b/resources/data/competitor-facts.php
@@ -17,6 +17,10 @@ declare(strict_types=1);
  * `contributors` is the total contributor count from the GitHub API
  * (`contributors_url`, unauthenticated commits only, no `anon=true`).
  *
+ * `source_urls` carries the primary sources behind the claims: `website` and
+ * `pricing` always, `repository` only where a public repository exists. The
+ * comparison pages render them so every fact is one click from its origin.
+ *
  * @return array<string, array{
  *     name: string,
  *     license: string,
@@ -30,6 +34,7 @@ declare(strict_types=1);
  *     self_host: string,
  *     ai: string,
  *     extensibility: string,
+ *     source_urls: array{website: string, pricing: string, repository?: string},
  *     verified: string,
  * }>
  */
@@ -47,6 +52,11 @@ return [
         'self_host' => 'Self-host free under AGPL-3.0, no feature gating',
         'ai' => '32 first-party MCP tools plus a built-in AI chat assistant; MCP, chat, and Ollama all work self-hosted',
         'extensibility' => 'REST API plus a 32-tool MCP server; the entire codebase is AGPL-3.0, so any part can be forked and extended directly',
+        'source_urls' => [
+            'website' => 'https://relaticle.com',
+            'pricing' => 'https://relaticle.com/pricing',
+            'repository' => 'https://github.com/relaticle/relaticle',
+        ],
         'verified' => '2026-08-13',
     ],
     'twenty' => [
@@ -62,6 +72,11 @@ return [
         'self_host' => 'Self-hostable core; enterprise-tagged files are license-restricted',
         'ai' => 'First-party MCP server marketed for Cloud workspaces',
         'extensibility' => 'MIT-licensed apps SDK (twenty-sdk, create-twenty-app) for building custom objects, server logic, and UI components as TypeScript packages, per docs.twenty.com/developers — the core CRM repo itself stays AGPL-3.0 + Twenty Application Exception',
+        'source_urls' => [
+            'website' => 'https://twenty.com',
+            'pricing' => 'https://twenty.com/pricing',
+            'repository' => 'https://github.com/twentyhq/twenty',
+        ],
         'verified' => '2026-08-13',
     ],
     'espocrm' => [
@@ -77,6 +92,11 @@ return [
         'self_host' => 'Free self-hosted core; paid extensions for self-hosters',
         'ai' => 'No first-party AI or MCP tooling',
         'extensibility' => 'No official first-party app store; paid extensions come from third-party marketplaces (e.g. OSOM, devcrm.it)',
+        'source_urls' => [
+            'website' => 'https://www.espocrm.com',
+            'pricing' => 'https://www.espocrm.com/pricing/',
+            'repository' => 'https://github.com/espocrm/espocrm',
+        ],
         'verified' => '2026-08-13',
     ],
     'attio' => [
@@ -92,6 +112,10 @@ return [
         'self_host' => 'No self-hosting option',
         'ai' => 'Proprietary AI research and enrichment features',
         'extensibility' => 'REST API and a small set of native integrations (Slack, Calendly, DocuSign, email/calendar) plus Zapier/Make for everything else; no first-party app marketplace',
+        'source_urls' => [
+            'website' => 'https://attio.com',
+            'pricing' => 'https://attio.com/pricing',
+        ],
         'verified' => '2026-08-13',
     ],
     'hubspot' => [
@@ -107,6 +131,10 @@ return [
         'self_host' => 'No self-hosting option',
         'ai' => 'Proprietary AI features bundled into paid Hubs',
         'extensibility' => 'Official App Marketplace for third-party integrations, agents, and templates',
+        'source_urls' => [
+            'website' => 'https://www.hubspot.com',
+            'pricing' => 'https://www.hubspot.com/pricing/crm',
+        ],
         'verified' => '2026-08-13',
     ],
 ];

--- a/resources/views/compare/show.blade.php
+++ b/resources/views/compare/show.blade.php
@@ -7,23 +7,23 @@
     $copy = [
         'twenty' => [
             'badge' => __('Comparison'),
-            'opening' => __('Relaticle and Twenty are both AGPL-3.0, self-hostable CRMs, so the choice comes down to what you\'re optimizing for. Pick Relaticle if you want AI tooling — chat and MCP — that runs fully self-hosted and flat pricing that doesn\'t grow with headcount. Pick Twenty if you want the larger open-source community or prefer a Node/NestJS stack over Laravel and PHP.'),
+            'opening' => __('Relaticle and Twenty CRM are both AGPL-3.0, self-hostable CRMs, so the choice comes down to what you\'re optimizing for. Pick Relaticle if you want AI tooling — chat and MCP — that runs fully self-hosted and flat pricing that doesn\'t grow with headcount. Pick Twenty if you want the larger open-source community or prefer a Node/NestJS stack over Laravel and PHP.'),
             'sections' => [
                 [
-                    'heading' => __('License & pricing'),
-                    'body' => __('Both projects publish under AGPL-3.0 — Twenty adds a Twenty Application Exception that license-tags its enterprise files in-repo. Relaticle charges a flat :relaticlePricing. Twenty prices per user (:twentyPricing), so its bill scales with every seat you add.', ['relaticlePricing' => $relaticle['pricing'], 'twentyPricing' => $competitor['pricing']]),
+                    'heading' => __('How do Relaticle and Twenty pricing compare?'),
+                    'body' => __('Relaticle charges :relaticlePricing — the bill is the same whether two people use the workspace or two hundred. Twenty prices per user (:twentyPricing), so its bill scales with every seat you add, and the gap between the two models widens as your team grows. On licensing, both projects publish under AGPL-3.0; Twenty adds a Twenty Application Exception that license-tags its enterprise files in-repo, which means some functionality stays legally reserved even in a self-hosted deploy. Relaticle has no equivalent carve-out: the self-hosted and hosted versions run the same codebase with no feature gating.', ['relaticlePricing' => $relaticle['pricing'], 'twentyPricing' => $competitor['pricing']]),
                 ],
                 [
-                    'heading' => __('AI and MCP tooling'),
-                    'body' => __('Relaticle ships :relaticleAi. Twenty\'s offering is :twentyAi — self-hosters get the core CRM, but the AI tooling itself is Cloud-oriented.', ['relaticleAi' => $relaticle['ai'], 'twentyAi' => $competitor['ai']]),
+                    'heading' => __('Which one runs AI and MCP self-hosted?'),
+                    'body' => __('Relaticle ships :relaticleAi. Every write the built-in assistant proposes renders as an approval card — old value to new value, per field — and executes only when a human accepts it, so the AI layer is safe to point at real customer data. Twenty\'s offering is :twentyAi — self-hosters get the core CRM, but the AI tooling itself is Cloud-oriented, and its public self-hosting documentation does not describe an equivalent out-of-the-box MCP setup. If self-hosted AI is the requirement, this is the sharpest difference between the two products.', ['relaticleAi' => $relaticle['ai'], 'twentyAi' => $competitor['ai']]),
                 ],
                 [
-                    'heading' => __('Tech stack & deployment'),
-                    'body' => __('Relaticle runs on :relaticleStack. Twenty runs on :twentyStack — more moving parts to operate yourself if you self-host.', ['relaticleStack' => $relaticle['stack'], 'twentyStack' => $competitor['stack']]),
+                    'heading' => __('What does self-hosting each one take?'),
+                    'body' => __('Relaticle runs on :relaticleStack — one process to operate, and :relaticleSelfHost. Twenty runs on :twentyStack, which means more moving parts to provision, monitor, and upgrade yourself. Twenty\'s position is :twentySelfHost. If you want the smallest possible operational footprint, a single Laravel server is hard to beat; if you already operate Node services with Redis and Postgres, Twenty\'s stack will feel familiar.', ['relaticleStack' => $relaticle['stack'], 'relaticleSelfHost' => lcfirst($relaticle['self_host']), 'twentyStack' => $competitor['stack'], 'twentySelfHost' => lcfirst($competitor['self_host'])]),
                 ],
                 [
-                    'heading' => __('Community & extensibility'),
-                    'body' => __('Twenty has the bigger open-source footprint — :twentyStars GitHub stars and :twentyContributors contributors, against Relaticle\'s :relaticleStars stars and :relaticleContributors. Twenty also ships :twentyExtensibility. Relaticle\'s extensibility is :relaticleExtensibility.', [
+                    'heading' => __('Who has the bigger community and ecosystem?'),
+                    'body' => __('Twenty CRM has the bigger open-source footprint — :twentyStars GitHub stars and :twentyContributors contributors on the twentyhq/twenty repository, against Relaticle\'s :relaticleStars stars and :relaticleContributors. Twenty also ships :twentyExtensibility. Relaticle\'s extensibility is :relaticleExtensibility. If community size, third-party extensions, or the confidence of a large existing user base decides it for you, that point goes to Twenty; if you want a smaller codebase you can read end to end and extend directly, that favors Relaticle.', [
                         'twentyStars' => number_format($competitor['stars']),
                         'twentyContributors' => $competitor['contributors'],
                         'relaticleStars' => number_format($relaticle['stars']),
@@ -39,19 +39,19 @@
             'opening' => __('Relaticle and EspoCRM are both open-source, AGPL-3.0, self-hosted-first CRMs built to run on a single PHP server. Pick Relaticle if built-in AI — a chat assistant plus a 32-tool MCP server — matters to you, since EspoCRM ships neither today. Pick EspoCRM if you want a more established codebase and its paid extension ecosystem for specific integrations.'),
             'sections' => [
                 [
-                    'heading' => __('License & pricing'),
-                    'body' => __('Both are AGPL-3.0. Relaticle charges a flat :relaticlePricing. EspoCRM prices per user with seat minimums (:espocrmPricing).', ['relaticlePricing' => $relaticle['pricing'], 'espocrmPricing' => $competitor['pricing']]),
+                    'heading' => __('How do Relaticle and EspoCRM pricing compare?'),
+                    'body' => __('Both are AGPL-3.0, and both can be self-hosted for free. On the hosted side the models split: Relaticle charges :relaticlePricing, while EspoCRM prices per user with seat minimums (:espocrmPricing), so a small team pays for seats it may not fill. Self-hosters should also note the difference in what "free" covers — Relaticle ships one codebase with no feature gating, while EspoCRM sells paid extensions on top of its free core.', ['relaticlePricing' => $relaticle['pricing'], 'espocrmPricing' => $competitor['pricing']]),
                 ],
                 [
-                    'heading' => __('AI and MCP tooling'),
-                    'body' => __('Relaticle ships :relaticleAi. EspoCRM\'s AI: :espocrmAi.', ['relaticleAi' => $relaticle['ai'], 'espocrmAi' => $competitor['ai']]),
+                    'heading' => __('Which one has built-in AI and MCP support?'),
+                    'body' => __('Relaticle ships :relaticleAi. Every write the built-in assistant proposes is a human-approved card, so the AI can work real customer data without acting unilaterally. EspoCRM\'s AI: :espocrmAi. If AI tooling matters to your evaluation, this is the deciding dimension — EspoCRM simply does not compete on it today.', ['relaticleAi' => $relaticle['ai'], 'espocrmAi' => $competitor['ai']]),
                 ],
                 [
-                    'heading' => __('Tech stack & deployment'),
-                    'body' => __('Relaticle runs on :relaticleStack. EspoCRM runs on :espocrmStack — both are single-server-friendly PHP deployments.', ['relaticleStack' => $relaticle['stack'], 'espocrmStack' => $competitor['stack']]),
+                    'heading' => __('What does self-hosting each one take?'),
+                    'body' => __('Relaticle runs on :relaticleStack. EspoCRM runs on :espocrmStack — both are single-server-friendly PHP deployments, so neither demands a heavy operations setup. On hosting economics the split is :relaticleSelfHost for Relaticle versus :espocrmSelfHost for EspoCRM.', ['relaticleStack' => $relaticle['stack'], 'espocrmStack' => $competitor['stack'], 'relaticleSelfHost' => lcfirst($relaticle['self_host']), 'espocrmSelfHost' => lcfirst($competitor['self_host'])]),
                 ],
                 [
-                    'heading' => __('Community & extensibility'),
+                    'heading' => __('Who has the bigger community and ecosystem?'),
                     'body' => __('EspoCRM has the longer track record — :espocrmStars GitHub stars and :espocrmContributors contributors, against Relaticle\'s :relaticleStars stars and :relaticleContributors. EspoCRM\'s extensibility is :espocrmExtensibility. Relaticle\'s is :relaticleExtensibility.', [
                         'espocrmStars' => number_format($competitor['stars']),
                         'espocrmContributors' => $competitor['contributors'],
@@ -77,7 +77,16 @@
 
     $title = $titles[$competitorSlug];
     $description = $descriptions[$competitorSlug];
-    $factsVerifiedAt = \Carbon\CarbonImmutable::parse($relaticle['verified'])->format('F j, Y');
+    $factsVerifiedDate = \Carbon\CarbonImmutable::parse($relaticle['verified']);
+    $factsVerifiedAt = $factsVerifiedDate->format('F j, Y');
+
+    $primarySources = collect([$relaticle, $competitor])
+        ->flatMap(fn (array $facts): array => array_filter([
+            ['label' => __(':name pricing', ['name' => $facts['name']]), 'url' => $facts['source_urls']['pricing']],
+            isset($facts['source_urls']['repository'])
+                ? ['label' => __(':name on GitHub', ['name' => $facts['name']]), 'url' => $facts['source_urls']['repository']]
+                : null,
+        ]));
 @endphp
 
 <x-guest-layout
@@ -132,8 +141,15 @@
                 @endforeach
             </div>
 
-            <p class="text-xs text-gray-400 dark:text-gray-500 mb-16">
+            <p class="text-xs text-gray-400 dark:text-gray-500 mb-3">
                 {{ __('Facts verified :date. Sources are dated in the underlying facts file — see :repo.', ['date' => $factsVerifiedAt, 'repo' => 'github.com/relaticle/relaticle']) }}
+            </p>
+
+            <p class="text-xs text-gray-400 dark:text-gray-500 mb-16">
+                {{ __('Primary sources:') }}
+                @foreach ($primarySources as $source)
+                    <a href="{{ $source['url'] }}" rel="nofollow noopener" target="_blank" class="underline decoration-gray-300 dark:decoration-gray-600 underline-offset-2 hover:text-gray-600 dark:hover:text-gray-300">{{ $source['label'] }}</a>{{ $loop->last ? '.' : ',' }}
+                @endforeach
             </p>
 
             {{-- CTA --}}
@@ -158,11 +174,26 @@
     </section>
 
     @php
+        $aboutEntity = function (array $facts): \Spatie\SchemaOrg\SoftwareApplication {
+            $application = \Spatie\SchemaOrg\Schema::softwareApplication()
+                ->name($facts['name'])
+                ->url($facts['source_urls']['website'])
+                ->applicationCategory('BusinessApplication');
+
+            if (isset($facts['source_urls']['repository'])) {
+                $application->sameAs([$facts['source_urls']['repository']]);
+            }
+
+            return $application;
+        };
+
         $schema = (new \Spatie\SchemaOrg\Graph())
             ->webPage(fn ($page) => $page
                 ->name($title)
                 ->description($description)
-                ->url(url()->current()))
+                ->url(url()->current())
+                ->dateModified($factsVerifiedDate)
+                ->about([$aboutEntity($relaticle), $aboutEntity($competitor)]))
             ->breadcrumbList(fn ($list) => $list
                 ->itemListElement([
                     \Spatie\SchemaOrg\Schema::listItem()->position(1)->name('Relaticle')->item(url('/')),

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\JoinTeamViaLinkController;
 use App\Http\Controllers\PrivacyPolicyController;
 use App\Http\Controllers\TermsOfServiceController;
+use App\Http\Middleware\AddVaryAcceptHeader;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Support\Facades\Route;
@@ -50,7 +51,7 @@ Route::middleware('guest')->group(function () {
     Route::get('/forgot-password', fn () => redirect()->to(url()->getAppUrl('forgot-password')))->name('password.request');
 });
 
-Route::middleware(ProvideMarkdownResponse::class)->group(function (): void {
+Route::middleware([ProvideMarkdownResponse::class, AddVaryAcceptHeader::class])->group(function (): void {
     Route::get('/', HomeController::class);
     Route::get('/terms-of-service', TermsOfServiceController::class)->name('terms.show');
     Route::get('/privacy-policy', PrivacyPolicyController::class)->name('policy.show');

--- a/tests/Feature/ComparisonPagesTest.php
+++ b/tests/Feature/ComparisonPagesTest.php
@@ -27,6 +27,26 @@ it('serves comparison pages as clean markdown without nav chrome', function (): 
         ->and($markdown)->not->toContain('Skip to');
 });
 
+it('renders question-shaped headings and primary source links on comparison pages', function (): void {
+    $html = $this->get('/compare/relaticle-vs-twenty')->assertOk()->getContent();
+
+    expect($html)->toContain('How do Relaticle and Twenty pricing compare?')
+        ->and($html)->toContain('Which one runs AI and MCP self-hosted?')
+        ->and($html)->toContain('Twenty CRM')
+        ->and($html)->toContain(__('Primary sources:'))
+        ->and($html)->toContain('https://twenty.com/pricing')
+        ->and($html)->toContain('https://github.com/twentyhq/twenty');
+});
+
+it('marks comparison pages with dateModified and about entities in the JSON-LD graph', function (): void {
+    $html = $this->get('/compare/relaticle-vs-espocrm')->assertOk()->getContent();
+
+    expect($html)->toContain('"dateModified"')
+        ->and($html)->toContain('"about"')
+        ->and($html)->toContain('"SoftwareApplication"')
+        ->and($html)->toContain('https://github.com/espocrm/espocrm');
+});
+
 it('does not lowercase the leading acronym of an extensibility fact in alternatives prose', function (): void {
     $html = $this->get('/alternatives/attio')->assertOk()->getContent();
 

--- a/tests/Feature/Documentation/HelpSeoTest.php
+++ b/tests/Feature/Documentation/HelpSeoTest.php
@@ -135,7 +135,12 @@ it('serves an llms.txt indexing help and docs', function (): void {
     expect($body)->toContain('/help/getting-started/create-your-first-company')
         ->and($body)->toContain('/developers/self-hosting')
         ->and($body)->toContain('Help Centre')
-        ->and($body)->toContain('Documentation');
+        ->and($body)->toContain('Documentation')
+        ->and($body)->toContain('/compare/relaticle-vs-twenty')
+        ->and($body)->toContain('/compare/relaticle-vs-espocrm')
+        ->and($body)->toContain('/alternatives/attio')
+        ->and($body)->toContain('/alternatives/hubspot')
+        ->and($body)->toContain('/press');
 });
 
 it('gives the search index anchors that equal the real heading ids the renderer emits', function (): void {

--- a/tests/Feature/MarkdownResponseTest.php
+++ b/tests/Feature/MarkdownResponseTest.php
@@ -47,6 +47,19 @@ it('decodes html entities instead of leaking double-escaped ampersands', functio
         ->and($markdown)->not->toContain('Import &amp; Export');
 });
 
+it('declares Vary: Accept on both variants of a content-negotiated route', function (): void {
+    $htmlVary = $this->get('/compare/relaticle-vs-twenty')
+        ->assertOk()
+        ->headers->get('Vary', '');
+
+    $markdownVary = $this->get('/compare/relaticle-vs-twenty', ['Accept' => 'text/markdown'])
+        ->assertOk()
+        ->headers->get('Vary', '');
+
+    expect($htmlVary)->toContain('Accept')
+        ->and($markdownVary)->toContain('Accept');
+});
+
 it('converts a real html table to pipe-table markdown', function (): void {
     Route::middleware(ProvideMarkdownResponse::class)->get('/__markdown-table-fixture', fn () => response(<<<'HTML'
         <html>


### PR DESCRIPTION
Ships the 6 fixes from the 2026-08-18 compare-page GEO audit as one PR.

## Changes

1. **llms.txt now indexes the marketing surface.** New sections: Comparisons & Alternatives (from `config/comparisons.php` + `CompetitorFacts`), Company (press kit), and Blog (published posts via ink, emitted only when the blog routes are registered). Previously `HelpController::llmsTxtBody` indexed help and developer docs only.
2. **Vary header bug fixed.** The HTML variant of every content-negotiated URL left with no `Vary: Accept` while the markdown variant declared it (reproduced on production). Latent while cache-control is private; breaks the moment CDN caching is enabled. New `AddVaryAcceptHeader` middleware (standalone, no inheritance, arch-clean) registered inside all three negotiated groups: marketing routes, developer/help docs, blog.
3. **Body depth.** Compare-page sections rewritten with question-shaped headings ("How do Relaticle and Twenty pricing compare?") and fuller prose. All competitor numbers still flow exclusively from `resources/data/competitor-facts.php` placeholders.
4. **'Twenty CRM' bigram** added in the opening and community sections for entity matching.
5. **JSON-LD**: WebPage now carries `dateModified` (facts verified date) and `about` entities (SoftwareApplication for Relaticle and the competitor, with GitHub `sameAs` where a repo exists).
6. **Primary-source links per fact.** `competitor-facts.php` entries gain `source_urls` (website, pricing, repository); compare pages render a "Primary sources" block. All 8 URLs verified 200 before shipping.

## Verification

- Reproduce-first on fix 2: new test failed against the old behavior (HTML Vary was empty), passes with the middleware. Production repro captured: markdown variant sent `Vary: Accept`, HTML sent `Vary: Accept-Encoding` only.
- Full suite: 2,984 tests, 2,982 passed, 2 skipped. PHPStan clean, type coverage 100%, pint + rector applied, `gtm:stale-facts` reports all facts fresh.
- Browser-verified light + dark at 1440px on `/compare/relaticle-vs-twenty`; question headings, sources block, and JSON-LD (`dateModified`, `about`) confirmed in the rendered page.

## Test plan

- `php artisan test --compact tests/Feature/ComparisonPagesTest.php tests/Feature/MarkdownResponseTest.php tests/Feature/Documentation/`
- After deploy: `curl -sI https://relaticle.com/compare/relaticle-vs-twenty | grep -i vary` should include `Accept`; `curl https://relaticle.com/llms.txt` should list compare, alternatives, press, and blog entries.