### PR TITLE
chore: publish com.relaticle/crm to the mcp registry on every release

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,8 +1,9 @@
 name: Publish to MCP Registry
 
 # Keeps the com.relaticle/crm listing on registry.modelcontextprotocol.io in
-# lockstep with product releases. The listing's version is taken from the
-# release tag, not from server.json, so the committed file never needs a bump.
+# lockstep with product releases. server.json is fully static: its version
+# field is the literal placeholder ${VERSION}, substituted from the release
+# tag here at publish time (the same pattern github/github-mcp-server uses).
 #
 # Auth is DNS-based (TXT record on the relaticle.com apex). MCP_PRIVATE_KEY is
 # an Environment secret on `mcp-registry-publish`, restricted to v* tags, so
@@ -34,6 +35,7 @@ jobs:
         run: |
           VERSION="${TAG_NAME#v}"
           jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+          jq -e '.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+")' server.json > /dev/null
           echo "Publishing version ${VERSION}"
 
       - name: Authenticate to MCP Registry

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,43 @@
+name: Publish to MCP Registry
+
+# Keeps the com.relaticle/crm listing on registry.modelcontextprotocol.io in
+# lockstep with product releases. The listing's version is taken from the
+# release tag, not from server.json, so the committed file never needs a bump.
+#
+# Auth is DNS-based (TXT record on the relaticle.com apex). MCP_PRIVATE_KEY is
+# an Environment secret on `mcp-registry-publish`, restricted to v* tags, so
+# only release refs can ever read it.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    if: github.repository == 'relaticle/relaticle'
+    runs-on: ubuntu-latest
+    environment: mcp-registry-publish
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Set version from release tag
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+          echo "Publishing version ${VERSION}"
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login dns --domain relaticle.com --private-key "${{ secrets.MCP_PRIVATE_KEY }}"
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.relaticle/crm",
+  "title": "Relaticle",
+  "description": "Open-source CRM for AI agents: 32 MCP tools over companies, people, deals, tasks, and notes.",
+  "version": "3.4.9",
+  "remotes": [
+    { "type": "streamable-http", "url": "https://mcp.relaticle.com" }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -2,9 +2,12 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.relaticle/crm",
   "title": "Relaticle",
-  "description": "Open-source CRM for AI agents: 32 MCP tools over companies, people, deals, tasks, and notes.",
-  "version": "3.4.9",
+  "description": "Open-source CRM your AI agents can write to: 32 MCP tools for companies, people, deals, and tasks.",
+  "version": "3.4.10-1",
   "remotes": [
-    { "type": "streamable-http", "url": "https://mcp.relaticle.com" }
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.relaticle.com"
+    }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "com.relaticle/crm",
   "title": "Relaticle",
   "description": "Open-source CRM your AI agents can write to: 32 MCP tools for companies, people, deals, and tasks.",
-  "version": "3.4.10-1",
+  "version": "${VERSION}",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Automates the MCP registry listing so it stays in lockstep with product releases. `com.relaticle/crm` v3.4.9 was published manually today (2026-08-19); from the next release onward this workflow keeps it current.

## How it works

- **Trigger:** `release: published` — the same event that gates production deploys, so the registry version always matches what production runs.
- **Version:** taken from the release tag (`v3.5.0` → `3.5.0`) and injected into `server.json` with jq at publish time. The committed `server.json` never needs a version bump; it is the reviewable source of the listing's name, description, and endpoint URL.
- **Auth:** DNS-based (the `v=MCPv1` TXT record now on the relaticle.com apex). The Ed25519 signing key lives in the new `MCP_PRIVATE_KEY` secret.

## Security setup (already done, via API)

Following the registry's official CI hardening guide:

- Created the `mcp-registry-publish` **environment** with a deployment policy restricted to `v*` **tags** — only release refs can read the secret, so a repo writer pushing a branch can never reach it.
- `MCP_PRIVATE_KEY` is stored as an **environment secret**, not a repo secret.
- The job carries `permissions: contents: read` only and a `github.repository` guard so forks never attempt it.

## Verification

- Workflow YAML parses (5 steps); `server.json` matches the live listing exactly (name `com.relaticle/crm`, 92-char description — the registry caps descriptions at 100).
- The identical login + publish sequence was executed manually today end to end: DNS auth succeeded and the listing is live and searchable at registry.modelcontextprotocol.io.

## Test plan

After merging, the next `gh release create vX.Y.Z` should show a "Publish to MCP Registry" run; confirm with:
`curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=relaticle'` — the version should match the new tag.