### PR TITLE
fix(chat): cache the replayed transcript on Anthropic requests

### DIFF
--- a/packages/Chat/config/chat.php
+++ b/packages/Chat/config/chat.php
@@ -49,10 +49,13 @@ return [
     | Anthropic Prompt Caching
     |--------------------------------------------------------------------------
     |
-    | Marks the static system prompt with a cache_control breakpoint, which
-    | caches the whole request prefix (all tool schemas + instructions) on
-    | Anthropic's side. Cuts per-turn input tokens dramatically for multi-turn
-    | conversations. Disable if a model/provider combination misbehaves.
+    | Places two cache_control breakpoints on every Anthropic request. One marks
+    | the static system prompt, caching the whole prefix (tool schemas plus
+    | instructions) so a new conversation never rewrites it. The other is
+    | Anthropic's automatic caching, which follows the last block of the request,
+    | so each step of the agent loop reads the transcript the previous step
+    | wrote. Cuts per-turn input tokens dramatically. Disable if a
+    | model/provider combination misbehaves.
     */
 
     'anthropic_prompt_caching' => (bool) env('CHAT_ANTHROPIC_PROMPT_CACHING', true),

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -491,6 +491,12 @@ PROMPT;
      * static instructions (~10k+ tokens) — per-turn context rides in a second,
      * uncached block. Measured pre-caching waste: 96:1 input:output tokens.
      *
+     * The top-level `cache_control` is Anthropic's automatic caching: it places a
+     * second breakpoint after the last block of the request, which moves forward
+     * as the conversation grows. Without it every step of the agent loop re-reads
+     * the whole transcript at full price: the static prefix is cached, but the
+     * replayed messages and each new tool result are not.
+     *
      * @return array<string, mixed>
      */
     private function anthropicCachedSystemBlocks(): array
@@ -514,7 +520,10 @@ PROMPT;
             ];
         }
 
-        return ['system' => $blocks];
+        return [
+            'system' => $blocks,
+            'cache_control' => ['type' => 'ephemeral'],
+        ];
     }
 
     /**

--- a/packages/Chat/src/Jobs/ProcessChatMessage.php
+++ b/packages/Chat/src/Jobs/ProcessChatMessage.php
@@ -230,6 +230,8 @@ final class ProcessChatMessage implements ShouldQueue
                 ChatTelemetry::breadcrumb('stream.completed', [
                     'input_tokens' => $streamedResponse->usage->promptTokens,
                     'output_tokens' => $streamedResponse->usage->completionTokens,
+                    'cache_read_tokens' => $streamedResponse->usage->cacheReadInputTokens,
+                    'cache_write_tokens' => $streamedResponse->usage->cacheWriteInputTokens,
                 ]);
 
                 $this->broadcastSafely(new ConversationResolved(

--- a/tests/Feature/Chat/SequentialWriteEnforcementTest.php
+++ b/tests/Feature/Chat/SequentialWriteEnforcementTest.php
@@ -57,6 +57,61 @@ it('returns provider-specific options for parallel-tool-call control', function 
     expect($agent->providerOptions(Lab::Anthropic))->toHaveKey('tool_choice');
 });
 
+it('caches both the static prefix and the growing transcript on Anthropic', function (): void {
+    $options = resolve(CrmAssistant::class)->providerOptions(Lab::Anthropic);
+
+    expect($options['system'][0]['cache_control'])->toBe(['type' => 'ephemeral'])
+        ->and($options['cache_control'])->toBe(['type' => 'ephemeral']);
+});
+
+it('sends both cache breakpoints in the Anthropic request body', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $this->actingAs($user);
+
+    Http::fake([
+        'https://api.anthropic.com/*' => Http::response([
+            'id' => 'msg_test',
+            'type' => 'message',
+            'role' => 'assistant',
+            'content' => [['type' => 'text', 'text' => 'Hello!']],
+            'model' => 'claude-sonnet-4-6',
+            'stop_reason' => 'end_turn',
+            'usage' => ['input_tokens' => 5, 'output_tokens' => 3],
+        ]),
+    ]);
+
+    DB::table('agent_conversations')->insert([
+        'id' => '019df800-0000-7000-8000-000000000002',
+        'participant_type' => 'user',
+        'participant_id' => (string) $user->getKey(),
+        'team_id' => $user->currentTeam->getKey(),
+        'title' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $agent = resolve(CrmAssistant::class);
+    $agent->withConversationId('019df800-0000-7000-8000-000000000002');
+    $agent->prompt('hi', provider: 'anthropic', model: 'claude-sonnet-4-6');
+
+    Http::assertSent(function ($request): bool {
+        $body = $request->data();
+
+        return ($body['system'][0]['cache_control']['type'] ?? null) === 'ephemeral'
+            && ($body['cache_control']['type'] ?? null) === 'ephemeral';
+    });
+});
+
+it('omits every cache breakpoint when prompt caching is disabled', function (): void {
+    config()->set('chat.anthropic_prompt_caching', false);
+
+    $options = resolve(CrmAssistant::class)->providerOptions(Lab::Anthropic);
+
+    expect($options)->not->toHaveKey('cache_control')
+        ->and($options)->not->toHaveKey('system')
+        ->and($options)->toHaveKey('tool_choice');
+});
+
 it('write tool result includes agent_should_stop=true in meta', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
     Auth::guard('web')->setUser($user);


### PR DESCRIPTION
Only the static prefix (tool schemas plus instructions) carried a `cache_control` breakpoint, so every step of a `MaxSteps(15)` agent loop re-read the whole growing conversation at full price. Adding a top-level `cache_control` turns on Anthropic's automatic caching, which places a second breakpoint after the last block and moves it forward as the conversation grows; `laravel/ai` merges provider options straight into the request body, so this needs no gateway override. Measured against the real API on `claude-sonnet-4-6` over a 3-step loop with ~2.8k token tool results, uncached input per step went from 73/2945/5816 down to 3/1/1. It also records cache read and write tokens on the `stream.completed` breadcrumb, since `usage.input_tokens` reports only the uncached remainder and gave no way to tell whether caching was working. Worth a separate follow-up: because `input_tokens` excludes cached tokens, `AiSpendStatsWidget` and `ai_credit_transactions` understate real cost.

## Test plan

- `php artisan test tests/Feature/Chat tests/Feature/AI` on an isolated database: 761 passed
- `pint`, `rector --dry-run`, `phpstan analyse` (0 errors), `composer test:type-coverage` (100%)
- Real queued turn through Horizon on Redis: the assistant called a tool and answered "142 companies and 10 people", both matching the database, and the turn recorded `input_tokens=4`
- Kill switch covered: `CHAT_ANTHROPIC_PROMPT_CACHING=false` removes both breakpoints
