### PR TITLE
fix: members page 500 on orphaned membership, restore section descriptions

### DIFF
--- a/app/Livewire/App/AccessTokens/CreateAccessToken.php
+++ b/app/Livewire/App/AccessTokens/CreateAccessToken.php
@@ -41,6 +41,9 @@ final class CreateAccessToken extends BaseLivewireComponent
             ->schema([
                 Section::make(__('access-tokens.sections.create.title'))
                     ->aside()
+                    ->description(
+                        __('access-tokens.sections.create.description'),
+                    )
                     ->schema([
                         TextInput::make('name')
                             ->label(__('access-tokens.form.name'))

--- a/app/Livewire/App/Profile/DeleteAccount.php
+++ b/app/Livewire/App/Profile/DeleteAccount.php
@@ -28,6 +28,7 @@ final class DeleteAccount extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('profile.sections.delete_account.title'))
+                    ->description(__('profile.sections.delete_account.description'))
                     ->aside()
                     ->schema([
                         TextEntry::make('deleteAccountNotice')

--- a/app/Livewire/App/Profile/LogoutOtherBrowserSessions.php
+++ b/app/Livewire/App/Profile/LogoutOtherBrowserSessions.php
@@ -28,6 +28,7 @@ final class LogoutOtherBrowserSessions extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('profile.sections.browser_sessions.title'))
+                    ->description(__('profile.sections.browser_sessions.description'))
                     ->aside()
                     ->schema([
                         Forms\Components\ViewField::make('browserSessions')

--- a/app/Livewire/App/Profile/UpdatePassword.php
+++ b/app/Livewire/App/Profile/UpdatePassword.php
@@ -35,6 +35,7 @@ final class UpdatePassword extends BaseLivewireComponent
             ->schema([
                 Section::make($hasPassword ? __('profile.sections.update_password.title') : __('profile.sections.set_password.title'))
                     ->aside()
+                    ->description($hasPassword ? __('profile.sections.update_password.description') : __('profile.sections.set_password.description'))
                     ->schema([
                         TextInput::make('currentPassword')
                             ->label(__('profile.form.current_password.label'))

--- a/app/Livewire/App/Profile/UpdateProfileInformation.php
+++ b/app/Livewire/App/Profile/UpdateProfileInformation.php
@@ -67,6 +67,7 @@ final class UpdateProfileInformation extends BaseLivewireComponent
             ->schema([
                 Section::make(__('profile.sections.update_profile_information.title'))
                     ->aside()
+                    ->description(__('profile.sections.update_profile_information.description'))
                     ->schema([
                         FileUpload::make('profile_photo_path')
                             ->label(__('profile.form.profile_photo.label'))

--- a/app/Livewire/App/Teams/AddTeamMember.php
+++ b/app/Livewire/App/Teams/AddTeamMember.php
@@ -44,6 +44,7 @@ final class AddTeamMember extends BaseLivewireComponent
                 Section::make(__('teams.sections.add_team_member.title'))
                     ->aside()
                     ->visible(fn () => Gate::check('addTeamMember', $this->team))
+                    ->description(__('teams.sections.add_team_member.description'))
                     ->schema([
                         TextEntry::make('addTeamMemberNotice')
                             ->hiddenLabel()

--- a/app/Livewire/App/Teams/DeleteTeam.php
+++ b/app/Livewire/App/Teams/DeleteTeam.php
@@ -32,6 +32,7 @@ final class DeleteTeam extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('teams.sections.delete_team.title'))
+                    ->description(__('teams.sections.delete_team.description'))
                     ->aside()
                     ->visible(fn () => Gate::check('delete', $this->team))
                     ->schema([

--- a/app/Livewire/App/Teams/TeamMembers.php
+++ b/app/Livewire/App/Teams/TeamMembers.php
@@ -41,7 +41,7 @@ final class TeamMembers extends BaseLivewireComponent implements Tables\Contract
         $teamForeignKeyColumn = 'team_id';
 
         return $table
-            ->query(fn (): Builder => $model::with('user')->where($teamForeignKeyColumn, $this->team->id))
+            ->query(fn (): Builder => $model::with('user')->whereHas('user')->where($teamForeignKeyColumn, $this->team->id))
             ->columns([
                 Tables\Columns\Layout\Split::make([
                     Tables\Columns\ImageColumn::make('profile_photo_url')

--- a/app/Livewire/App/Teams/UpdateTeamName.php
+++ b/app/Livewire/App/Teams/UpdateTeamName.php
@@ -41,6 +41,7 @@ final class UpdateTeamName extends BaseLivewireComponent
             ->schema([
                 Section::make(__('teams.sections.update_team_name.title'))
                     ->aside()
+                    ->description(__('teams.sections.update_team_name.description'))
                     ->schema([
                         TextInput::make('name')
                             ->label(__('teams.form.team_name.label'))

--- a/lang/en/access-tokens.php
+++ b/lang/en/access-tokens.php
@@ -78,6 +78,7 @@ return [
 
     'connectors' => [
         'title' => 'AI Connectors',
+        'description' => 'Assistants such as Claude and ChatGPT that you connected through the consent screen. Revoking one immediately invalidates its access.',
         'columns' => [
             'name' => 'Connector',
             'team' => 'Workspace',

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -35,15 +35,19 @@ return [
     'sections' => [
         'update_profile_information' => [
             'title' => 'Profile Information',
+            'description' => 'Update your account\'s profile information and email address.',
         ],
         'update_password' => [
             'title' => 'Update Password',
+            'description' => 'Ensure your account is using a long, random password to stay secure.',
         ],
         'set_password' => [
             'title' => 'Set Password',
+            'description' => 'Add a password to your account so you can also sign in with your email and password.',
         ],
         'browser_sessions' => [
             'title' => 'Browser Sessions',
+            'description' => 'Manage and log out your active sessions on other browsers and devices.',
             'notice' => 'If necessary, you may log out of all of your other browser sessions across all of your devices. Some of your recent sessions are listed below; however, this list may not be exhaustive. If you feel your account has been compromised, you should also update your password.',
             'labels' => [
                 'current_device' => 'This device',
@@ -53,6 +57,7 @@ return [
         ],
         'delete_account' => [
             'title' => 'Delete Account',
+            'description' => 'Schedule your account for deletion.',
             'notice' => 'Deleting your account will schedule it for permanent removal after a 30-day grace period. You can cancel the deletion by logging back in at any time before that. After the grace period, all your data will be permanently deleted.',
         ],
     ],

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -19,19 +19,24 @@ return [
     'sections' => [
         'update_team_name' => [
             'title' => 'Workspace Name',
+            'description' => 'The workspace\'s name and owner information.',
         ],
         'add_team_member' => [
             'title' => 'Add Member',
+            'description' => 'Add a new member to your workspace, allowing them to collaborate with you.',
             'notice' => 'Please provide the email address of the person you would like to add to this workspace.',
         ],
         'team_members' => [
             'title' => 'Members',
+            'description' => 'All of the people that are part of this workspace.',
         ],
         'pending_team_invitations' => [
             'title' => 'Pending Invitations',
+            'description' => 'These people have been invited to your workspace and have been sent an invitation email. They may join the workspace by accepting the email invitation.',
         ],
         'delete_team' => [
             'title' => 'Delete Workspace',
+            'description' => 'Schedule this workspace for deletion.',
             'notice' => 'Deleting this workspace will schedule it for permanent removal after a 30-day grace period. You can cancel the deletion at any time before that. After the grace period, all resources and data will be permanently deleted.',
             'scheduled_notice' => 'This workspace is scheduled for deletion on :date.',
         ],

--- a/resources/views/livewire/app/access-tokens/manage-access-tokens.blade.php
+++ b/resources/views/livewire/app/access-tokens/manage-access-tokens.blade.php
@@ -2,6 +2,9 @@
     <x-slot name="heading">
         {{ __('access-tokens.sections.manage.title') }}
     </x-slot>
+    <x-slot name="description">
+        {{ __('access-tokens.sections.manage.description') }}
+    </x-slot>
 
     {{ $this->table }}
 

--- a/resources/views/livewire/app/access-tokens/manage-oauth-connectors.blade.php
+++ b/resources/views/livewire/app/access-tokens/manage-oauth-connectors.blade.php
@@ -2,6 +2,9 @@
     <x-slot name="heading">
         {{ __('access-tokens.connectors.title') }}
     </x-slot>
+    <x-slot name="description">
+        {{ __('access-tokens.connectors.description') }}
+    </x-slot>
 
     {{ $this->table }}
 

--- a/resources/views/livewire/app/teams/pending-team-invitations.blade.php
+++ b/resources/views/livewire/app/teams/pending-team-invitations.blade.php
@@ -2,6 +2,9 @@
     <x-slot name="heading">
         {{ __('teams.sections.pending_team_invitations.title') }}
     </x-slot>
+    <x-slot name="description">
+        {{ __('teams.sections.pending_team_invitations.description') }}
+    </x-slot>
 
     {{ $this->table }}
 

--- a/resources/views/livewire/app/teams/team-members.blade.php
+++ b/resources/views/livewire/app/teams/team-members.blade.php
@@ -2,6 +2,9 @@
     <x-slot name="heading">
         {{ __('teams.sections.team_members.title') }}
     </x-slot>
+    <x-slot name="description">
+        {{ __('teams.sections.team_members.description') }}
+    </x-slot>
 
     {{ $this->table }}
 

--- a/tests/Feature/Teams/TeamMembersTest.php
+++ b/tests/Feature/Teams/TeamMembersTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\App\Teams\TeamMembers;
+use App\Models\Membership;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+mutates(TeamMembers::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    $this->team = $this->user->currentTeam;
+    Filament::setTenant($this->team);
+});
+
+test('the members table renders every member of the team', function (): void {
+    $members = User::factory()->count(2)->create();
+
+    $this->team->users()->attach($members->mapWithKeys(
+        fn (User $member): array => [$member->id => ['role' => 'editor']]
+    )->all());
+
+    livewire(TeamMembers::class, ['team' => $this->team])
+        ->assertCanSeeTableRecords(Membership::query()->where('team_id', $this->team->id)->get())
+        ->assertSee($members->first()->email)
+        ->assertSee($members->last()->email);
+});
+
+test('the members table skips a membership row whose user no longer exists', function (): void {
+    Schema::table('team_user', function (Blueprint $table): void {
+        $table->dropForeign(['user_id']);
+    });
+
+    $member = User::factory()->create();
+    $deletedUser = User::factory()->create();
+
+    $this->team->users()->attach([
+        $member->id => ['role' => 'editor'],
+        $deletedUser->id => ['role' => 'editor'],
+    ]);
+
+    $membership = Membership::query()->where('user_id', $member->id)->sole();
+    $orphanedMembership = Membership::query()->where('user_id', $deletedUser->id)->sole();
+
+    $deletedUser->delete();
+
+    livewire(TeamMembers::class, ['team' => $this->team])
+        ->assertCanSeeTableRecords([$membership])
+        ->assertCanNotSeeTableRecords([$orphanedMembership])
+        ->assertSee($member->email);
+});


### PR DESCRIPTION
The workspace members page 500'd because `Filament::getUserAvatarUrl()` is typed non-nullable and was handed `$record->user` as null: production has one orphaned `team_user` row (team Maxforms, created 2025-05-18) whose user was deleted after the ULID migration, and prod is missing the `team_user` foreign keys so nothing cascaded the pivot away. Filtering the table query with `whereHas('user')` drops rows that have no user to render, and every other member surface already reads through `$team->users()`, an inner join that skips orphans, so this page was the only one affected. The second commit reverts the section half of #502: the line under each settings card heading is back, while page subheadings (billing and notifications subtitles, the Custom Fields null override) stay removed and the access tokens move is untouched.

Note for review: after deploy the Maxforms members section renders "No memberships", because the orphan was that team's only pivot row and the workspace owner has never appeared in this table.

## Test plan

- `tests/Feature/Teams/TeamMembersTest.php` drops the `team_user` user_id constraint inside its transaction to reproduce production's schema, then asserts the surviving member renders and the orphan does not. It fails with the exact production TypeError without the fix.
- `php artisan test tests/Feature/Teams tests/Feature/AccessTokens tests/Feature/Profile` passes (207 tests), plus pint, rector, phpstan and 100% type coverage.
- Browser walked: members page populated and orphan-only empty state, then profile, notifications, access tokens, workspace general and members after the copy restore.

## Follow-ups (not in this PR)

- SystemAdmin `UserResource` deletes users with a bare `DeleteAction`/`DeleteBulkAction`, which strands pivot rows and owned teams. Vector exists in code, attribution for this specific deletion unconfirmed.
- Production still holds 1 orphan `team_user` row, 1 orphan `task_user` row and 30 teams whose owner no longer exists. Cleanup and FK restoration belong with the pending `duplicate-team-members` work.
