### PR TITLE
fix(seo): lead the pricing snippet with the price and what is included

### DIFF
--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -1,7 +1,7 @@
 <x-guest-layout
-    title="Pricing - Relaticle"
-    description="Relaticle pricing. No per-seat pricing — flat workspace plans. Unlimited users and records. Self-host free forever."
-    ogTitle="Pricing - Relaticle"
+    title="Pricing - $19/mo flat, unlimited users - Relaticle"
+    description="No per-seat pricing. One flat workspace plan at $19/mo billed yearly, with unlimited users and records. 14-day trial, no card. Self-host free forever."
+    ogTitle="Pricing - $19/mo flat, unlimited users - Relaticle"
 >
     <section class="relative pt-32 pb-24 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">
         <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_50%_at_50%_50%,black_30%,transparent_100%)]"></div>


### PR DESCRIPTION
The `/pricing` page already ranks well and converts almost none of it.

Search Console, 30 days to 2026-08-17: **337 impressions, position 3.3, 1 click** — a 0.30% CTR where position 3 would normally see roughly 10%. The ranking is won; the snippet was throwing the traffic away.

The old title said nothing a searcher comparing CRMs could act on:

```
Pricing - Relaticle
```

The new one leads with the two facts that differentiate us in a result list full of per-seat products:

```
Pricing - $19/mo flat, unlimited users - Relaticle
```

## Claims

Every claim is taken from the rendered page, not invented:

| Claim | Source on the page |
|---|---|
| $19/mo billed yearly | `$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)` |
| unlimited users and records | `includes unlimited users and records` |
| 14-day trial, no card | `14-day trial automatically, with no card required` |
| self-host free forever | h1: `Self-host for free forever` |

An earlier draft led with $24/mo. The page leads with **$19**, so that would have undersold the product in every search result.

## Test plan

- `tests/Feature/PricingPageTest.php` — 22/22 pass, verified green both with and without this change on a clean `main` worktree, so the suite is unaffected either way
- `tests/Feature/Public/PublicPagesTest.php` + `tests/Feature/PanelNoindexTest.php` — 75/75 pass (these are the other two files touching `/pricing`)
- Rendered at HTTP 200 through the real vhost; `<title>`, `<meta name="description">` and `og:title` all confirmed in the output
- Title 50 chars, description 150 chars — both inside Google's truncation limits
- `vendor/bin/pint --dirty` passes

No test asserted the old title string, and the only `/pricing` copy assertion is on the `<h1>`, which is untouched.

## Measuring it

Re-check impressions and CTR for `/pricing` in ~3 weeks:

```
php ~/.claude/scripts/gsc-query.php query sc-domain:relaticle.com <from> <to> page 1000
```

Going 0.3% → 5% at current impressions is roughly 16 extra high-intent clicks a month.