### PR TITLE
feat: make the workspace ownership cap configurable, default 10

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,6 +169,9 @@ FATHOM_ANALYTICS_SITE_ID=
 # RELATICLE_FEATURE_SUPPORT_MENU=true
 # RELATICLE_FEATURE_BLOG=true
 
+# How many workspaces one user may own (invited workspaces do not count)
+# RELATICLE_MAX_OWNED_WORKSPACES=10
+
 # Community Links
 DISCORD_INVITE_URL=https://discord.gg/b9WxzUce4Q
 

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -33,7 +33,7 @@ final readonly class TeamPolicy
      */
     public function create(User $user): bool
     {
-        return $user->ownedTeams()->count() < 3;
+        return $user->ownedTeams()->count() < (int) config('relaticle.workspaces.max_owned_per_user');
     }
 
     /**

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -31,6 +31,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Workspaces
+    |--------------------------------------------------------------------------
+    |
+    | How many workspaces one user may own. Workspaces they were invited into
+    | belong to someone else and never count. A workspace scheduled for
+    | deletion still occupies a slot until the grace period above elapses.
+    |
+    */
+
+    'workspaces' => [
+        'max_owned_per_user' => (int) env('RELATICLE_MAX_OWNED_WORKSPACES', 10),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Horizon Access
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
+++ b/tests/Feature/Onboarding/CreateTeamOnboardingTest.php
@@ -21,6 +21,7 @@ use App\Models\People;
 use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
+use App\Policies\TeamPolicy;
 use Filament\Actions\Testing\TestAction;
 use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Mail;
@@ -34,7 +35,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\RawMessage;
 
-mutates(CreateTeam::class, CreateTeamAction::class, StartProTrial::class, OnboardSeedManager::class, CreateTeamCustomFields::class);
+mutates(CreateTeam::class, CreateTeamAction::class, StartProTrial::class, OnboardSeedManager::class, CreateTeamCustomFields::class, TeamPolicy::class);
 
 // This file is the coverage for demo seeding itself, so it opts back into the
 // feature that TestCase switches off for the rest of the suite.
@@ -1069,7 +1070,21 @@ it('labels the submit button for what it will actually do', function (): void {
         ->assertDontSee(__('filament/pages/teams.create_team.actions.get_started'));
 });
 
+it('allows a fourth workspace under the default cap', function (): void {
+    $user = User::factory()->create();
+
+    Team::factory()->count(3)->create(['user_id' => $user->id]);
+
+    $this->actingAs($user);
+
+    $this->get(route('filament.app.tenant.registration'))->assertSuccessful();
+});
+
 it('explains the workspace limit instead of returning a bare 404', function (): void {
+    // A low cap keeps the fixture small; the point is the behavior at the cap,
+    // whatever the configured number happens to be.
+    config()->set('relaticle.workspaces.max_owned_per_user', 3);
+
     $user = User::factory()->create();
 
     Team::factory()->count(3)->create(['user_id' => $user->id]);
@@ -1084,6 +1099,8 @@ it('explains the workspace limit instead of returning a bare 404', function (): 
 });
 
 it('lets a user finish a wizard run whose workspace pushed them to the limit', function (): void {
+    config()->set('relaticle.workspaces.max_owned_per_user', 3);
+
     $user = User::factory()->create();
 
     // Two existing workspaces: creating this one takes them to the cap of three.
@@ -1113,6 +1130,8 @@ it('lets a user finish a wizard run whose workspace pushed them to the limit', f
 });
 
 it('still refuses a brand new wizard once the user is at the limit', function (): void {
+    config()->set('relaticle.workspaces.max_owned_per_user', 3);
+
     $user = User::factory()->create();
 
     Team::factory()->count(3)->create(['user_id' => $user->id]);


### PR DESCRIPTION
The per-user workspace cap was a bare `< 3` inside `TeamPolicy::create`, so forks and self-hosted deployments could not change it without patching the policy. It now reads `relaticle.workspaces.max_owned_per_user` (env `RELATICLE_MAX_OWNED_WORKSPACES`), and the default rises from 3 to 10. Workspaces a user was invited into still do not count; only ownership does.

**Test plan:** the new test `allows a fourth workspace under the default cap` fails with a 302 when the cap is forced back to 3 and passes at the shipped default, and the three onboarding tests that hardcoded 3 now set the config explicitly so they assert behavior at the cap rather than a number. Full suite green (3039 passed, 0 failures), along with pint, rector, PHPStan and 100% type coverage.