### PR TITLE
Adapt email previews to dark mode

### DIFF
--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -499,8 +499,8 @@ trait HasEmailComposeActions
                         .'</span>'
                         .'<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>'
                         .'</div>'
-                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white">'
-                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0" style="height:20rem"></iframe>'
+                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950">'
+                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0 [color-scheme:light] dark:[color-scheme:dark]" style="height:20rem"></iframe>'
                         .'</div>'
                         .'</div>'
                     );

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -499,8 +499,8 @@ trait HasEmailComposeActions
                         .'</span>'
                         .'<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>'
                         .'</div>'
-                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950">'
-                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0 [color-scheme:light] dark:[color-scheme:dark]" style="height:20rem"></iframe>'
+                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-white/25 dark:bg-neutral-900">'
+                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0 bg-white [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]" style="height:20rem"></iframe>'
                         .'</div>'
                         .'</div>'
                     );

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -1122,8 +1122,8 @@ final class EmailInboxPage extends Page
                         .'</span>'
                         .'<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>'
                         .'</div>'
-                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950">'
-                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0 [color-scheme:light] dark:[color-scheme:dark]" style="height:20rem"></iframe>'
+                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-white/25 dark:bg-neutral-900">'
+                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0 bg-white [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]" style="height:20rem"></iframe>'
                         .'</div>'
                         .'</div>'
                     );

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -1122,8 +1122,8 @@ final class EmailInboxPage extends Page
                         .'</span>'
                         .'<div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>'
                         .'</div>'
-                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white">'
-                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0" style="height:20rem"></iframe>'
+                        .'<div x-show="open" x-collapse class="mt-2 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-950">'
+                        .'<iframe srcdoc="'.e($safeQuotedHtml).'" sandbox="allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" class="block w-full border-0 [color-scheme:light] dark:[color-scheme:dark]" style="height:20rem"></iframe>'
                         .'</div>'
                         .'</div>'
                     );

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -219,6 +220,32 @@ final class Email extends Model
     public function from(): HasMany
     {
         return $this->hasMany(EmailParticipant::class)->where('role', 'from');
+    }
+
+    public function fromParticipant(): ?EmailParticipant
+    {
+        return $this->participants->firstWhere('role', EmailParticipantRole::FROM);
+    }
+
+    /**
+     * @return EloquentCollection<int, EmailParticipant>
+     */
+    public function toParticipants(): EloquentCollection
+    {
+        return $this->participants->where('role', EmailParticipantRole::TO);
+    }
+
+    /**
+     * @return EloquentCollection<int, EmailParticipant>
+     */
+    public function ccParticipants(): EloquentCollection
+    {
+        return $this->participants->where('role', EmailParticipantRole::CC);
+    }
+
+    public function aiLabel(): ?EmailLabel
+    {
+        return $this->labels->firstWhere('source', 'ai');
     }
 
     /**

--- a/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
+++ b/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
@@ -79,7 +79,7 @@ final readonly class EmailHtmlSanitizer
 html, body { margin: 0; background: #ffffff; color: #111827; }
 body {
     box-sizing: border-box;
-    padding: clamp(20px, 4vw, 44px);
+    padding: 0;
     overflow-wrap: anywhere;
 }
 img, video { max-width: 100%; height: auto; }

--- a/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
+++ b/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
@@ -77,7 +77,13 @@ final readonly class EmailHtmlSanitizer
 <style>
 :root { color-scheme: light dark; background: #ffffff; }
 html, body { margin: 0; background: #ffffff; color: #111827; }
+body {
+    box-sizing: border-box;
+    padding: clamp(20px, 4vw, 44px);
+    overflow-wrap: anywhere;
+}
 img, video { max-width: 100%; height: auto; }
+table { max-width: 100%; }
 pre { white-space: pre-wrap; }
 @media (prefers-color-scheme: dark) {
     :root { background: #17181a; }

--- a/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
+++ b/packages/EmailIntegration/src/Support/EmailHtmlSanitizer.php
@@ -59,6 +59,42 @@ final readonly class EmailHtmlSanitizer
 
         $clean = new HtmlSanitizer($config)->sanitize($html);
 
-        return trim($clean) === '' ? null : $clean;
+        if (trim($clean) === '') {
+            return null;
+        }
+
+        return self::wrapPreviewDocument($clean);
+    }
+
+    private static function wrapPreviewDocument(string $html): string
+    {
+        return <<<'HTML'
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="color-scheme" content="light dark">
+<style>
+:root { color-scheme: light dark; background: #ffffff; }
+html, body { margin: 0; background: #ffffff; color: #111827; }
+img, video { max-width: 100%; height: auto; }
+pre { white-space: pre-wrap; }
+@media (prefers-color-scheme: dark) {
+    :root { background: #17181a; }
+    html, body { background: #17181a !important; color: #f3f4f6 !important; }
+    body, table, tbody, thead, tfoot, tr, td, th, div, p, span, section, article, main, blockquote, li {
+        background-color: transparent !important;
+        border-color: #4b5563 !important;
+        color: #f3f4f6 !important;
+    }
+    a { color: #93c5fd !important; }
+    [bgcolor] { background-color: transparent !important; }
+}
+</style>
+</head>
+<body>
+HTML
+            .$html
+            .'</body></html>';
     }
 }

--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -2,16 +2,15 @@
 
 @php
     use Relaticle\EmailIntegration\Enums\EmailDirection;
-    use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
     use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
     use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 
     $authUser = auth()->user();
 
-    $from    = $record->participants->firstWhere('role', EmailParticipantRole::FROM);
-    $toList  = $record->participants->where('role', EmailParticipantRole::TO);
-    $ccList  = $record->participants->where('role', EmailParticipantRole::CC);
-    $aiLabel = $record->labels->firstWhere('source', 'ai');
+    $from    = $record->fromParticipant();
+    $toList  = $record->toParticipants();
+    $ccList  = $record->ccParticipants();
+    $aiLabel = $record->aiLabel();
 
     $canViewSubject = $authUser->can('viewSubject', $record);
     $canViewBody    = $authUser->can('viewBody', $record);
@@ -283,7 +282,8 @@
 
                         if (! doc?.documentElement) return
 
-                        $refs.body.style.height = doc.documentElement.scrollHeight + 'px'
+                        $refs.body.style.height = '1px'
+                        $refs.body.style.height = Math.max(doc.documentElement.scrollHeight, 160) + 'px'
                     },
                     init() {
                         this.fit()
@@ -302,29 +302,31 @@
                         setTimeout(() => { this.ready = true }, 5000)
                     },
                 }"
-                class="relative shrink-0 bg-white dark:bg-gray-950"
+                class="flex shrink-0 justify-center bg-gray-50 px-4 py-5 dark:bg-gray-950 sm:px-6"
             >
-                {{-- Centred over the frame's own area, not the whole reader --}}
-                <div
-                    x-show="! ready"
-                    x-cloak
-                    class="absolute inset-0 z-10 flex items-center justify-center bg-white dark:bg-gray-950"
-                >
-                    <x-filament::loading-indicator class="h-8 w-8 text-primary-500" />
-                </div>
+                <div class="relative w-full max-w-3xl overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-white/25 dark:bg-neutral-900">
+                    {{-- Centred over the frame's own area, not the whole reader --}}
+                    <div
+                        x-show="! ready"
+                        x-cloak
+                        class="absolute inset-0 z-10 flex items-center justify-center bg-white dark:bg-neutral-900"
+                    >
+                        <x-filament::loading-indicator class="h-8 w-8 text-primary-500" />
+                    </div>
 
-                <iframe
-                    x-ref="body"
-                    x-bind:class="ready ? 'opacity-100' : 'opacity-0'"
-                    srcdoc="{{ $safeHtml }}"
-                    sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-                    referrerpolicy="no-referrer"
-                    scrolling="no"
-                    class="block w-full border-0 transition-opacity duration-150 [color-scheme:light] dark:[color-scheme:dark]"
-                    {{-- A placeholder tall enough to centre the spinner in; replaced by
-                         the measured content height the moment the frame loads. --}}
-                    style="height: 24rem"
-                ></iframe>
+                    <iframe
+                        x-ref="body"
+                        x-bind:class="ready ? 'opacity-100' : 'opacity-0'"
+                        srcdoc="{{ $safeHtml }}"
+                        sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+                        referrerpolicy="no-referrer"
+                        scrolling="no"
+                        class="block w-full border-0 bg-white transition-opacity duration-150 [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]"
+                        {{-- A placeholder tall enough to centre the spinner in; replaced by
+                             the measured content height the moment the frame loads. --}}
+                        style="height: 24rem"
+                    ></iframe>
+                </div>
             </div>
         @else
             <div class="shrink-0 px-6 py-5">

--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -320,7 +320,7 @@
                     sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                     referrerpolicy="no-referrer"
                     scrolling="no"
-                    class="block w-full border-0 transition-opacity duration-150"
+                    class="block w-full border-0 transition-opacity duration-150 [color-scheme:light] dark:[color-scheme:dark]"
                     {{-- A placeholder tall enough to centre the spinner in; replaced by
                          the measured content height the moment the frame loads. --}}
                     style="height: 24rem"

--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -302,14 +302,13 @@
                         setTimeout(() => { this.ready = true }, 5000)
                     },
                 }"
-                class="flex shrink-0 justify-center bg-gray-50 px-4 py-5 dark:bg-gray-950 sm:px-6"
+                class="shrink-0 bg-gray-50 dark:bg-gray-950"
             >
-                <div class="relative w-full max-w-3xl overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-white/25 dark:bg-neutral-900">
-                    {{-- Centred over the frame's own area, not the whole reader --}}
+                <div class="relative w-full overflow-hidden border-y border-gray-100 bg-white dark:border-gray-800 dark:bg-neutral-950">
                     <div
                         x-show="! ready"
                         x-cloak
-                        class="absolute inset-0 z-10 flex items-center justify-center bg-white dark:bg-neutral-900"
+                        class="absolute inset-0 z-10 flex items-center justify-center bg-white dark:bg-neutral-950"
                     >
                         <x-filament::loading-indicator class="h-8 w-8 text-primary-500" />
                     </div>
@@ -321,7 +320,7 @@
                         sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                         referrerpolicy="no-referrer"
                         scrolling="no"
-                        class="block w-full border-0 bg-white transition-opacity duration-150 [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]"
+                        class="block w-full border-0 bg-white transition-opacity duration-150 [color-scheme:light] dark:bg-neutral-950 dark:[color-scheme:dark]"
                         {{-- A placeholder tall enough to centre the spinner in; replaced by
                              the measured content height the moment the frame loads. --}}
                         style="height: 24rem"

--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -277,6 +277,7 @@
                  Never add `allow-scripts` here without removing `allow-same-origin`. --}}
             <div
                 x-data="{
+                    ready: false,
                     fit() {
                         const doc = $refs.body?.contentDocument
 
@@ -302,9 +303,13 @@
                         setTimeout(() => { this.ready = true }, 5000)
                     },
                 }"
-                class="shrink-0 bg-gray-50 dark:bg-gray-950"
+                x-bind:class="ready ? 'shrink-0' : 'flex min-h-0 flex-1 flex-col'"
+                class="bg-gray-50 dark:bg-gray-950"
             >
-                <div class="relative w-full overflow-hidden border-y border-gray-100 bg-white dark:border-gray-800 dark:bg-neutral-950">
+                <div
+                    x-bind:class="ready ? '' : 'min-h-0 flex-1'"
+                    class="relative w-full overflow-hidden border-y border-gray-100 bg-white dark:border-gray-800 dark:bg-neutral-950"
+                >
                     <div
                         x-show="! ready"
                         x-cloak

--- a/resources/views/components/emails/quoted-message.blade.php
+++ b/resources/views/components/emails/quoted-message.blade.php
@@ -6,11 +6,10 @@
      carries the reply actions and the draft dock itself — rendering it inside the
      composer would nest a composer in a composer. This shows only who wrote what. --}}
 @php
-    use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
     use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 
     $authUser = auth()->user();
-    $from = $record->participants->firstWhere('role', EmailParticipantRole::FROM);
+    $from = $record->fromParticipant();
     $senderName = $from?->name ?: $from?->email_address ?: '?';
 
     $initials = collect(explode(' ', trim($senderName)))
@@ -59,7 +58,8 @@
 
                     if (! doc?.documentElement) return
 
-                    $refs.quoted.style.height = doc.documentElement.scrollHeight + 'px'
+                    $refs.quoted.style.height = '1px'
+                    $refs.quoted.style.height = Math.max(doc.documentElement.scrollHeight, 112) + 'px'
                 },
                 init() {
                     this.fit()
@@ -73,17 +73,19 @@
                     })
                 },
             }"
-            class="shrink-0 bg-white dark:bg-gray-950"
+            class="flex shrink-0 justify-center bg-gray-50 px-4 py-4 dark:bg-gray-950 sm:px-6"
         >
-            <iframe
-                x-ref="quoted"
-                srcdoc="{{ $safeHtml }}"
-                sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-                referrerpolicy="no-referrer"
-                scrolling="no"
-                class="block w-full border-0 [color-scheme:light] dark:[color-scheme:dark]"
-                style="height: 12rem"
-            ></iframe>
+            <div class="w-full max-w-3xl overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-white/25 dark:bg-neutral-900">
+                <iframe
+                    x-ref="quoted"
+                    srcdoc="{{ $safeHtml }}"
+                    sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+                    referrerpolicy="no-referrer"
+                    scrolling="no"
+                    class="block w-full border-0 bg-white [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]"
+                    style="height: 12rem"
+                ></iframe>
+            </div>
         </div>
     @else
         <p class="px-4 pb-4 text-sm italic text-gray-400 dark:text-gray-500 sm:px-6">

--- a/resources/views/components/emails/quoted-message.blade.php
+++ b/resources/views/components/emails/quoted-message.blade.php
@@ -81,7 +81,7 @@
                 sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                 referrerpolicy="no-referrer"
                 scrolling="no"
-                class="block w-full border-0"
+                class="block w-full border-0 [color-scheme:light] dark:[color-scheme:dark]"
                 style="height: 12rem"
             ></iframe>
         </div>

--- a/resources/views/filament/emails/email-thread.blade.php
+++ b/resources/views/filament/emails/email-thread.blade.php
@@ -172,7 +172,7 @@
                                 srcdoc="{{ $safeHtml }}"
                                 sandbox="allow-popups allow-popups-to-escape-sandbox"
                                 referrerpolicy="no-referrer"
-                                class="w-full rounded-lg border-0"
+                                class="w-full rounded-lg border-0 [color-scheme:light] dark:[color-scheme:dark]"
                                 style="min-height: 200px; height: 60vh"
                             ></iframe>
                         @elseif ($email->body?->body_text)

--- a/resources/views/filament/emails/email-thread.blade.php
+++ b/resources/views/filament/emails/email-thread.blade.php
@@ -1,6 +1,5 @@
 @php
     use Relaticle\EmailIntegration\Enums\EmailDirection;
-    use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
     use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 
     $authUser    = auth()->user();
@@ -25,10 +24,10 @@
     {{-- ── Stacked emails ──────────────────────────────────────────── --}}
     @foreach ($emails as $email)
         @php
-            $from    = $email->from->first();
-            $toList  = $email->participants->where('role', EmailParticipantRole::TO->value);
-            $ccList  = $email->participants->where('role', EmailParticipantRole::CC->value);
-            $aiLabel = $email->labels->firstWhere('source', 'ai');
+            $from    = $email->fromParticipant();
+            $toList  = $email->toParticipants();
+            $ccList  = $email->ccParticipants();
+            $aiLabel = $email->aiLabel();
 
             $senderName = $from?->name ?: $from?->email_address ?: '?';
             $initials   = collect(explode(' ', trim($senderName)))
@@ -165,14 +164,14 @@
 
             {{-- ── Body ──────────────────────────────────────────────── --}}
             @if ($canViewBody)
-                <div class="bg-gray-50 dark:bg-gray-900/30 px-6 pb-5">
-                    <div class="rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-950 px-7 py-5 shadow-xs">
+                <div class="bg-gray-50 px-6 pb-5 dark:bg-gray-950">
+                    <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-white/25 dark:bg-neutral-900">
                         @if ($safeHtml)
                             <iframe
                                 srcdoc="{{ $safeHtml }}"
                                 sandbox="allow-popups allow-popups-to-escape-sandbox"
                                 referrerpolicy="no-referrer"
-                                class="w-full rounded-lg border-0 [color-scheme:light] dark:[color-scheme:dark]"
+                                class="w-full border-0 bg-white [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]"
                                 style="min-height: 200px; height: 60vh"
                             ></iframe>
                         @elseif ($email->body?->body_text)

--- a/resources/views/filament/emails/email-view.blade.php
+++ b/resources/views/filament/emails/email-view.blade.php
@@ -1,15 +1,14 @@
 @php
     use Relaticle\EmailIntegration\Enums\EmailDirection;
-    use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
     use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
     use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 
     $authUser = auth()->user();
 
-    $from    = $record->participants->firstWhere('role', EmailParticipantRole::FROM);
-    $toList  = $record->participants->where('role', EmailParticipantRole::TO);
-    $ccList  = $record->participants->where('role', EmailParticipantRole::CC);
-    $aiLabel = $record->labels->firstWhere('source', 'ai');
+    $from    = $record->fromParticipant();
+    $toList  = $record->toParticipants();
+    $ccList  = $record->ccParticipants();
+    $aiLabel = $record->aiLabel();
 
     $canViewSubject = $authUser->can('viewSubject', $record);
     $canViewBody    = $authUser->can('viewBody', $record);
@@ -164,8 +163,8 @@
 
     {{-- ── Body ────────────────────────────────────────────────────────────── --}}
     @if ($canViewBody)
-        <div class="flex flex-col items-center bg-gray-50 dark:bg-gray-900/30 px-6 py-6">
-            <div class="w-full max-w-3xl rounded-xl border border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-950 px-8 py-6 shadow-xs">
+        <div class="flex flex-col items-center bg-gray-50 px-6 py-6 dark:bg-gray-950">
+            <div class="w-full max-w-3xl overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-white/25 dark:bg-neutral-900">
                 @if ($record->body?->body_html)
                     @php
                         $safeHtml = EmailHtmlSanitizer::sanitize($record->body->body_html);
@@ -174,7 +173,7 @@
                         srcdoc="{{ $safeHtml }}"
                         sandbox="allow-popups allow-popups-to-escape-sandbox"
                         referrerpolicy="no-referrer"
-                        class="w-full rounded-lg border-0 [color-scheme:light] dark:[color-scheme:dark]"
+                        class="w-full border-0 bg-white [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]"
                         style="min-height: 100vh"
                     ></iframe>
                 @elseif ($record->body?->body_text)

--- a/resources/views/filament/emails/email-view.blade.php
+++ b/resources/views/filament/emails/email-view.blade.php
@@ -174,7 +174,7 @@
                         srcdoc="{{ $safeHtml }}"
                         sandbox="allow-popups allow-popups-to-escape-sandbox"
                         referrerpolicy="no-referrer"
-                        class="w-full rounded-lg border-0"
+                        class="w-full rounded-lg border-0 [color-scheme:light] dark:[color-scheme:dark]"
                         style="min-height: 100vh"
                     ></iframe>
                 @elseif ($record->body?->body_text)

--- a/resources/views/filament/infolists/entries/email-recipients.blade.php
+++ b/resources/views/filament/infolists/entries/email-recipients.blade.php
@@ -1,8 +1,6 @@
 @php
-    use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
-
-    $toList = $record->participants->where('role', EmailParticipantRole::TO);
-    $ccList = $record->participants->where('role', EmailParticipantRole::CC);
+    $toList = $record->toParticipants();
+    $ccList = $record->ccParticipants();
 @endphp
 
 @if ($toList->isNotEmpty() || $ccList->isNotEmpty())

--- a/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
+++ b/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
@@ -116,6 +116,18 @@ it('does not truncate email bodies larger than the sanitizer default input cap',
         ->assertMountedActionModalSeeHtml('END-MARKER-9F3A');
 });
 
+it('wraps sanitized email html in a scriptless dark-mode preview document', function (): void {
+    $html = EmailHtmlSanitizer::sanitize('<p style="color:#111111;background:#ffffff">Body</p>');
+
+    expect($html)
+        ->toContain('<meta name="color-scheme" content="light dark">')
+        ->toContain('@media (prefers-color-scheme: dark)')
+        ->toContain('background: #17181a')
+        ->toContain('background-color: transparent !important')
+        ->toContain('<p style="color:#111111;background:#ffffff">Body</p>')
+        ->not->toContain('<script');
+});
+
 it('renders the email view iframe without a same-origin sandbox', function (): void {
     $email = makeEmailWithBody('<p>body</p>');
 
@@ -123,6 +135,7 @@ it('renders the email view iframe without a same-origin sandbox', function (): v
         ->assertMountedActionModalSeeHtml('<iframe')
         ->assertMountedActionModalSeeHtml('sandbox="allow-popups allow-popups-to-escape-sandbox"')
         ->assertMountedActionModalSeeHtml('referrerpolicy="no-referrer"')
+        ->assertMountedActionModalSeeHtml('[color-scheme:light] dark:[color-scheme:dark]')
         ->assertMountedActionModalDontSeeHtml('allow-same-origin');
 });
 
@@ -144,6 +157,7 @@ it('sandboxes the threaded iframe without same-origin access', function (): void
 
     expect($html)
         ->toContain('sandbox="allow-popups allow-popups-to-escape-sandbox"')
+        ->toContain('[color-scheme:light] dark:[color-scheme:dark]')
         ->not->toContain('allow-scripts')
         ->not->toContain('allow-same-origin');
 });

--- a/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
+++ b/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
@@ -9,12 +9,13 @@ use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Livewire\Features\SupportTesting\Testable;
+use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 
-mutates(EmailHtmlSanitizer::class);
+mutates(Email::class, EmailHtmlSanitizer::class);
 
 beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
@@ -100,6 +101,39 @@ it('preserves inline styles and presentational attributes used by email layouts'
         ->assertMountedActionModalSeeHtml('align=&quot;center&quot;');
 });
 
+it('renders email participants and ai label through the email view helpers', function (): void {
+    $email = makeEmailWithBody('<p>body</p>');
+
+    $email->participants()->createMany([
+        [
+            'role' => EmailParticipantRole::FROM,
+            'name' => 'Alice Sender',
+            'email_address' => 'alice@example.test',
+        ],
+        [
+            'role' => EmailParticipantRole::TO,
+            'name' => 'Tara Recipient',
+            'email_address' => 'tara@example.test',
+        ],
+        [
+            'role' => EmailParticipantRole::CC,
+            'name' => 'Cal Copy',
+            'email_address' => 'cal@example.test',
+        ],
+    ]);
+
+    $email->labels()->create([
+        'source' => 'ai',
+        'label' => 'Sales',
+    ]);
+
+    mountEmailView($email->fresh(['body', 'participants', 'labels', 'attachments']))
+        ->assertMountedActionModalSeeHtml('Alice Sender')
+        ->assertMountedActionModalSeeHtml('Tara Recipient')
+        ->assertMountedActionModalSeeHtml('Cal Copy')
+        ->assertMountedActionModalSeeHtml('Sales');
+});
+
 it('does not truncate email bodies larger than the sanitizer default input cap', function (): void {
     // Symfony HtmlSanitizer truncates input at 20 KB by default; real email
     // bodies routinely exceed that, so the tail of the message must survive.
@@ -123,6 +157,7 @@ it('wraps sanitized email html in a scriptless dark-mode preview document', func
         ->toContain('<meta name="color-scheme" content="light dark">')
         ->toContain('@media (prefers-color-scheme: dark)')
         ->toContain('background: #17181a')
+        ->toContain('padding: clamp(20px, 4vw, 44px)')
         ->toContain('background-color: transparent !important')
         ->toContain('<p style="color:#111111;background:#ffffff">Body</p>')
         ->not->toContain('<script');
@@ -135,7 +170,8 @@ it('renders the email view iframe without a same-origin sandbox', function (): v
         ->assertMountedActionModalSeeHtml('<iframe')
         ->assertMountedActionModalSeeHtml('sandbox="allow-popups allow-popups-to-escape-sandbox"')
         ->assertMountedActionModalSeeHtml('referrerpolicy="no-referrer"')
-        ->assertMountedActionModalSeeHtml('[color-scheme:light] dark:[color-scheme:dark]')
+        ->assertMountedActionModalSeeHtml('dark:bg-neutral-900 dark:[color-scheme:dark]')
+        ->assertMountedActionModalSeeHtml('dark:bg-gray-950')
         ->assertMountedActionModalDontSeeHtml('allow-same-origin');
 });
 
@@ -157,7 +193,8 @@ it('sandboxes the threaded iframe without same-origin access', function (): void
 
     expect($html)
         ->toContain('sandbox="allow-popups allow-popups-to-escape-sandbox"')
-        ->toContain('[color-scheme:light] dark:[color-scheme:dark]')
+        ->toContain('dark:bg-neutral-900 dark:[color-scheme:dark]')
+        ->toContain('dark:bg-gray-950')
         ->not->toContain('allow-scripts')
         ->not->toContain('allow-same-origin');
 });

--- a/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
+++ b/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
@@ -157,7 +157,7 @@ it('wraps sanitized email html in a scriptless dark-mode preview document', func
         ->toContain('<meta name="color-scheme" content="light dark">')
         ->toContain('@media (prefers-color-scheme: dark)')
         ->toContain('background: #17181a')
-        ->toContain('padding: clamp(20px, 4vw, 44px)')
+        ->toContain('padding: 0')
         ->toContain('background-color: transparent !important')
         ->toContain('<p style="color:#111111;background:#ffffff">Body</p>')
         ->not->toContain('<script');


### PR DESCRIPTION
## Summary
- Wrap sanitized email HTML previews in a scriptless document that supports light/dark color schemes
- Propagate app dark mode to sandboxed email preview iframes
- Keep iframe script execution disabled while improving dark-mode readability with `#17181a`

## Tests
- `php artisan test --compact tests/Feature/EmailIntegration/EmailBodySanitizationTest.php`
- `php artisan test --compact tests/Feature/EmailIntegration/EmailComposerTest.php --filter='counts saved draft attachments against the total size cap'`