### PR TITLE
feat(agents): publish openapi at the root, document errors and scopes, markdown 404s

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -105,7 +105,7 @@ final class Team extends JetstreamTeam implements HasAvatar
         // Content & info pages
         'about', 'blog', 'docs', 'documentation', 'faq', 'help', 'support',
         'privacy-policy', 'terms-of-service', 'legal', 'security', 'changelog',
-        'discord', 'llms.txt',
+        'discord', 'llms.txt', 'openapi.json', 'openapi.yaml',
 
         // API & developer
         'api', 'graphql', 'mcp', 'webhooks', 'developer', 'developers', 'connect', 'user', 'users',

--- a/app/Scribe/OpenApi/ErrorResponsesGenerator.php
+++ b/app/Scribe/OpenApi/ErrorResponsesGenerator.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scribe\OpenApi;
+
+use Knuckles\Camel\Output\OutputEndpointData;
+use Knuckles\Scribe\Writing\OpenApiSpecGenerators\OpenApiGenerator;
+
+/**
+ * Adds what Scribe cannot extract from a successful response call: the error
+ * envelope Laravel returns on every endpoint, the token abilities that gate
+ * each HTTP method, and the rate-limit headers the throttle middleware sets.
+ */
+final class ErrorResponsesGenerator extends OpenApiGenerator
+{
+    private const string ERROR_SCHEMA = '#/components/schemas/Error';
+
+    private const string VALIDATION_ERROR_SCHEMA = '#/components/schemas/ValidationError';
+
+    /**
+     * @param  array<string, mixed>  $root
+     * @param  array<int, array{description: string, name: string, endpoints: OutputEndpointData[]}>  $groupedEndpoints
+     * @return array<string, mixed>
+     */
+    public function root(array $root, array $groupedEndpoints): array
+    {
+        $root['components']['schemas']['Error'] = [
+            'type' => 'object',
+            'required' => ['message'],
+            'properties' => [
+                'message' => ['type' => 'string', 'description' => 'Human-readable explanation of the failure.'],
+            ],
+        ];
+
+        $root['components']['schemas']['ValidationError'] = [
+            'type' => 'object',
+            'required' => ['message', 'errors'],
+            'properties' => [
+                'message' => ['type' => 'string', 'description' => 'Summary of the first validation failure.'],
+                'errors' => [
+                    'type' => 'object',
+                    'description' => 'Validation messages keyed by the offending field name.',
+                    'additionalProperties' => ['type' => 'array', 'items' => ['type' => 'string']],
+                ],
+            ],
+        ];
+
+        $root['components']['securitySchemes']['default']['description'] = implode("\n\n", [
+            'Generate an access token from **Settings > Access Tokens** in the Relaticle app.',
+            'Tokens carry scoped abilities: `read` (GET), `create` (POST), `update` (PUT/PATCH), `delete` (DELETE). A request whose token lacks the ability for its HTTP method is rejected with 403.',
+            'Every token is bound to one workspace; responses only ever contain that workspace\'s records.',
+        ]);
+
+        return $root;
+    }
+
+    /**
+     * @param  array<string, mixed>  $pathItem
+     * @param  array<int, array{description: string, name: string, endpoints: OutputEndpointData[]}>  $groupedEndpoints
+     * @return array<string, mixed>
+     */
+    public function pathItem(array $pathItem, array $groupedEndpoints, OutputEndpointData $endpoint): array
+    {
+        $method = strtoupper($endpoint->httpMethods[0]);
+
+        $errors = [
+            '401' => $this->errorResponse('Missing or invalid access token.'),
+            '403' => $this->errorResponse('The token lacks the `'.$this->abilityFor($method).'` ability, or the record belongs to another workspace.'),
+            '429' => [
+                'description' => 'Rate limit exceeded. Back off for the number of seconds in `Retry-After`.',
+                'headers' => [
+                    'Retry-After' => ['schema' => ['type' => 'integer'], 'description' => 'Seconds until the limit resets.'],
+                    'X-RateLimit-Limit' => ['schema' => ['type' => 'integer']],
+                    'X-RateLimit-Remaining' => ['schema' => ['type' => 'integer']],
+                ],
+                'content' => ['application/json' => ['schema' => ['$ref' => self::ERROR_SCHEMA]]],
+            ],
+        ];
+
+        if ($endpoint->urlParameters !== []) {
+            $errors['404'] = $this->errorResponse('No record with that ID exists in the workspace.');
+        }
+
+        if (in_array($method, ['POST', 'PUT', 'PATCH'], true)) {
+            $errors['422'] = [
+                'description' => 'Validation failed.',
+                'content' => ['application/json' => ['schema' => ['$ref' => self::VALIDATION_ERROR_SCHEMA]]],
+            ];
+        }
+
+        $existing = is_array($pathItem['responses'] ?? null) ? $pathItem['responses'] : [];
+
+        $pathItem['responses'] = $existing + $errors;
+        ksort($pathItem['responses']);
+
+        return $pathItem;
+    }
+
+    /** @return array<string, mixed> */
+    private function errorResponse(string $description): array
+    {
+        return [
+            'description' => $description,
+            'content' => ['application/json' => ['schema' => ['$ref' => self::ERROR_SCHEMA]]],
+        ];
+    }
+
+    private function abilityFor(string $method): string
+    {
+        return match ($method) {
+            'POST' => 'create',
+            'PUT', 'PATCH' => 'update',
+            'DELETE' => 'delete',
+            default => 'read',
+        };
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
@@ -24,6 +25,7 @@ use Sentry\Laravel\Integration;
 use Spatie\Health\Commands\DispatchQueueCheckJobsCommand;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -151,7 +153,41 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         Integration::handles($exceptions);
-        $exceptions->shouldRenderJsonWhen(fn (Request $request): bool => $request->is('api/*') || $request->getHost() === config('app.api_domain') || $request->expectsJson());
+        $rendersJson = fn (Request $request): bool => $request->is('api/*') || $request->getHost() === config('app.api_domain') || $request->expectsJson();
+
+        $exceptions->shouldRenderJsonWhen($rendersJson);
+
+        // Agents fetching a dead URL get a markdown body that points at the
+        // indexes, so they can recover instead of guessing. Browsers send
+        // text/html and keep the regular error page.
+        $exceptions->render(function (NotFoundHttpException $e, Request $request) use ($rendersJson): ?Response {
+            $accept = (string) $request->header('Accept', '');
+            $wantsMarkdown = str_contains($accept, 'text/markdown') || ! str_contains($accept, 'text/html');
+
+            if ($rendersJson($request) || ! $wantsMarkdown) {
+                return null;
+            }
+
+            $indexes = array_filter([
+                __('Site index') => 'llms-txt',
+                __('Help centre') => 'help.index',
+                __('Developer docs') => 'documentation.index',
+                __('REST API spec') => 'openapi.json',
+            ], Route::has(...));
+
+            $lines = ['# '.__('Not found'), '', __('Nothing lives at :url.', ['url' => $request->url()]), ''];
+
+            foreach ($indexes as $label => $routeName) {
+                $lines[] = "- {$label}: ".route($routeName);
+            }
+
+            $lines[] = '- '.__('Home: :url', ['url' => config('app.url')]);
+            $lines[] = '';
+
+            $body = implode("\n", $lines);
+
+            return response($body, 404, ['Content-Type' => 'text/markdown; charset=UTF-8']);
+        });
 
         // Stale tabs and deploy boundaries produce checksum failures that
         // Livewire already renders as 419 (page expired -> client refreshes).

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Scribe\OpenApi\ErrorResponsesGenerator;
 use App\Scribe\Strategies\GetFromSpatieQueryBuilder;
 use Knuckles\Scribe\Config\AuthIn;
 use Knuckles\Scribe\Config\Defaults;
@@ -27,7 +28,13 @@ return [
     'intro_text' => <<<'INTRO'
     Welcome to the Relaticle API documentation. This API follows the [JSON:API](https://jsonapi.org/) specification.
 
-    All endpoints require authentication via Bearer token. Generate an access token from **Settings > Access Tokens** in the Relaticle app.
+    All endpoints require authentication via Bearer token. Generate an access token from **Settings > Access Tokens** in the Relaticle app. Tokens carry scoped abilities (`read`, `create`, `update`, `delete`) that map to the HTTP method of each request.
+
+    The API is versioned in the URL path (`/v1/`). Breaking changes ship under a new path version; the previous version keeps working for at least six months after the new one is announced.
+
+    Limits are 600 requests per minute per workspace, and per token 300 reads and 60 writes per minute. Every authenticated response carries `X-RateLimit-Limit` and `X-RateLimit-Remaining`. When a limit is exceeded the API returns `429` with a `Retry-After` header giving the seconds to wait.
+
+    Errors use a consistent JSON envelope: `{"message": "..."}`, and validation failures (`422`) add an `errors` object keyed by field name.
     INTRO
     ,
     // The base URL displayed in the docs.
@@ -171,7 +178,9 @@ return [
 
         // Additional generators to use when generating the OpenAPI spec.
         // Should extend `Knuckles\Scribe\Writing\OpenApiSpecGenerators\OpenApiGenerator`.
-        'generators' => [],
+        'generators' => [
+            ErrorResponsesGenerator::class,
+        ],
     ],
 
     'groups' => [

--- a/packages/Documentation/routes/web.php
+++ b/packages/Documentation/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\AddVaryAcceptHeader;
 use Illuminate\Support\Facades\Route;
 use Relaticle\Documentation\Http\Controllers\DocumentationController;
 use Relaticle\Documentation\Http\Controllers\HelpController;
+use Relaticle\Documentation\Http\Controllers\OpenApiSpecController;
 use Spatie\MarkdownResponse\Middleware\ProvideMarkdownResponse;
 
 Route::middleware([ProvideMarkdownResponse::class, AddVaryAcceptHeader::class])->prefix('developers')->name('documentation.')->group(function (): void {
@@ -14,6 +15,8 @@ Route::middleware([ProvideMarkdownResponse::class, AddVaryAcceptHeader::class])-
 });
 
 Route::get('/llms.txt', [HelpController::class, 'llmsTxt'])->name('llms-txt');
+Route::get('/openapi.json', [OpenApiSpecController::class, 'json'])->name('openapi.json');
+Route::get('/openapi.yaml', [OpenApiSpecController::class, 'yaml'])->name('openapi.yaml');
 
 Route::middleware([ProvideMarkdownResponse::class, AddVaryAcceptHeader::class])->prefix('help')->name('help.')->group(function (): void {
     Route::get('/', [HelpController::class, 'index'])->name('index');

--- a/packages/Documentation/src/Http/Controllers/HelpController.php
+++ b/packages/Documentation/src/Http/Controllers/HelpController.php
@@ -116,6 +116,8 @@ final readonly class HelpController
             '> '.__('Open-source, self-hosted CRM with a built-in AI chat and an MCP server for external AI agents.'),
         ];
 
+        array_push($lines, '', '## '.__('When to use Relaticle'), '', ...$this->llmsTxtWhenToUseEntries());
+
         $help = $this->llmsTxtHelpEntries();
 
         if ($help !== []) {
@@ -277,7 +279,22 @@ final readonly class HelpController
         $apiReference = config('documentation.api_reference');
 
         $entries[] = sprintf('- [%s](%s): %s', $apiReference['title'], url($apiReference['url']), $apiReference['description']);
+        $entries[] = sprintf('- [%s](%s): %s', __('OpenAPI Specification'), route('openapi.json'), __('Machine-readable OpenAPI 3.1 spec for the REST API, also available as YAML at /openapi.yaml.'));
+        $entries[] = sprintf('- [%s](%s): %s', __('MCP Endpoint'), url()->getMcpUrl(), __('Streamable HTTP MCP server with OAuth; connect it from Claude, ChatGPT, or any MCP client.'));
 
         return $entries;
+    }
+
+    /** @return list<string> */
+    private function llmsTxtWhenToUseEntries(): array
+    {
+        return [
+            __('Use Relaticle when an agent needs to read or change CRM records: companies, people, opportunities, tasks, notes, and per-workspace custom fields.'),
+            '',
+            '- '.__('Good fits: logging a lead or meeting, moving a deal between pipeline stages, listing open tasks for a person, updating contact details, attaching a note to a company.'),
+            '- '.__('Not a fit: email sending, calendar scheduling, marketing automation, or invoicing. Relaticle stores the relationship data; it does not run those workflows.'),
+            '- '.__('How to call it: the REST API at :api with a Bearer access token created in Settings > Access Tokens (abilities: read, create, update, delete), or the MCP server at :mcp over OAuth.', ['api' => url()->getApiUrl('v1'), 'mcp' => url()->getMcpUrl()]),
+            '- '.__('Every write is scoped to one workspace; the token or OAuth grant decides which one.'),
+        ];
     }
 }

--- a/packages/Documentation/src/Http/Controllers/OpenApiSpecController.php
+++ b/packages/Documentation/src/Http/Controllers/OpenApiSpecController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Documentation\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Serves the Scribe-generated spec at the root URLs agents probe by
+ * convention (/openapi.json, /openapi.yaml). The file exists only after
+ * scribe:generate has run, so a missing spec is a 404 rather than a 500.
+ */
+final readonly class OpenApiSpecController
+{
+    public function json(): Response
+    {
+        $spec = Yaml::parse($this->spec());
+
+        return response(json_encode($spec, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR), 200, [
+            'Content-Type' => 'application/json',
+        ]);
+    }
+
+    public function yaml(): Response
+    {
+        return response($this->spec(), 200, [
+            'Content-Type' => 'application/yaml; charset=UTF-8',
+        ]);
+    }
+
+    private function spec(): string
+    {
+        abort_unless(Storage::disk('local')->exists('scribe/openapi.yaml'), 404);
+
+        return (string) Storage::disk('local')->get('scribe/openapi.yaml');
+    }
+}

--- a/tests/Feature/Api/V1/ApiMiddlewareTest.php
+++ b/tests/Feature/Api/V1/ApiMiddlewareTest.php
@@ -85,6 +85,35 @@ describe('rate limiting', function (): void {
     });
 });
 
+describe('rate limit headers', function (): void {
+    it('reports the limit and remaining budget on every authenticated response', function (): void {
+        $token = $this->user->createToken('test', ['*'])->plainTextToken;
+
+        $response = $this->withToken($token)
+            ->getJson('/api/v1/companies')
+            ->assertOk();
+
+        expect((int) $response->headers->get('X-RateLimit-Limit'))->toBeGreaterThan(0)
+            ->and((int) $response->headers->get('X-RateLimit-Remaining'))->toBeLessThan((int) $response->headers->get('X-RateLimit-Limit'));
+    });
+
+    it('tells a throttled client how long to wait', function (): void {
+        RateLimiter::for('api', fn () => Limit::perMinute(1)->by($this->user->id));
+
+        $token = $this->user->createToken('test', ['*'])->plainTextToken;
+
+        $this->withToken($token)->getJson('/api/v1/companies')->assertOk();
+
+        $response = $this->withToken($token)
+            ->getJson('/api/v1/companies')
+            ->assertTooManyRequests()
+            ->assertJsonStructure(['message']);
+
+        expect((int) $response->headers->get('Retry-After'))->toBeGreaterThan(0)
+            ->and($response->headers->get('X-RateLimit-Remaining'))->toBe('0');
+    });
+});
+
 describe('real-token middleware chain', function (): void {
     it('authenticates and scopes via real bearer token through full middleware stack', function (): void {
         $companies = Company::factory()->recycle([$this->user, $this->team])->count(2)->create();

--- a/tests/Feature/Documentation/HelpSeoTest.php
+++ b/tests/Feature/Documentation/HelpSeoTest.php
@@ -143,6 +143,16 @@ it('serves an llms.txt indexing help and docs', function (): void {
         ->and($body)->toContain('/press');
 });
 
+it('tells agents when to use Relaticle and where the machine-readable surfaces are', function (): void {
+    $body = $this->get('/llms.txt')->assertOk()->getContent();
+
+    expect($body)->toContain('## When to use Relaticle')
+        ->and($body)->toContain('Not a fit:')
+        ->and($body)->toContain(url()->getApiUrl('v1'))
+        ->and($body)->toContain(route('openapi.json'))
+        ->and($body)->toContain(url()->getMcpUrl());
+});
+
 it('lists the product pages in llms.txt', function (): void {
     $body = $this->get('/llms.txt')->assertOk()->getContent();
 

--- a/tests/Feature/Documentation/OpenApiSpecTest.php
+++ b/tests/Feature/Documentation/OpenApiSpecTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Scribe\OpenApi\ErrorResponsesGenerator;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Relaticle\Documentation\Http\Controllers\OpenApiSpecController;
+
+mutates(OpenApiSpecController::class, ErrorResponsesGenerator::class);
+
+beforeEach(function (): void {
+    Storage::fake('local');
+});
+
+it('404s both spec URLs until scribe has generated the spec', function (): void {
+    $this->get('/openapi.json')->assertNotFound();
+    $this->get('/openapi.yaml')->assertNotFound();
+});
+
+it('serves the generated spec as yaml and as json', function (): void {
+    Storage::disk('local')->put('scribe/openapi.yaml', "openapi: 3.1.0\ninfo:\n  title: Relaticle\npaths: {}\n");
+
+    $this->get('/openapi.yaml')
+        ->assertOk()
+        ->assertHeader('content-type', 'application/yaml; charset=UTF-8')
+        ->assertSee('openapi: 3.1.0', false);
+
+    $this->get('/openapi.json')
+        ->assertOk()
+        ->assertHeader('content-type', 'application/json')
+        ->assertExactJson(['openapi' => '3.1.0', 'info' => ['title' => 'Relaticle'], 'paths' => []]);
+});
+
+it('documents the error envelope, scoped abilities, and rate limits on every operation', function (): void {
+    $generatedView = resource_path('views/scribe/index.blade.php');
+    $committedView = File::get($generatedView);
+
+    try {
+        $this->artisan('scribe:generate', ['--no-interaction' => true, '--force' => true, '--scribe-dir' => storage_path('framework/testing/scribe')])
+            ->assertSuccessful();
+    } finally {
+        File::put($generatedView, $committedView);
+        File::deleteDirectory(storage_path('framework/testing/scribe'));
+    }
+
+    $spec = $this->get('/openapi.json')->assertOk()->json();
+
+    expect($spec['components']['schemas'])->toHaveKeys(['Error', 'ValidationError'])
+        ->and($spec['components']['securitySchemes']['default']['description'])->toContain('`read` (GET)');
+
+    foreach ($spec['paths'] as $path => $operations) {
+        foreach ($operations as $method => $operation) {
+            if ($method === 'parameters') {
+                continue;
+            }
+
+            expect($operation['responses'])->toHaveKeys(['401', '403', '429'], "{$method} {$path}");
+            expect($operation['responses']['429']['headers'])->toHaveKey('Retry-After');
+            expect(isset($operation['responses']['404']))->toBe(str_contains($path, '{id}'), "{$method} {$path}");
+            expect(isset($operation['responses']['422']))->toBe(in_array($method, ['post', 'put', 'patch'], true), "{$method} {$path}");
+        }
+    }
+});

--- a/tests/Feature/MarkdownResponseTest.php
+++ b/tests/Feature/MarkdownResponseTest.php
@@ -87,3 +87,24 @@ it('converts a real html table to pipe-table markdown', function (): void {
         ->and($markdown)->toContain('| Free | $0 |')
         ->and($markdown)->toContain('| Pro | $29 |');
 });
+
+it('gives agents a markdown 404 that links the indexes, and browsers the html page', function (): void {
+    $this->get('/no-such-page', ['Accept' => 'text/markdown'])
+        ->assertNotFound()
+        ->assertHeader('content-type', 'text/markdown; charset=UTF-8')
+        ->assertSee('# Not found', false)
+        ->assertSee(route('llms-txt'), false)
+        ->assertSee(route('openapi.json'), false);
+
+    $this->get('/no-such-page', ['Accept' => '*/*'])
+        ->assertNotFound()
+        ->assertHeader('content-type', 'text/markdown; charset=UTF-8');
+
+    $this->get('/no-such-page', ['Accept' => 'text/html,application/xhtml+xml,*/*;q=0.8'])
+        ->assertNotFound()
+        ->assertHeader('content-type', 'text/html; charset=UTF-8');
+
+    $this->getJson('/api/v1/no-such-endpoint')
+        ->assertNotFound()
+        ->assertHeader('content-type', 'application/json');
+});


### PR DESCRIPTION
## Why

The is-agentic.com scan of relaticle.com scored 73/100. Most failures were discovery, not capability: the spec lived only at `/developers/api.openapi`, carried no error responses or scope description, and `llms.txt` never said when an agent should reach for Relaticle. Items addressed, in the order they were prioritised:

1. Agent-friendly 404s: non-browser clients (`Accept: text/markdown`, or any Accept without `text/html`) get a markdown body linking `llms.txt`, help, developer docs, and the spec. Browsers keep the html error page, the API keeps json.
2. Agent instruction: `llms.txt` gains a `When to use Relaticle` section (fits, non-fits, how to call REST and MCP) and links `/openapi.json` and the MCP endpoint.
3. OpenAPI published at `/openapi.json` and `/openapi.yaml` (same Scribe output). A custom generator adds 401/403/429 to every operation, 404 to `{id}` routes, 422 to writes, shared `Error` / `ValidationError` schemas, `Retry-After` + `X-RateLimit-*` on 429, and documents token abilities (`read`/`create`/`update`/`delete`) as scopes on the bearer scheme.
4. Rate limits: headers were already sent by `throttle:api`; the scanner hit `api.relaticle.com/api/v1/...` (wrong path, 404). Added a test asserting `X-RateLimit-Limit`/`Remaining` on authenticated responses and `Retry-After` on 429, and documented the conventions in the API intro.
5. Versioning policy documented in the API intro (path versioning, previous version kept at least six months after a new one is announced).

## Product decisions to confirm

- The six-month deprecation window in `config/scribe.php` is a new written promise. Change the wording if you want a different commitment.
- Spec changes and the scanner re-score only land after the next deploy (Scribe generates on build; `storage/app/scribe` is not tracked).

## Not done on purpose

CLI tool, Organization address/phone schema, content-efficiency and heading tweaks, brand-search work. None are code-justified; see the discussion in the workspace.

## Test plan

- [x] `tests/Feature/Documentation/OpenApiSpecTest.php`: 404 until generated, yaml and json served, every operation carries the error envelope after a real `scribe:generate`
- [x] `HelpSeoTest`: llms.txt when-to-use section, spec and MCP links
- [x] `MarkdownResponseTest`: markdown 404 for agents, html for browsers, json for API
- [x] `ApiMiddlewareTest`: rate-limit headers and `Retry-After`
- [x] pint, rector, phpstan, type coverage 100%, arch suite, 429 tests across Documentation/Api/Smoke green
- [x] Herd: `curl https://bishkek.test/openapi.json` returns 3.1.0 with `Error`/`ValidationError`; bare `curl` on a dead URL returns a markdown 404, browser Accept returns html