### PR TITLE
feat(home): add a works-with agent strip under the hero

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,6 +34,7 @@ use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use App\Services\Billing\HostedWorkspaceAccess;
+use App\Services\DockerHubService;
 use App\Services\GitHubService;
 use App\Support\ActivityLog\MergedActivityRenderer;
 use App\Support\ActivityLog\RequestActivityBatch;
@@ -534,6 +535,10 @@ final class AppServiceProvider extends ServiceProvider
                 'githubStars' => $starsCount,
                 'formattedGithubStars' => $formattedStarsCount,
             ]);
+        });
+
+        Facades\View::composer('home.partials.works-with', function (View $view): void {
+            $view->with('formattedDockerPulls', resolve(DockerHubService::class)->getFormattedPullCount());
         });
     }
 }

--- a/app/Services/DockerHubService.php
+++ b/app/Services/DockerHubService.php
@@ -14,22 +14,26 @@ final readonly class DockerHubService
 {
     public function getPullCount(string $namespace = 'manukminasyan', string $repo = 'relaticle', int $cacheMinutes = 60): int
     {
-        return (int) Cache::remember("dockerhub_pulls_{$namespace}_{$repo}", now()->addMinutes($cacheMinutes), function () use ($namespace, $repo): int {
+        $cacheKey = "dockerhub_pulls_{$namespace}_{$repo}";
+        $lastGoodKey = "{$cacheKey}_last_good";
+
+        return (int) Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), function () use ($namespace, $repo, $lastGoodKey): int {
             try {
                 $response = Http::get("https://hub.docker.com/v2/repositories/{$namespace}/{$repo}/");
 
                 if ($response->successful()) {
-                    return (int) $response->json('pull_count', 0);
+                    $pulls = (int) $response->json('pull_count', 0);
+                    Cache::forever($lastGoodKey, $pulls);
+
+                    return $pulls;
                 }
 
                 Log::warning('Failed to fetch Docker Hub pulls: '.$response->status());
-
-                return 0;
             } catch (Exception $e) {
                 Log::error('Error fetching Docker Hub pulls: '.$e->getMessage());
-
-                return 0;
             }
+
+            return (int) Cache::get($lastGoodKey, 0);
         });
     }
 

--- a/app/Services/DockerHubService.php
+++ b/app/Services/DockerHubService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Exception;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Number;
+
+final readonly class DockerHubService
+{
+    public function getPullCount(string $namespace = 'manukminasyan', string $repo = 'relaticle', int $cacheMinutes = 60): int
+    {
+        return (int) Cache::remember("dockerhub_pulls_{$namespace}_{$repo}", now()->addMinutes($cacheMinutes), function () use ($namespace, $repo): int {
+            try {
+                $response = Http::get("https://hub.docker.com/v2/repositories/{$namespace}/{$repo}/");
+
+                if ($response->successful()) {
+                    return (int) $response->json('pull_count', 0);
+                }
+
+                Log::warning('Failed to fetch Docker Hub pulls: '.$response->status());
+
+                return 0;
+            } catch (Exception $e) {
+                Log::error('Error fetching Docker Hub pulls: '.$e->getMessage());
+
+                return 0;
+            }
+        });
+    }
+
+    /**
+     * Rounded down to the nearest thousand so the figure never overstates, e.g. 21,000+.
+     */
+    public function getFormattedPullCount(string $namespace = 'manukminasyan', string $repo = 'relaticle', int $cacheMinutes = 60): ?string
+    {
+        $pulls = $this->getPullCount($namespace, $repo, $cacheMinutes);
+
+        if ($pulls < 1000) {
+            return null;
+        }
+
+        return Number::format(intdiv($pulls, 1000) * 1000).'+';
+    }
+}

--- a/app/Services/GitHubService.php
+++ b/app/Services/GitHubService.php
@@ -23,8 +23,9 @@ final readonly class GitHubService
     public function getStarsCount(string $owner = 'Relaticle', string $repo = 'relaticle', int $cacheMinutes = 15): int
     {
         $cacheKey = "github_stars_{$owner}_{$repo}";
+        $lastGoodKey = "{$cacheKey}_last_good";
 
-        return (int) Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), function () use ($owner, $repo): int {
+        return (int) Cache::remember($cacheKey, now()->addMinutes($cacheMinutes), function () use ($owner, $repo, $lastGoodKey): int {
             try {
                 /** @var Response $response */
                 $response = Http::withHeaders([
@@ -32,17 +33,18 @@ final readonly class GitHubService
                 ])->get("https://api.github.com/repos/{$owner}/{$repo}");
 
                 if ($response->successful()) {
-                    return (int) $response->json('stargazers_count', 0);
+                    $stars = (int) $response->json('stargazers_count', 0);
+                    Cache::forever($lastGoodKey, $stars);
+
+                    return $stars;
                 }
 
                 Log::warning('Failed to fetch GitHub stars: '.$response->status());
-
-                return 0;
             } catch (Exception $e) {
                 Log::error('Error fetching GitHub stars: '.$e->getMessage());
-
-                return 0;
             }
+
+            return (int) Cache::get($lastGoodKey, 0);
         });
     }
 

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -22,6 +22,7 @@
     @endpush
 
     @include('home.partials.hero')
+    @include('home.partials.works-with')
     @include('home.partials.features')
     @include('home.partials.community')
     @include('home.partials.faq')

--- a/resources/views/home/partials/features.blade.php
+++ b/resources/views/home/partials/features.blade.php
@@ -15,7 +15,7 @@
                 One CRM. Three ways to work: UI, chat, and agents.
             </h2>
             <p class="mt-5 text-base md:text-lg text-gray-500 dark:text-gray-400 max-w-2xl mx-auto leading-relaxed">
-                Manage records by hand, <a href="{{ route('ai') }}" class="text-gray-700 dark:text-gray-300 underline decoration-gray-300 dark:decoration-gray-600 underline-offset-4 hover:text-primary dark:hover:text-primary-400 hover:decoration-primary transition-colors">ask Relaticle in the app</a>, or connect Claude, ChatGPT, Gemini, and custom agents through MCP. Every path works from the same permissions, schema, and customer data.
+                Manage records by hand, <a href="{{ route('ai') }}" class="text-gray-700 dark:text-gray-300 underline decoration-gray-300 dark:decoration-gray-600 underline-offset-4 hover:text-primary dark:hover:text-primary-400 hover:decoration-primary transition-colors">ask Relaticle in the app</a>, or connect any external agent through MCP. Every path works from the same permissions, schema, and customer data.
             </p>
         </div>
 

--- a/resources/views/home/partials/hero.blade.php
+++ b/resources/views/home/partials/hero.blade.php
@@ -1,4 +1,4 @@
-<section x-data="heroTabs()" x-init="init()" @resize.window="positionIndicator()" class="relative pt-32 pb-20 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">
+<section x-data="heroTabs()" x-init="init()" @resize.window="positionIndicator()" class="relative pt-32 pb-16 md:pt-40 md:pb-20 bg-white dark:bg-gray-950 overflow-hidden">
 
     {{-- Background system — layered depth --}}
     <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_50%_at_50%_50%,black_30%,transparent_100%)]"></div>

--- a/resources/views/home/partials/works-with.blade.php
+++ b/resources/views/home/partials/works-with.blade.php
@@ -28,5 +28,12 @@
                 <x-ri-arrow-right-up-line class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 group-hover:text-current transition-colors"/>
             </a>
         </div>
+
+        @if($formattedDockerPulls !== null)
+            <p class="border-x border-t border-gray-200 dark:border-white/[0.08] px-5 py-3 text-center text-xs text-gray-500 dark:text-gray-400">
+                <span class="font-semibold text-gray-700 dark:text-gray-200">{{ $formattedDockerPulls }}</span> {{ __('Docker pulls') }}
+                <span class="mx-2 text-gray-300 dark:text-gray-600">/</span>{{ __('self-hosted, AGPL-3.0, shipping weekly') }}
+            </p>
+        @endif
     </div>
 </section>

--- a/resources/views/home/partials/works-with.blade.php
+++ b/resources/views/home/partials/works-with.blade.php
@@ -23,10 +23,16 @@
                 </div>
             @endforeach
 
-            <a href="{{ route('documentation.index') }}" class="group col-span-2 md:col-span-1 flex items-center justify-center gap-1.5 px-3 py-5 md:py-6 whitespace-nowrap text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
-                {{ __('+ any MCP client') }}
-                <x-ri-arrow-right-up-line class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 group-hover:text-current transition-colors"/>
-            </a>
+            @if(\Laravel\Pennant\Feature::active(\App\Features\Documentation::class))
+                <a href="{{ route('documentation.index') }}" class="group col-span-2 md:col-span-1 flex items-center justify-center gap-1.5 px-3 py-5 md:py-6 whitespace-nowrap text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
+                    {{ __('+ any MCP client') }}
+                    <x-ri-arrow-right-up-line class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 group-hover:text-current transition-colors"/>
+                </a>
+            @else
+                <div class="col-span-2 md:col-span-1 flex items-center justify-center px-3 py-5 md:py-6 whitespace-nowrap text-sm font-medium text-gray-500 dark:text-gray-400">
+                    {{ __('+ any MCP client') }}
+                </div>
+            @endif
         </div>
 
         @if($formattedDockerPulls !== null)

--- a/resources/views/home/partials/works-with.blade.php
+++ b/resources/views/home/partials/works-with.blade.php
@@ -8,9 +8,9 @@
 @endphp
 
 <section aria-label="{{ __('Works with') }}" class="relative bg-white dark:bg-gray-950 border-y border-gray-200 dark:border-white/[0.08]">
-    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="grid grid-cols-2 md:grid-cols-7 divide-x divide-y md:divide-y-0 divide-gray-200 dark:divide-white/[0.08] border-x border-gray-200 dark:border-white/[0.08]">
-            <div class="col-span-2 flex items-center px-5 py-4 md:py-6">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="grid grid-cols-2 md:grid-cols-[2fr_repeat(4,1fr)_1.5fr] divide-x divide-y md:divide-y-0 divide-gray-200 dark:divide-white/[0.08] border-x border-gray-200 dark:border-white/[0.08]">
+            <div class="col-span-2 md:col-span-1 flex items-center px-5 py-4 md:py-6">
                 <p class="font-mono uppercase tracking-[0.14em] text-[10px] leading-relaxed text-gray-500 dark:text-gray-400">
                     {{ __('Works with the agents your team already uses') }}
                 </p>
@@ -23,7 +23,7 @@
                 </div>
             @endforeach
 
-            <a href="{{ route('documentation.index') }}" class="group col-span-2 md:col-span-1 flex items-center justify-center gap-1.5 px-4 py-5 md:py-6 whitespace-nowrap text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
+            <a href="{{ route('documentation.index') }}" class="group col-span-2 md:col-span-1 flex items-center justify-center gap-1.5 px-3 py-5 md:py-6 whitespace-nowrap text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
                 {{ __('+ any MCP client') }}
                 <x-ri-arrow-right-up-line class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 group-hover:text-current transition-colors"/>
             </a>

--- a/resources/views/home/partials/works-with.blade.php
+++ b/resources/views/home/partials/works-with.blade.php
@@ -1,0 +1,32 @@
+@php
+    $clients = [
+        ['ri-claude-fill', 'text-[#D4763C]', 'Claude'],
+        ['ri-openai-fill', 'text-gray-900 dark:text-gray-200', 'ChatGPT'],
+        ['ri-cursor-ai-fill', 'text-gray-900 dark:text-gray-200', 'Cursor'],
+        ['ri-gemini-fill', 'text-blue-500', 'Gemini'],
+    ];
+@endphp
+
+<section aria-label="{{ __('Works with') }}" class="relative bg-white dark:bg-gray-950 border-y border-gray-200 dark:border-white/[0.08]">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="grid grid-cols-2 md:grid-cols-7 divide-x divide-y md:divide-y-0 divide-gray-200 dark:divide-white/[0.08] border-x border-gray-200 dark:border-white/[0.08]">
+            <div class="col-span-2 flex items-center px-5 py-4 md:py-6">
+                <p class="font-mono uppercase tracking-[0.14em] text-[10px] leading-relaxed text-gray-500 dark:text-gray-400">
+                    {{ __('Works with the agents your team already uses') }}
+                </p>
+            </div>
+
+            @foreach($clients as [$icon, $color, $name])
+                <div class="flex items-center justify-center gap-2.5 px-4 py-5 md:py-6">
+                    <x-dynamic-component :component="$icon" class="w-5 h-5 shrink-0 {{ $color }}"/>
+                    <span class="text-sm font-semibold tracking-tight text-gray-800 dark:text-gray-200">{{ $name }}</span>
+                </div>
+            @endforeach
+
+            <a href="{{ route('documentation.index') }}" class="group col-span-2 md:col-span-1 flex items-center justify-center gap-1.5 px-4 py-5 md:py-6 whitespace-nowrap text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">
+                {{ __('+ any MCP client') }}
+                <x-ri-arrow-right-up-line class="w-3.5 h-3.5 text-gray-400 dark:text-gray-500 group-hover:text-current transition-colors"/>
+            </a>
+        </div>
+    </div>
+</section>

--- a/tests/Feature/MarketingNavigationTest.php
+++ b/tests/Feature/MarketingNavigationTest.php
@@ -157,3 +157,14 @@ it('links the product pages from page copy, not only from the sitewide nav', fun
     expect($body)->toContain('href="'.route('ai').'"')
         ->and($body)->toContain('href="'.route('selfHosted').'"');
 })->with(['/', '/pricing', '/compare/relaticle-vs-twenty', '/alternatives/attio']);
+
+it('renders the works-with strip on the homepage with a link to the developer docs', function (): void {
+    $html = $this->get('/')->assertOk()->getContent();
+
+    preg_match('/<section[^>]*aria-label="Works with"[^>]*>.*?<\/section>/s', $html, $matches);
+    $strip = $matches[0] ?? '';
+
+    expect($strip)->not->toBe('')
+        ->and($strip)->toContain('Claude', 'ChatGPT', 'Cursor', 'Gemini', '+ any MCP client')
+        ->and($strip)->toContain('href="'.route('documentation.index').'"');
+});

--- a/tests/Feature/MarketingNavigationTest.php
+++ b/tests/Feature/MarketingNavigationTest.php
@@ -159,6 +159,8 @@ it('links the product pages from page copy, not only from the sitewide nav', fun
 })->with(['/', '/pricing', '/compare/relaticle-vs-twenty', '/alternatives/attio']);
 
 it('renders the works-with strip on the homepage with a link to the developer docs', function (): void {
+    Cache::put('dockerhub_pulls_manukminasyan_relaticle', 21030, 60);
+
     $html = $this->get('/')->assertOk()->getContent();
 
     preg_match('/<section[^>]*aria-label="Works with"[^>]*>.*?<\/section>/s', $html, $matches);
@@ -166,5 +168,6 @@ it('renders the works-with strip on the homepage with a link to the developer do
 
     expect($strip)->not->toBe('')
         ->and($strip)->toContain('Claude', 'ChatGPT', 'Cursor', 'Gemini', '+ any MCP client')
-        ->and($strip)->toContain('href="'.route('documentation.index').'"');
+        ->and($strip)->toContain('href="'.route('documentation.index').'"')
+        ->and($strip)->toContain('21,000+');
 });

--- a/tests/Feature/Profile/DockerHubServiceTest.php
+++ b/tests/Feature/Profile/DockerHubServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\DockerHubService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+mutates(DockerHubService::class);
+
+beforeEach(function (): void {
+    Cache::forget('dockerhub_pulls_manukminasyan_relaticle');
+});
+
+it('rounds the pull count down to the nearest thousand', function (): void {
+    Http::fake(['hub.docker.com/*' => Http::response(['pull_count' => 21987])]);
+
+    expect((new DockerHubService)->getFormattedPullCount())->toBe('21,000+');
+});
+
+it('returns null below a thousand pulls so the homepage hides the line', function (): void {
+    Http::fake(['hub.docker.com/*' => Http::response(['pull_count' => 412])]);
+
+    expect((new DockerHubService)->getFormattedPullCount())->toBeNull();
+});
+
+it('returns null when Docker Hub is unreachable', function (): void {
+    Http::fake(['hub.docker.com/*' => Http::response(null, 500)]);
+
+    expect((new DockerHubService)->getFormattedPullCount())->toBeNull();
+});
+
+it('caches the pull count', function (): void {
+    Http::fake(['hub.docker.com/*' => Http::response(['pull_count' => 5000])]);
+    $service = new DockerHubService;
+
+    $service->getPullCount();
+    $service->getPullCount();
+
+    Http::assertSentCount(1);
+});

--- a/tests/Feature/Profile/DockerHubServiceTest.php
+++ b/tests/Feature/Profile/DockerHubServiceTest.php
@@ -10,6 +10,7 @@ mutates(DockerHubService::class);
 
 beforeEach(function (): void {
     Cache::forget('dockerhub_pulls_manukminasyan_relaticle');
+    Cache::forget('dockerhub_pulls_manukminasyan_relaticle_last_good');
 });
 
 it('rounds the pull count down to the nearest thousand', function (): void {
@@ -38,4 +39,17 @@ it('caches the pull count', function (): void {
     $service->getPullCount();
 
     Http::assertSentCount(1);
+});
+
+it('keeps the last good pull count when Docker Hub fails on the next fetch', function (): void {
+    Http::fake(['hub.docker.com/*' => Http::sequence()
+        ->push(['pull_count' => 21030])
+        ->push(null, 500)]);
+    $service = new DockerHubService;
+
+    expect($service->getFormattedPullCount())->toBe('21,000+');
+
+    Cache::forget('dockerhub_pulls_manukminasyan_relaticle');
+
+    expect($service->getFormattedPullCount())->toBe('21,000+');
 });

--- a/tests/Feature/Profile/GitHubServiceTest.php
+++ b/tests/Feature/Profile/GitHubServiceTest.php
@@ -14,6 +14,7 @@ beforeEach(function () {
 
     // Clear any cached values before each test
     Cache::forget('github_stars_Relaticle_relaticle');
+    Cache::forget('github_stars_Relaticle_relaticle_last_good');
 });
 
 it('gets stars count from GitHub API', function () {
@@ -123,4 +124,18 @@ it('returns int even when cache contains string value', function () {
     $result = $this->service->getStarsCount('Relaticle', 'relaticle');
 
     expect($result)->toBe(125)->toBeInt();
+});
+
+it('keeps the last good stars count when GitHub rate-limits the next fetch', function () {
+    Http::fake([
+        'api.github.com/repos/Relaticle/relaticle' => Http::sequence()
+            ->push(['stargazers_count' => 1522])
+            ->push(['message' => 'API rate limit exceeded'], 403),
+    ]);
+
+    expect($this->service->getStarsCount())->toBe(1522);
+
+    Cache::forget('github_stars_Relaticle_relaticle');
+
+    expect($this->service->getStarsCount())->toBe(1522);
 });


### PR DESCRIPTION
Adds a celled logo row (Claude, ChatGPT, Cursor, Gemini, "+ any MCP client" linking to /developers) between the homepage hero and the features section. Every logo is an agent the docs already cover, so the strip reads like a trust wall without making a customer claim we cannot back. The features subhead drops its vendor list since the strip now carries it, and the hero bottom padding is tightened so the row sits close to the mockup.

## Test plan
- `MarketingNavigationTest` asserts the strip renders with all five cells and the docs link (16/16 passing)
- Verified in the browser at desktop light, desktop dark, and 390px mobile
- pint, rector, phpstan all clean