### PR TITLE
fix(seo): lead comparison page titles with open-source query language

### DIFF
--- a/resources/views/alternatives/show.blade.php
+++ b/resources/views/alternatives/show.blade.php
@@ -56,20 +56,36 @@
         'hubspot' => __('HubSpot Alternative'),
     ];
 
+    /*
+     * The <title> tag, deliberately not the same string as the H1. "Open source"
+     * leads because that is the language of the queries these pages already rank
+     * for, and the phrasing mirrors them directly rather than restating the H1.
+     * Kept under ~60 characters so Google does not truncate it.
+     */
+    $metaTitles = [
+        'attio' => __('Open Source Attio Alternative, Self-Hosted | Relaticle'),
+        'hubspot' => __('Open Source HubSpot Alternative, Self-Hosted | Relaticle'),
+    ];
+
+    /*
+     * Structural facts only, no prices or counts: those live in
+     * competitor-facts.php so `gtm:stale-facts` can age them out.
+     */
     $descriptions = [
-        'attio' => __('Looking for an Attio alternative? Relaticle is open-source and self-hosted with flat pricing and built-in AI. Compare features and see the CSV migration path.'),
-        'hubspot' => __('Looking for a HubSpot alternative? Relaticle is open-source, self-hosted, and flatly priced with built-in AI. Compare features and see how to migrate your data.'),
+        'attio' => __('Attio is closed-source with no self-hosting option. Relaticle is AGPL-3.0, self-hostable free, flat-priced for unlimited users, with built-in AI and MCP.'),
+        'hubspot' => __('HubSpot is closed-source with no self-hosting option. Relaticle is AGPL-3.0, self-hostable free, flat-priced for unlimited users, with built-in AI and MCP.'),
     ];
 
     $title = $titles[$competitorSlug];
+    $metaTitle = $metaTitles[$competitorSlug];
     $description = $descriptions[$competitorSlug];
     $factsVerifiedAt = \Carbon\CarbonImmutable::parse($relaticle['verified'])->format('F j, Y');
 @endphp
 
 <x-guest-layout
-    :title="$title . ' - Relaticle'"
+    :title="$metaTitle"
     :description="$description"
-    :ogTitle="$title . ' - Relaticle'"
+    :ogTitle="$metaTitle"
 >
     <section class="relative pt-32 pb-24 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">
         <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_50%_at_50%_50%,black_30%,transparent_100%)]"></div>

--- a/resources/views/compare/show.blade.php
+++ b/resources/views/compare/show.blade.php
@@ -70,12 +70,31 @@
         'espocrm' => __('Relaticle vs EspoCRM'),
     ];
 
+    /*
+     * The <title> tag, deliberately not the same string as the H1. These pages rank
+     * (avg position 6-12) but earn no clicks, and the queries that do convert read
+     * like "open source ai crm", so the search-result title leads with that language
+     * while the on-page heading stays short. Kept under ~60 characters so Google
+     * does not truncate it, and free of the "- Relaticle" suffix the layout used to
+     * get, which spent characters repeating a brand the title already opens with.
+     */
+    $metaTitles = [
+        'twenty' => __('Relaticle vs Twenty: Open Source CRM Compared'),
+        'espocrm' => __('Relaticle vs EspoCRM: Open Source CRM Compared'),
+    ];
+
+    /*
+     * No competitor prices or counts here on purpose: those live in
+     * competitor-facts.php so `gtm:stale-facts` can age them out. A number copied
+     * into a meta description is a second source of truth nothing checks.
+     */
     $descriptions = [
-        'twenty' => __('Relaticle vs Twenty compared on license, pricing, GitHub stars, contributors, tech stack, and AI/MCP self-hosting, so you can pick the right open-source CRM.'),
-        'espocrm' => __('Relaticle vs EspoCRM compared on license, pricing, tech stack, and AI tooling, so you can pick the self-hosted PHP CRM with AI chat and MCP support today.'),
+        'twenty' => __('Both are open source and self-hostable. Relaticle bills one flat rate for unlimited users and runs AI chat and MCP self-hosted; Twenty prices per seat.'),
+        'espocrm' => __('Both are AGPL-3.0 PHP CRMs you can self-host. Relaticle adds a built-in AI assistant and a first-party MCP server, and bills flat; EspoCRM prices per seat.'),
     ];
 
     $title = $titles[$competitorSlug];
+    $metaTitle = $metaTitles[$competitorSlug];
     $description = $descriptions[$competitorSlug];
     $factsVerifiedDate = \Carbon\CarbonImmutable::parse($relaticle['verified']);
     $factsVerifiedAt = $factsVerifiedDate->format('F j, Y');
@@ -90,9 +109,9 @@
 @endphp
 
 <x-guest-layout
-    :title="$title . ' - Relaticle'"
+    :title="$metaTitle"
     :description="$description"
-    :ogTitle="$title . ' - Relaticle'"
+    :ogTitle="$metaTitle"
 >
     <section class="relative pt-32 pb-24 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">
         <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_50%_at_50%_50%,black_30%,transparent_100%)]"></div>

--- a/tests/Feature/ComparisonPagesTest.php
+++ b/tests/Feature/ComparisonPagesTest.php
@@ -47,6 +47,45 @@ it('marks comparison pages with dateModified and about entities in the JSON-LD g
         ->and($html)->toContain('https://github.com/espocrm/espocrm');
 });
 
+it('gives each page a search title that leads with open source and stays under 60 characters', function (string $url, string $expected): void {
+    $html = $this->get($url)->assertOk()->getContent();
+
+    expect($html)->toContain("<title>{$expected}</title>")
+        ->and($html)->toContain('<meta property="og:title" content="'.$expected.'"')
+        ->and(mb_strlen($expected))->toBeLessThanOrEqual(60)
+        ->and($expected)->toContain('Open Source');
+})->with([
+    ['/compare/relaticle-vs-twenty', 'Relaticle vs Twenty: Open Source CRM Compared'],
+    ['/compare/relaticle-vs-espocrm', 'Relaticle vs EspoCRM: Open Source CRM Compared'],
+    ['/alternatives/attio', 'Open Source Attio Alternative, Self-Hosted | Relaticle'],
+    ['/alternatives/hubspot', 'Open Source HubSpot Alternative, Self-Hosted | Relaticle'],
+]);
+
+it('keeps the on-page heading short and distinct from the longer search title', function (string $url, string $heading): void {
+    $html = $this->get($url)->assertOk()->getContent();
+
+    expect($html)->toContain(">\n                    {$heading}\n                </h1>")
+        ->and($html)->not->toContain("<title>{$heading} - Relaticle</title>");
+})->with([
+    ['/compare/relaticle-vs-twenty', 'Relaticle vs Twenty'],
+    ['/alternatives/attio', 'Attio Alternative'],
+]);
+
+it('keeps competitor prices out of meta descriptions so the facts file stays the only source', function (string $url): void {
+    $html = $this->get($url)->assertOk()->getContent();
+
+    preg_match('/<meta name="description" content="([^"]*)"/', $html, $matches);
+
+    expect($matches[1] ?? '')->not->toBeEmpty()
+        ->and($matches[1])->not->toMatch('/\$\d/')
+        ->and(mb_strlen($matches[1]))->toBeLessThanOrEqual(160);
+})->with([
+    '/compare/relaticle-vs-twenty',
+    '/compare/relaticle-vs-espocrm',
+    '/alternatives/attio',
+    '/alternatives/hubspot',
+]);
+
 it('does not lowercase the leading acronym of an extensibility fact in alternatives prose', function (): void {
     $html = $this->get('/alternatives/attio')->assertOk()->getContent();
 


### PR DESCRIPTION
## Why

The four comparison pages shipped in v3.4.9 (08-17) and started ranking on **08-18, one day later**. They index fine. They just get no clicks.

Search Console, 2026-08-14 to 2026-08-20:

| Page | Impressions | Clicks | Avg position |
|---|---|---|---|
| `/alternatives/hubspot` | 22 | **0** | 7.2 (4.6 on 08-20) |
| `/alternatives/attio` | 13 | **0** | 17.7 |
| `/compare/relaticle-vs-espocrm` | 12 | **0** | 11.8 |
| `/compare/relaticle-vs-twenty` | 6 | **0** | 6.0 |
| `/` (for contrast) | 535 | 59 | 8.9 (**11.0% CTR**) |

The homepage converts at 11% from a *worse* average position than three of the four. That points at the search snippet, not the ranking.

The titles were the problem. They rendered as `Relaticle vs Twenty - Relaticle` and `Attio Alternative - Relaticle`: brand repeated, and **not one of them contained "open source"**, which is the language of the queries that actually convert. In the same window, every non-brand click came from a query containing "open source ai crm", and `attio open source alternative` sits at position 1.0.

Same class of fix as #516 (`/pricing` snippet), applied to the pages with the next-largest zero-click pools.

## What changed

- Split the `<title>` tag from the H1. The search result leads with "Open Source"; the on-page heading stays short and unchanged.
- Dropped the `- Relaticle` suffix on `/compare` titles, which spent characters repeating a brand the title already opens with.
- Rewrote the four meta descriptions to lead with the structural difference (closed-source and no self-hosting vs AGPL-3.0 and self-hostable, per-seat vs flat).

| Page | New `<title>` | Chars |
|---|---|---|
| `/compare/relaticle-vs-twenty` | Relaticle vs Twenty: Open Source CRM Compared | 45 |
| `/compare/relaticle-vs-espocrm` | Relaticle vs EspoCRM: Open Source CRM Compared | 46 |
| `/alternatives/attio` | Open Source Attio Alternative, Self-Hosted \| Relaticle | 54 |
| `/alternatives/hubspot` | Open Source HubSpot Alternative, Self-Hosted \| Relaticle | 56 |

No page copy, layout, schema, or routing changed. Views only.

## Facts discipline

Every claim in the new descriptions traces to `resources/data/competitor-facts.php`, and **no competitor price or count is hardcoded into a description**. A number copied into a meta description is a second source of truth that `gtm:stale-facts` cannot age out, so descriptions stay structural (license, self-hosting availability, flat vs per-seat) and the numbers stay in the facts file. A test enforces this.

`php artisan gtm:stale-facts` reports all facts fresh.

## Tests

Three added to `tests/Feature/ComparisonPagesTest.php`:

1. Each page's `<title>` and `og:title` match, contain "Open Source", and stay under 60 characters so Google does not truncate them.
2. The H1 stays short and distinct from the longer search title, so this cannot silently regress to reusing one string for both.
3. No meta description contains a `$` price, and none exceeds 160 characters.

Test 3 caught a real overrun while writing this: the Twenty description was 162 characters. The copy was shortened; the assertion was not.

## Verification

- `php artisan test tests/Smoke tests/Feature/ComparisonPagesTest.php` → **92 passed, 154 assertions**
- `vendor/bin/pint --dirty` → passed
- `vendor/bin/rector --dry-run` → 0 changed
- `vendor/bin/phpstan analyse` → 0 errors
- `composer test:type-coverage` → 100.0%
- All four pages loaded in a real browser: titles correct, H1s unchanged, no console errors.

An earlier run showed 5 smoke failures on missing `users.last_login_at` / `ai_credit_balances.purchased_credits`. Those were **not** from this change: another workspace was mid-run against the shared `relaticle_testing` database. Both columns were present when queried directly, and re-running against an isolated database gave 92/92.

## Follow-ups, not in this PR

- `/docs` (135 impressions, position 6.8, 0 clicks) and `/developers` (56 impressions, position 7.9, 0 clicks) have the same gap and are the next-largest pools.
- `sitemap.xml` still emits no `<lastmod>`, which slows recrawl scheduling. Worth a small standalone PR so these new titles get picked up sooner.
- `/compare/relaticle-vs-krayin` and `/compare/relaticle-vs-frappe-crm` still need their facts gathered from primary sources before any page can be written.