### PR TITLE
refactor(notifications): drop the one-shot setup reminder toggle

### DIFF
--- a/app/Console/Commands/SendSetupNudgeCommand.php
+++ b/app/Console/Commands/SendSetupNudgeCommand.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Enums\ActivationStep;
-use App\Enums\Notifications\NotificationChannel;
-use App\Enums\Notifications\NotificationType;
 use App\Filament\Pages\Dashboard;
 use App\Mail\SetupNudgeMail;
 use App\Models\Team;
@@ -117,10 +115,6 @@ final class SendSetupNudgeCommand extends Command
             return false;
         }
 
-        if (! $user->wantsNotification(NotificationType::SetupNudge, NotificationChannel::Email)) {
-            return false;
-        }
-
         $stepKey = $this->topUnfinishedStep($team);
 
         if (! $stepKey instanceof ActivationStep) {
@@ -130,7 +124,7 @@ final class SendSetupNudgeCommand extends Command
         $conversationUrl = $this->continueUrl($team);
 
         Mail::to($user)
-            ->send(new SetupNudgeMail($user, $team, $stepKey->value, $conversationUrl));
+            ->send(new SetupNudgeMail($user, $stepKey->value, $conversationUrl));
 
         $team->forceFill(['setup_nudge_sent_at' => now()])->save();
 

--- a/app/Enums/Notifications/NotificationGroup.php
+++ b/app/Enums/Notifications/NotificationGroup.php
@@ -8,5 +8,4 @@ enum NotificationGroup: string
 {
     case Collaboration = 'collaboration';
     case Digest = 'digest';
-    case Onboarding = 'onboarding';
 }

--- a/app/Enums/Notifications/NotificationType.php
+++ b/app/Enums/Notifications/NotificationType.php
@@ -8,14 +8,12 @@ enum NotificationType: string
 {
     case TaskAssigned = 'task_assigned';
     case TaskDigest = 'task_digest';
-    case SetupNudge = 'setup_nudge';
 
     public function group(): NotificationGroup
     {
         return match ($this) {
             self::TaskAssigned => NotificationGroup::Collaboration,
             self::TaskDigest => NotificationGroup::Digest,
-            self::SetupNudge => NotificationGroup::Onboarding,
         };
     }
 
@@ -35,7 +33,6 @@ enum NotificationType: string
         return match ($this) {
             self::TaskAssigned => [NotificationChannel::InApp, NotificationChannel::Email],
             self::TaskDigest => [NotificationChannel::Email],
-            self::SetupNudge => [NotificationChannel::Email],
         };
     }
 
@@ -44,7 +41,6 @@ enum NotificationType: string
         return match ($this) {
             self::TaskAssigned => $channel === NotificationChannel::InApp,
             self::TaskDigest => true,
-            self::SetupNudge => true,
         };
     }
 

--- a/app/Livewire/App/Notifications/ManageNotificationPreferences.php
+++ b/app/Livewire/App/Notifications/ManageNotificationPreferences.php
@@ -17,8 +17,6 @@ final class ManageNotificationPreferences extends BaseLivewireComponent
 
     public bool $digestEnabled = true;
 
-    public bool $setupNudgeEnabled = true;
-
     public function mount(): void
     {
         $user = $this->authUser();
@@ -30,7 +28,6 @@ final class ManageNotificationPreferences extends BaseLivewireComponent
         }
 
         $this->digestEnabled = $user->wantsNotification(NotificationType::TaskDigest, NotificationChannel::Email);
-        $this->setupNudgeEnabled = $user->wantsNotification(NotificationType::SetupNudge, NotificationChannel::Email);
     }
 
     public function updatedCells(bool $value, string $key): void
@@ -56,11 +53,6 @@ final class ManageNotificationPreferences extends BaseLivewireComponent
     public function updatedDigestEnabled(bool $value): void
     {
         $this->persist(NotificationType::TaskDigest, NotificationChannel::Email, $value);
-    }
-
-    public function updatedSetupNudgeEnabled(bool $value): void
-    {
-        $this->persist(NotificationType::SetupNudge, NotificationChannel::Email, $value);
     }
 
     public function render(): View

--- a/app/Mail/SetupNudgeMail.php
+++ b/app/Mail/SetupNudgeMail.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
-use App\Filament\Pages\NotificationPreferences;
-use App\Models\Team;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -20,7 +18,6 @@ final class SetupNudgeMail extends Mailable implements ShouldQueue
 
     public function __construct(
         public User $user,
-        public Team $team,
         public string $stepKey,
         public string $conversationUrl,
     ) {}
@@ -39,10 +36,6 @@ final class SetupNudgeMail extends Mailable implements ShouldQueue
                 'stepLabel' => __("filament/pages/dashboard.activation.steps.{$this->stepKey}.label"),
                 'stepDescription' => __("filament/pages/dashboard.activation.steps.{$this->stepKey}.description"),
                 'conversationUrl' => $this->conversationUrl,
-                'manageSettingsUrl' => NotificationPreferences::getUrl(
-                    panel: 'app',
-                    tenant: $this->team,
-                ),
                 'companyName' => (string) config('relaticle.company.name'),
                 'companyAddress' => (string) config('relaticle.company.address'),
             ],

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -12,9 +12,6 @@ return [
     ],
 
     'onboarding' => [
-        'heading' => 'Getting started',
-        'title' => 'Setup reminders',
-        'description' => 'One reminder a couple of days after you create a workspace, if it is still empty.',
         'subject' => 'Your workspace is waiting',
         'mail_heading' => ':name, your workspace is still waiting',
         'mail_button' => 'Continue in Rela',
@@ -38,10 +35,6 @@ return [
         'task_digest' => [
             'label' => 'Daily Digest',
             'description' => 'Notify me every morning about tasks overdue and due today.',
-        ],
-        'setup_nudge' => [
-            'label' => 'Setup Reminder',
-            'description' => 'Remind me about workspace setup steps I have not finished.',
         ],
     ],
 

--- a/resources/views/livewire/app/notifications/manage-notification-preferences.blade.php
+++ b/resources/views/livewire/app/notifications/manage-notification-preferences.blade.php
@@ -15,22 +15,6 @@
         </div>
     </x-filament::section>
 
-    {{-- Getting started --}}
-    <x-filament::section :heading="__('notifications.onboarding.heading')">
-        <div class="flex items-center justify-between gap-4">
-            <div>
-                <span class="block text-sm font-medium text-gray-950 dark:text-white">
-                    {{ __('notifications.onboarding.title') }}
-                </span>
-                <span class="mt-1 block text-sm text-gray-500 dark:text-gray-400">
-                    {{ __('notifications.onboarding.description') }}
-                </span>
-            </div>
-
-            <x-filament::toggle state="$wire.$entangle('setupNudgeEnabled').live" />
-        </div>
-    </x-filament::section>
-
     {{-- Collaboration matrix --}}
     <x-filament::section :heading="__('notifications.collaboration.heading')">
         <div class="-mx-6 -my-4 divide-y divide-gray-200 dark:divide-white/10">

--- a/resources/views/mail/setup-nudge.blade.php
+++ b/resources/views/mail/setup-nudge.blade.php
@@ -11,7 +11,5 @@
 
 <x-slot:subcopy>
 {{ $companyName }}@if($companyAddress !== '') · {{ $companyAddress }}@endif
-
-[Manage notification settings]({{ $manageSettingsUrl }})
 </x-slot:subcopy>
 </x-mail::message>

--- a/tests/Feature/Notifications/ManageNotificationPreferencesTest.php
+++ b/tests/Feature/Notifications/ManageNotificationPreferencesTest.php
@@ -48,15 +48,3 @@ it('renders the standalone notifications page', function (): void {
         ->assertSee('Daily digest')
         ->assertSee('Task Assignments');
 });
-
-it('turns the setup nudge off', function (): void {
-    $user = User::factory()->withPersonalTeam()->create();
-    $this->actingAs($user);
-
-    Livewire::test(ManageNotificationPreferences::class)
-        ->assertSet('setupNudgeEnabled', true)
-        ->set('setupNudgeEnabled', false);
-
-    expect($user->fresh()->wantsNotification(NotificationType::SetupNudge, NotificationChannel::Email))
-        ->toBeFalse();
-});

--- a/tests/Feature/Notifications/SendSetupNudgeCommandTest.php
+++ b/tests/Feature/Notifications/SendSetupNudgeCommandTest.php
@@ -2,11 +2,8 @@
 
 declare(strict_types=1);
 
-use App\Actions\User\UpdateNotificationPreferences;
 use App\Enums\ActivationStep;
 use App\Enums\CreationSource;
-use App\Enums\Notifications\NotificationChannel;
-use App\Enums\Notifications\NotificationType;
 use App\Filament\Pages\ChatConversation;
 use App\Filament\Pages\Dashboard;
 use App\Mail\SetupNudgeMail;
@@ -16,9 +13,8 @@ use Illuminate\Support\Facades\Mail;
 
 it('renders the nudge naming the unfinished step', function (): void {
     $owner = User::factory()->withPersonalTeam()->create(['name' => 'Dana Reed']);
-    $team = $owner->currentTeam;
 
-    $mail = new SetupNudgeMail($owner, $team, ActivationStep::FirstRecord->value, 'https://example.test/chat');
+    $mail = new SetupNudgeMail($owner, ActivationStep::FirstRecord->value, 'https://example.test/chat');
 
     $rendered = $mail->render();
 
@@ -36,10 +32,9 @@ it('renders the nudge naming the unfinished step', function (): void {
 
 it('never lets an unresolved step label reach the rendered body', function (): void {
     $owner = User::factory()->withPersonalTeam()->create(['name' => 'Dana Reed']);
-    $team = $owner->currentTeam;
 
     foreach (ActivationStep::cases() as $step) {
-        $mail = new SetupNudgeMail($owner, $team, $step->value, 'https://example.test/chat');
+        $mail = new SetupNudgeMail($owner, $step->value, 'https://example.test/chat');
 
         expect($mail->render())->not->toContain('filament/pages/dashboard.');
     }
@@ -71,26 +66,6 @@ it('skips a workspace that already has its own record', function (): void {
 
     $team->forceFill(['created_at' => now()->subDays(2)])->save();
     Company::factory()->for($team)->create(['creation_source' => CreationSource::WEB]);
-
-    $this->artisan('notifications:send-setup-nudge')->assertSuccessful();
-
-    Mail::assertNothingQueued();
-});
-
-it('skips an owner who turned setup reminders off', function (): void {
-    Mail::fake();
-
-    $owner = User::factory()->withPersonalTeam()->create(['timezone' => 'UTC']);
-
-    $this->travelTo(now()->setTime(9, 0));
-
-    $owner->currentTeam->forceFill(['created_at' => now()->subDays(2)])->save();
-    resolve(UpdateNotificationPreferences::class)->execute(
-        $owner,
-        NotificationType::SetupNudge,
-        NotificationChannel::Email,
-        false,
-    );
 
     $this->artisan('notifications:send-setup-nudge')->assertSuccessful();
 

--- a/tests/Feature/SystemAdmin/UserResourceTest.php
+++ b/tests/Feature/SystemAdmin/UserResourceTest.php
@@ -119,7 +119,6 @@ it('hydrates notification toggles from the enum defaults', function (): void {
             'notification_preferences' => [
                 'task_assigned' => ['in_app' => true, 'email' => false],
                 'task_digest' => ['email' => true],
-                'setup_nudge' => ['email' => true],
             ],
         ]);
 });


### PR DESCRIPTION
The setup nudge sends exactly one email per user ever, since the command only picks a personal team with a null `setup_nudge_sent_at` inside the day 2-3 window and stamps it on send, so a dedicated settings section for it is a control nobody can reach at the only moment it would matter. This removes the `SetupNudge` type, the `Onboarding` group, the "Getting started" section, and the preference gate in the command, while every other guard (one-shot, verified email only, local 09:00 band, has-own-record check) stays exactly as it was. The mail also loses its "Manage notification settings" subcopy link, which could not turn off the email it appeared in, plus its now-unused team argument. Attio exposes no equivalent row: its notification settings cover workspace activity only. One edge worth knowing: users who switched the toggle off since #527 keep an inert `setup_nudge` key in their preferences JSON that is no longer read, so anyone currently inside the day 2-3 window will receive the nudge anyway.