### PR TITLE
Polish user menu, avatars, and account deletion copy

### DIFF
--- a/app/Models/Concerns/HasProfilePhoto.php
+++ b/app/Models/Concerns/HasProfilePhoto.php
@@ -47,11 +47,7 @@ trait HasProfilePhoto
 
     protected function defaultProfilePhotoUrl(): string
     {
-        $name = trim(
-            collect(explode(' ', $this->name))->map(fn ($segment): string => mb_substr($segment, 0, 1))->join(' ')
-        );
-
-        return 'https://ui-avatars.com/api/?name='.urlencode($name).'&color=7F9CF5&background=EBF4FF';
+        return resolve(AvatarService::class)->generateAuto($this->name);
     }
 
     protected function profilePhotoDisk(): string
@@ -68,7 +64,7 @@ trait HasProfilePhoto
     {
         return $this->profile_photo_path
             ? $this->resolveSameOriginUrl($this->profile_photo_path)
-            : resolve(AvatarService::class)->generate($this->name);
+            : $this->defaultProfilePhotoUrl();
     }
 
     private function resolveSameOriginUrl(string $path): string

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -251,14 +251,6 @@ final class AppPanelProvider extends PanelProvider
                 ],
             ])
             ->viteTheme('resources/css/filament/app/theme.css')
-            ->userMenuItems([
-                Action::make('settings')
-                    ->label(__('filament/panel.user_menu.settings'))
-                    ->icon('heroicon-m-cog-6-tooth')
-                    ->url(fn (): string => $this->shouldRegisterMenuItem()
-                        ? url(Settings::getUrl())
-                        : url($panel->getPath())),
-            ])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->discoverPages(in: base_path('packages/ImportWizard/src/Filament/Pages'), for: 'Relaticle\\ImportWizard\\Filament\\Pages')
@@ -369,18 +361,29 @@ final class AppPanelProvider extends PanelProvider
                 },
             );
 
+        $accountMenuItems = [
+            Action::make('settings')
+                ->label(__('filament/panel.user_menu.settings'))
+                ->icon('heroicon-m-cog-6-tooth')
+                ->url(fn (): string => $this->shouldRegisterMenuItem()
+                    ? url(Settings::getUrl())
+                    : url($panel->getPath())),
+        ];
+
         if (Features::hasApiFeatures()) {
-            $panel->userMenuItems([
-                Action::make('api_tokens')
-                    ->label(__('access-tokens.user_menu'))
-                    ->icon('heroicon-o-key')
-                    ->url(fn (): string => $this->shouldRegisterMenuItem()
-                        ? url(AccessTokens::getUrl())
-                        : url($panel->getPath())),
-            ]);
+            $accountMenuItems[] = Action::make('api_tokens')
+                ->label(__('access-tokens.user_menu'))
+                ->icon('heroicon-o-key')
+                ->url(fn (): string => $this->shouldRegisterMenuItem()
+                    ? url(AccessTokens::getUrl())
+                    : url($panel->getPath()));
         }
 
-        $panel->userMenuItems($this->supportMenuItems());
+        $panel->userMenuItems([
+            $accountMenuItems,
+            $this->supportMenuItems(),
+            [],
+        ]);
 
         $panel
             ->tenant(Team::class, slugAttribute: 'slug', ownershipRelationship: 'team')

--- a/app/Services/AvatarService.php
+++ b/app/Services/AvatarService.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Str;
 
 final readonly class AvatarService
 {
+    private const string CACHE_VERSION = 'v2';
+
     /**
      * Minimum contrast ratio for WCAG AA compliance.
      */
@@ -48,7 +50,7 @@ final readonly class AvatarService
         // Add custom colors to cache key if provided
         $bgColorKey = in_array($bgColor, [null, '', '0'], true) ? '' : "_bg{$bgColor}";
         $textColorKey = in_array($textColor, [null, '', '0'], true) ? '' : "_txt{$textColor}";
-        $cacheKey = 'avatar_'.hash('sha256', "{$name}_{$size}{$bgColorKey}{$textColorKey}_initials{$initialCount}");
+        $cacheKey = self::CACHE_VERSION.'_avatar_'.hash('sha256', "{$name}_{$size}{$bgColorKey}{$textColorKey}_initials{$initialCount}");
 
         return $this->cache->remember(
             $cacheKey,
@@ -67,7 +69,7 @@ final readonly class AvatarService
      */
     public function generateAuto(string $name, int $size = 64, int $initialCount = 2): string
     {
-        $cacheKey = 'avatar_auto_'.hash('sha256', "{$name}_{$size}_initials{$initialCount}");
+        $cacheKey = self::CACHE_VERSION.'_avatar_auto_'.hash('sha256', "{$name}_{$size}_initials{$initialCount}");
 
         return $this->cache->remember(
             $cacheKey,
@@ -266,7 +268,7 @@ final readonly class AvatarService
     private function generateSvg(string $initials, string $bgColor, string $textColor, int $size): string
     {
         // Byte length would read a single CJK glyph as 3 characters and shrink it.
-        $fontSize = mb_strlen($initials) > 1 ? 44 : 48;
+        $fontSize = mb_strlen($initials) > 1 ? 40 : 46;
 
         // Initials derive from a user-supplied name, so they can carry characters that
         // are markup here. Unescaped, a workspace named "<script>x" produced initials
@@ -275,10 +277,12 @@ final readonly class AvatarService
 
         return <<<SVG
         <svg xmlns="http://www.w3.org/2000/svg" width="{$size}" height="{$size}" viewBox="0 0 100 100">
-            <rect x="0" y="0" width="100" height="100" fill="{$bgColor}" />
-            <text x="50%" y="50%" alignment-baseline="middle" dominant-baseline="middle" text-anchor="middle"
-                  dy=".1em" fill="{$textColor}" font-family="Arial, Helvetica, sans-serif"
-                  font-size="{$fontSize}" font-weight="medium" letter-spacing="-1">
+            <rect width="100" height="100" fill="{$bgColor}" />
+            <circle cx="12" cy="4" r="70" fill="#ffffff" fill-opacity="0.12" />
+            <circle cx="96" cy="102" r="50" fill="#000000" fill-opacity="0.04" />
+            <text x="50" y="52" dominant-baseline="middle" text-anchor="middle"
+                  fill="{$textColor}" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+                  font-size="{$fontSize}" font-weight="600" letter-spacing="-1.5">
                 {$initials}
             </text>
         </svg>

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -57,8 +57,8 @@ return [
         ],
         'delete_account' => [
             'title' => 'Delete Account',
-            'description' => 'Schedule your account for deletion.',
-            'notice' => 'Deleting your account will schedule it for permanent removal after a 30-day grace period. You can cancel the deletion by logging back in at any time before that. After the grace period, all your data will be permanently deleted.',
+            'description' => 'Permanently delete your account after a 30-day grace period.',
+            'notice' => 'Your profile and sign-in account will be permanently deleted after 30 days. Workspaces that only you belong to, including their CRM data, will also be deleted. Records in shared workspaces will remain without your profile. Sign in before the deletion date to cancel.',
         ],
     ],
 
@@ -85,8 +85,8 @@ return [
 
     'modals' => [
         'delete_account' => [
-            'notice' => 'This will schedule your account for deletion. You will have 30 days to cancel by logging back in. After that, all data will be permanently removed. Please enter your password to confirm.',
-            'notice_no_password' => 'This will schedule your account for deletion. You will have 30 days to cancel by logging back in. After that, all data will be permanently removed.',
+            'notice' => 'Your profile and sign-in account will be deleted after 30 days. Workspaces that only you belong to will also be deleted. Shared workspace records will remain. Sign in before the deletion date to cancel. Enter your password to confirm.',
+            'notice_no_password' => 'Your profile and sign-in account will be deleted after 30 days. Workspaces that only you belong to will also be deleted. Shared workspace records will remain. Sign in before the deletion date to cancel.',
         ],
         'log_out_other_browsers' => [
             'title' => 'Log Out Other Browser Sessions',
@@ -98,11 +98,19 @@ return [
     'edit_profile' => 'Edit Profile',
 
     'scheduled_deletion_interstitial' => [
+        'heading' => 'Your account is scheduled for deletion',
+        'details' => [
+            'account' => 'Your profile and sign-in account will be permanently deleted.',
+            'deletion_date' => 'Deletion date:',
+            'workspaces' => ':count sole-owned workspace and its CRM data will also be deleted.|:count sole-owned workspaces and their CRM data will also be deleted.',
+            'shared_records' => 'Records in shared workspaces will remain without your profile.',
+        ],
+        'help' => 'Changed your mind? Keep your account to cancel this deletion and restore access.',
         'actions' => [
             'cancel_deletion' => [
                 'label' => 'Keep my account',
                 'modal_heading' => 'Keep your account?',
-                'modal_description' => 'Your scheduled deletion will be cancelled and all your data will be preserved.',
+                'modal_description' => 'Your scheduled deletion will be cancelled. You will regain access to your account and workspaces.',
                 'modal_submit_label' => 'Yes, keep my account',
             ],
             'logout' => [

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -441,6 +441,10 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     @apply rounded-full;
 }
 
+.fi-user-avatar {
+    @apply ring-1 ring-gray-950/10 dark:ring-white/15;
+}
+
 /* User Menu */
 .fi-user-menu-trigger {
     @apply rounded-xl;
@@ -706,4 +710,3 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
 
 /* Chat record chips moved to resources/css/theme.css: the marketing hero
    mock renders the same chips and only loads that shared bundle. */
-

--- a/resources/views/livewire/app/profile/scheduled-deletion-interstitial.blade.php
+++ b/resources/views/livewire/app/profile/scheduled-deletion-interstitial.blade.php
@@ -23,7 +23,7 @@
 
                 {{-- Heading --}}
                 <h1 class="text-center text-lg font-semibold text-gray-950 dark:text-white">
-                    Your account is being deleted
+                    {{ __('profile.scheduled_deletion_interstitial.heading') }}
                 </h1>
 
                 {{-- Countdown --}}
@@ -42,11 +42,17 @@
                 {{-- Details --}}
                 <div class="mt-5 space-y-2 text-center text-sm text-gray-500 dark:text-gray-400">
                     <p>
-                        Your account and all associated data will be permanently deleted on
-                        <strong class="text-gray-950 dark:text-white">{{ $deletionDate->format('F j, Y') }}</strong>.
+                        {{ __('profile.scheduled_deletion_interstitial.details.account') }}
                     </p>
                     <p>
-                        This includes {{ $teamCount }} {{ Str::plural('workspace', $teamCount) }}, contacts, companies, opportunities, and notes.
+                        {{ __('profile.scheduled_deletion_interstitial.details.deletion_date') }}
+                        <strong class="text-gray-950 dark:text-white">{{ $deletionDate->format('F j, Y') }}</strong>
+                    </p>
+                    <p>
+                        {{ trans_choice('profile.scheduled_deletion_interstitial.details.workspaces', $teamCount, ['count' => $teamCount]) }}
+                    </p>
+                    <p>
+                        {{ __('profile.scheduled_deletion_interstitial.details.shared_records') }}
                     </p>
                 </div>
 
@@ -61,7 +67,7 @@
 
             {{-- Help text --}}
             <p class="mt-4 text-center text-xs text-gray-400 dark:text-gray-500">
-                Changed your mind? Cancel the deletion above and your account will be fully restored.
+                {{ __('profile.scheduled_deletion_interstitial.help') }}
             </p>
         </div>
     </div>

--- a/tests/Feature/Auth/UserModelTest.php
+++ b/tests/Feature/Auth/UserModelTest.php
@@ -6,9 +6,10 @@ use App\Models\Task;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\UserSocialAccount;
+use App\Services\AvatarService;
 use Filament\Panel;
 
-mutates(User::class);
+mutates(User::class, AvatarService::class);
 
 test('user has many social accounts', function () {
     $user = User::factory()->create();
@@ -51,11 +52,13 @@ test('user can access tenant', function () {
     expect($user->canAccessTenant($team))->toBeTrue();
 });
 
-test('user has avatar', function () {
+test('user has a consistent local initial avatar', function () {
     $user = User::factory()->create([
         'name' => 'John Doe',
     ]);
 
-    expect($user->getFilamentAvatarUrl())->not->toBeNull()
-        ->and($user->avatar)->not->toBeNull();
+    expect($user->getFilamentAvatarUrl())
+        ->toStartWith('data:image/svg+xml;base64,')
+        ->toBe($user->profile_photo_url)
+        ->and($user->avatar)->toBe($user->profile_photo_url);
 });

--- a/tests/Feature/Middleware/CheckScheduledDeletionTest.php
+++ b/tests/Feature/Middleware/CheckScheduledDeletionTest.php
@@ -32,7 +32,21 @@ test('interstitial component renders for user with scheduled deletion', function
 
     livewire(ScheduledDeletionInterstitial::class)
         ->assertSuccessful()
-        ->assertSee('Your account is being deleted');
+        ->assertSee('Your account is scheduled for deletion')
+        ->assertSee('Your profile and sign-in account will be permanently deleted.')
+        ->assertSee('1 sole-owned workspace and its CRM data will also be deleted.')
+        ->assertSee('Records in shared workspaces will remain without your profile.');
+});
+
+test('cancel confirmation explains that account access will be restored', function () {
+    $user = User::factory()->withPersonalTeam()->scheduledForDeletion()->create();
+
+    $this->actingAs($user);
+
+    livewire(ScheduledDeletionInterstitial::class)
+        ->mountAction('cancelDeletion')
+        ->assertMountedActionModalSee('Your scheduled deletion will be cancelled.')
+        ->assertMountedActionModalSee('You will regain access to your account and workspaces.');
 });
 
 test('interstitial redirects non-scheduled user to home', function () {

--- a/tests/Feature/Profile/AvatarServiceTest.php
+++ b/tests/Feature/Profile/AvatarServiceTest.php
@@ -129,7 +129,17 @@ it('sizes the font by character count, not byte length', function () {
     // A single CJK glyph is three bytes; strlen() read it as multiple characters and
     // shrank the text to the two-initial size.
     expect(extractSvgFromDataUrl($this->avatarService->generate('株', initialCount: 1)))
-        ->toContain('font-size="48"')
+        ->toContain('font-size="46"')
         ->and(extractSvgFromDataUrl($this->avatarService->generate('株式会社テスト')))
-        ->toContain('font-size="44"');
+        ->toContain('font-size="40"');
+});
+
+it('renders initials with a polished system type treatment', function () {
+    $svg = extractSvgFromDataUrl($this->avatarService->generateAuto('John Doe'));
+
+    expect($svg)
+        ->toContain("font-family=\"-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif\"")
+        ->toContain('font-weight="600"')
+        ->toContain('fill-opacity="0.12"')
+        ->toContain('fill-opacity="0.04"');
 });

--- a/tests/Feature/Profile/DeleteAccountTest.php
+++ b/tests/Feature/Profile/DeleteAccountTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Livewire\App\Profile\DeleteAccount;
 use App\Models\User;
 use App\Notifications\UserDeletionScheduledNotification;
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Support\Facades\Notification;
 use Livewire\Livewire;
 
@@ -67,5 +68,28 @@ test('delete account component renders correctly', function () {
 
     Livewire::test(DeleteAccount::class)
         ->assertSuccessful()
-        ->assertSee('Delete Account');
+        ->assertSee('Delete Account')
+        ->assertSee('Permanently delete your account after a 30-day grace period.')
+        ->assertSee('Records in shared workspaces will remain without your profile.')
+        ->assertDontSee('all your data');
+});
+
+test('password confirmation explains what deletion keeps and removes', function () {
+    $this->actingAs(User::factory()->withPersonalTeam()->create());
+
+    Livewire::test(DeleteAccount::class)
+        ->mountAction(TestAction::make('deleteAccount')->schemaComponent())
+        ->assertMountedActionModalSee('Your profile and sign-in account will be deleted after 30 days.')
+        ->assertMountedActionModalSee('Shared workspace records will remain.')
+        ->assertMountedActionModalSee('Enter your password to confirm.');
+});
+
+test('social account confirmation explains what deletion keeps and removes', function () {
+    $this->actingAs(User::factory()->withPersonalTeam()->socialOnly()->create());
+
+    Livewire::test(DeleteAccount::class)
+        ->mountAction(TestAction::make('deleteAccount')->schemaComponent())
+        ->assertMountedActionModalSee('Your profile and sign-in account will be deleted after 30 days.')
+        ->assertMountedActionModalSee('Shared workspace records will remain.')
+        ->assertDontSee('Enter your password to confirm.');
 });

--- a/tests/Feature/SupportMenuTest.php
+++ b/tests/Feature/SupportMenuTest.php
@@ -6,11 +6,13 @@ use App\Enums\SupportFormType;
 use App\Features\SupportMenu;
 use App\Filament\Pages\Dashboard;
 use App\Models\User;
+use App\Providers\Filament\AppPanelProvider;
 use App\Support\SupportForms;
 use Filament\Facades\Filament;
 use Illuminate\Testing\TestResponse;
+use Symfony\Component\DomCrawler\Crawler;
 
-mutates(SupportForms::class);
+mutates(AppPanelProvider::class, SupportForms::class);
 mutates(SupportFormType::class);
 mutates(SupportMenu::class);
 
@@ -39,6 +41,30 @@ it('renders the help menu items for the configured support forms', function (): 
         ->assertSee('form.maxforms.com/relcontact', false)
         ->assertSee('form.maxforms.com/relbug', false)
         ->assertSee('form.maxforms.com/relfeature', false);
+});
+
+it('separates account, support, and logout actions into distinct menu groups', function (): void {
+    config([
+        'relaticle.features.support_menu' => true,
+        'support.forms.contact' => 'https://form.maxforms.com/relcontact',
+        'support.forms.bug' => null,
+        'support.forms.feature' => null,
+    ]);
+
+    $response = visitDashboard()->assertOk();
+    $groups = collect((new Crawler($response->getContent()))
+        ->filter('.fi-user-menu .fi-dropdown-list')
+        ->each(fn (Crawler $group): string => $group->text()));
+
+    $settingsGroup = $groups->search(fn (string $group): bool => str_contains($group, 'Settings'));
+    $supportGroup = $groups->search(fn (string $group): bool => str_contains($group, 'Contact / Help'));
+    $logoutGroup = $groups->search(fn (string $group): bool => str_contains($group, 'Sign out'));
+
+    expect($settingsGroup)->toBeInt()
+        ->and($supportGroup)->toBeInt()
+        ->and($logoutGroup)->toBeInt()
+        ->and($settingsGroup)->toBeLessThan($supportGroup)
+        ->and($supportGroup)->toBeLessThan($logoutGroup);
 });
 
 it('hides the entire help menu when the support_menu feature is disabled', function (): void {


### PR DESCRIPTION
## Summary

- Group account, support, and sign-out actions with clear user-menu separators.
- Replace external initial avatars with polished local SVG avatars and a subtle avatar ring.
- Clarify the 30-day deletion outcome across settings, confirmation modals, and the scheduled-deletion page.

## Verification

- Pint, Rector, PHPStan, 100% type coverage, full lint, and 38 affected tests with 127 assertions.