### PR TITLE
Fix email privacy tier selection in sharing cards

### DIFF
--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -321,6 +321,7 @@ abstract class BaseRecordEmailsPage extends Page
                             ->schema([
                                 Radio::make('privacy_tier')
                                     ->hiddenLabel()
+                                    ->options(EmailPrivacyTier::class)
                                     ->view('email-integration::forms.sharing-tier-cards')
                                     ->viewData(['ariaLabel' => __('filament/pages/record-emails.fields.privacy_tier.label')])
                                     ->required(),

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -586,6 +586,7 @@ final class EmailInboxPage extends Page
                             ->schema([
                                 Radio::make('privacy_tier')
                                     ->hiddenLabel()
+                                    ->options(EmailPrivacyTier::class)
                                     ->view('email-integration::forms.sharing-tier-cards')
                                     ->viewData(['ariaLabel' => __('filament/pages/email-inbox.sharing.fields.privacy_tier.label')])
                                     ->required(),

--- a/tests/Feature/EmailIntegration/EmailPageTabsTest.php
+++ b/tests/Feature/EmailIntegration/EmailPageTabsTest.php
@@ -126,6 +126,25 @@ it('does not mark an email as read when the page is loaded on another tab', func
     expect($email->reads()->where('user_id', $this->user->id)->exists())->toBeFalse();
 });
 
+it('saves an email privacy tier from the sharing cards', function (): void {
+    $email = Email::factory()->inbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+    ]);
+
+    Livewire::test(EmailInboxPage::class)
+        ->callAction('manageSharing', data: [
+            'privacy_tier' => EmailPrivacyTier::FULL->value,
+            'shares' => [],
+        ], arguments: ['emailId' => $email->id])
+        ->assertHasNoActionErrors()
+        ->assertNotified('Sharing settings saved.');
+
+    expect($email->fresh()->privacy_tier)->toBe(EmailPrivacyTier::FULL);
+});
+
 it('lists only the signed-in user\'s own drafts', function (): void {
     $mine = makeDraft($this->user, $this->account);
 

--- a/tests/Feature/EmailIntegration/RecordEmailsMarkAllReadTest.php
+++ b/tests/Feature/EmailIntegration/RecordEmailsMarkAllReadTest.php
@@ -7,6 +7,7 @@ use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
@@ -92,6 +93,18 @@ it('shows sender and recipient metadata in the email list', function (): void {
     livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
         ->assertSee('Alex Sender')
         ->assertSee('Taylor Recipient');
+});
+
+it('saves an email privacy tier from the sharing cards', function (): void {
+    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->callAction('manageSharing', data: [
+            'privacy_tier' => EmailPrivacyTier::SUBJECT->value,
+            'shares' => [],
+        ], arguments: ['emailId' => $this->newer->id])
+        ->assertHasNoActionErrors()
+        ->assertNotified('Sharing settings saved.');
+
+    expect($this->newer->fresh()->privacy_tier)->toBe(EmailPrivacyTier::SUBJECT);
 });
 
 it('does not mark emails belonging to other records', function (): void {


### PR DESCRIPTION
## Summary

- register `EmailPrivacyTier` as valid options for the custom sharing radio cards
- fix saving sharing settings from both the inbox and CRM record email pages
- add regression coverage for both flows

## Verification

- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/rector --dry-run`
- `vendor/bin/phpstan analyse --memory-limit=2G --no-progress`
- `php -d memory_limit=2G vendor/bin/pest --type-coverage --min=100`
- manually opened the sharing dialog and confirmed all privacy tiers render without the validation error