### PR TITLE
Add failed emails tab to inbox

### DIFF
--- a/lang/en/filament/pages/email-inbox.php
+++ b/lang/en/filament/pages/email-inbox.php
@@ -11,6 +11,7 @@ return [
     'tabs' => [
         'drafts' => 'Drafts',
         'outbox' => 'Outbox',
+        'failed' => 'Failed',
         'templates' => 'Templates',
     ],
     'drafts' => [
@@ -33,6 +34,12 @@ return [
         'notifications' => [
             'deleted' => 'Draft deleted',
             'bulk_deleted' => '{1}1 draft deleted|[2,*]:count drafts deleted',
+        ],
+    ],
+    'failed' => [
+        'empty' => [
+            'heading' => 'No failed emails',
+            'description' => 'Emails that could not be delivered will appear here.',
         ],
     ],
     'folders' => [

--- a/packages/EmailIntegration/src/Enums/EmailPageTab.php
+++ b/packages/EmailIntegration/src/Enums/EmailPageTab.php
@@ -16,6 +16,7 @@ enum EmailPageTab: string implements HasIcon, HasLabel
 {
     case DRAFTS = 'drafts';
     case OUTBOX = 'outbox';
+    case FAILED = 'failed';
     case TEMPLATES = 'templates';
 
     public function getLabel(): string
@@ -23,6 +24,7 @@ enum EmailPageTab: string implements HasIcon, HasLabel
         return match ($this) {
             self::DRAFTS => __('filament/pages/email-inbox.tabs.drafts'),
             self::OUTBOX => __('filament/pages/email-inbox.tabs.outbox'),
+            self::FAILED => __('filament/pages/email-inbox.tabs.failed'),
             self::TEMPLATES => __('filament/pages/email-inbox.tabs.templates'),
         };
     }
@@ -32,6 +34,7 @@ enum EmailPageTab: string implements HasIcon, HasLabel
         return match ($this) {
             self::DRAFTS => Heroicon::OutlinedPencilSquare,
             self::OUTBOX => Heroicon::OutlinedClock,
+            self::FAILED => Heroicon::OutlinedExclamationCircle,
             self::TEMPLATES => Heroicon::OutlinedDocumentDuplicate,
         };
     }
@@ -43,8 +46,20 @@ enum EmailPageTab: string implements HasIcon, HasLabel
     {
         return match ($this) {
             self::DRAFTS => 'email-integration.drafts-table',
-            self::OUTBOX => 'email-integration.outbox-table',
+            self::OUTBOX, self::FAILED => 'email-integration.outbox-table',
             self::TEMPLATES => 'email-integration.templates-table',
+        };
+    }
+
+    /**
+     * @return array<string, bool|EmailStatus>
+     */
+    public function livewireParameters(): array
+    {
+        return match ($this) {
+            self::OUTBOX => ['includeFailedFilter' => false],
+            self::FAILED => ['lockedStatus' => EmailStatus::FAILED],
+            default => [],
         };
     }
 }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -154,6 +154,7 @@ final class EmailInboxPage extends Page
             // The composer saves/discards drafts and queues mail from outside this
             // component, so the tab badges have to be told when those counts move.
             'drafts:changed' => 'refreshTabCounts',
+            'outbox:changed' => 'refreshTabCounts',
         ];
     }
 
@@ -330,9 +331,9 @@ final class EmailInboxPage extends Page
     }
 
     /**
-     * Badge counts for the tab bar. Drafts are the user's own unsent messages and
-     * the outbox counts what is still waiting to go out; templates count what the
-     * user may actually apply (shared, or their own).
+     * Badge counts for the tab bar. Drafts are the user's own unsent messages,
+     * the outbox counts what is still waiting to go out, failed counts delivery
+     * failures, and templates count what the user may actually apply.
      *
      * @return array<string, int>
      */
@@ -351,7 +352,12 @@ final class EmailInboxPage extends Page
             EmailPageTab::OUTBOX->value => Email::query()
                 ->forTeam($teamId)
                 ->where('user_id', $user->getKey())
-                ->whereIn('status', [EmailStatus::QUEUED, EmailStatus::FAILED])
+                ->where('status', EmailStatus::QUEUED)
+                ->count(),
+            EmailPageTab::FAILED->value => Email::query()
+                ->forTeam($teamId)
+                ->where('user_id', $user->getKey())
+                ->where('status', EmailStatus::FAILED)
                 ->count(),
             EmailPageTab::TEMPLATES->value => EmailTemplate::query()
                 ->where('team_id', $teamId)

--- a/packages/EmailIntegration/src/Livewire/OutboxTable.php
+++ b/packages/EmailIntegration/src/Livewire/OutboxTable.php
@@ -44,20 +44,22 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    public ?EmailStatus $lockedStatus = null;
+
+    public bool $includeFailedFilter = true;
+
     public function table(Table $table): Table
     {
         return $table
             ->query($this->buildQuery())
-            ->filters([
-                SelectFilter::make('status_tab')
-                    ->options(OutboxTab::class)
-                    ->default(OutboxTab::QUEUED->value)
-                    ->selectablePlaceholder(false)
-                    ->query(fn (Builder $query, array $data): Builder => $this->applyStatusTab(
-                        $query,
-                        OutboxTab::tryFrom((string) ($data['value'] ?? '')) ?? OutboxTab::QUEUED,
-                    )),
-            ])
+            ->filters($this->lockedStatus instanceof EmailStatus ? [] : [$this->statusFilter()])
+            ->when(
+                $this->lockedStatus === EmailStatus::FAILED,
+                fn (Table $table): Table => $table
+                    ->emptyStateHeading(__('filament/pages/email-inbox.failed.empty.heading'))
+                    ->emptyStateDescription(__('filament/pages/email-inbox.failed.empty.description'))
+                    ->emptyStateIcon(Heroicon::ExclamationCircle),
+            )
             ->columns([
                 TextColumn::make('subject')->limit(50)->searchable(),
                 TextColumn::make('participants_to')
@@ -67,7 +69,9 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
                 TextColumn::make('status')->badge(),
                 TextColumn::make('scheduled_for')->dateTime()->label(__('filament/pages/email-outbox.columns.scheduled_for')),
                 TextColumn::make('priority')->badge(),
-                TextColumn::make('last_error')->toggleable(isToggledHiddenByDefault: true)->wrap(),
+                TextColumn::make('last_error')
+                    ->toggleable(isToggledHiddenByDefault: $this->lockedStatus !== EmailStatus::FAILED)
+                    ->wrap(),
             ])
             ->recordActions([
                 Action::make('cancel')
@@ -77,6 +81,7 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
                     ->visible(fn (Email $record): bool => $record->status === EmailStatus::QUEUED)
                     ->action(function (Email $record): void {
                         resolve(CancelQueuedEmailAction::class)->execute($record);
+                        $this->dispatch('outbox:changed');
                         Notification::make()->title(__('filament/pages/email-outbox.notifications.cancelled'))->success()->send();
                     }),
                 Action::make('reschedule')
@@ -100,6 +105,7 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
                     ->visible(fn (Email $record): bool => $record->status === EmailStatus::FAILED)
                     ->action(function (Email $record): void {
                         resolve(RetryFailedEmailAction::class)->execute($record);
+                        $this->dispatch('outbox:changed');
                         Notification::make()->title(__('filament/pages/email-outbox.notifications.retry_queued'))->success()->send();
                     }),
             ])
@@ -134,6 +140,7 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
                             ? __('filament/pages/email-outbox.notifications.bulk_cancelled_with_skipped', ['cancelled' => $cancelled, 'skipped' => $skipped])
                             : __('filament/pages/email-outbox.notifications.bulk_cancelled', ['count' => $cancelled]);
 
+                        $this->dispatch('outbox:changed');
                         Notification::make()->title($title)->success()->send();
                     }),
             ]);
@@ -153,7 +160,34 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
             ->with(['participants'])
             ->where('team_id', filament()->getTenant()?->getKey())
             ->where('user_id', auth()->id())
-            ->where('direction', EmailDirection::OUTBOUND);
+            ->where('direction', EmailDirection::OUTBOUND)
+            ->when(
+                $this->lockedStatus instanceof EmailStatus,
+                fn (Builder $query): Builder => $query->where('status', $this->lockedStatus),
+            );
+    }
+
+    private function statusFilter(): SelectFilter
+    {
+        return SelectFilter::make('status_tab')
+            ->options($this->statusFilterOptions())
+            ->default(OutboxTab::QUEUED->value)
+            ->selectablePlaceholder(false)
+            ->query(fn (Builder $query, array $data): Builder => $this->applyStatusTab(
+                $query,
+                OutboxTab::tryFrom((string) ($data['value'] ?? '')) ?? OutboxTab::QUEUED,
+            ));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function statusFilterOptions(): array
+    {
+        return collect(OutboxTab::cases())
+            ->reject(fn (OutboxTab $tab): bool => ! $this->includeFailedFilter && $tab === OutboxTab::FAILED)
+            ->mapWithKeys(fn (OutboxTab $tab): array => [$tab->value => $tab->getLabel()])
+            ->all();
     }
 
     /**

--- a/resources/views/components/emails/page-tab.blade.php
+++ b/resources/views/components/emails/page-tab.blade.php
@@ -5,7 +5,7 @@
     wire:click="setTab('{{ $tab->value }}')"
     wire:loading.attr="disabled"
     @class([
-        'flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none',
+        'flex shrink-0 items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none',
         'bg-gray-100 text-gray-900 dark:bg-white/10 dark:text-white' => $active,
         'text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200' => ! $active,
     ])

--- a/resources/views/filament/pages/email-inbox.blade.php
+++ b/resources/views/filament/pages/email-inbox.blade.php
@@ -7,9 +7,9 @@
             />
         </div>
     @else
-    {{-- ── Page tabs: the drafts, outbox and template lists, each a nested
+    {{-- ── Page tabs: the drafts, outbox, failed and template lists, each a nested
          Livewire component also hosted by a standalone page. ────────────── --}}
-    <div class="flex items-center gap-1 border-b border-gray-200 pb-2 dark:border-gray-700">
+    <div class="flex items-center gap-1 overflow-x-auto border-b border-gray-200 pb-2 dark:border-gray-700">
         @foreach (\Relaticle\EmailIntegration\Enums\EmailPageTab::cases() as $pageTab)
             <x-emails.page-tab
                 :tab="$pageTab"
@@ -20,7 +20,7 @@
     </div>
 
     {{-- No wrapper: the Filament table renders its own card. --}}
-    @livewire($tab->livewireComponent(), key($tab->value.'-table'))
+    @livewire($tab->livewireComponent(), $tab->livewireParameters(), key($tab->value.'-table'))
     @endif
 
     <x-filament-actions::modals />

--- a/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
@@ -30,7 +30,7 @@ beforeEach(function (): void {
 
 function makeOutboxEmail(User $user, ConnectedAccount $account, EmailStatus $status, array $overrides = []): Email
 {
-    return Email::create(array_merge([
+    return Email::query()->create(array_merge([
         'team_id' => $user->currentTeam->id,
         'user_id' => $user->id,
         'connected_account_id' => $account->id,
@@ -74,12 +74,72 @@ it('failed tab filters to failed emails', function (): void {
         ->assertCanNotSeeTableRecords([$queued]);
 });
 
+it('locked failed mode lists every failed email owned by the user', function (): void {
+    $firstAccountFailure = makeOutboxEmail($this->user, $this->account, EmailStatus::FAILED, [
+        'last_error' => 'SMTP bounce',
+    ]);
+    $firstAccountFailure->forceFill(['created_at' => now()->subYears(3)])->saveQuietly();
+    $secondAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+    $secondAccountFailure = makeOutboxEmail($this->user, $secondAccount, EmailStatus::FAILED, [
+        'last_error' => 'Provider timeout',
+    ]);
+    $queued = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED);
+
+    $teammate = User::factory()->create(['current_team_id' => $this->team->id]);
+    $teammateAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+    ]));
+    $teammateFailure = makeOutboxEmail($teammate, $teammateAccount, EmailStatus::FAILED);
+
+    $otherUser = User::factory()->withTeam()->create();
+    $otherAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $otherUser->current_team_id,
+        'user_id' => $otherUser->id,
+    ]));
+    $otherTeamFailure = makeOutboxEmail($otherUser, $otherAccount, EmailStatus::FAILED);
+
+    $component = livewire(OutboxTable::class, ['lockedStatus' => EmailStatus::FAILED])
+        ->assertCanSeeTableRecords([$firstAccountFailure, $secondAccountFailure])
+        ->assertCanNotSeeTableRecords([$queued, $teammateFailure, $otherTeamFailure])
+        ->assertTableColumnVisible('last_error');
+
+    expect($component->instance()->getTable()->getFilter('status_tab'))->toBeNull();
+});
+
+it('locked failed mode has a dedicated empty state', function (): void {
+    livewire(OutboxTable::class, ['lockedStatus' => EmailStatus::FAILED])
+        ->assertSee('No failed emails');
+});
+
+it('can exclude failed from the status filter without changing standalone outbox', function (): void {
+    $emailPageOptions = livewire(OutboxTable::class, ['includeFailedFilter' => false])
+        ->instance()
+        ->getTable()
+        ->getFilter('status_tab')
+        ?->getOptions();
+
+    $standaloneOptions = livewire(OutboxTable::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('status_tab')
+        ?->getOptions();
+
+    expect($emailPageOptions)
+        ->not->toHaveKey('failed')
+        ->and($standaloneOptions)->toHaveKey('failed');
+});
+
 it('cancel row action moves a queued email to CANCELLED', function (): void {
     $email = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED);
 
     livewire(OutboxTable::class)
         ->callAction(TestAction::make('cancel')->table($email))
-        ->assertNotified();
+        ->assertNotified()
+        ->assertDispatched('outbox:changed');
 
     expect($email->refresh()->status)->toBe(EmailStatus::CANCELLED);
 });
@@ -117,7 +177,8 @@ it('retry row action re-queues a failed email', function (): void {
         ->filterTable('status_tab', 'failed')
         ->assertCanSeeTableRecords([$email])
         ->callAction([['name' => 'retry', 'context' => ['table' => true, 'recordKey' => $email->getKey()]]])
-        ->assertNotified();
+        ->assertNotified()
+        ->assertDispatched('outbox:changed');
 
     expect($email->refresh())
         ->status->toBe(EmailStatus::QUEUED)
@@ -142,7 +203,8 @@ it('bulkCancel cancels selected queued rows', function (): void {
     livewire(OutboxTable::class)
         ->selectTableRecords([$queuedA, $queuedB])
         ->callAction([['name' => 'bulkCancel', 'context' => ['table' => true, 'bulk' => true]]])
-        ->assertNotified();
+        ->assertNotified()
+        ->assertDispatched('outbox:changed');
 
     expect($queuedA->refresh()->status)->toBe(EmailStatus::CANCELLED)
         ->and($queuedB->refresh()->status)->toBe(EmailStatus::CANCELLED);
@@ -159,7 +221,7 @@ it('bulkCancel skips a row that raced to SENDING and still cancels the rest', fu
     // Simulate the row transitioning QUEUED -> SENDING between render and the
     // bulk action firing. The action re-locks the row and throws RuntimeException;
     // the loop must catch it, skip that row, and still cancel the others.
-    Email::withoutEvents(fn () => Email::whereKey($racing->getKey())->update(['status' => EmailStatus::SENDING]));
+    Email::withoutEvents(fn () => Email::query()->whereKey($racing->getKey())->update(['status' => EmailStatus::SENDING]));
 
     $component
         ->callAction([['name' => 'bulkCancel', 'context' => ['table' => true, 'bulk' => true]]])

--- a/tests/Feature/EmailIntegration/EmailPageTabsTest.php
+++ b/tests/Feature/EmailIntegration/EmailPageTabsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
@@ -16,6 +17,7 @@ use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
 use Relaticle\EmailIntegration\Livewire\DraftsTable;
 use Relaticle\EmailIntegration\Livewire\EmailComposer;
+use Relaticle\EmailIntegration\Livewire\OutboxTable;
 use Relaticle\EmailIntegration\Livewire\TemplatesTable;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -42,7 +44,7 @@ beforeEach(function (): void {
 
 function makeDraft(User $user, ConnectedAccount $account, array $overrides = []): Email
 {
-    return Email::create(array_merge([
+    return Email::query()->create(array_merge([
         'team_id' => $user->currentTeam->id,
         'user_id' => $user->id,
         'connected_account_id' => $account->id,
@@ -54,26 +56,49 @@ function makeDraft(User $user, ConnectedAccount $account, array $overrides = [])
     ], $overrides));
 }
 
+it('uses an outlined icon for the failed tab', function (): void {
+    expect(EmailPageTab::FAILED->getIcon())->toBe(Heroicon::OutlinedExclamationCircle);
+});
+
 it('defaults to the first tab and switches between tabs', function (): void {
     Livewire::test(EmailInboxPage::class)
         ->assertSet('tab', EmailPageTab::DRAFTS)
         ->call('setTab', 'outbox')
         ->assertSet('tab', EmailPageTab::OUTBOX)
+        ->call('setTab', 'failed')
+        ->assertSet('tab', EmailPageTab::FAILED)
         ->call('setTab', 'templates')
         ->assertSet('tab', EmailPageTab::TEMPLATES);
+});
+
+it('loads the failed tab from the URL', function (): void {
+    Livewire::withQueryParams(['tab' => 'failed'])
+        ->test(EmailInboxPage::class)
+        ->assertSet('tab', EmailPageTab::FAILED);
 });
 
 it('counts drafts, pending outbox mail and available templates for the tab badges', function (): void {
     makeDraft($this->user, $this->account);
     makeDraft($this->user, $this->account, ['subject' => 'Second draft']);
 
-    Email::create([
+    Email::query()->create([
         'team_id' => $this->team->id,
         'user_id' => $this->user->id,
         'connected_account_id' => $this->account->id,
         'subject' => 'Waiting to go out',
         'direction' => EmailDirection::OUTBOUND,
         'status' => EmailStatus::QUEUED,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'creation_source' => EmailCreationSource::COMPOSE,
+    ]);
+
+    Email::query()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Could not be delivered',
+        'direction' => EmailDirection::OUTBOUND,
+        'status' => EmailStatus::FAILED,
         'privacy_tier' => EmailPrivacyTier::FULL,
         'creation_source' => EmailCreationSource::COMPOSE,
     ]);
@@ -89,6 +114,7 @@ it('counts drafts, pending outbox mail and available templates for the tab badge
     expect($counts)->toBe([
         'drafts' => 2,
         'outbox' => 1,
+        'failed' => 1,
         'templates' => 1,
     ]);
 });
@@ -108,6 +134,33 @@ it('refreshes the tab badges when the composer saves a draft', function (): void
     $page->dispatch('drafts:changed');
 
     expect($page->instance()->tabCounts()['drafts'])->toBe(1);
+});
+
+it('refreshes the outbox and failed badges when a failed email is retried', function (): void {
+    $failed = Email::query()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Retry me',
+        'direction' => EmailDirection::OUTBOUND,
+        'status' => EmailStatus::FAILED,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'creation_source' => EmailCreationSource::COMPOSE,
+    ]);
+
+    $page = Livewire::test(EmailInboxPage::class);
+
+    expect($page->instance()->tabCounts())
+        ->toMatchArray(['outbox' => 0, 'failed' => 1]);
+
+    Livewire::test(OutboxTable::class, ['lockedStatus' => EmailStatus::FAILED])
+        ->callAction(TestAction::make('retry')->table($failed))
+        ->assertDispatched('outbox:changed');
+
+    $page->dispatch('outbox:changed');
+
+    expect($page->instance()->tabCounts())
+        ->toMatchArray(['outbox' => 1, 'failed' => 0]);
 });
 
 it('does not mark an email as read when the page is loaded on another tab', function (): void {


### PR DESCRIPTION
## Summary
- add a dedicated Failed tab to the Emails page
- split queued and failed badge counts, refreshing them after retry/cancel actions
- show failure reasons and retry actions in a locked failed-only Outbox table
- keep the standalone Outbox page’s Failed filter unchanged

## Verification
- `php -d memory_limit=1G vendor/bin/pest --exclude-testsuite=Browser`
- `php -d memory_limit=1G vendor/bin/pest --compact tests/Feature/EmailIntegration/EmailOutboxPageTest.php tests/Feature/EmailIntegration/EmailPageTabsTest.php`