### PR TITLE
Improve workspace privacy layout

### DIFF
--- a/lang/en/filament/pages/email-privacy-settings.php
+++ b/lang/en/filament/pages/email-privacy-settings.php
@@ -13,10 +13,9 @@ return [
         'description' => 'Applied to all newly synced emails unless a team member sets their own preference.',
         'tier_label' => 'Default Sharing Tier for Connected Email Accounts',
     ],
-    'auto_hide_internal' => [
-        'heading' => 'Auto-hide Internal Emails',
-        'description' => "Internal emails are automatically hidden from teammates' views.",
-        'content' => 'Emails where every participant is a member of this workspace are classified as internal and are automatically hidden from all teammates. Only the syncing user can see them. This behaviour is always on and cannot be disabled.',
+    'privacy_protections' => [
+        'heading' => 'Privacy Protections',
+        'description' => 'Internal emails are always hidden from teammates. Add addresses or domains below to protect those emails workspace-wide too.',
     ],
     'protected_recipients' => [
         'heading' => 'Protected Recipients',

--- a/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
@@ -9,11 +9,11 @@ use App\Features\EmailIntegration;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\Action;
-use Filament\Forms\Components\Placeholder;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\ViewField;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -132,37 +132,32 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
     public function form(Schema $schema): Schema
     {
         return $schema->schema([
-            Section::make(__('filament/pages/email-privacy-settings.workspace_default.heading'))
-                ->description(__('filament/pages/email-privacy-settings.workspace_default.description'))
-                ->schema([
-                    Select::make('default_email_sharing_tier')
-                        ->label(__('filament/pages/email-privacy-settings.workspace_default.tier_label'))
-                        ->options(EmailPrivacyTier::class)
-                        ->required(),
-                ])->compact(),
+            Grid::make(2)->schema([
+                Section::make(__('filament/pages/email-privacy-settings.workspace_default.heading'))
+                    ->description(__('filament/pages/email-privacy-settings.workspace_default.description'))
+                    ->schema([
+                        ViewField::make('default_email_sharing_tier')
+                            ->label(__('filament/pages/email-privacy-settings.workspace_default.tier_label'))
+                            ->view('email-integration::forms.sharing-tier-cards')
+                            ->viewData([
+                                'ariaLabel' => __('filament/pages/email-privacy-settings.workspace_default.tier_label'),
+                            ]),
+                    ])->compact(),
 
-            Section::make(__('filament/pages/email-privacy-settings.auto_hide_internal.heading'))
-                ->description(__('filament/pages/email-privacy-settings.auto_hide_internal.description'))
-                ->compact()
-                ->schema([
-                    Placeholder::make('internal_emails_info')
-                        ->hiddenLabel()
-                        ->content(__('filament/pages/email-privacy-settings.auto_hide_internal.content')),
-                ]),
-
-            Section::make(__('filament/pages/email-privacy-settings.protected_recipients.heading'))
-                ->compact()
-                ->description(__('filament/pages/email-privacy-settings.protected_recipients.description'))
-                ->schema([
-                    TagsInput::make('protected_emails')
-                        ->label(__('filament/pages/email-privacy-settings.protected_recipients.emails_label'))
-                        ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.emails_placeholder'))
-                        ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.emails_after_label')),
-                    TagsInput::make('protected_domains')
-                        ->label(__('filament/pages/email-privacy-settings.protected_recipients.domains_label'))
-                        ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.domains_placeholder'))
-                        ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.domains_after_label')),
-                ]),
+                Section::make(__('filament/pages/email-privacy-settings.privacy_protections.heading'))
+                    ->description(__('filament/pages/email-privacy-settings.privacy_protections.description'))
+                    ->compact()
+                    ->schema([
+                        TagsInput::make('protected_emails')
+                            ->label(__('filament/pages/email-privacy-settings.protected_recipients.emails_label'))
+                            ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.emails_placeholder'))
+                            ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.emails_after_label')),
+                        TagsInput::make('protected_domains')
+                            ->label(__('filament/pages/email-privacy-settings.protected_recipients.domains_label'))
+                            ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.domains_placeholder'))
+                            ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.domains_after_label')),
+                    ]),
+            ]),
         ]);
     }
 }

--- a/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
@@ -27,6 +27,18 @@ it('updates the team default_email_sharing_tier on save', function (): void {
     expect($this->team->fresh()->default_email_sharing_tier)->toBe(EmailPrivacyTier::FULL);
 });
 
+it('shows each sharing tier with its explanation', function (): void {
+    livewire(EmailPrivacySettingsPage::class)
+        ->assertSee(EmailPrivacyTier::METADATA_ONLY->getDescription())
+        ->assertSee(EmailPrivacyTier::SUBJECT->getDescription())
+        ->assertSee(EmailPrivacyTier::FULL->getDescription());
+});
+
+it('shows the workspace privacy sections in two columns on large screens', function (): void {
+    livewire(EmailPrivacySettingsPage::class)
+        ->assertSeeHtml('--cols-lg: repeat(2, minmax(0, 1fr));');
+});
+
 it('creates ProtectedRecipient rows with type email on save', function (): void {
     livewire(EmailPrivacySettingsPage::class)
         ->set('protected_emails', ['legal@acme.com', 'hr@acme.com'])


### PR DESCRIPTION
## Summary
- Replace the sharing-tier dropdown with existing descriptive tier cards.
- Combine privacy guidance and protected recipients.
- Show the two privacy sections side-by-side on large screens, stacked on mobile.

## Verification
- `php artisan test --compact tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php`
- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/rector --dry-run`
- `vendor/bin/phpstan analyse`
- `php -d memory_limit=1G vendor/bin/pest --type-coverage --min=100`