### PR TITLE
Tell a trial apart from a paying workspace, and stop orphaning workspaces on delete

### DIFF
--- a/app/Actions/Billing/CancelTeamSubscription.php
+++ b/app/Actions/Billing/CancelTeamSubscription.php
@@ -13,6 +13,12 @@ final readonly class CancelTeamSubscription
 {
     public function execute(Team $team, bool $immediately = false): void
     {
+        // Cashier's subscription() reads the relation off the model. Deletion
+        // paths arrive with a team that was never loaded with its subscriptions
+        // (DeleteUser walks owned teams, the purge command chunks them), which
+        // is both an N+1 and a strict-lazy-loading violation outside production.
+        $team->loadMissing('subscriptions');
+
         $subscription = $team->subscription();
 
         if (! $subscription instanceof Subscription || $subscription->ended()) {

--- a/app/Actions/Jetstream/DeleteUser.php
+++ b/app/Actions/Jetstream/DeleteUser.php
@@ -26,6 +26,7 @@ final readonly class DeleteUser implements DeletesUsers
         DB::transaction(function () use ($user): void {
             $this->deleteTeams($user);
             $user->deleteProfilePhoto();
+            $user->loadMissing('tokens');
             $user->tokens->each->delete();
             $user->delete();
         });
@@ -37,6 +38,7 @@ final readonly class DeleteUser implements DeletesUsers
     private function deleteTeams(User $user): void
     {
         $user->teams()->detach();
+        $user->loadMissing('ownedTeams');
 
         $user->ownedTeams->each(function (Model $team): void {
             /** @var Team $team */

--- a/app/Console/Commands/ProcessTrialsCommand.php
+++ b/app/Console/Commands/ProcessTrialsCommand.php
@@ -43,8 +43,11 @@ final class ProcessTrialsCommand extends Command
             ->with('owner')
             ->chunkById(100, function (Collection $teams) use (&$count): void {
                 $teams->each(function (Team $team) use (&$count): void {
-                    /** @var User $owner */
                     $owner = $team->owner;
+
+                    if (! $owner instanceof User) {
+                        return;
+                    }
 
                     Mail::to($owner->email)->queue(new ProTrialEndingSoonMail($team));
                     $count++;

--- a/app/Console/Commands/PurgeScheduledDeletionsCommand.php
+++ b/app/Console/Commands/PurgeScheduledDeletionsCommand.php
@@ -88,8 +88,11 @@ final class PurgeScheduledDeletionsCommand extends Command
             ->with('owner')
             ->chunkById(100, function (Collection $teams): void {
                 $teams->each(function (Team $team): void {
-                    /** @var User $owner */
                     $owner = $team->owner;
+
+                    if (! $owner instanceof User) {
+                        return;
+                    }
 
                     $owner->notify(new TeamDeletionReminderNotification($team));
                 });

--- a/app/Enums/BillingStatus.php
+++ b/app/Enums/BillingStatus.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use App\Models\Team;
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * Why a workspace has the plan it has.
+ *
+ * `teams.plan` records capability, not provenance: a trial writes `Plan::Pro`
+ * so that the workspace gets Pro credits and rate limits, which makes a
+ * trialling workspace indistinguishable from a paying one wherever the plan
+ * column is rendered on its own. This answers the question that column cannot.
+ *
+ * Read-only and derived. Nothing persists it, and it deliberately says nothing
+ * about whether a workspace can currently reach the app — that is
+ * `HostedWorkspaceAccess`, which layers the billing feature flag on top.
+ */
+enum BillingStatus: string implements HasColor, HasLabel
+{
+    case PastDue = 'past_due';
+
+    case Subscribed = 'subscribed';
+
+    case Enterprise = 'enterprise';
+
+    case Trialing = 'trialing';
+
+    case Grandfathered = 'grandfathered';
+
+    case Granted = 'granted';
+
+    case Free = 'free';
+
+    /**
+     * Ordered by precedence, most specific first. Past due comes before
+     * subscribed because this app calls `Cashier::keepPastDueSubscriptionsActive()`,
+     * which leaves `valid()` true for a subscription that has stopped paying.
+     */
+    public static function fromTeam(Team $team): self
+    {
+        $subscription = $team->subscription();
+
+        if ($subscription?->pastDue() === true) {
+            return self::PastDue;
+        }
+
+        if ($subscription?->valid() === true) {
+            return self::Subscribed;
+        }
+
+        if ($team->plan === Plan::Enterprise) {
+            return self::Enterprise;
+        }
+
+        if ($team->onGenericTrial()) {
+            return self::Trialing;
+        }
+
+        if ($team->hosted_free_grandfathered_at !== null) {
+            return self::Grandfathered;
+        }
+
+        if ($team->plan !== Plan::Free) {
+            return self::Granted;
+        }
+
+        return self::Free;
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::PastDue => 'Past due',
+            self::Subscribed => 'Pro',
+            self::Enterprise => 'Enterprise',
+            self::Trialing => 'Trial',
+            self::Grandfathered => 'Free (legacy)',
+            self::Granted => 'Granted',
+            self::Free => 'Free',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::PastDue => 'danger',
+            self::Subscribed => 'success',
+            self::Enterprise => 'primary',
+            self::Trialing => 'info',
+            self::Grandfathered, self::Free => 'gray',
+            self::Granted => 'warning',
+        };
+    }
+}

--- a/app/Enums/Plan.php
+++ b/app/Enums/Plan.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
-enum Plan: string
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum Plan: string implements HasColor, HasLabel
 {
     case Free = 'free';
     case Pro = 'pro';
@@ -37,12 +40,21 @@ enum Plan: string
         return null;
     }
 
-    public function label(): string
+    public function getLabel(): string
     {
         return match ($this) {
             self::Free => 'Free',
             self::Pro => 'Pro',
             self::Enterprise => 'Enterprise',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Free => 'gray',
+            self::Pro => 'success',
+            self::Enterprise => 'primary',
         };
     }
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\BillingStatus;
 use App\Enums\OnboardingReferralSource;
 use App\Enums\OnboardingUseCase;
 use App\Enums\Plan;
@@ -232,6 +233,16 @@ final class Team extends JetstreamTeam implements HasAvatar, Onboardable
     public function isScheduledForDeletion(): bool
     {
         return $this->scheduled_deletion_at !== null;
+    }
+
+    /**
+     * Reads the `subscriptions` relation, so eager load it when rendering this
+     * for more than one team. It deliberately does not `loadMissing()` on your
+     * behalf: that would turn a visible N+1 into a silent one.
+     */
+    public function billingStatus(): BillingStatus
+    {
+        return BillingStatus::fromTeam($this);
     }
 
     /**

--- a/packages/Chat/resources/views/livewire/chat/partials/_model-state.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/partials/_model-state.blade.php
@@ -4,7 +4,7 @@
      $persistSelection: whether picking a model writes chat:model to
      localStorage (the full chat persists, the dashboard does not). --}}
 currentPlan: @js(auth()->user()?->currentTeam?->plan?->value ?? \App\Enums\Plan::default()->value),
-currentPlanLabel: @js(auth()->user()?->currentTeam?->plan?->label() ?? \App\Enums\Plan::default()->label()),
+currentPlanLabel: @js(auth()->user()?->currentTeam?->plan?->getLabel() ?? \App\Enums\Plan::default()->getLabel()),
 {{-- Null when billing is off or no tenant is bound (tenant-less pages/tests):
      the locked-model hint then renders without a link. --}}
 upgradeUrl: @js(

--- a/packages/Chat/src/Http/Controllers/ChatController.php
+++ b/packages/Chat/src/Http/Controllers/ChatController.php
@@ -129,7 +129,7 @@ final readonly class ChatController
 
                 return response()->json([
                     'error' => 'model_not_allowed',
-                    'message' => __(':model is not available on the :plan plan.', ['model' => $descriptor->label, 'plan' => $team->plan->label()]),
+                    'message' => __(':model is not available on the :plan plan.', ['model' => $descriptor->label, 'plan' => $team->plan->getLabel()]),
                     'plan' => $team->plan->value,
                     'requested_model' => $descriptor->id,
                     'upgrade_available' => $isFree,
@@ -150,7 +150,7 @@ final readonly class ChatController
 
             return response()->json([
                 'error' => 'credits_exhausted',
-                'message' => "You have used all {$team->plan->credits()} credits for this {$team->plan->label()} plan period.",
+                'message' => "You have used all {$team->plan->credits()} credits for this {$team->plan->getLabel()} plan period.",
                 'plan' => $team->plan->value,
                 'allowance' => $team->plan->credits(),
                 'reset_at' => $balance?->period_ends_at?->toIso8601String(),

--- a/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
@@ -319,7 +319,7 @@ final class AiCreditBalanceResource extends Resource
     private static function planOptions(): array
     {
         return collect(Plan::cases())
-            ->mapWithKeys(fn (Plan $plan): array => [$plan->value => $plan->label()])
+            ->mapWithKeys(fn (Plan $plan): array => [$plan->value => $plan->getLabel()])
             ->all();
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources;
 
+use App\Enums\BillingStatus;
 use App\Enums\OnboardingReferralSource;
 use App\Enums\OnboardingUseCase;
 use App\Models\Team;
@@ -24,6 +25,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Laravel\Jetstream\Contracts\DeletesTeams;
 use Override;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\CreateTeam;
@@ -57,6 +59,16 @@ final class TeamResource extends Resource
     protected static ?string $pluralModelLabel = 'Teams';
 
     protected static ?string $slug = 'teams';
+
+    /**
+     * @return Builder<Team>
+     */
+    #[Override]
+    public static function getEloquentQuery(): Builder
+    {
+        // billingStatus() reads the subscriptions relation per row.
+        return parent::getEloquentQuery()->with('subscriptions');
+    }
 
     public static function getNavigationBadge(): ?string
     {
@@ -103,6 +115,17 @@ final class TeamResource extends Resource
                     IconEntry::make('personal_team')
                         ->label('Personal')
                         ->boolean(),
+                    TextEntry::make('billing_status')
+                        ->label('Billing')
+                        ->state(fn (Team $record): BillingStatus => $record->billingStatus())
+                        ->badge(),
+                    TextEntry::make('plan')
+                        ->label('Plan')
+                        ->badge(),
+                    TextEntry::make('trial_ends_at')
+                        ->label('Trial Ends')
+                        ->dateTime()
+                        ->placeholder('—'),
                     TextEntry::make('onboarding_use_case')
                         ->label('Use Case')
                         ->badge()
@@ -145,6 +168,16 @@ final class TeamResource extends Resource
                 IconColumn::make('personal_team')
                     ->label('Personal')
                     ->boolean(),
+                TextColumn::make('billing_status')
+                    ->label('Billing')
+                    ->tooltip('Why this workspace has the plan it has')
+                    ->state(fn (Team $record): BillingStatus => $record->billingStatus())
+                    ->badge(),
+                TextColumn::make('plan')
+                    ->label('Plan')
+                    ->badge()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('onboarding_use_case')
                     ->label('Use Case')
                     ->badge()

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
@@ -9,7 +9,6 @@ use App\Enums\OnboardingUseCase;
 use App\Models\Team;
 use App\Rules\ValidTeamSlug;
 use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Select;
@@ -25,6 +24,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
+use Laravel\Jetstream\Contracts\DeletesTeams;
 use Override;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\CreateTeam;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\EditTeam;
@@ -40,6 +40,7 @@ use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\Peopl
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\SubscriptionsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\TasksRelationManager;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\SafeDelete;
 
 final class TeamResource extends Resource
 {
@@ -179,7 +180,9 @@ final class TeamResource extends Resource
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    SafeDelete::bulkAction(function (Team $record): void {
+                        resolve(DeletesTeams::class)->delete($record);
+                    }),
                 ]),
             ]);
     }

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/Pages/EditTeam.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/Pages/EditTeam.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages;
 
-use Filament\Actions\DeleteAction;
+use App\Models\Team;
 use Filament\Resources\Pages\EditRecord;
+use Laravel\Jetstream\Contracts\DeletesTeams;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
+use Relaticle\SystemAdmin\Filament\Support\SafeDelete;
 
 final class EditTeam extends EditRecord
 {
@@ -15,7 +17,9 @@ final class EditTeam extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            DeleteAction::make(),
+            SafeDelete::action(function (Team $record): void {
+                resolve(DeletesTeams::class)->delete($record);
+            }),
         ];
     }
 }

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource.php
@@ -9,7 +9,6 @@ use App\Enums\Notifications\NotificationType;
 use App\Enums\SubscriberTagEnum;
 use App\Models\User;
 use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DateTimePicker;
@@ -28,6 +27,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Laravel\Jetstream\Contracts\DeletesUsers;
 use Override;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\CreateUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\EditUser;
@@ -36,6 +36,7 @@ use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ViewUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\OwnedTeamsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\TeamsRelationManager;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\SafeDelete;
 
 final class UserResource extends Resource
 {
@@ -202,7 +203,9 @@ final class UserResource extends Resource
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    SafeDelete::bulkAction(function (User $record): void {
+                        resolve(DeletesUsers::class)->delete($record);
+                    }),
                 ]),
             ]);
     }

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource/Pages/EditUser.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages;
 
-use Filament\Actions\DeleteAction;
+use App\Models\User;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\EditRecord;
+use Laravel\Jetstream\Contracts\DeletesUsers;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\SafeDelete;
 
 final class EditUser extends EditRecord
 {
@@ -17,7 +19,9 @@ final class EditUser extends EditRecord
     {
         return [
             ViewAction::make(),
-            DeleteAction::make(),
+            SafeDelete::action(function (User $record): void {
+                resolve(DeletesUsers::class)->delete($record);
+            }),
         ];
     }
 }

--- a/packages/SystemAdmin/src/Filament/Support/SafeDelete.php
+++ b/packages/SystemAdmin/src/Filament/Support/SafeDelete.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Support;
+
+use Closure;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use Throwable;
+
+/**
+ * Filament's delete actions call `$record->delete()` on the model, which is the
+ * wrong entry point for a user or a team. Both are owned by a Jetstream deleter
+ * that runs side effects the model knows nothing about: deleting a user must
+ * also delete the teams it owns, and deleting a team must first cancel its
+ * Stripe subscription. Skipping them leaves ownerless workspaces (`teams.user_id`
+ * carries no foreign key) and subscriptions that keep billing a workspace nobody
+ * can reach.
+ *
+ * These factories keep Filament's per-record failure reporting, so a partially
+ * failed bulk delete still reports "deleted 3 of 5" rather than claiming success.
+ */
+final class SafeDelete
+{
+    /**
+     * @param  Closure(covariant Model): void  $delete
+     */
+    public static function action(Closure $delete): DeleteAction
+    {
+        return DeleteAction::make()
+            ->using(function (Model $record) use ($delete): bool {
+                $delete($record);
+
+                return true;
+            });
+    }
+
+    /**
+     * @param  Closure(covariant Model): void  $delete
+     */
+    public static function bulkAction(Closure $delete): DeleteBulkAction
+    {
+        return DeleteBulkAction::make()
+            // Without this Filament may issue one mass `DELETE` query and never
+            // hydrate a model, which would bypass the deleter entirely.
+            ->fetchSelectedRecords()
+            ->using(function (DeleteBulkAction $action, EloquentCollection|Collection|LazyCollection $records) use ($delete): void {
+                $isFirstException = true;
+
+                $records->each(function (Model $record) use ($action, $delete, &$isFirstException): void {
+                    try {
+                        $delete($record);
+                    } catch (Throwable $exception) {
+                        $action->reportBulkProcessingFailure();
+
+                        if ($isFirstException) {
+                            report($exception);
+
+                            $isFirstException = false;
+                        }
+                    }
+                });
+            });
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Widgets;
 
-use App\Enums\Plan;
+use App\Enums\BillingStatus;
 use App\Models\Team;
 use App\Models\User;
 use Carbon\CarbonImmutable;
@@ -54,16 +54,11 @@ final class TopTeamsTableWidget extends BaseWidget
                     ->color('primary')
                     ->url(fn (Team $record): ?string => $record->owner ? UserResource::getUrl('view', ['record' => $record->owner]) : null),
 
-                TextColumn::make('plan')
-                    ->label('Plan')
-                    ->badge()
-                    ->formatStateUsing(fn (Plan $state): string => $state->label())
-                    ->color(fn (Plan $state): string => match ($state) {
-                        Plan::Free => 'gray',
-                        Plan::Pro => 'success',
-                        Plan::Enterprise => 'primary',
-                    })
-                    ->sortable(),
+                TextColumn::make('billing_status')
+                    ->label('Billing')
+                    ->tooltip('Why this workspace has the plan it has')
+                    ->state(fn (Team $record): BillingStatus => $record->billingStatus())
+                    ->badge(),
 
                 TextColumn::make('members_count')
                     ->label('Members')
@@ -147,6 +142,8 @@ final class TopTeamsTableWidget extends BaseWidget
             ->groupBy('team_id');
 
         return Team::query()
+            // billingStatus() reads the subscriptions relation per row.
+            ->with('subscriptions')
             ->select([
                 'teams.*',
                 'activity.records_touched',

--- a/tests/Feature/Billing/TrialLifecycleTest.php
+++ b/tests/Feature/Billing/TrialLifecycleTest.php
@@ -134,6 +134,26 @@ it('emails the owner when the trial ends in three days', function (): void {
     Mail::assertQueued(ProTrialEndingSoonMail::class, 1);
 });
 
+it('skips ownerless workspaces without aborting trial reminders', function (): void {
+    $this->travelTo(now()->startOfDay()->addHours(12));
+    Mail::fake();
+
+    [$deletedOwner, $ownerlessTeam] = trialOwnerAndTeam();
+    $ownerlessTeam->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(3)->addHour()])->save();
+    $deletedOwner->delete();
+
+    [, $ownedTeam] = trialOwnerAndTeam();
+    $ownedTeam->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(3)->addHour()])->save();
+
+    $this->artisan('billing:process-trials')->assertSuccessful();
+
+    Mail::assertQueued(
+        ProTrialEndingSoonMail::class,
+        fn (ProTrialEndingSoonMail $mail): bool => $mail->team->is($ownedTeam),
+    );
+    Mail::assertQueuedCount(1);
+});
+
 it('does not email when the trial is outside the three-day window', function (): void {
     Mail::fake();
 

--- a/tests/Feature/Commands/PurgeScheduledDeletionsCommandTest.php
+++ b/tests/Feature/Commands/PurgeScheduledDeletionsCommandTest.php
@@ -117,3 +117,20 @@ test('day 25 reminder is sent to team owner only', function () {
     Notification::assertSentTo($owner, TeamDeletionReminderNotification::class);
     Notification::assertNotSentTo($member, TeamDeletionReminderNotification::class);
 });
+
+test('ownerless workspaces are skipped without aborting the deletion reminders', function () {
+    Notification::fake();
+
+    $ownerlessTeam = User::factory()->withTeam()->create()->currentTeam;
+    $ownerlessTeam->update(['scheduled_deletion_at' => now()->addDays(5)]);
+    User::query()->whereKey($ownerlessTeam->user_id)->delete();
+
+    $owner = User::factory()->withTeam()->create();
+    $owner->currentTeam->update(['scheduled_deletion_at' => now()->addDays(5)]);
+
+    $this->artisan('app:purge-scheduled-deletions')
+        ->assertExitCode(0);
+
+    Notification::assertSentTo($owner, TeamDeletionReminderNotification::class);
+    Notification::assertSentTimes(TeamDeletionReminderNotification::class, 1);
+});

--- a/tests/Feature/SystemAdmin/TeamResourceTest.php
+++ b/tests/Feature/SystemAdmin/TeamResourceTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Enums\BillingStatus;
+use App\Enums\Plan;
 use App\Models\Company;
 use App\Models\Team;
 use App\Models\User;
@@ -15,7 +17,7 @@ use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\Membe
 use Relaticle\SystemAdmin\Filament\Support\PivotSafeTableQuery;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
-mutates(TeamResource::class, MembersRelationManager::class, CompaniesRelationManager::class, PivotSafeTableQuery::class);
+mutates(BillingStatus::class, TeamResource::class, MembersRelationManager::class, CompaniesRelationManager::class, PivotSafeTableQuery::class);
 
 beforeEach(function (): void {
     $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
@@ -84,4 +86,81 @@ it('deletes teams in bulk through the Jetstream deleter so members keep no dangl
 
     expect(Team::query()->whereKey([$team->getKey(), $second->getKey()])->count())->toBe(0)
         ->and($member->refresh()->current_team_id)->toBeNull();
+});
+
+function billingStatusTeam(): Team
+{
+    return User::factory()->withPersonalTeam()->create()->ownedTeams()->firstOrFail();
+}
+
+it('labels a workspace by why it has its plan, not by the plan alone', function (callable $arrange, BillingStatus $expected): void {
+    $team = billingStatusTeam();
+    $arrange($team);
+
+    expect($team->fresh()?->billingStatus())->toBe($expected);
+
+    livewire(ListTeams::class)
+        ->assertCanSeeTableRecords([$team])
+        ->assertSee($expected->getLabel());
+})->with([
+    'a trial reads Trial, never Pro' => [
+        fn (Team $team) => $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save(),
+        BillingStatus::Trialing,
+    ],
+    'a paid subscription reads Pro' => [
+        function (Team $team): void {
+            $team->forceFill(['plan' => Plan::Pro])->save();
+            $team->subscriptions()->create([
+                'type' => 'default',
+                'stripe_id' => 'sub_active',
+                'stripe_status' => 'active',
+                'stripe_price' => 'price_pro_monthly_test',
+                'quantity' => 1,
+            ]);
+        },
+        BillingStatus::Subscribed,
+    ],
+    'a lapsed subscription reads Past due, not Pro' => [
+        function (Team $team): void {
+            $team->forceFill(['plan' => Plan::Pro])->save();
+            $team->subscriptions()->create([
+                'type' => 'default',
+                'stripe_id' => 'sub_due',
+                'stripe_status' => 'past_due',
+                'stripe_price' => 'price_pro_monthly_test',
+                'quantity' => 1,
+            ]);
+        },
+        BillingStatus::PastDue,
+    ],
+    'a hand-assigned plan reads Granted, not Pro' => [
+        fn (Team $team) => $team->forceFill(['plan' => Plan::Pro])->save(),
+        BillingStatus::Granted,
+    ],
+    'an enterprise workspace reads Enterprise' => [
+        fn (Team $team) => $team->forceFill(['plan' => Plan::Enterprise])->save(),
+        BillingStatus::Enterprise,
+    ],
+    'a pre-billing workspace reads Free (legacy)' => [
+        fn (Team $team) => $team->forceFill(['hosted_free_grandfathered_at' => now()])->save(),
+        BillingStatus::Grandfathered,
+    ],
+]);
+
+it('prefers a live subscription over a trial that has not run out yet', function (): void {
+    $team = billingStatusTeam();
+    $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save();
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_converted',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    expect($team->fresh()?->billingStatus())->toBe(BillingStatus::Subscribed);
+});
+
+it('reads a workspace with nothing bought and no trial as Free', function (): void {
+    expect(billingStatusTeam()->billingStatus())->toBe(BillingStatus::Free);
 });

--- a/tests/Feature/SystemAdmin/TeamResourceTest.php
+++ b/tests/Feature/SystemAdmin/TeamResourceTest.php
@@ -3,9 +3,12 @@
 declare(strict_types=1);
 
 use App\Models\Company;
+use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\EditTeam;
+use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\ListTeams;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\ViewTeam;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\CompaniesRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\RelationManagers\MembersRelationManager;
@@ -47,4 +50,38 @@ it('links team companies to the company view page', function (): void {
         ->assertSuccessful()
         ->assertSeeHtml("companies/{$company->getKey()}")
         ->assertSeeHtml("users/{$owner->getKey()}");
+});
+
+it('deletes a team through the Jetstream deleter so members keep no dangling current team', function (): void {
+    $owner = User::factory()->withPersonalTeam()->create();
+    $team = $owner->ownedTeams()->firstOrFail();
+
+    $member = User::factory()->withPersonalTeam()->create();
+    $team->users()->attach($member, ['role' => 'admin']);
+    $member->forceFill(['current_team_id' => $team->getKey()])->save();
+
+    livewire(EditTeam::class, ['record' => $team->getKey()])
+        ->callAction('delete')
+        ->assertHasNoActionErrors();
+
+    expect(Team::query()->find($team->getKey()))->toBeNull()
+        ->and($member->refresh()->current_team_id)->toBeNull();
+});
+
+it('deletes teams in bulk through the Jetstream deleter so members keep no dangling current team', function (): void {
+    $owner = User::factory()->withPersonalTeam()->create();
+    $team = $owner->ownedTeams()->firstOrFail();
+    $second = User::factory()->withPersonalTeam()->create()->ownedTeams()->firstOrFail();
+
+    $member = User::factory()->withPersonalTeam()->create();
+    $team->users()->attach($member, ['role' => 'admin']);
+    $member->forceFill(['current_team_id' => $team->getKey()])->save();
+
+    livewire(ListTeams::class)
+        ->selectTableRecords([$team->getKey(), $second->getKey()])
+        ->callAction([['name' => 'delete', 'context' => ['table' => true, 'bulk' => true]]])
+        ->assertHasNoActionErrors();
+
+    expect(Team::query()->whereKey([$team->getKey(), $second->getKey()])->count())->toBe(0)
+        ->and($member->refresh()->current_team_id)->toBeNull();
 });

--- a/tests/Feature/SystemAdmin/TopTeamsTableWidgetTest.php
+++ b/tests/Feature/SystemAdmin/TopTeamsTableWidgetTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\BillingStatus;
 use App\Enums\Plan;
 use App\Models\ActivityLog\Activity;
 use App\Models\ActivityLog\Scopes\TeamScope;
@@ -11,7 +12,7 @@ use Filament\Facades\Filament;
 use Relaticle\SystemAdmin\Filament\Widgets\TopTeamsTableWidget;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
-mutates(TopTeamsTableWidget::class);
+mutates(BillingStatus::class, TopTeamsTableWidget::class);
 
 function seedTeamActivity(Team $team, User $causer, string $subjectId, ?DateTimeInterface $createdAt = null): void
 {
@@ -39,7 +40,7 @@ it('renders the widget', function (): void {
         ->assertSuccessful();
 });
 
-it('lists an active team with its plan badge and active member count', function (): void {
+it('lists an active team with its billing badge and active member count', function (): void {
     $owner = User::factory()->withTeam()->create();
     $team = $owner->currentTeam;
     $team->forceFill(['plan' => Plan::Pro])->save();
@@ -50,8 +51,36 @@ it('lists an active team with its plan badge and active member count', function 
     livewire(TopTeamsTableWidget::class)
         ->assertOk()
         ->assertCanSeeTableRecords([$team])
-        ->assertSee('Pro')
+        // Pro with nothing bought and no trial running is a hand-assigned plan.
+        ->assertSee(BillingStatus::Granted->getLabel())
         ->assertSee('1 / 1');
+});
+
+it('separates a trialling workspace from a paying one', function (): void {
+    $trialOwner = User::factory()->withTeam()->create();
+    $trialTeam = $trialOwner->currentTeam;
+    $trialTeam->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save();
+    seedTeamActivity($trialTeam, $trialOwner, 'trial-subject-1');
+
+    $payingOwner = User::factory()->withTeam()->create();
+    $payingTeam = $payingOwner->currentTeam;
+    $payingTeam->forceFill(['plan' => Plan::Pro])->save();
+    $payingTeam->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_widget',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+    seedTeamActivity($payingTeam, $payingOwner, 'paying-subject-1');
+
+    expect($trialTeam->fresh()?->billingStatus())->toBe(BillingStatus::Trialing)
+        ->and($payingTeam->fresh()?->billingStatus())->toBe(BillingStatus::Subscribed);
+
+    livewire(TopTeamsTableWidget::class)
+        ->assertCanSeeTableRecords([$trialTeam, $payingTeam])
+        ->assertSee(BillingStatus::Trialing->getLabel())
+        ->assertSee(BillingStatus::Subscribed->getLabel());
 });
 
 it('ranks by distinct records touched, not raw event volume', function (): void {

--- a/tests/Feature/SystemAdmin/UserResourceTest.php
+++ b/tests/Feature/SystemAdmin/UserResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\Notifications\NotificationChannel;
 use App\Enums\Notifications\NotificationType;
+use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Auth;
@@ -11,6 +12,7 @@ use Illuminate\Support\Facades\Hash;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\CreateUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\EditUser;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ViewUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\OwnedTeamsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\TeamsRelationManager;
@@ -188,4 +190,30 @@ describe('team relation managers', function (): void {
             ->assertSuccessful()
             ->assertSeeHtml("teams/{$team->getKey()}");
     });
+});
+
+it('deletes a user through the Jetstream deleter so their workspaces are not orphaned', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $team = $user->ownedTeams()->firstOrFail();
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->callAction('delete')
+        ->assertHasNoActionErrors();
+
+    expect(User::query()->find($user->getKey()))->toBeNull()
+        ->and(Team::query()->find($team->getKey()))->toBeNull();
+});
+
+it('deletes users in bulk through the Jetstream deleter so their workspaces are not orphaned', function (): void {
+    $first = User::factory()->withPersonalTeam()->create();
+    $second = User::factory()->withPersonalTeam()->create();
+    $teamIds = [$first->ownedTeams()->firstOrFail()->getKey(), $second->ownedTeams()->firstOrFail()->getKey()];
+
+    livewire(ListUsers::class)
+        ->selectTableRecords([$first->getKey(), $second->getKey()])
+        ->callAction([['name' => 'delete', 'context' => ['table' => true, 'bulk' => true]]])
+        ->assertHasNoActionErrors();
+
+    expect(User::query()->whereKey([$first->getKey(), $second->getKey()])->count())->toBe(0)
+        ->and(Team::query()->whereKey($teamIds)->count())->toBe(0);
 });


### PR DESCRIPTION
Fixes RELATICLE-CRM-6C.

Three commits, in the order the problem unravelled.

## 1. Ownerless workspaces abort the trial command

`billing:process-trials` dereferenced `$team->owner` behind a `/** @var User $owner */` that was not true. A workspace whose owner no longer exists aborted the whole run, so every later workspace lost its reminder.

Guarded, with the same guard applied to `app:purge-scheduled-deletions`, which had the identical unguarded dereference in its own scheduled command.

## 2. Where ownerless workspaces come from

Sysadmin's delete actions called `$record->delete()` on the model, so they skipped the Jetstream deleters that own the cascade. `teams.user_id` carries no foreign key, so nothing caught it either: deleting a user left its workspaces behind pointing at a user that no longer exists.

Deleting a team had the same shape and cost money. It skipped `CancelTeamSubscription`, so Stripe kept billing a deleted workspace, and skipped `purge()`, leaving members with a `current_team_id` aimed at a team that no longer exists.

All four sites (both resources, both edit pages) now route through `DeletesUsers` / `DeletesTeams`, keeping Filament's per-record failure reporting so a partially failed bulk delete still reports "deleted 3 of 5" rather than claiming success.

Wiring the deleters into a bulk action surfaced two lazy-loading violations on the same path: `CancelTeamSubscription` read `subscriptions` off a team it was handed, and `DeleteUser` read `ownedTeams` and `tokens` off the user. Both are N+1s in production and hard failures everywhere else, since `preventLazyLoading` is on outside production. Each is covered by a test that fails without the fix.

## 3. A trial and a paying customer looked identical

`teams.plan` records capability, not provenance. Starting a trial writes `Plan::Pro` so the workspace gets Pro credits and rate limits, which left every sysadmin surface rendering the plan column unable to tell a trialling workspace from a paying one. Both read "Pro", in green.

`App\Enums\BillingStatus` is derived from the team and never persisted, and answers why a workspace has the plan it has: past due, subscribed, enterprise, trialing, grandfathered, granted, free. The precedence is the one `AiCreditBalanceResource` and `HostedWorkspaceAccess` already agreed on, written once. Past due sits above subscribed because this app calls `keepPastDueSubscriptionsActive()`, which leaves `valid()` true after payment stops.

It carries its own labels and colours through Filament's `HasColor` / `HasLabel`, so no consumer writes a `match` over it. That matters here: `packages/SystemAdmin` is excluded from PHPStan, and an unhandled enum case there has already reached production once.

`Plan` gains the same contracts, retiring the hand-rolled colour match in `TopTeamsTableWidget`. Its `label()` becomes `getLabel()`, with all four callers migrated.

The Teams table and detail page carried no billing information at all. They now show provenance and plan side by side, so nothing is lost.

## Verification

Full suite green (3523 tests, 0 failures), plus `composer test:lint` whole-repo, Rector, PHPStan, 100% type coverage, and the arch suite.

Walked in the browser against the sysadmin panel:

- All seven billing states render distinctly. **Pro** in green appears only on a real subscriber; a trialling `plan=pro` workspace reads **Trial**; a `plan=pro` workspace with nothing bought reads **Granted**. Checked light and dark.
- The Team page shows `Billing: Trial` next to `Plan: Pro`.
- Deleted a throwaway user through the sysadmin UI: redirected to `/sysadmin/users`, and both the user and its owned team were gone, with no orphan left behind.

## Deliberately not in this PR

- **A foreign key on `teams.user_id`.** Production already has orphaned rows, so `constrained()` would fail to apply without a data-repair pass first. Needs its own change and your approval.
- **A billing-status filter.** The value is derived, so filtering means expressing the same precedence a second time in SQL. Worth adding behind a test that holds the enum and the scope in agreement, not before.
