### PR TITLE
Report sysadmin analytics on the viewer's calendar days

### DIFF
--- a/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/ActivityResource.php
@@ -25,6 +25,7 @@ use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ListActiviti
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource\Pages\ViewActivity;
 use Relaticle\SystemAdmin\Filament\Resources\SystemAdministrators\SystemAdministratorResource;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ViewerTime;
 
 final class ActivityResource extends Resource
 {
@@ -170,9 +171,14 @@ final class ActivityResource extends Resource
                         DatePicker::make('from')->label('From'),
                         DatePicker::make('until')->label('Until'),
                     ])
+                    /**
+                     * The picked dates are days on the administrator's calendar,
+                     * which is what the table renders too, so they widen to that
+                     * day's UTC bounds rather than being compared with whereDate.
+                     */
                     ->query(fn (Builder $query, array $data): Builder => $query
-                        ->when(filled($data['from'] ?? null), fn (Builder $q): Builder => $q->whereDate('activity_log.created_at', '>=', $data['from']))
-                        ->when(filled($data['until'] ?? null), fn (Builder $q): Builder => $q->whereDate('activity_log.created_at', '<=', $data['until']))),
+                        ->when(filled($data['from'] ?? null), fn (Builder $q): Builder => $q->where('activity_log.created_at', '>=', ViewerTime::startOfDayUtc((string) $data['from'])))
+                        ->when(filled($data['until'] ?? null), fn (Builder $q): Builder => $q->where('activity_log.created_at', '<=', ViewerTime::endOfDayUtc((string) $data['until'])))),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
@@ -34,6 +34,7 @@ use Relaticle\SystemAdmin\Filament\Resources\AiCreditBalanceResource\Pages\EditA
 use Relaticle\SystemAdmin\Filament\Resources\AiCreditBalanceResource\Pages\ListAiCreditBalances;
 use Relaticle\SystemAdmin\Filament\Resources\AiCreditBalanceResource\Pages\ViewAiCreditBalance;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ViewerTime;
 
 final class AiCreditBalanceResource extends Resource
 {
@@ -144,11 +145,19 @@ final class AiCreditBalanceResource extends Resource
                     ->numeric()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
+                /**
+                 * A date-only column resolves its zone to config('app.timezone'),
+                 * not FilamentTimezone, so the period bounds have to name the
+                 * viewer's zone or the table shows a different day than the
+                 * infolist does for the same record.
+                 */
                 TextColumn::make('period_starts_at')
                     ->date()
+                    ->timezone(fn (): string => ViewerTime::timezone())
                     ->sortable(),
                 TextColumn::make('period_ends_at')
                     ->date()
+                    ->timezone(fn (): string => ViewerTime::timezone())
                     ->sortable()
                     ->badge()
                     ->color(fn (?Carbon $state): string => $state?->isPast() ? 'danger' : 'gray'),

--- a/packages/SystemAdmin/src/Filament/Resources/AiCreditTransactions/Tables/AiCreditTransactionsTable.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AiCreditTransactions/Tables/AiCreditTransactionsTable.php
@@ -16,6 +16,7 @@ use Relaticle\Chat\Models\AiCreditTransaction;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
+use Relaticle\SystemAdmin\Filament\Support\ViewerTime;
 
 final class AiCreditTransactionsTable
 {
@@ -81,9 +82,14 @@ final class AiCreditTransactionsTable
                         DatePicker::make('from'),
                         DatePicker::make('until'),
                     ])
+                    /**
+                     * The picked dates are days on the administrator's calendar,
+                     * which is what the table renders too, so they widen to that
+                     * day's UTC bounds rather than being compared with whereDate.
+                     */
                     ->query(fn (Builder $query, array $data): Builder => $query
-                        ->when($data['from'] ?? null, fn (Builder $q, mixed $date): Builder => $q->whereDate('created_at', '>=', $date))
-                        ->when($data['until'] ?? null, fn (Builder $q, mixed $date): Builder => $q->whereDate('created_at', '<=', $date))),
+                        ->when($data['from'] ?? null, fn (Builder $q, mixed $date): Builder => $q->where('created_at', '>=', ViewerTime::startOfDayUtc((string) $date)))
+                        ->when($data['until'] ?? null, fn (Builder $q, mixed $date): Builder => $q->where('created_at', '<=', ViewerTime::endOfDayUtc((string) $date)))),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/packages/SystemAdmin/src/Filament/Support/ViewerTime.php
+++ b/packages/SystemAdmin/src/Filament/Support/ViewerTime.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Support;
+
+use Carbon\CarbonImmutable;
+use Filament\Support\Facades\FilamentTimezone;
+
+/**
+ * The calendar the signed-in administrator reads the panel in.
+ *
+ * Every datetime column is UTC, so anything that groups or filters by a *day*
+ * has to decide whose day it means. Table and infolist output already answers
+ * that with FilamentTimezone (resolved once in AppServiceProvider); this keeps
+ * the analytics and filter layers on the same answer rather than silently
+ * falling back to the server's day.
+ *
+ * Boundaries are handed back already converted to UTC: query bindings are
+ * formatted in whatever zone the Carbon instance carries, so a viewer-zone
+ * instance would compare a local wall clock against a UTC column.
+ */
+final readonly class ViewerTime
+{
+    public static function timezone(): string
+    {
+        return FilamentTimezone::get();
+    }
+
+    public static function now(): CarbonImmutable
+    {
+        return CarbonImmutable::now(self::timezone());
+    }
+
+    /**
+     * Midnight opening the viewer's current day.
+     */
+    public static function today(): CarbonImmutable
+    {
+        return self::now()->startOfDay();
+    }
+
+    /**
+     * First UTC instant of the viewer's calendar day $date (a `Y-m-d` string).
+     */
+    public static function startOfDayUtc(string $date): CarbonImmutable
+    {
+        return CarbonImmutable::parse($date, self::timezone())->startOfDay()->setTimezone('UTC');
+    }
+
+    /**
+     * Last UTC instant of the viewer's calendar day $date (a `Y-m-d` string).
+     */
+    public static function endOfDayUtc(string $date): CarbonImmutable
+    {
+        return CarbonImmutable::parse($date, self::timezone())->endOfDay()->setTimezone('UTC');
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Widgets/SignupTrendChartWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/SignupTrendChartWidget.php
@@ -11,6 +11,7 @@ use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Relaticle\SystemAdmin\Filament\Support\ViewerTime;
 
 final class SignupTrendChartWidget extends ChartWidget
 {
@@ -40,7 +41,7 @@ final class SignupTrendChartWidget extends ChartWidget
 
     public function getDescription(): string
     {
-        return 'New users and teams over time.';
+        return 'New users and teams over time, by '.ViewerTime::timezone().' calendar days. The last point is today so far.';
     }
 
     protected function getType(): string
@@ -51,20 +52,29 @@ final class SignupTrendChartWidget extends ChartWidget
     protected function getData(): array
     {
         $days = (int) ($this->pageFilters['period'] ?? 30);
-        $end = CarbonImmutable::now();
-        $start = $end->subDays($days);
 
-        $intervals = $this->buildIntervals($start, $end, $days);
-        $labels = $intervals->pluck('label')->toArray();
-
+        $timezone = ViewerTime::timezone();
         $groupFormat = $this->getGroupFormat($days);
 
-        $userCountsByBucket = $this->getCountsByBucket(User::query(), $start, $end, $groupFormat);
+        /**
+         * Intervals run whole buckets in the viewer's calendar, the last one
+         * being the bucket today falls in — so the window is derived from them
+         * rather than from a bare `now() - N days`, which would start mid-bucket
+         * and end a bucket short.
+         */
+        $intervals = $this->buildIntervals($days);
+        $labels = $intervals->pluck('label')->all();
+
+        $start = $intervals->first()['start'];
+        $end = ViewerTime::now()->setTimezone('UTC');
+
+        $userCountsByBucket = $this->getCountsByBucket(User::query(), $start, $end, $groupFormat, $timezone);
         $teamCountsByBucket = $this->getCountsByBucket(
             Team::query()->where('personal_team', false),
             $start,
             $end,
             $groupFormat,
+            $timezone,
         );
 
         $userCounts = $intervals->map(
@@ -103,6 +113,10 @@ final class SignupTrendChartWidget extends ChartWidget
     }
 
     /**
+     * `created_at` is a UTC-bearing `timestamp without time zone`, so it is
+     * relabelled as UTC before being shifted into the viewer's zone — otherwise
+     * a signup just after local midnight buckets into the previous day.
+     *
      * @return Collection<string, int>
      */
     private function getCountsByBucket(
@@ -110,13 +124,17 @@ final class SignupTrendChartWidget extends ChartWidget
         CarbonImmutable $start,
         CarbonImmutable $end,
         string $groupFormat,
+        string $timezone,
     ): Collection {
-        $bucketExpression = "to_char(created_at, '{$groupFormat}')";
-
         return $query
-            ->selectRaw("{$bucketExpression} as bucket, COUNT(*) as cnt")
+            ->selectRaw(
+                "to_char(created_at AT TIME ZONE 'UTC' AT TIME ZONE ?, ?) as bucket, COUNT(*) as cnt",
+                [$timezone, $groupFormat],
+            )
             ->whereBetween('created_at', [$start->toDateTimeString(), $end->toDateTimeString()])
-            ->groupByRaw($bucketExpression)
+            // Grouped by output position: repeating the expression would repeat its
+            // placeholders, and Postgres will not match two distinct parameters.
+            ->groupByRaw('1')
             ->pluck('cnt', 'bucket')
             ->map(fn (mixed $value): int => (int) $value);
     }
@@ -135,52 +153,53 @@ final class SignupTrendChartWidget extends ChartWidget
     }
 
     /**
-     * @return Collection<int, array{label: string, start: CarbonImmutable, end: CarbonImmutable, bucket: string}>
+     * @return Collection<int, array{label: string, start: CarbonImmutable, bucket: string}>
      */
-    private function buildIntervals(CarbonImmutable $start, CarbonImmutable $end, int $days): Collection
+    private function buildIntervals(int $days): Collection
     {
         if ($days <= 30) {
-            return $this->buildDailyIntervals($start, $days);
+            return $this->buildDailyIntervals($days);
         }
 
         if ($days <= 90) {
-            return $this->buildWeeklyIntervals($start, $end);
+            return $this->buildWeeklyIntervals($days);
         }
 
-        return $this->buildMonthlyIntervals($start, $end);
+        return $this->buildMonthlyIntervals($days);
     }
 
     /**
-     * @return Collection<int, array{label: string, start: CarbonImmutable, end: CarbonImmutable, bucket: string}>
+     * @return Collection<int, array{label: string, start: CarbonImmutable, bucket: string}>
      */
-    private function buildDailyIntervals(CarbonImmutable $start, int $days): Collection
+    private function buildDailyIntervals(int $days): Collection
     {
-        return collect(range(0, $days - 1))->map(function (int $i) use ($start): array {
-            $day = $start->addDays($i);
+        $first = ViewerTime::today()->subDays($days - 1);
+
+        return collect(range(0, $days - 1))->map(function (int $offset) use ($first): array {
+            $day = $first->addDays($offset);
 
             return [
                 'label' => $day->format('M j'),
-                'start' => $day->startOfDay(),
-                'end' => $day->endOfDay(),
+                'start' => $day->setTimezone('UTC'),
                 'bucket' => $day->format('Y-m-d'),
             ];
         });
     }
 
     /**
-     * @return Collection<int, array{label: string, start: CarbonImmutable, end: CarbonImmutable, bucket: string}>
+     * @return Collection<int, array{label: string, start: CarbonImmutable, bucket: string}>
      */
-    private function buildWeeklyIntervals(CarbonImmutable $start, CarbonImmutable $end): Collection
+    private function buildWeeklyIntervals(int $days): Collection
     {
-        $intervals = collect();
-        $current = $start->startOfWeek();
+        $today = ViewerTime::today();
+        $current = $today->subDays($days - 1)->startOfWeek();
 
-        while ($current->lt($end)) {
-            $weekEnd = $current->endOfWeek()->min($end);
+        $intervals = collect();
+
+        while ($current->lte($today)) {
             $intervals->push([
                 'label' => $current->format('M j'),
-                'start' => $current,
-                'end' => $weekEnd,
+                'start' => $current->setTimezone('UTC'),
                 'bucket' => $current->format('o-W'),
             ]);
             $current = $current->addWeek();
@@ -190,19 +209,19 @@ final class SignupTrendChartWidget extends ChartWidget
     }
 
     /**
-     * @return Collection<int, array{label: string, start: CarbonImmutable, end: CarbonImmutable, bucket: string}>
+     * @return Collection<int, array{label: string, start: CarbonImmutable, bucket: string}>
      */
-    private function buildMonthlyIntervals(CarbonImmutable $start, CarbonImmutable $end): Collection
+    private function buildMonthlyIntervals(int $days): Collection
     {
-        $intervals = collect();
-        $current = $start->startOfMonth();
+        $today = ViewerTime::today();
+        $current = $today->subDays($days - 1)->startOfMonth();
 
-        while ($current->lt($end)) {
-            $monthEnd = $current->endOfMonth()->min($end);
+        $intervals = collect();
+
+        while ($current->lte($today)) {
             $intervals->push([
                 'label' => $current->format('M Y'),
-                'start' => $current,
-                'end' => $monthEnd,
+                'start' => $current->setTimezone('UTC'),
                 'bucket' => $current->format('Y-m'),
             ]);
             $current = $current->addMonth();

--- a/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\DB;
 use Relaticle\SystemAdmin\Filament\Resources\ActivityResource;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource;
+use Relaticle\SystemAdmin\Filament\Support\ViewerTime;
 
 /**
  * Ranks teams by the distinct records they worked on in the selected period,
@@ -99,9 +100,15 @@ final class TopTeamsTableWidget extends BaseWidget
                     ->since()
                     ->sortable(),
 
+                /**
+                 * A date-only column resolves its zone to config('app.timezone'),
+                 * not FilamentTimezone, so it has to name the viewer's zone to
+                 * agree with the relative column above it.
+                 */
                 TextColumn::make('created_at')
                     ->label('Created')
                     ->date('M j, Y')
+                    ->timezone(fn (): string => ViewerTime::timezone())
                     ->sortable(),
             ])
             ->recordActions([

--- a/packages/SystemAdmin/src/Filament/Widgets/UserRetentionChartWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/UserRetentionChartWidget.php
@@ -9,6 +9,7 @@ use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Relaticle\SystemAdmin\Filament\Support\ViewerTime;
 use Relaticle\SystemAdmin\Filament\Widgets\Concerns\HasPeriodComparison;
 
 final class UserRetentionChartWidget extends ChartWidget
@@ -31,7 +32,7 @@ final class UserRetentionChartWidget extends ChartWidget
 
     public function getDescription(): string
     {
-        return 'New active vs returning users per week.';
+        return 'New active vs returning users per week, in '.ViewerTime::timezone().'.';
     }
 
     protected function getType(): string
@@ -42,10 +43,8 @@ final class UserRetentionChartWidget extends ChartWidget
     protected function getData(): array
     {
         $days = (int) ($this->pageFilters['period'] ?? 30);
-        $end = CarbonImmutable::now();
-        $start = $end->subDays($days);
 
-        $intervals = $this->buildWeeklyIntervals($start, $end);
+        $intervals = $this->buildWeeklyIntervals($days);
 
         $newActive = [];
         $returning = [];
@@ -108,19 +107,25 @@ final class UserRetentionChartWidget extends ChartWidget
     }
 
     /**
+     * Weeks are the viewer's weeks: built in their zone for the label, handed
+     * back as UTC instants because query bindings are formatted in whatever
+     * zone the instance carries.
+     *
      * @return Collection<int, array{label: string, start: CarbonImmutable, end: CarbonImmutable}>
      */
-    private function buildWeeklyIntervals(CarbonImmutable $start, CarbonImmutable $end): Collection
+    private function buildWeeklyIntervals(int $days): Collection
     {
-        $intervals = collect();
-        $current = $start->startOfWeek();
+        $now = ViewerTime::now();
+        $current = $now->startOfDay()->subDays($days - 1)->startOfWeek();
 
-        while ($current->lt($end)) {
-            $weekEnd = $current->endOfWeek()->min($end);
+        $intervals = collect();
+
+        while ($current->lte($now)) {
+            $weekEnd = $current->endOfWeek()->min($now);
             $intervals->push([
                 'label' => $current->format('M j'),
-                'start' => $current,
-                'end' => $weekEnd,
+                'start' => $current->setTimezone('UTC'),
+                'end' => $weekEnd->setTimezone('UTC'),
             ]);
             $current = $current->addWeek();
         }

--- a/tests/Feature/SystemAdmin/ActivityResourceTest.php
+++ b/tests/Feature/SystemAdmin/ActivityResourceTest.php
@@ -93,6 +93,21 @@ it('filters activity by date range', function (): void {
         ->assertCanNotSeeTableRecords([$outOfRange]);
 });
 
+it('filters activity by the date range on the administrator calendar, not the server one', function (): void {
+    $this->admin->forceFill(['timezone' => 'Asia/Yerevan'])->save();
+    $this->actingAs($this->admin->refresh(), 'sysadmin');
+
+    // 01:30 on Jun 10 in Yerevan, still Jun 9 on the server.
+    $justInside = $this->travelTo('2026-06-09 21:30:00', fn (): Activity => seedActivity($this->teamA, $this->ownerA, ['description' => 'just inside']));
+    // 01:30 on Jun 21 in Yerevan, still Jun 20 on the server.
+    $justOutside = $this->travelTo('2026-06-20 21:30:00', fn (): Activity => seedActivity($this->teamA, $this->ownerA, ['description' => 'just outside']));
+
+    livewire(ListActivities::class)
+        ->filterTable('created_at', ['from' => '2026-06-10', 'until' => '2026-06-20'])
+        ->assertCanSeeTableRecords([$justInside])
+        ->assertCanNotSeeTableRecords([$justOutside]);
+});
+
 it('renders the view page with a standard attribute diff', function (): void {
     $activity = seedActivity($this->teamA, $this->ownerA, [
         'event' => 'updated',

--- a/tests/Feature/SystemAdmin/AiCreditBalanceResourceTest.php
+++ b/tests/Feature/SystemAdmin/AiCreditBalanceResourceTest.php
@@ -88,3 +88,20 @@ it('rejects an edit that would drop credits_remaining below purchased_credits', 
 
     expect($balance->refresh()->credits_remaining)->toBe(500);
 });
+
+it('renders the period dates on the administrator calendar day, not the server one', function (): void {
+    $admin = SystemAdministrator::factory()->create(['timezone' => 'Asia/Yerevan']);
+    $this->actingAs($admin, 'sysadmin');
+
+    $team = Team::factory()->create();
+    AiCreditBalance::query()->where('team_id', $team->getKey())->delete();
+
+    // 01:00 on Jun 10 in Yerevan, still Jun 9 on the server.
+    $balance = AiCreditBalance::factory()->create([
+        'team_id' => $team->getKey(),
+        'period_starts_at' => '2026-06-09 21:00:00',
+    ]);
+
+    livewire(ListAiCreditBalances::class)
+        ->assertTableColumnFormattedStateSet('period_starts_at', 'Jun 10, 2026', $balance);
+});

--- a/tests/Feature/SystemAdmin/AiCreditTransactionResourceTest.php
+++ b/tests/Feature/SystemAdmin/AiCreditTransactionResourceTest.php
@@ -14,7 +14,8 @@ use Relaticle\SystemAdmin\Models\SystemAdministrator;
 mutates(AiCreditTransactionResource::class);
 
 beforeEach(function (): void {
-    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    $this->admin = SystemAdministrator::factory()->create();
+    $this->actingAs($this->admin, 'sysadmin');
     Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
 });
 
@@ -66,4 +67,19 @@ it('renders a reservation-type transaction without crashing (regression: unhandl
 
     livewire(ViewAiCreditTransaction::class, ['record' => $reservation->getKey()])
         ->assertSuccessful();
+});
+
+it('filters transactions by the date range on the administrator calendar, not the server one', function (): void {
+    $this->admin->forceFill(['timezone' => 'Asia/Yerevan'])->save();
+    $this->actingAs($this->admin->refresh(), 'sysadmin');
+
+    // 01:30 on Jun 10 in Yerevan, still Jun 9 on the server.
+    $justInside = AiCreditTransaction::factory()->create(['created_at' => '2026-06-09 21:30:00']);
+    // 01:30 on Jun 21 in Yerevan, still Jun 20 on the server.
+    $justOutside = AiCreditTransaction::factory()->create(['created_at' => '2026-06-20 21:30:00']);
+
+    livewire(ListAiCreditTransactions::class)
+        ->filterTable('date_range', ['from' => '2026-06-10', 'until' => '2026-06-20'])
+        ->assertCanSeeTableRecords([$justInside])
+        ->assertCanNotSeeTableRecords([$justOutside]);
 });

--- a/tests/Feature/SystemAdmin/SignupTrendChartWidgetTest.php
+++ b/tests/Feature/SystemAdmin/SignupTrendChartWidgetTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Date;
+use Relaticle\SystemAdmin\Filament\Widgets\SignupTrendChartWidget;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+mutates(SignupTrendChartWidget::class);
+
+function actAsSignupTrendAdmin(?string $timezone = null): void
+{
+    $admin = SystemAdministrator::factory()->create(['timezone' => $timezone]);
+
+    test()->actingAs($admin, 'sysadmin');
+    Filament::setCurrentPanel('sysadmin');
+}
+
+/**
+ * @return array<string, int>
+ */
+function signupTrendSeries(string $dataset = 'New Users', int $period = 30): array
+{
+    $component = livewire(SignupTrendChartWidget::class, ['pageFilters' => ['period' => (string) $period]])
+        ->assertOk();
+
+    $data = invade($component->instance())->getData();
+
+    $counts = collect($data['datasets'])->firstWhere('label', $dataset)['data'];
+
+    return array_combine($data['labels'], $counts);
+}
+
+it('ends the daily series on today rather than yesterday', function (): void {
+    $this->travelTo(Date::parse('2026-08-27 10:31:00', 'UTC'));
+    actAsSignupTrendAdmin();
+
+    User::factory()->create(['created_at' => Date::parse('2026-08-27 09:00:00', 'UTC')]);
+
+    $series = signupTrendSeries();
+
+    expect(array_key_last($series))->toBe('Aug 27')
+        ->and($series['Aug 27'])->toBe(1)
+        ->and($series)->toHaveCount(30)
+        ->and(array_key_first($series))->toBe('Jul 29');
+});
+
+it('buckets a signup by the administrator calendar day, not the server day', function (): void {
+    $this->travelTo(Date::parse('2026-08-27 10:31:00', 'UTC'));
+    actAsSignupTrendAdmin('Asia/Yerevan');
+
+    // 01:30 on Aug 27 in Yerevan, still Aug 26 on the server.
+    User::factory()->create(['created_at' => Date::parse('2026-08-26 21:30:00', 'UTC')]);
+
+    $series = signupTrendSeries();
+
+    expect($series['Aug 27'])->toBe(1)
+        ->and($series['Aug 26'])->toBe(0);
+});
+
+it('keeps an administrator without a zone on server days', function (): void {
+    $this->travelTo(Date::parse('2026-08-27 10:31:00', 'UTC'));
+    actAsSignupTrendAdmin();
+
+    User::factory()->create(['created_at' => Date::parse('2026-08-26 21:30:00', 'UTC')]);
+
+    $series = signupTrendSeries();
+
+    expect($series['Aug 26'])->toBe(1)
+        ->and($series['Aug 27'])->toBe(0);
+});
+
+it('counts a signup made later today in the administrator zone', function (): void {
+    // 02:00 on Aug 28 in Yerevan is still Aug 27 on the server, so the viewer's
+    // "today" bucket has to reach past the server's midnight.
+    $this->travelTo(Date::parse('2026-08-27 22:30:00', 'UTC'));
+    actAsSignupTrendAdmin('Asia/Yerevan');
+
+    User::factory()->create(['created_at' => Date::parse('2026-08-27 22:00:00', 'UTC')]);
+
+    $series = signupTrendSeries();
+
+    expect(array_key_last($series))->toBe('Aug 28')
+        ->and($series['Aug 28'])->toBe(1);
+});
+
+it('starts the weekly series on a whole week and ends on the current one', function (): void {
+    $this->travelTo(Date::parse('2026-08-27 10:31:00', 'UTC'));
+    actAsSignupTrendAdmin('Asia/Yerevan');
+
+    // Monday of the week holding 2026-05-30, the 90th day back from Aug 27.
+    User::factory()->create(['created_at' => Date::parse('2026-05-25 03:00:00', 'UTC')]);
+    User::factory()->create(['created_at' => Date::parse('2026-08-24 03:00:00', 'UTC')]);
+
+    $series = signupTrendSeries(period: 90);
+
+    expect(array_key_first($series))->toBe('May 25')
+        ->and($series['May 25'])->toBe(1)
+        ->and(array_key_last($series))->toBe('Aug 24')
+        ->and($series['Aug 24'])->toBe(1);
+});
+
+it('counts only non-personal teams in the teams series', function (): void {
+    $this->travelTo(Date::parse('2026-08-27 10:31:00', 'UTC'));
+    actAsSignupTrendAdmin();
+
+    $owner = User::factory()->withTeam()->create();
+    $owner->currentTeam->forceFill(['created_at' => Date::parse('2026-08-27 09:00:00', 'UTC')])->save();
+
+    expect(signupTrendSeries('New Teams')['Aug 27'])->toBe(1);
+});


### PR DESCRIPTION
Reported symptom: with the sysadmin timezone set to Asia/Yerevan, Signup Trends ended on Aug 26 while it was Aug 27.

The timezone was the wrong suspect for that particular point. At 10:31 **UTC** on Aug 27 the chart still ended Aug 26, because `buildDailyIntervals` walked `range(0, $days - 1)` from `now()` minus N days, so the last interval was always yesterday. Today's rows were inside the query window but landed in a bucket that had no interval, so they were counted and then dropped. The first bucket also only covered part of its day, since the window started mid-day.

The timezone bug is real, just separate: `to_char(created_at, 'YYYY-MM-DD')` grouped by server days, so a 01:30 Yerevan signup counted against the previous day.

## What changed

Intervals are now whole buckets on the administrator's calendar, ending with the one today falls in, and the query window is derived from them. The Postgres bucket relabels `created_at` as UTC before shifting it into that zone. User Retention aligns its weeks the same way.

The activity and credit-transaction date filters compared picked dates with `whereDate` against UTC, which excluded rows the same table rendered inside the range. They now widen each picked date to that day's UTC bounds.

`ViewerTime` resolves the zone from `FilamentTimezone`, so display and aggregation cannot drift apart.

## Why a helper rather than a setting

There is no global switch for this, verified against the installed vendor rather than assumed:

- `FilamentTimezone` has exactly 3 call sites in all of Filament (tables `CanFormatState`, infolists `CanFormatState`, `DateTimePicker`). It is a display setting; there is no panel API and no query hook.
- Postgres session `SET TIME ZONE` is a no-op on `timestamp without time zone`. With the session on Asia/Yerevan, `to_char(TIMESTAMP '2026-08-26 21:30:00', 'YYYY-MM-DD')` still returns `2026-08-26`, while the same instant as `timestamptz` returns `2026-08-27`. Only a column-type migration would make it global.
- Setting PHP's default timezone per request relabels rather than converts on read (a stored 11:50 UTC displays as 11:50+04 instead of 15:50+04) and serializes local wall clock into UTC columns on write.

Rolling `now() - N days` windows (`HasPeriodComparison` and the stat widgets) are zone-neutral and deliberately untouched.

## Verification

Six new tests for `SignupTrendChartWidget`, which previously had none. All six fail against the original widget, confirmed by reverting it.

Checked in the running panel as a Yerevan administrator:

- Chart runs Jul 29 to Aug 27, 30 points, last point is today.
- Grouped both ways in the database, two rows fall on a different Yerevan day than server day, and the chart matches the Yerevan grouping exactly (Aug 26 = 9, Aug 27 = 2).
- Activity filtered to Aug 26 returns 283 rows, the Yerevan-day count. The previous `whereDate` returned 229, silently excluding 54 rows the table itself rendered as "Aug 26 ... +04".

Local gates: Pint, Rector, PHPStan 0 errors, type coverage 100%, SystemAdmin suite 186/186, Arch 26/26.