### PR TITLE
Replace the free-to-use clause in Terms with paid-plan terms

### DIFF
--- a/resources/markdown/terms.md
+++ b/resources/markdown/terms.md
@@ -1,6 +1,6 @@
 # Terms of Service
 
-**Effective date:** March 20, 2026
+**Effective date:** August 26, 2026
 
 These Terms of Service ("Terms") govern your use of Relaticle, an open-source CRM platform provided by Relaticle ("we", "us", "our"). By accessing or using our services, you agree to these Terms.
 
@@ -46,7 +46,7 @@ Access to the REST API and MCP server is governed by API tokens scoped to specif
 
 ## 6. Pricing
 
-Relaticle is free to use. Both the Cloud and Self-Hosted options are available at no cost. We may introduce paid features in the future, but existing free functionality will remain free.
+Self-hosted software has no license fee under AGPL-3.0. The hosted Cloud service may offer trial, free, and paid plans. Current pricing and included features appear on the pricing page or during checkout. Charges apply only after you accept the displayed paid terms. Price changes apply prospectively after notice.
 
 ## 7. Availability
 

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -72,14 +72,21 @@ describe('Home page', function () {
 });
 
 describe('Legal pages', function () {
-    it('displays the terms of service page with product-specific content', function () {
+    it('displays the terms of service page with current pricing terms', function () {
         $response = $this->get('/terms-of-service');
 
         $response->assertStatus(200);
         $response->assertSee('Terms of Service');
         $response->assertSee('Relaticle');
+        $response->assertSee('August 26, 2026');
+        $response->assertSee('Self-hosted software has no license fee under AGPL-3.0.');
+        $response->assertSee('The hosted Cloud service may offer trial, free, and paid plans.');
+        $response->assertSee('Current pricing and included features appear on the pricing page or during checkout.');
+        $response->assertSee('Charges apply only after you accept the displayed paid terms.');
+        $response->assertSee('Price changes apply prospectively after notice.');
         $response->assertDontSee('word usage');
         $response->assertDontSee('Basic" plan');
+        $response->assertDontSee('Both the Cloud and Self-Hosted options are available at no cost.');
     });
 
     it('displays the privacy policy page with product-specific content', function () {


### PR DESCRIPTION
## What

Terms of Service section 6 said:

> Relaticle is free to use. Both the Cloud and Self-Hosted options are available at
> no cost. We may introduce paid features in the future, but existing free
> functionality will remain free.

It now says:

> Self-hosted software has no license fee under AGPL-3.0. The hosted Cloud service
> may offer trial, free, and paid plans. Current pricing and included features
> appear on the pricing page or during checkout. Charges apply only after you
> accept the displayed paid terms. Price changes apply prospectively after notice.

Effective date moves to August 26, 2026.

## Why

The hosted service has paid plans. `/pricing` advertises Cloud Pro at $19/mo, the
billing pages take payment, and `HostedWorkspaceAccess` pauses workspaces that are
neither subscribed, on trial, nor grandfathered. The old clause promised the
opposite of what is sold, so it needed correcting on its own terms.

The wording keeps the AGPL position explicit for self-hosted users, points pricing
and included features at the page and checkout rather than pinning numbers into the
Terms, and makes charges conditional on accepting the displayed terms.

## Origin

Split out of #541. That PR is an MCP tools change and this has no MCP dependency, so
it ships separately rather than riding along where a pricing contract change would
not get read on its merits. The privacy policy rewrite stays on #541, since that one
is the MCP data disclosure the connector directories require.

## Testing

`tests/Feature/Public/PublicPagesTest.php` asserts the new section 6 text and the new
effective date, and asserts the removed sentence is gone.

- `php artisan test tests/Feature/Public/PublicPagesTest.php`: 75 passed, 246 assertions
- `vendor/bin/pint --test --parallel`: passed
- `vendor/bin/phpstan analyse`: 0 errors
- `/terms-of-service` and `/privacy-policy` both render, verified in the browser
