### PR TITLE
fix(sysadmin): explain each billing status in its own tooltip

### DIFF
--- a/app/Enums/BillingStatus.php
+++ b/app/Enums/BillingStatus.php
@@ -6,6 +6,7 @@ namespace App\Enums;
 
 use App\Models\Team;
 use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
 
 /**
@@ -20,7 +21,7 @@ use Filament\Support\Contracts\HasLabel;
  * about whether a workspace can currently reach the app — that is
  * `HostedWorkspaceAccess`, which layers the billing feature flag on top.
  */
-enum BillingStatus: string implements HasColor, HasLabel
+enum BillingStatus: string implements HasColor, HasDescription, HasLabel
 {
     case PastDue = 'past_due';
 
@@ -82,6 +83,24 @@ enum BillingStatus: string implements HasColor, HasLabel
             self::Grandfathered => 'Free (legacy)',
             self::Granted => 'Granted',
             self::Free => 'Free',
+        };
+    }
+
+    /**
+     * The one-line reason behind the badge, for the tooltip the sysadmin
+     * tables hang off it. A label alone cannot separate a plan someone paid
+     * for from one an admin typed in.
+     */
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::PastDue => 'Paid subscription whose latest charge failed. Access stays open until Stripe cancels it.',
+            self::Subscribed => 'Paying for Pro through a live Stripe subscription.',
+            self::Enterprise => 'Put on the Enterprise plan by hand. No self-serve price exists for it.',
+            self::Trialing => 'Running an unexpired Pro trial. Nothing has been charged yet.',
+            self::Grandfathered => 'Existed before billing shipped, so hosted access stays free for good.',
+            self::Granted => 'Given a paid plan by hand, with no subscription or trial behind it.',
+            self::Free => 'No subscription, trial, or grandfathering. Hosted access is paused while billing is on.',
         };
     }
 

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
@@ -170,8 +170,8 @@ final class TeamResource extends Resource
                     ->boolean(),
                 TextColumn::make('billing_status')
                     ->label('Billing')
-                    ->tooltip('Why this workspace has the plan it has')
                     ->state(fn (Team $record): BillingStatus => $record->billingStatus())
+                    ->tooltip(fn (BillingStatus $state): string => $state->getDescription())
                     ->badge(),
                 TextColumn::make('plan')
                     ->label('Plan')

--- a/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/TopTeamsTableWidget.php
@@ -57,8 +57,8 @@ final class TopTeamsTableWidget extends BaseWidget
 
                 TextColumn::make('billing_status')
                     ->label('Billing')
-                    ->tooltip('Why this workspace has the plan it has')
                     ->state(fn (Team $record): BillingStatus => $record->billingStatus())
+                    ->tooltip(fn (BillingStatus $state): string => $state->getDescription())
                     ->badge(),
 
                 TextColumn::make('members_count')

--- a/tests/Feature/SystemAdmin/TeamResourceTest.php
+++ b/tests/Feature/SystemAdmin/TeamResourceTest.php
@@ -101,7 +101,8 @@ it('labels a workspace by why it has its plan, not by the plan alone', function 
 
     livewire(ListTeams::class)
         ->assertCanSeeTableRecords([$team])
-        ->assertSee($expected->getLabel());
+        ->assertSee($expected->getLabel())
+        ->assertSeeHtml($expected->getDescription());
 })->with([
     'a trial reads Trial, never Pro' => [
         fn (Team $team) => $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save(),

--- a/tests/Feature/SystemAdmin/TopTeamsTableWidgetTest.php
+++ b/tests/Feature/SystemAdmin/TopTeamsTableWidgetTest.php
@@ -53,6 +53,7 @@ it('lists an active team with its billing badge and active member count', functi
         ->assertCanSeeTableRecords([$team])
         // Pro with nothing bought and no trial running is a hand-assigned plan.
         ->assertSee(BillingStatus::Granted->getLabel())
+        ->assertSeeHtml(BillingStatus::Granted->getDescription())
         ->assertSee('1 / 1');
 });
 


### PR DESCRIPTION
The Billing column in the sysadmin Teams table and the Top Teams widget hung one static sentence off every row, "Why this workspace has the plan it has", which restated the column header instead of explaining the badge under the cursor. This moves the reason onto `BillingStatus` as `getDescription()` (implementing Filament's `HasDescription`) and renders it per row, so hovering Pro says a live Stripe subscription is paying while hovering Granted says an admin assigned the plan by hand. The tooltip closure takes the injected `$state`, so the status is still derived once per row.

Both existing badge tests now also assert the row's own description reaches the HTML; removing the tooltip fails them. Verified in the browser on both surfaces in light and dark: hovering a Free (legacy) badge renders "Existed before billing shipped, so hosted access stays free for good."