### PR TITLE
docs(workflow): record that milestones are themes, not releases

### DIFF
--- a/.ai/guidelines/relaticle/workflow.md
+++ b/.ai/guidelines/relaticle/workflow.md
@@ -20,6 +20,24 @@
   parity (`git log origin/main..main` and the reverse are both empty) → tag
   `vX.Y.Z` (minor for features, patch for fixes) → `git push origin <tag>`.
 
+## Issues and milestones
+
+- Milestones are **product themes, never releases**, and never carry a version
+  number. Releases are cut from merged PRs and land continuously, so a milestone
+  can never track a version: naming them `vX.Y` guaranteed drift, and it did.
+  `v3.5.0` shipped the chat rebuild and MCP work while the `v3.5` milestone held
+  one unstarted issue that did not ship.
+- The live themes are `Infrastructure & Data`, `Integration Platform`,
+  `User Experience`, `Billing & Monetization`, and `AI Intelligence`. Each carries
+  its scope in its GitHub description. Put a new issue in the theme it belongs to;
+  do not re-sync milestones with release tags.
+- Milestones carry no due dates. A theme is not time-boxed, and a permanently
+  overdue date trains everyone to ignore the field.
+- Every issue gets a milestone, an issue type (Bug, Feature, or Task), and a
+  Roadmap project status (default Todo). Ask which milestone before choosing one.
+  Issue type is set with the GraphQL `updateIssue` mutation and `issueTypeId`;
+  `gh issue edit` does not support it.
+
 ## External communication
 
 - PR/issue comments, Discord replies, and any other outbound text: show the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,24 @@ test directories; if one is ever needed, declare it in BOTH `phpunit.xml` and
   parity (`git log origin/main..main` and the reverse are both empty) → tag
   `vX.Y.Z` (minor for features, patch for fixes) → `git push origin <tag>`.
 
+## Issues and milestones
+
+- Milestones are **product themes, never releases**, and never carry a version
+  number. Releases are cut from merged PRs and land continuously, so a milestone
+  can never track a version: naming them `vX.Y` guaranteed drift, and it did.
+  `v3.5.0` shipped the chat rebuild and MCP work while the `v3.5` milestone held
+  one unstarted issue that did not ship.
+- The live themes are `Infrastructure & Data`, `Integration Platform`,
+  `User Experience`, `Billing & Monetization`, and `AI Intelligence`. Each carries
+  its scope in its GitHub description. Put a new issue in the theme it belongs to;
+  do not re-sync milestones with release tags.
+- Milestones carry no due dates. A theme is not time-boxed, and a permanently
+  overdue date trains everyone to ignore the field.
+- Every issue gets a milestone, an issue type (Bug, Feature, or Task), and a
+  Roadmap project status (default Todo). Ask which milestone before choosing one.
+  Issue type is set with the GraphQL `updateIssue` mutation and `issueTypeId`;
+  `gh issue edit` does not support it.
+
 ## External communication
 
 - PR/issue comments, Discord replies, and any other outbound text: show the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,24 @@ test directories; if one is ever needed, declare it in BOTH `phpunit.xml` and
   parity (`git log origin/main..main` and the reverse are both empty) → tag
   `vX.Y.Z` (minor for features, patch for fixes) → `git push origin <tag>`.
 
+## Issues and milestones
+
+- Milestones are **product themes, never releases**, and never carry a version
+  number. Releases are cut from merged PRs and land continuously, so a milestone
+  can never track a version: naming them `vX.Y` guaranteed drift, and it did.
+  `v3.5.0` shipped the chat rebuild and MCP work while the `v3.5` milestone held
+  one unstarted issue that did not ship.
+- The live themes are `Infrastructure & Data`, `Integration Platform`,
+  `User Experience`, `Billing & Monetization`, and `AI Intelligence`. Each carries
+  its scope in its GitHub description. Put a new issue in the theme it belongs to;
+  do not re-sync milestones with release tags.
+- Milestones carry no due dates. A theme is not time-boxed, and a permanently
+  overdue date trains everyone to ignore the field.
+- Every issue gets a milestone, an issue type (Bug, Feature, or Task), and a
+  Roadmap project status (default Todo). Ask which milestone before choosing one.
+  Issue type is set with the GraphQL `updateIssue` mutation and `issueTypeId`;
+  `gh issue edit` does not support it.
+
 ## External communication
 
 - PR/issue comments, Discord replies, and any other outbound text: show the

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -341,6 +341,24 @@ test directories; if one is ever needed, declare it in BOTH `phpunit.xml` and
   parity (`git log origin/main..main` and the reverse are both empty) → tag
   `vX.Y.Z` (minor for features, patch for fixes) → `git push origin <tag>`.
 
+## Issues and milestones
+
+- Milestones are **product themes, never releases**, and never carry a version
+  number. Releases are cut from merged PRs and land continuously, so a milestone
+  can never track a version: naming them `vX.Y` guaranteed drift, and it did.
+  `v3.5.0` shipped the chat rebuild and MCP work while the `v3.5` milestone held
+  one unstarted issue that did not ship.
+- The live themes are `Infrastructure & Data`, `Integration Platform`,
+  `User Experience`, `Billing & Monetization`, and `AI Intelligence`. Each carries
+  its scope in its GitHub description. Put a new issue in the theme it belongs to;
+  do not re-sync milestones with release tags.
+- Milestones carry no due dates. A theme is not time-boxed, and a permanently
+  overdue date trains everyone to ignore the field.
+- Every issue gets a milestone, an issue type (Bug, Feature, or Task), and a
+  Roadmap project status (default Todo). Ask which milestone before choosing one.
+  Issue type is set with the GraphQL `updateIssue` mutation and `issueTypeId`;
+  `gh issue edit` does not support it.
+
 ## External communication
 
 - PR/issue comments, Discord replies, and any other outbound text: show the


### PR DESCRIPTION
Milestones were named `v3.0 - Infrastructure & Data` through `v3.5 - AI Intelligence`, which read as release plans but never matched a release. `v3.5.0` shipped on 2026-08-24 with the chat rebuild, the MCP server and agent foundations, exactly the "AI Intelligence" theme, while the `v3.5` milestone held one unstarted issue that did not ship. Eight `v3.4.x` releases went out with no `v3.4` milestone at all.

Releases are cut from merged PRs. Milestones are theme buckets. They shared a version naming scheme and nothing else, so they drifted by construction.

The milestones themselves are already reorganised on GitHub: version prefixes dropped, due dates cleared, scopes written into each description, `Billing & Monetization` renamed from `Enterprise` to match its contents, and the empty `v2.1.0` deleted. This commit records the convention in the repo so it survives.

Adds an `## Issues and milestones` section to `.ai/guidelines/relaticle/workflow.md` covering:

- milestones are themes, never releases, and never carry a version number
- the five live themes and where a new issue goes
- no due dates, and why a permanently overdue field is worse than no field
- every issue gets a milestone, an issue type, and a Roadmap status, and issue type needs the GraphQL `updateIssue` mutation because `gh issue edit` does not support it

`CLAUDE.md`, `AGENTS.md` and `GEMINI.md` are the regenerated artifacts from `php artisan boost:update` plus `cp AGENTS.md GEMINI.md`. `tests/Arch/ConventionsTest.php` passes.

Note: `boost:update` also produced unrelated package drift (dropping `echo-development` from `boost.json`, deleting its skill file, and rewriting `.ai/rules/boost/tests.md`). That was reverted here and belongs in its own change.
