### PR TITLE
Fix launch-blocking import and AI page issues

### DIFF
--- a/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
+++ b/packages/ImportWizard/src/Jobs/ExecuteImportJob.php
@@ -20,10 +20,12 @@ use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\Timeout;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\FailOnException;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use LogicException;
 use Relaticle\CustomFields\CustomFields;
 use Relaticle\CustomFields\Enums\FieldDataType;
 use Relaticle\CustomFields\Filament\Integration\Support\Imports\ImportDataStorage;
@@ -97,6 +99,12 @@ final class ExecuteImportJob implements ShouldQueue
         $this->onQueue('imports');
     }
 
+    /** @return list<FailOnException> */
+    public function middleware(): array
+    {
+        return [new FailOnException([LogicException::class])];
+    }
+
     public function handle(): void
     {
         $import = Import::query()->findOrFail($this->importId);
@@ -112,6 +120,8 @@ final class ExecuteImportJob implements ShouldQueue
         }
 
         $store->ensureProcessedColumn();
+
+        throw_if($store->query()->where('processed', false)->whereNull('match_action')->exists(), LogicException::class, 'Import match resolution is incomplete.');
 
         $this->importerTimezone = $import->user?->effectiveTimezone() ?? (string) config('app.timezone');
 

--- a/packages/ImportWizard/src/Livewire/Steps/PreviewStep.php
+++ b/packages/ImportWizard/src/Livewire/Steps/PreviewStep.php
@@ -85,6 +85,12 @@ final class PreviewStep extends Component implements HasActions, HasForms
     }
 
     #[Computed]
+    public function hasUnresolvedMatches(): bool
+    {
+        return $this->store()->query()->whereNull('match_action')->exists();
+    }
+
+    #[Computed]
     public function isImporting(): bool
     {
         if ($this->isCompleted) {
@@ -283,11 +289,24 @@ final class PreviewStep extends Component implements HasActions, HasForms
 
     public function startImportAction(): Action
     {
+        $resolvingMatches = $this->matchResolutionBatchId !== null;
+        $matchesIncomplete = ! $resolvingMatches && $this->hasUnresolvedMatches();
+        $label = match (true) {
+            $resolvingMatches => __('Resolving matches...'),
+            $matchesIncomplete => __('Match resolution failed'),
+            default => __('Start Import'),
+        };
+        $icon = match (true) {
+            $resolvingMatches => Heroicon::OutlinedArrowPath,
+            $matchesIncomplete => Heroicon::OutlinedExclamationTriangle,
+            default => Heroicon::OutlinedPlay,
+        };
+
         return Action::make('startImport')
-            ->label($this->matchResolutionBatchId !== null ? 'Resolving matches...' : 'Start Import')
+            ->label($label)
             ->color('primary')
-            ->icon($this->matchResolutionBatchId !== null ? Heroicon::OutlinedArrowPath : Heroicon::OutlinedPlay)
-            ->disabled(fn (): bool => $this->matchResolutionBatchId !== null)
+            ->icon($icon)
+            ->disabled(fn (): bool => $resolvingMatches || $matchesIncomplete)
             ->requiresConfirmation()
             ->modalHeading('Start import')
             ->modalDescription('Are you sure that you want to start running this import?')
@@ -348,7 +367,7 @@ final class PreviewStep extends Component implements HasActions, HasForms
 
     public function startImport(): void
     {
-        if ($this->matchResolutionBatchId !== null || $this->batchId !== null || $this->isCompleted) {
+        if ($this->matchResolutionBatchId !== null || $this->hasUnresolvedMatches() || $this->batchId !== null || $this->isCompleted) {
             return;
         }
 

--- a/resources/views/ai.blade.php
+++ b/resources/views/ai.blade.php
@@ -6,13 +6,30 @@
     $freeCloudModels = $toolCapableCloudModels->where('min_plan', 'free')->pluck('label')->join(', ', ' and ');
     $paidCloudModels = $toolCapableCloudModels->where('min_plan', 'pro')->pluck('label')->join(', ', ' and ');
 
+    $billingActive = \Laravel\Pennant\Feature::active(\App\Features\Billing::class);
     $freeCredits = number_format(\App\Enums\Plan::Free->credits());
+    $proCredits = number_format(\App\Enums\Plan::Pro->credits());
+    $trialDays = \App\Actions\Billing\StartProTrial::TRIAL_DAYS;
     $maxBatchSize = (int) config('chat.max_batch_size');
     // Rendered as a human duration so raising the config never leaks "1440 minutes" into the page.
     $pendingActionExpiry = \Carbon\CarbonInterval::minutes((int) config('chat.pending_action_expiry_minutes'))
         ->cascade()
         ->forHumans(short: false, parts: 1);
     $opportunityIcon = \Relaticle\Chat\Support\RecordChipRenderer::iconPath('opportunity');
+
+    if ($billingActive) {
+        $includedPlanQuestion = __('Is :name included with Relaticle Cloud?', ['name' => $assistantName]);
+        $includedPlanAnswer = __(
+            'Yes. New Cloud workspaces include :name during a :days-day Cloud Pro trial. Cloud Pro includes a :credits-credit monthly allowance and every supported cloud model. If the trial ends without a subscription, hosted access pauses. Self-hosted installs use the Free plan\'s :freeCredits-credit monthly allowance and require your own provider key or local model.',
+            ['name' => $assistantName, 'days' => $trialDays, 'credits' => $proCredits, 'freeCredits' => $freeCredits]
+        );
+    } else {
+        $includedPlanQuestion = __('Is :name included in the free plan?', ['name' => $assistantName]);
+        $includedPlanAnswer = __(
+            'Yes. Every Relaticle Cloud workspace gets :name with a :credits-credit monthly allowance on the free-tier model. A self-hosted install ships without a provider. You add your own key or local model, and pay that provider directly.',
+            ['name' => $assistantName, 'credits' => $freeCredits]
+        );
+    }
 
     $title = __(':name: AI Assistant for Relaticle CRM', ['name' => $assistantName]).' - Relaticle';
     $description = __(
@@ -43,11 +60,8 @@
             ),
         ],
         [
-            __('Is :name included in the free plan?', ['name' => $assistantName]),
-            __(
-                'Yes. On Relaticle Cloud every workspace, free or paid, gets :name with a :credits-credit monthly allowance on the free-tier model, and upgrading raises the allowance and unlocks the higher-tier models. A self-hosted install ships with no provider configured, so you add your own key or point it at a local model, and you pay that provider directly.',
-                ['name' => $assistantName, 'credits' => $freeCredits]
-            ),
+            $includedPlanQuestion,
+            $includedPlanAnswer,
         ],
     ];
 @endphp

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobCoreTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobCoreTest.php
@@ -12,6 +12,7 @@ use App\Models\Task;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Queue\Middleware\FailOnException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Laravel\Jetstream\Events\TeamCreated;
@@ -304,7 +305,7 @@ it('sets store status to Completed on success', function (): void {
     expect($import->status)->toBe(ImportStatus::Completed);
 });
 
-it('skips rows with null match_action without crashing', function (): void {
+it('fails before writing records when match resolution is incomplete', function (): void {
     ImportExecutionFixture::readyStore($this, ['Name'], [
         ImportExecutionFixture::row(2, ['Name' => 'Good Person'], ['match_action' => RowMatchAction::Create->value]),
         ImportExecutionFixture::row(3, ['Name' => 'Null Action'], ['match_action' => null]),
@@ -312,14 +313,47 @@ it('skips rows with null match_action without crashing', function (): void {
         ColumnData::toField(source: 'Name', target: 'name'),
     ]);
 
-    ImportExecutionFixture::run($this);
+    $job = new ExecuteImportJob(
+        importId: $this->import->id,
+        teamId: (string) $this->team->id,
+    );
+
+    expect(fn () => $job->handle())
+        ->toThrow(LogicException::class, 'Import match resolution is incomplete.');
+
+    $job->failed(new LogicException('Import match resolution is incomplete.'));
 
     $import = $this->import->fresh();
-    expect($import->status)->toBe(ImportStatus::Completed);
-
-    expect($import->created_rows)->toBe(1)
-        ->and($import->skipped_rows)->toBe(1)
+    expect($import->status)->toBe(ImportStatus::Failed)
+        ->and($import->created_rows)->toBe(0)
+        ->and($import->skipped_rows)->toBe(0)
         ->and($import->failed_rows)->toBe(0);
+
+    expect(People::query()
+        ->where('team_id', $this->team->id)
+        ->where('name', 'Good Person')
+        ->exists())->toBeFalse();
+});
+
+it('fails incomplete match resolution without retrying', function (): void {
+    ImportExecutionFixture::readyStore($this, ['Name'], [
+        ImportExecutionFixture::row(2, ['Name' => 'Null Action'], ['match_action' => null]),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+    ]);
+
+    $job = (new ExecuteImportJob(
+        importId: $this->import->id,
+        teamId: (string) $this->team->id,
+    ))->withFakeQueueInteractions();
+
+    $middleware = $job->middleware()[0];
+
+    expect($middleware)->toBeInstanceOf(FailOnException::class)
+        ->and(fn () => $middleware->handle($job, fn (): mixed => $job->handle()))
+        ->toThrow(LogicException::class, 'Import match resolution is incomplete.');
+
+    $job->assertFailedWith(LogicException::class);
 });
 
 it('stores results with counts in meta', function (): void {

--- a/tests/Feature/ImportWizard/Livewire/PreviewStepTest.php
+++ b/tests/Feature/ImportWizard/Livewire/PreviewStepTest.php
@@ -373,6 +373,28 @@ it('startImport dispatches ExecuteImportJob and sets status to Importing', funct
     expect($freshImport->status)->toBe(ImportStatus::Importing);
 });
 
+it('does not start while match resolution is incomplete', function (): void {
+    Bus::fake();
+
+    createPreviewReadyStore($this, ['Name'], [
+        makePreviewRow(2, ['Name' => 'John']),
+    ], [
+        ColumnData::toField(source: 'Name', target: 'name'),
+    ]);
+
+    $this->store->query()->update(['match_action' => null]);
+
+    $component = mountPreviewStep($this);
+    $component
+        ->assertActionDisabled('startImport')
+        ->assertActionHasLabel('startImport', 'Match resolution failed')
+        ->call('startImport');
+
+    Bus::assertNothingBatched();
+
+    expect($this->import->fresh()->status)->toBe(ImportStatus::Reviewing);
+});
+
 it('startImport proceeds even when rows have validation errors', function (): void {
     Bus::fake();
 

--- a/tests/Feature/Public/ProductPagesTest.php
+++ b/tests/Feature/Public/ProductPagesTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Features\Billing as BillingFeature;
+use Laravel\Pennant\Feature;
+
 it('renders the Rela page with verified capability claims', function (): void {
     $html = $this->get('/ai')->assertOk()->getContent();
 
@@ -16,6 +19,26 @@ it('does not claim hosted models ship with self-hosted installs', function (): v
     $html = $this->get('/ai')->assertOk()->getContent();
 
     expect($html)->toContain(__('bring your own API key'));
+});
+
+it('describes the Cloud Pro trial when billing is on', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $html = $this->get('/ai')->assertOk()->getContent();
+
+    expect($html)->toContain(__('Is Rela included with Relaticle Cloud?'))
+        ->and($html)->toContain('14-day Cloud Pro trial')
+        ->and($html)->toContain('2,000-credit monthly allowance')
+        ->and($html)->not->toContain('every workspace, free or paid');
+});
+
+it('describes the free Cloud plan when billing is off', function (): void {
+    Feature::define(BillingFeature::class, false);
+
+    $html = $this->get('/ai')->assertOk()->getContent();
+
+    expect($html)->toContain(__('Is Rela included in the free plan?'))
+        ->and($html)->toContain('300-credit monthly allowance');
 });
 
 it('describes batch approval as per record, matching how the service resolves batches', function (): void {


### PR DESCRIPTION
## What changed

- Stop import execution before any records are written when match resolution remains incomplete.
- Mark this deterministic queue failure as non-retriable.
- Disable the start action and show a clear match-resolution failure state.
- Match hosted AI copy to the Billing feature flag and current plan limits.

## Why

Incomplete match resolution previously skipped affected rows and allowed a partial import to finish successfully.

The AI page also promised free hosted access when billing could require a Cloud Pro trial and subscription.

## Verification

- `composer test:lint`
- `composer test:refactor`
- `composer test:types`
- `composer test:type-coverage` (100%)
- `DB_DATABASE=relaticle_testing_tyler php artisan test --compact tests/Feature/ImportWizard tests/Feature/Public/ProductPagesTest.php` (340 passed, 1 skipped)
- Isolated full suite: 3,749 passed, 2 skipped, 1 failure.
- The lone failure reproduces unchanged at the merge base in `WorkspaceActivityLogTest`.

## Verification gap

- Visual verification was unavailable because no Conductor browser was connected.
