### PR TITLE
feat(chat): make the AI model catalog editable from the sysadmin panel

### DIFF
--- a/.ai/rules/boost/tests.md
+++ b/.ai/rules/boost/tests.md
@@ -9,9 +9,16 @@ paths:
 - Faker: Use methods such as `$this->faker->word()` or `fake()->randomDigit()`. Follow existing conventions whether to use `$this->faker` or `fake()`.
 - When creating tests, make use of `php artisan make:test [options] {name}` to create a feature test, and pass `--unit` to create a unit test. Most tests should be feature tests.
 
-## Pest
+# Pest
 
-- This project uses Pest for testing. Create tests: `php artisan make:test --pest {name}`.
-- The `{name}` argument should not include the test suite directory. Use `php artisan make:test --pest SomeFeatureTest` instead of `php artisan make:test --pest Feature/SomeFeatureTest`.
-- Run tests: `php artisan test --compact` or filter: `php artisan test --compact --filter=testName`.
-- Do NOT delete tests without approval.
+- This project uses Pest. Create tests with `php artisan make:test --pest {name}`.
+- Do not include the test suite directory in `{name}`. Use `SomeFeatureTest`, not `Feature/SomeFeatureTest`.
+- Read the `testing-best-practices` skill for guidance on coverage, naming, structure, dependency isolation, and review.
+- Do not delete tests or test files without approval. They are part of the application.
+
+## Running Tests
+
+- Run the narrowest set of tests that covers the change. Pass a file path or `--filter=testName` to `php artisan test --compact`.
+- Rerun a test after each change to it.
+- Run `vendor/bin/pest` to call the test runner directly. It accepts the same file path and `--filter=testName` arguments.
+- After the feature tests pass, ask the user to run the complete suite with `php artisan test --compact`.

--- a/.ai/rules/chat.md
+++ b/.ai/rules/chat.md
@@ -219,9 +219,16 @@ Edited from the sysadmin panel at /sysadmin/ai-models, seeded from `config/chat.
   one real step carrying the full CrmAssistant surface and reports what the provider
   accepted. An unprobed or rejected entry gets `prompt`, never `api`: claiming the API
   refuses parallel tool calls when it may not is the unsafe direction.
-- **`models[].key` is the stable id** stored in `ai_preferences.default_model`. Rename it
-  and every user who picked that model silently falls back to Auto. Change `model`, never
-  `key`.
+- **`models[].model` is the entry's id**, not just the tag sent to the provider: it is what
+  the picker stores in `localStorage['chat:model']`, what `?model=` carries, and what
+  `ai_credit_transactions.model` already records. So it is unique across the catalog
+  (`distinct()` on the panel's Select, and `ratesFor()` would otherwise let a retired row
+  price an active one), and retagging a row makes it a different model — every user who
+  had picked the old tag silently lands back on Auto, which the client does by sanitizing
+  its stored pick against the live options. That is the accepted cost of having no
+  operator-typed id to mistype or rename; add a succession pointer if it ever stops being
+  acceptable. `users.ai_preferences['default_model']` is read by `AiModelResolver` but has
+  never been written by any code path — check before assuming a preference is stored.
 - A disabled entry stays only so `AiSpendStatsWidget` can price historical
   `ai_credit_transactions` rows that still name its model. `ModelRegistry::ratesFor()`
   therefore reads disabled entries too, while `all()` skips them.

--- a/.ai/rules/chat.md
+++ b/.ai/rules/chat.md
@@ -8,7 +8,7 @@ paths:
 ## Chat always passes a resolved provider, so #[Provider] failover lists never run
 AiModelResolver::resolve() returns one concrete provider, ChatController hands it to ProcessChatMessage, and the job calls $agent->stream(provider: ...). laravel/ai reads the #[Provider] attribute ONLY when the prompt's provider argument is null (Promptable::getProvidersAndModels), so a provider LIST on CrmAssistant would never fail over. To actually get provider failover, stream() has to receive the array - a product decision, because the fallback provider runs a different model.
 Two related limits: StreamErrorException is not a FailoverableException, and StreamableAgentResponse::hasYielded() suppresses failover once any event reached the consumer, so a mid-stream failure cannot fail over either.
-Provider failover therefore lives in the job, not the attribute. When resolution came from `auto` (resolve() tags it `source`), nothing has streamed yet, and transient retries are exhausted, ProcessChatMessage re-dispatches itself once against the next entry in `chat.auto_chain` (failoverDepth bounds it to one hop). An EXPLICIT model pick never fails over: users pay per-model credit multipliers, so a silent swap is worse than an error.
+Provider failover therefore lives in the job, not the attribute. When resolution came from `auto` (resolve() tags it `source`), nothing has streamed yet, and transient retries are exhausted, ProcessChatMessage re-dispatches itself once against the next entry in `ModelRegistry::autoChain()` (failoverDepth bounds it to one hop). An EXPLICIT model pick never fails over: users pay per-model credit multipliers, so a silent swap is worse than an error.
 
 ## Anthropic prompt caching rides on providerOptions() overriding the request body
 laravel/ai still has no native prompt-cache API (v0.11.0; PR #860 closed, #869 open). CrmAssistant::anthropicCachedSystemBlocks() works only because Gateway\Anthropic\Concerns\BuildsTextRequests ends with array_merge($body, $providerOptions), so the returned 'system' array of content blocks replaces Anthropic's plain-string system prompt and carries the cache_control breakpoint. Tool schemas render before system in Anthropic's cache prefix, so the one breakpoint covers all of them plus the static instructions; per-turn context must stay in the second, uncached block.
@@ -174,3 +174,107 @@ Two consequences for future work: never add a prompt rule that asks the model to
 state how many rows the user can see, and if a payload field is ever wanted for it,
 it must be the SERVER telling the model the paint budget, not the model guessing.
 Prompt constraints are probabilistic: this narrows the tail, it does not close it.
+
+## Never put a sampling attribute on an Anthropic agent
+Anthropic removed `temperature`, `top_p` and `top_k` on Opus 4.7 and every model
+released after it (Opus 4.8/5, Sonnet 5, Fable 5). A request carrying one is rejected
+with a flat 400 and the body `` `temperature` is deprecated for this model ``. Sonnet
+4.6 and earlier still accept them, which is what makes this bite so unevenly:
+`#[Temperature(0.3)]` on `CrmAssistant` broke 100% of Opus 4.7 turns in production
+(Sentry RELATICLE-CRM-6D) while Sonnet, the auto-chain default, kept working, so it
+surfaced only when a Pro user picked Opus by hand. An explicit model pick never fails
+over, so those users just saw "The assistant encountered an error" on every retry.
+The replacement dial is `output_config.effort` (low/medium/high/xhigh/max), sent from
+`CrmAssistant::anthropicEffort()` via `providerOptions()` and configured by
+`chat.anthropic_effort`. It matters more than temperature did: from Opus 5 onward
+thinking is on by default, so a turn spends output tokens before writing a word.
+An unrecognised value sends nothing rather than forwarding the typo to the provider.
+`AnthropicPromptCachingTest` asserts the built body carries no sampling key; keep that
+green, and never reintroduce `#[Temperature]`/`#[TopP]` on an agent that can run on a
+current Anthropic model. `ConversationTitler` and `NextStepSuggester` still carry one
+only because `#[UseCheapestModel]` pins them to Haiku 4.5, which still accepts it.
+
+## Retiring a model id silently re-prices it at 1x
+`ModelRegistry::multiplierFor()` matches on the `model` string and returns 1.0 when
+nothing matches, so deleting an entry outright re-prices every settlement that still
+names it. Disable the entry instead of deleting it: a disabled entry keeps its
+multiplier and its price, stays out of the picker and out of Auto, and keeps
+`AiSpendStatsWidget` able to price historical `ai_credit_transactions`. The catalog is
+runtime-editable now, so treat the fail-open default as a live hazard: a typo'd `model`
+would undercharge every turn on that entry, silently.
+
+## One catalog list: cloud in settings, self-hosted in env, capabilities probed
+`chat.models` is the whole catalog. Each entry carries its own Auto membership (`auto`
+plus list order), its own price (`input_per_mtok`/`output_per_mtok`) and its own
+`capabilities`. There is no `chat.auto_chain` and no `chat.model_costs`; folding them in
+is what makes a dangling Auto id and an unpriced model impossible rather than unlikely.
+Edited from the sysadmin panel at /sysadmin/ai-models, seeded from `config/chat.php`.
+
+- **Self-hosted models are never stored.** `ModelRegistry::customFromConfig()` builds
+  them from `OLLAMA_MODEL` and `SELF_HOSTED_AI_*` on every read, so `.env` stays their
+  only source and an operator does not need the panel. They are also appended to
+  `autoChain()`, because that tail is what makes Auto work on an install with no cloud
+  keys at all.
+- **`supports_tools` and `write_guard` are measured, never typed.** `ModelProbe` sends
+  one real step carrying the full CrmAssistant surface and reports what the provider
+  accepted. An unprobed or rejected entry gets `prompt`, never `api`: claiming the API
+  refuses parallel tool calls when it may not is the unsafe direction.
+- **`models[].key` is the stable id** stored in `ai_preferences.default_model`. Rename it
+  and every user who picked that model silently falls back to Auto. Change `model`, never
+  `key`.
+- A disabled entry stays only so `AiSpendStatsWidget` can price historical
+  `ai_credit_transactions` rows that still name its model. `ModelRegistry::ratesFor()`
+  therefore reads disabled entries too, while `all()` skips them.
+- The settings push must stay the first line of `ChatServiceProvider::boot()`
+  (`ModelRegistry` is a singleton that reads config once), wrapped in `rescue()` (the
+  table does not exist on a fresh install's first migrate), and a save must dispatch
+  `queue:restart` or a worker keeps serving the catalog it booted with.
+
+## A field missing from a repeater schema is dropped on save
+The catalog's credits and prices are edited through a per-row gear modal
+(`extraItemActions`) rather than as table columns, but they must still be declared in
+the repeater's schema as `Hidden::make()`. Filament builds state from the schema, so a
+key that is only in the stored array and not in the schema silently disappears the next
+time the form is saved — every price on every model, in one click. Filament renders
+`Hidden` components inside a table repeater without giving them a column, which is
+exactly what makes this work. `ManageAiSettingsTest` pins it; do not "tidy away" those
+three Hidden fields.
+
+## A Filament Select bound to live provider options must merge the current value
+`ManageAiSettings::modelOptions()` adds the entry's stored model to the option list. A
+Select silently drops a value that is not among its options, so without the merge every
+entry goes invalid the moment a provider is unreachable or its key is absent on this
+install — which is exactly what happened the first time this page was built. The same
+page must also coerce form state to primitives before writing (`normalizeModels()`): a
+Select bound to an enum hands back a `Plan` instance, and pint's `strict_comparison`
+fixer will rewrite any `==` you reach for, so cast instead of compare.
+
+## spatie/laravel-settings cannot parse the docblocks PHPStan wants
+It resolves each property's `@var` through phpdocumentor/type-resolver, which throws
+`Unexpected token "", expected '>'` on an `array{...}` shape and
+`CouldNotResolveDocblockType: mixed` on an `array<string, mixed>` leaf. PHPStan level 7
+meanwhile demands an iterable value type. Use `@phpstan-var` on settings properties:
+PHPStan reads it, phpdocumentor does not see a `@var` tag at all, and both are happy.
+
+## A Filament Select bound to an enum returns the enum, not its value
+`Select::make('min_plan')->options(Plan::class)` puts a `Plan` instance in form state.
+Written straight into the settings row it JSON-encodes as an object and then throws
+`Plan::from(): Argument #1 must be of type string, App\Enums\Plan given` inside
+`ModelDescriptor::fromConfig()`, which type-hints the primitives a PHP config file used
+to supply. `ManageAiSettings::normalizeModels()` coerces at that one write boundary;
+a test that fills the form with plain strings does NOT cover this path, so exercise it
+through the panel.
+
+## ModelProbe must run the assistant's own generation options
+The probe (`ModelProbe` + `ModelProbeAgent`) sends one real step carrying CrmAssistant's
+full surface so the provider can reject it before a bad model reaches the catalog. The
+trap: `TextGenerationOptions::forAgent()` reflects the agent that RUNS the prompt, so the
+first version — which delegated instructions, tools and providerOptions but not sampling
+parameters — passed with `#[Temperature(0.3)]` reintroduced, i.e. it did not catch the
+bug it was built for. `ModelProbeAgent::temperature()`/`topP()` now delegate. Verified by
+reintroducing the attribute and watching the probe go red; keep that property.
+`tool_choice: none` rides on the `#[ToolChoice]` attribute rather than `providerOptions()`
+because the gateway array_merges providerOptions last and would overwrite the guard, and
+because the attribute lets each gateway map "none" to its own spelling.
+Only NEW `(provider, model)` pairings are probed. Verifying the whole catalog on every
+save would let one provider with a stale key block edits to unrelated rows.

--- a/.ai/rules/chat.md
+++ b/.ai/rules/chat.md
@@ -278,3 +278,38 @@ because the gateway array_merges providerOptions last and would overwrite the gu
 because the attribute lets each gateway map "none" to its own spelling.
 Only NEW `(provider, model)` pairings are probed. Verifying the whole catalog on every
 save would let one provider with a stale key block edits to unrelated rows.
+
+## Register every package settings class in config/settings.php
+spatie/laravel-settings auto-discovers `app_path('Settings')` only, and every settings
+class here lives in `packages/<Name>/src/Settings`. An unregistered one still WORKS —
+the container autowires the concrete class and `Settings::__get()` loads it lazily — so
+nothing fails loudly and the omission survives review. What it costs: no `scoped`
+binding, so every `resolve()` is a fresh instance and its own query (three per
+`ManageAiSettings::save()`), and `SETTINGS_CACHE_ENABLED` can never reach the class
+while `ChatServiceProvider::boot()` reads it on every request, job and command.
+`config/settings.php` overrides only the `settings` key; `mergeConfigFrom` keeps the
+package's `migrations_paths`, `default_repository` and the rest as the base, so do not
+copy the whole vendor file in. `ChatCatalogShapeTest` pins the registration.
+
+## available() is "servable here", offered() is "what the product sells"
+`ModelRegistry::available()` requires `filled(ai.providers.<p>.key)`, so it answers a
+question about THIS INSTALL. The public `/pricing` and `/ai` pages must never route
+their model lists through it: the derived strings interpolate into sentences, so a key
+that is absent or rotated renders "Every plan can use  and any self-hosted model you
+connect yourself" and "1x for ; 1.5x for ; 3x for )" on a public page. The whole test
+suite is blind to it because `phpunit.xml` sets a fake key for every provider. Use
+`offered()` there — enabled, tool-capable, non-self-hosted, key-independent — which
+still cannot name a model `AiModelResolver::pick()` would refuse. `PricingPageTest`
+pins it with the keys nulled.
+
+## Never cache what you failed to learn
+`ProviderModelCatalog` caches only a non-empty listing; `ModelProbe` caches only a pass.
+An empty list or a rejection is what we could not learn, not what the provider offers,
+and a 24h `Cache::remember` over a vendor's bad minute blanks the model picker for a day.
+
+## composer test scripts need disableProcessTimeout
+Composer kills a script at 300s by default. `test:pest` had the guard and its siblings
+did not, so `composer test:pest:full` — the merge gate CLAUDE.md tells you to run —
+started aborting on the clock rather than on a test once the suite crossed five minutes.
+Every script that can run the whole suite or a slow subset now carries it. Add it to any
+new one.

--- a/app/Health/ChatProviderCheck.php
+++ b/app/Health/ChatProviderCheck.php
@@ -155,11 +155,17 @@ final class ChatProviderCheck extends Check
             return false;
         }
 
-        if (($entry['self_hosted'] ?? false) === true) {
+        if (($entry['enabled'] ?? true) !== true) {
             return false;
         }
 
-        if (($entry['supports_tools'] ?? false) !== true) {
+        // Capabilities are measured by ModelProbe and stored on the entry; a model
+        // nobody has probed carries none and is not worth a minute-by-minute call.
+        // Self-hosted models are never in this catalog (ModelRegistry merges them
+        // from env), so there is nothing to exclude for them here.
+        $capabilities = is_array($entry['capabilities'] ?? null) ? $entry['capabilities'] : [];
+
+        if (($capabilities['supports_tools'] ?? false) !== true) {
             return false;
         }
 

--- a/app/Health/ChatProviderCheck.php
+++ b/app/Health/ChatProviderCheck.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Health;
 
+use App\Enums\Plan;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response as ClientResponse;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use Relaticle\Chat\Support\CatalogEntry;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
 
@@ -128,48 +130,27 @@ final class ChatProviderCheck extends Check
      * per provider. Prefer the entry available on every plan — the one most
      * turns actually use — and fall back to the cheapest plan on offer.
      *
+     * `isServable()` is the same question every picker asks, so a model this
+     * check watches is exactly a model a user can land on. Self-hosted models are
+     * never in this catalog (ModelRegistry merges them from env), so there is
+     * nothing to exclude for them here.
+     *
      * @return array<string, string>
      */
     private static function reachableModels(): array
     {
-        /** @var Collection<int, array<string, mixed>> $models */
-        $models = new Collection(config('chat.models', []));
+        /** @var list<array<string, mixed>> $stored */
+        $stored = config('chat.models', []);
 
-        return $models
-            ->filter(static fn (array $entry): bool => self::isReachable($entry))
-            ->sortBy(static fn (array $entry): int => ($entry['min_plan'] ?? null) === 'free' ? 0 : 1)
-            ->groupBy('provider')
-            ->map(static fn (Collection $entries): string => (string) $entries->first()['model'])
+        return new Collection($stored)
+            ->map(static fn (array $entry): ?CatalogEntry => CatalogEntry::fromArray($entry))
+            ->filter(static fn (?CatalogEntry $entry): bool => $entry instanceof CatalogEntry
+                && $entry->isServable()
+                && filled(config("ai.providers.{$entry->provider}.key")))
+            ->sortBy(static fn (CatalogEntry $entry): int => $entry->minPlan === Plan::Free ? 0 : 1)
+            ->groupBy(static fn (CatalogEntry $entry): string => (string) $entry->provider)
+            ->map(static fn (Collection $entries): string => $entries->first()->model)
             ->all();
-    }
-
-    /**
-     * @param  array<string, mixed>  $entry
-     */
-    private static function isReachable(array $entry): bool
-    {
-        $provider = $entry['provider'] ?? null;
-        $model = $entry['model'] ?? null;
-
-        if (! is_string($provider) || ! is_string($model) || $model === '') {
-            return false;
-        }
-
-        if (($entry['enabled'] ?? true) !== true) {
-            return false;
-        }
-
-        // Capabilities are measured by ModelProbe and stored on the entry; a model
-        // nobody has probed carries none and is not worth a minute-by-minute call.
-        // Self-hosted models are never in this catalog (ModelRegistry merges them
-        // from env), so there is nothing to exclude for them here.
-        $capabilities = is_array($entry['capabilities'] ?? null) ? $entry['capabilities'] : [];
-
-        if (($capabilities['supports_tools'] ?? false) !== true) {
-            return false;
-        }
-
-        return filled(config("ai.providers.{$provider}.key"));
     }
 
     private function target(string $provider, string $model): self

--- a/composer.json
+++ b/composer.json
@@ -149,17 +149,35 @@
         ],
         "test:types": "phpstan analyse",
         "test:arch": "pest tests/Arch/ --no-tia",
-        "test:type-coverage": "pest --type-coverage --min=100 --no-tia",
+        "test:type-coverage": [
+            "Composer\\Config::disableProcessTimeout",
+            "pest --type-coverage --min=100 --no-tia"
+        ],
         "test:pest": [
             "Composer\\Config::disableProcessTimeout",
             "@putenv XDEBUG_MODE=coverage",
             "pest --parallel"
         ],
-        "test:pest:full": "pest --parallel --no-tia",
-        "test:pest:shard": "pest --parallel --shard=${SHARD} --no-tia",
-        "test:pest:ci": "pest --compact --parallel --configuration phpunit.ci.xml --shard=${SHARD} --ci --no-tia",
-        "test:update-shards": "pest --parallel --update-shards --no-tia",
-        "test:browser": "pest tests/Browser/ --no-tia",
+        "test:pest:full": [
+            "Composer\\Config::disableProcessTimeout",
+            "pest --parallel --no-tia"
+        ],
+        "test:pest:shard": [
+            "Composer\\Config::disableProcessTimeout",
+            "pest --parallel --shard=${SHARD} --no-tia"
+        ],
+        "test:pest:ci": [
+            "Composer\\Config::disableProcessTimeout",
+            "pest --compact --parallel --configuration phpunit.ci.xml --shard=${SHARD} --ci --no-tia"
+        ],
+        "test:update-shards": [
+            "Composer\\Config::disableProcessTimeout",
+            "pest --parallel --update-shards --no-tia"
+        ],
+        "test:browser": [
+            "Composer\\Config::disableProcessTimeout",
+            "pest tests/Browser/ --no-tia"
+        ],
         "test": [
             "@test:lint",
             "@test:refactor",

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Chat\Settings\ChatSettings;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Settings Classes
+    |--------------------------------------------------------------------------
+    |
+    | Only the keys this app overrides live here; everything else comes from the
+    | package's own config, which `mergeConfigFrom` keeps as the base.
+    |
+    | Registration is explicit because the package auto-discovers `app/Settings`
+    | only, and every settings class in this codebase lives in a package under
+    | `packages/<Name>/src/Settings`. An unregistered class still resolves (the
+    | container autowires it and it lazily loads itself), which is why this was
+    | easy to miss, but it gets no scoped binding, so every resolve is a fresh
+    | instance and its own query, and `SETTINGS_CACHE_ENABLED` can never reach it.
+    |
+    */
+
+    'settings' => [
+        ChatSettings::class,
+    ],
+
+];

--- a/database/migrations/2026_08_27_120000_create_settings_table.php
+++ b/database/migrations/2026_08_27_120000_create_settings_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // `?? 'settings'`, not a config() default: spatie ships that key explicitly
+        // set to null, so the key EXISTS and config()'s default is never reached.
+        // Rector's ApplyDefaultInsteadOfNullCoalesceRector rewrites this and the
+        // migration then tries to `create table ""`.
+        $table = config('settings.repositories.database.table') ?? 'settings';
+
+        Schema::create($table, function (Blueprint $table): void {
+            $table->id();
+
+            $table->string('group');
+            $table->string('name');
+            $table->boolean('locked')->default(false);
+            $table->json('payload');
+
+            $table->timestamps();
+
+            $table->unique(['group', 'name']);
+        });
+    }
+};

--- a/database/settings/2026_08_27_120001_create_chat_settings.php
+++ b/database/settings/2026_08_27_120001_create_chat_settings.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+/**
+ * Copies the catalog seed out of config and into settings, where the sysadmin
+ * panel can edit it without a deploy. The config values stay as the defaults a
+ * fresh install starts from, and as the fallback while this table does not exist.
+ */
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('chat.models', (array) config('chat.models', []));
+        $this->migrator->add('chat.anthropic_effort', (string) config('chat.anthropic_effort', 'high'));
+    }
+};

--- a/database/settings/2026_08_28_090000_drop_chat_model_keys.php
+++ b/database/settings/2026_08_28_090000_drop_chat_model_keys.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+/**
+ * Drops the per-entry `key` now that a catalog entry is identified by the
+ * provider's own model tag.
+ *
+ * A no-op on a fresh install, where the create migration already reads a keyless
+ * config. It exists for the installs that ran that migration before the change:
+ * a stale `key` is inert to every reader, but the panel writes the whole entry
+ * back on save, so without this it would outlive the concept forever.
+ */
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        // The migrator hands back what json_decode gives it, so an entry arrives as
+        // stdClass however the settings class later casts it.
+        $this->migrator->update('chat.models', fn (array $models): array => array_map(
+            static function (mixed $entry): array {
+                $entry = (array) $entry;
+
+                unset($entry['key']);
+
+                return $entry;
+            },
+            $models,
+        ));
+    }
+};

--- a/packages/Chat/config/chat.php
+++ b/packages/Chat/config/chat.php
@@ -85,6 +85,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Anthropic Reasoning Effort
+    |--------------------------------------------------------------------------
+    |
+    | How deeply Anthropic thinks per turn: low, medium, high, xhigh or max.
+    | Sampling parameters (temperature, top_p) were removed on Opus 4.7 and every
+    | model since, and a request carrying one is rejected outright, so this is the
+    | only quality-versus-cost dial those models expose. It is load-bearing rather
+    | than cosmetic from Opus 5 onward, where thinking is on by default and a turn
+    | spends output tokens before it writes a word. `high` is Anthropic's own
+    | default; an unrecognised value falls back to it.
+    */
+
+    'anthropic_effort' => env('CHAT_ANTHROPIC_EFFORT', 'high'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Provider Stream-Start Rate (per second, per provider)
     |--------------------------------------------------------------------------
     |
@@ -162,16 +178,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Chat Model Registry
+    | Chat Model Catalog
     |--------------------------------------------------------------------------
     |
-    | The user-facing model catalog. Each entry references a provider defined in
-    | config/ai.php. `auto` is synthetic (handled by the resolver) and is not
-    | listed here. Self-hosted custom models are merged in from SELF_HOSTED_AI_*
-    | env at boot. `supports_tools:false` hides a model (Gemini, until laravel/ai
-    | supports tool_config). `write_guard`: api = provider enforces one write per
-    | turn; prompt = relies on the prompt + the approval gate.
+    | The seed for the user-facing model catalog, copied into settings on first
+    | migrate and editable from the sysadmin panel thereafter. Cloud models only:
+    | self-hosted ones are merged in from SELF_HOSTED_AI_* / OLLAMA_* env at read
+    | time, so `.env` stays their single source of truth.
+    |
+    | Per entry: `key` is the stable id stored on a user's saved preference and must
+    | never be renamed. `auto` plus list order is the Auto failover chain, so it
+    | cannot name a model nobody offers. `capabilities` is measured by ModelProbe
+    | against a real request, never typed. A disabled entry stays only to price
+    | historical ai_credit_transactions rows that still name its model.
+    |
+    | Prices are USD per million tokens, vendor list price, short-context tier.
+    | Long-context requests bill higher (gpt-5.x above 272k input, gemini-3.1-pro
+    | above 200k), so the sysadmin figure is an estimate rather than an invoice.
     */
+
+    'ollama' => [
+        'model' => env('OLLAMA_MODEL'),
+    ],
 
     'self_hosted' => [
         'url' => env('SELF_HOSTED_AI_URL'),
@@ -179,41 +207,18 @@ return [
         'models' => env('SELF_HOSTED_AI_MODELS'),
     ],
 
-    'auto_chain' => ['claude-sonnet', 'gpt-5-5', 'ollama'],
-
     'models' => [
-        ['id' => 'claude-sonnet', 'label' => 'Sonnet 4.6', 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'supports_tools' => true, 'write_guard' => 'api', 'self_hosted' => false],
-        ['id' => 'claude-opus', 'label' => 'Opus 4.7', 'provider' => 'anthropic', 'model' => 'claude-opus-4-7', 'min_plan' => 'pro', 'credit_multiplier' => 3.0, 'supports_tools' => true, 'write_guard' => 'api', 'self_hosted' => false],
-        ['id' => 'gpt-5-5', 'label' => 'GPT 5.5', 'provider' => 'openai', 'model' => 'gpt-5.5', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'supports_tools' => true, 'write_guard' => 'api', 'self_hosted' => false],
-        ['id' => 'gpt-5-4', 'label' => 'GPT 5.4', 'provider' => 'openai', 'model' => 'gpt-5.4', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'supports_tools' => true, 'write_guard' => 'api', 'self_hosted' => false],
-        ['id' => 'gemini-3-flash', 'label' => 'Gemini 3 Flash', 'provider' => 'gemini', 'model' => 'gemini-3-flash', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'supports_tools' => false, 'write_guard' => 'prompt', 'self_hosted' => false],
-        ['id' => 'gemini-3-1-pro', 'label' => 'Gemini 3.1 Pro', 'provider' => 'gemini', 'model' => 'gemini-3.1-pro', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'supports_tools' => false, 'write_guard' => 'prompt', 'self_hosted' => false],
-        ['id' => 'ollama', 'label' => 'Ollama', 'provider' => 'ollama', 'model' => env('OLLAMA_MODEL'), 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'supports_tools' => true, 'write_guard' => 'prompt', 'self_hosted' => true],
-    ],
+        ['key' => 'claude-sonnet', 'label' => 'Sonnet 5', 'provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00, 'auto' => true, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['key' => 'gpt-5-5', 'label' => 'GPT 5.5', 'provider' => 'openai', 'model' => 'gpt-5.5', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 5.00, 'output_per_mtok' => 30.00, 'auto' => true, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['key' => 'claude-opus', 'label' => 'Opus 5', 'provider' => 'anthropic', 'model' => 'claude-opus-5', 'min_plan' => 'pro', 'credit_multiplier' => 3.0, 'input_per_mtok' => 5.00, 'output_per_mtok' => 25.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['key' => 'gpt-5-4', 'label' => 'GPT 5.4', 'provider' => 'openai', 'model' => 'gpt-5.4', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 2.50, 'output_per_mtok' => 15.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['key' => 'gemini-3-flash', 'label' => 'Gemini 3 Flash', 'provider' => 'gemini', 'model' => 'gemini-3-flash', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 0.50, 'output_per_mtok' => 3.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt'], 'verified_at' => null],
+        ['key' => 'gemini-3-1-pro', 'label' => 'Gemini 3.1 Pro', 'provider' => 'gemini', 'model' => 'gemini-3.1-pro', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 2.00, 'output_per_mtok' => 12.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt'], 'verified_at' => null],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Model Cost Rates (USD per million tokens)
-    |--------------------------------------------------------------------------
-    |
-    | Keys must match the `model` values above and any historical model strings
-    | in ai_credit_transactions. Models without an entry are surfaced as
-    | "unpriced" in the sysadmin cost widget — never silently zero.
-    |
-    | Vendor list prices, short-context tier. Long-context requests bill higher
-    | (gpt-5.x above 272k input, gemini-3.1-pro above 200k), so the widget's
-    | figure is an estimate rather than an invoice. Re-check when a vendor
-    | changes its price list. Ollama is self-hosted (no per-token API cost) and
-    | its model id is env-driven, so it has no entry.
-    */
-
-    'model_costs' => [
-        'claude-sonnet-4-6' => ['input_per_mtok' => 3.00, 'output_per_mtok' => 15.00],
-        'claude-opus-4-7' => ['input_per_mtok' => 5.00, 'output_per_mtok' => 25.00],
-        'gpt-5.5' => ['input_per_mtok' => 5.00, 'output_per_mtok' => 30.00],
-        'gpt-5.4' => ['input_per_mtok' => 2.50, 'output_per_mtok' => 15.00],
-        'gemini-3-flash' => ['input_per_mtok' => 0.50, 'output_per_mtok' => 3.00],
-        'gemini-3.1-pro' => ['input_per_mtok' => 2.00, 'output_per_mtok' => 12.00],
+        // Retired: no longer offered, kept only so the sysadmin spend widget can
+        // price ai_credit_transactions rows that still name these models.
+        ['key' => 'retired:claude-sonnet-4-6', 'label' => 'Sonnet 4.6', 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00, 'auto' => false, 'enabled' => false, 'capabilities' => null, 'verified_at' => null],
+        ['key' => 'retired:claude-opus-4-7', 'label' => 'Opus 4.7', 'provider' => 'anthropic', 'model' => 'claude-opus-4-7', 'min_plan' => 'pro', 'credit_multiplier' => 3.0, 'input_per_mtok' => 5.00, 'output_per_mtok' => 25.00, 'auto' => false, 'enabled' => false, 'capabilities' => null, 'verified_at' => null],
     ],
 
 ];

--- a/packages/Chat/config/chat.php
+++ b/packages/Chat/config/chat.php
@@ -186,8 +186,10 @@ return [
     | self-hosted ones are merged in from SELF_HOSTED_AI_* / OLLAMA_* env at read
     | time, so `.env` stays their single source of truth.
     |
-    | Per entry: `key` is the stable id stored on a user's saved preference and must
-    | never be renamed. `auto` plus list order is the Auto failover chain, so it
+    | Per entry: `model` is the provider's own tag AND the entry's identity — the
+    | value the picker stores, `?model=` carries and `ai_credit_transactions.model`
+    | already records — so it is unique across the catalog and retagging a row makes
+    | it a different model. `auto` plus list order is the Auto failover chain, so it
     | cannot name a model nobody offers. `capabilities` is measured by ModelProbe
     | against a real request, never typed. A disabled entry stays only to price
     | historical ai_credit_transactions rows that still name its model.
@@ -208,17 +210,17 @@ return [
     ],
 
     'models' => [
-        ['key' => 'claude-sonnet', 'label' => 'Sonnet 5', 'provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00, 'auto' => true, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
-        ['key' => 'gpt-5-5', 'label' => 'GPT 5.5', 'provider' => 'openai', 'model' => 'gpt-5.5', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 5.00, 'output_per_mtok' => 30.00, 'auto' => true, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
-        ['key' => 'claude-opus', 'label' => 'Opus 5', 'provider' => 'anthropic', 'model' => 'claude-opus-5', 'min_plan' => 'pro', 'credit_multiplier' => 3.0, 'input_per_mtok' => 5.00, 'output_per_mtok' => 25.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
-        ['key' => 'gpt-5-4', 'label' => 'GPT 5.4', 'provider' => 'openai', 'model' => 'gpt-5.4', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 2.50, 'output_per_mtok' => 15.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
-        ['key' => 'gemini-3-flash', 'label' => 'Gemini 3 Flash', 'provider' => 'gemini', 'model' => 'gemini-3-flash', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 0.50, 'output_per_mtok' => 3.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt'], 'verified_at' => null],
-        ['key' => 'gemini-3-1-pro', 'label' => 'Gemini 3.1 Pro', 'provider' => 'gemini', 'model' => 'gemini-3.1-pro', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 2.00, 'output_per_mtok' => 12.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt'], 'verified_at' => null],
+        ['label' => 'Sonnet 5', 'provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00, 'auto' => true, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['label' => 'GPT 5.5', 'provider' => 'openai', 'model' => 'gpt-5.5', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 5.00, 'output_per_mtok' => 30.00, 'auto' => true, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['label' => 'Opus 5', 'provider' => 'anthropic', 'model' => 'claude-opus-5', 'min_plan' => 'pro', 'credit_multiplier' => 3.0, 'input_per_mtok' => 5.00, 'output_per_mtok' => 25.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['label' => 'GPT 5.4', 'provider' => 'openai', 'model' => 'gpt-5.4', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 2.50, 'output_per_mtok' => 15.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'], 'verified_at' => null],
+        ['label' => 'Gemini 3 Flash', 'provider' => 'gemini', 'model' => 'gemini-3-flash', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 0.50, 'output_per_mtok' => 3.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt'], 'verified_at' => null],
+        ['label' => 'Gemini 3.1 Pro', 'provider' => 'gemini', 'model' => 'gemini-3.1-pro', 'min_plan' => 'pro', 'credit_multiplier' => 1.5, 'input_per_mtok' => 2.00, 'output_per_mtok' => 12.00, 'auto' => false, 'enabled' => true, 'capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt'], 'verified_at' => null],
 
         // Retired: no longer offered, kept only so the sysadmin spend widget can
         // price ai_credit_transactions rows that still name these models.
-        ['key' => 'retired:claude-sonnet-4-6', 'label' => 'Sonnet 4.6', 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00, 'auto' => false, 'enabled' => false, 'capabilities' => null, 'verified_at' => null],
-        ['key' => 'retired:claude-opus-4-7', 'label' => 'Opus 4.7', 'provider' => 'anthropic', 'model' => 'claude-opus-4-7', 'min_plan' => 'pro', 'credit_multiplier' => 3.0, 'input_per_mtok' => 5.00, 'output_per_mtok' => 25.00, 'auto' => false, 'enabled' => false, 'capabilities' => null, 'verified_at' => null],
+        ['label' => 'Sonnet 4.6', 'provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'min_plan' => 'free', 'credit_multiplier' => 1.0, 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00, 'auto' => false, 'enabled' => false, 'capabilities' => null, 'verified_at' => null],
+        ['label' => 'Opus 4.7', 'provider' => 'anthropic', 'model' => 'claude-opus-4-7', 'min_plan' => 'pro', 'credit_multiplier' => 3.0, 'input_per_mtok' => 5.00, 'output_per_mtok' => 25.00, 'auto' => false, 'enabled' => false, 'capabilities' => null, 'verified_at' => null],
     ],
 
 ];

--- a/packages/Chat/src/Agents/CrmAssistant.php
+++ b/packages/Chat/src/Agents/CrmAssistant.php
@@ -8,7 +8,6 @@ use App\Models\Team;
 use App\Services\WorkspaceActivationFacts;
 use Laravel\Ai\Attributes\MaxSteps;
 use Laravel\Ai\Attributes\Provider;
-use Laravel\Ai\Attributes\Temperature;
 use Laravel\Ai\Attributes\Timeout;
 use Laravel\Ai\Concerns\RemembersConversations;
 use Laravel\Ai\Contracts\Agent;
@@ -63,12 +62,14 @@ use Relaticle\Chat\Tools\Team\InviteTeamMemberTool;
 // over: to get failover, stream() has to receive the array.
 #[Provider(Lab::Anthropic)]
 #[MaxSteps(15)]
-#[Temperature(0.3)]
 #[Timeout(120)]
 final class CrmAssistant implements Agent, Conversational, HasProviderOptions, HasTools
 {
     use Promptable;
     use RemembersConversations;
+
+    /** @var list<string> */
+    private const array ANTHROPIC_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'];
 
     /**
      * Per-turn mention context injected into the system prompt.
@@ -640,6 +641,7 @@ PROMPT;
                     'type' => 'auto',
                     'disable_parallel_tool_use' => true,
                 ],
+                ...$this->anthropicEffort(),
                 ...$this->anthropicCachedSystemBlocks(),
             ],
             Lab::OpenAI->value => [
@@ -651,6 +653,38 @@ PROMPT;
             // sequential-write guard would be unenforceable.
             default => [],
         };
+    }
+
+    /**
+     * Anthropic removed `temperature` and `top_p` on Opus 4.7 and every model
+     * after it, rejecting a request that carries either with a flat 400. A
+     * #[Temperature] attribute on this class is therefore enough to break every
+     * turn on those models, which is exactly how Opus 4.7 went down in
+     * production. `output_config.effort` is the replacement dial, and it matters
+     * more than temperature ever did: from Opus 5 onward thinking is on by
+     * default, so a turn spends output tokens before it writes a word.
+     *
+     * An unrecognised configured value sends nothing at all rather than passing
+     * the typo to the provider, so a bad env degrades to Anthropic's own default
+     * instead of failing every turn. That failure mode is the whole reason this
+     * method exists.
+     *
+     * Lands at the request top level, next to (not inside) the `output_config`
+     * the gateway writes for structured output. This agent declares no schema,
+     * so the two cannot collide today; giving it one would need this merged
+     * rather than set.
+     *
+     * @return array{output_config?: array{effort: string}}
+     */
+    private function anthropicEffort(): array
+    {
+        $effort = config('chat.anthropic_effort');
+
+        if (! is_string($effort) || ! in_array($effort, self::ANTHROPIC_EFFORT_LEVELS, true)) {
+            return [];
+        }
+
+        return ['output_config' => ['effort' => $effort]];
     }
 
     /**

--- a/packages/Chat/src/Agents/ModelProbeAgent.php
+++ b/packages/Chat/src/Agents/ModelProbeAgent.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Agents;
+
+use Laravel\Ai\Attributes\MaxSteps;
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasProviderOptions;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Gateway\TextGenerationOptions;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\ToolChoice;
+
+/**
+ * CrmAssistant's exact request surface, with the model forbidden from calling
+ * anything.
+ *
+ * ModelProbe needs the provider to judge the real request: every tool schema, the
+ * cached system blocks, the effort dial. A probe that trimmed any of that would
+ * pass while production kept failing, which is the failure RELATICLE-CRM-6D
+ * actually was. But a settings page must not be able to touch CRM data, so
+ * `tool_choice: none` goes on instead: the schemas are still sent and still
+ * validated by the provider, and no tool call can come back to execute.
+ *
+ * The choice rides on the attribute rather than providerOptions() because the
+ * Anthropic gateway array_merges providerOptions LAST, over the body: a
+ * `tool_choice` returned from there would overwrite the guard. Stripping the
+ * assistant's own key and letting the gateway map the attribute also keeps the
+ * per-provider shape correct (Anthropic and OpenAI spell "none" differently).
+ */
+#[MaxSteps(1)]
+#[MaxTokens(16)]
+#[ToolChoice(ToolChoice::none)]
+final readonly class ModelProbeAgent implements Agent, HasProviderOptions, HasTools
+{
+    use Promptable;
+
+    public function __construct(private CrmAssistant $assistant) {}
+
+    public function instructions(): string
+    {
+        return $this->assistant->instructions();
+    }
+
+    /**
+     * @return list<Tool>
+     */
+    public function tools(): array
+    {
+        return $this->assistant->tools();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function providerOptions(Lab|string $provider): array
+    {
+        $options = $this->assistant->providerOptions($provider);
+
+        unset($options['tool_choice']);
+
+        return $options;
+    }
+
+    /**
+     * Sampling parameters are read off the AGENT that runs the prompt, so
+     * delegating them is what makes this probe able to catch the bug it exists
+     * for: a `#[Temperature]` on CrmAssistant is rejected by every current
+     * Anthropic model, and a probe carrying its own (absent) sampling config
+     * would sail through while production failed on every turn. Verified by
+     * reintroducing the attribute and watching the probe go red.
+     *
+     * maxSteps, maxTokens and toolChoice are deliberately NOT delegated: those
+     * are the probe's own cost and safety caps, and none of them can turn an
+     * accepted request into a rejected one.
+     */
+    public function temperature(): ?float
+    {
+        return TextGenerationOptions::forAgent($this->assistant)->temperature;
+    }
+
+    public function topP(): ?float
+    {
+        return TextGenerationOptions::forAgent($this->assistant)->topP;
+    }
+}

--- a/packages/Chat/src/ChatServiceProvider.php
+++ b/packages/Chat/src/ChatServiceProvider.php
@@ -34,6 +34,7 @@ use Relaticle\Chat\Livewire\App\Chat\ChatSidePanel;
 use Relaticle\Chat\Livewire\Chat\ChatInterface;
 use Relaticle\Chat\Livewire\Chat\ProposalCard;
 use Relaticle\Chat\Services\ModelRegistry;
+use Relaticle\Chat\Settings\ChatSettings;
 use Relaticle\Chat\Storage\SupersededAwareConversationStore;
 use Relaticle\Chat\Support\AgentRunTelemetry;
 
@@ -56,6 +57,7 @@ final class ChatServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->applyStoredSettings();
         $this->registerCommands();
         $this->registerChannels();
         $this->registerViews();
@@ -64,6 +66,20 @@ final class ChatServiceProvider extends ServiceProvider
         $this->registerRenderHooks();
         $this->registerInsightsCacheInvalidation();
         $this->registerRunTelemetry();
+    }
+
+    /**
+     * Push the runtime-editable model catalog over the config seed defaults.
+     *
+     * Guarded because the settings table does not exist on a fresh install's
+     * first `migrate`, nor while the app boots to run that migration; until then
+     * the config values in chat.php simply stay in force. Runs before
+     * ModelRegistry can be resolved (it is a singleton that reads config once in
+     * its constructor), which is why this is the first line of boot().
+     */
+    private function applyStoredSettings(): void
+    {
+        rescue(fn () => config(resolve(ChatSettings::class)->toConfig()), report: false);
     }
 
     /**

--- a/packages/Chat/src/Commands/ChatModelsCommand.php
+++ b/packages/Chat/src/Commands/ChatModelsCommand.php
@@ -7,12 +7,12 @@ namespace Relaticle\Chat\Commands;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Http;
+use Relaticle\Chat\Services\ModelProbe;
 use Relaticle\Chat\Services\ModelRegistry;
 use Relaticle\Chat\Support\ModelDescriptor;
 
-#[Description('List the chat model registry and optionally probe a model for tool-calling')]
-#[Signature('chat:models {--probe= : Send a tool-calling smoke test to this model id}')]
+#[Description('List the chat model registry and optionally verify a model against its provider')]
+#[Signature('chat:models {--probe= : Verify this model id against its provider}')]
 final class ChatModelsCommand extends Command
 {
     public function handle(ModelRegistry $registry): int
@@ -42,54 +42,26 @@ final class ChatModelsCommand extends Command
     {
         $descriptor = $registry->find($id);
 
-        if (! $descriptor instanceof ModelDescriptor || $descriptor->model === null) {
+        if (! $descriptor instanceof ModelDescriptor || $descriptor->model === null || $descriptor->provider === null) {
             $this->error("Unknown or unconfigured model: {$id}");
 
             return self::FAILURE;
         }
 
-        if (! $descriptor->selfHosted) {
-            $this->error("Probe is only supported for self-hosted endpoints (ollama / SELF_HOSTED_AI_*). '{$id}' runs on the {$descriptor->provider} SDK and can't be probed this way.");
+        $report = resolve(ModelProbe::class)($descriptor->provider, $descriptor->model);
+
+        if ($report['ok'] === false) {
+            $this->error("{$descriptor->model}: {$report['error']}");
 
             return self::FAILURE;
         }
 
-        /** @var array<string, mixed> $connection */
-        $connection = config("ai.providers.{$descriptor->provider}", []);
-        $base = rtrim((string) ($connection['url'] ?? ''), '/');
-        $endpoint = str_ends_with($base, '/v1') ? "{$base}/chat/completions" : "{$base}/api/chat";
-
-        $this->line("Probing {$descriptor->model} at {$endpoint} ...");
-
-        $response = Http::timeout(120)->post($endpoint, [
-            'model' => $descriptor->model,
-            'stream' => false,
-            'messages' => [['role' => 'user', 'content' => "Call create_task with title 'probe'."]],
-            'tools' => [[
-                'type' => 'function',
-                'function' => [
-                    'name' => 'create_task',
-                    'description' => 'Create a task',
-                    'parameters' => [
-                        'type' => 'object',
-                        'properties' => ['title' => ['type' => 'string']],
-                        'required' => ['title'],
-                    ],
-                ],
-            ]],
+        $this->info("{$descriptor->model}: accepted by {$descriptor->provider}");
+        $this->table(['capability', 'value'], [
+            ['supports_tools', $report['supports_tools'] ? 'yes' : 'no'],
+            ['write_guard', $report['write_guard']],
         ]);
 
-        $body = json_encode($response->json()) ?: '';
-        $calledTool = str_contains($body, 'tool_calls') && str_contains($body, 'create_task');
-
-        if ($calledTool) {
-            $this->info("OK - {$descriptor->model} returned a tool call.");
-
-            return self::SUCCESS;
-        }
-
-        $this->error("{$descriptor->model} did NOT return a tool call - unsafe for CRM write tools.");
-
-        return self::FAILURE;
+        return self::SUCCESS;
     }
 }

--- a/packages/Chat/src/Services/AiModelResolver.php
+++ b/packages/Chat/src/Services/AiModelResolver.php
@@ -16,9 +16,12 @@ final readonly class AiModelResolver
     /**
      * Resolve the provider and model for a chat request. An available,
      * plan-allowed explicit choice (or stored user preference) is honored;
-     * anything else falls to the configured `auto_chain`: first available +
-     * plan-allowed, then first available regardless of plan (self-hosted
-     * infrastructure is not plan-gated), then a safe cloud default.
+     * anything else falls to the Auto chain: first available + plan-allowed, then
+     * first available regardless of plan (self-hosted infrastructure is not
+     * plan-gated), then the head of the chain even though nothing can serve it,
+     * so the caller gets a named model to report rather than an exception. No
+     * model id is hardcoded here: the catalog is editable without a deploy, so a
+     * literal one would be a code change on the next vendor retirement.
      *
      * `source` records whether the resolution was the user's explicit pick or
      * the auto chain: ProcessChatMessage only fails over to the next chain
@@ -88,10 +91,9 @@ final readonly class AiModelResolver
             }
         }
 
-        return $this->registry->find('claude-sonnet')
-            ?? $chain[0]
+        return $chain[0]
             ?? $this->registry->all()[0]
-            ?? throw new RuntimeException('No chat model is configured; set at least one provider in config/chat.php.');
+            ?? throw new RuntimeException('No chat model is configured; add one at /sysadmin/ai-models or seed one in config/chat.php.');
     }
 
     /**

--- a/packages/Chat/src/Services/ModelProbe.php
+++ b/packages/Chat/src/Services/ModelProbe.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Services;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Cache;
+use Relaticle\Chat\Agents\CrmAssistant;
+use Relaticle\Chat\Agents\ModelProbeAgent;
+use Relaticle\Chat\Enums\WriteGuard;
+use Throwable;
+
+/**
+ * Asks a provider whether it will actually serve a chat turn on a given model,
+ * by sending one real step built exactly the way a real turn builds it.
+ *
+ * This exists because of RELATICLE-CRM-6D: a `#[Temperature]` attribute made
+ * every Opus 4.7 turn fail with a 400, and nothing short of a real request to
+ * the real endpoint could have caught it. A probe that sends a simplified body
+ * would have passed while production kept failing, so this one carries the full
+ * CrmAssistant surface — every tool schema, the cached system blocks, the
+ * tool_choice guard and the effort dial — and lets the provider judge it.
+ *
+ * It runs through `prompt()`, the same public entry point a real turn uses, so
+ * nothing here can quietly drift from production. ModelProbeAgent forbids tool
+ * calls, so a settings page can never execute one against the CRM.
+ *
+ * A pass is remembered forever with what it measured (a model that served a real
+ * request does not lose the ability); a failure is never cached, so a provider
+ * having a bad minute is simply retried.
+ */
+final readonly class ModelProbe
+{
+    private const int TIMEOUT_SECONDS = 30;
+
+    /**
+     * @return array{ok: bool, error: string|null, supports_tools: bool, write_guard: string}
+     */
+    public function __invoke(string $provider, string $model): array
+    {
+        $cached = Cache::get($this->cacheKey($provider, $model));
+
+        if (is_array($cached)) {
+            /** @var array{ok: bool, error: string|null, supports_tools: bool, write_guard: string} $cached */
+            return $cached;
+        }
+
+        try {
+            new ModelProbeAgent(new CrmAssistant)->prompt(
+                'Reply with the single word OK.',
+                provider: $provider,
+                model: $model,
+                timeout: self::TIMEOUT_SECONDS,
+            );
+        } catch (Throwable $e) {
+            // Claim nothing on failure, and cache nothing either: a rejection may be
+            // a bad model or may be a provider having a bad minute. `prompt` is the
+            // weaker guard, and asserting `api` without proof would tell the write
+            // path the provider refuses parallel tool calls when it may not.
+            return [
+                'ok' => false,
+                'error' => $this->readableMessage($e),
+                'supports_tools' => false,
+                'write_guard' => WriteGuard::Prompt->value,
+            ];
+        }
+
+        $result = [
+            'ok' => true,
+            'error' => null,
+            // The request carried every CrmAssistant tool schema and the provider
+            // took it, so tools are usable on this model.
+            'supports_tools' => true,
+            'write_guard' => $this->writeGuardFor($provider),
+        ];
+
+        Cache::forever($this->cacheKey($provider, $model), $result);
+
+        return $result;
+    }
+
+    public function passedAt(string $provider, string $model): ?string
+    {
+        return is_array(Cache::get($this->cacheKey($provider, $model))) ? 'verified' : null;
+    }
+
+    /**
+     * `api` means the provider itself refuses parallel tool calls, which is what
+     * makes the sequential approval flow unbypassable. Only providers whose options
+     * CrmAssistant actually sets that on can claim it; everything else leans on the
+     * prompt plus the PendingAction approval gate.
+     */
+    private function writeGuardFor(string $provider): string
+    {
+        $options = new CrmAssistant()->providerOptions($provider);
+
+        $enforced = ($options['tool_choice']['disable_parallel_tool_use'] ?? false) === true
+            || ($options['parallel_tool_calls'] ?? null) === false;
+
+        return $enforced ? WriteGuard::Api->value : WriteGuard::Prompt->value;
+    }
+
+    public function forget(string $provider, string $model): void
+    {
+        Cache::forget($this->cacheKey($provider, $model));
+    }
+
+    private function cacheKey(string $provider, string $model): string
+    {
+        return "chat:model-probe:{$provider}:{$model}";
+    }
+
+    /**
+     * Providers bury the useful sentence inside a JSON body that the HTTP client
+     * has already stringified into the exception message. Surface that sentence:
+     * `temperature is deprecated for this model` is the whole answer, and a bare
+     * "HTTP request returned status code 400" is the reason this bug took a live
+     * repro to diagnose in the first place.
+     */
+    private function readableMessage(Throwable $e): string
+    {
+        // The exception message is truncated to 120 characters by Laravel, which
+        // is usually mid-JSON. The response is not, so read the body when there
+        // is one and fall back to the message otherwise.
+        $nested = $e instanceof RequestException
+            ? $e->response->json('error.message')
+            : null;
+
+        return str(is_string($nested) ? $nested : $e->getMessage())->squish()->limit(300)->toString();
+    }
+}

--- a/packages/Chat/src/Services/ModelProbe.php
+++ b/packages/Chat/src/Services/ModelProbe.php
@@ -80,11 +80,6 @@ final readonly class ModelProbe
         return $result;
     }
 
-    public function passedAt(string $provider, string $model): ?string
-    {
-        return is_array(Cache::get($this->cacheKey($provider, $model))) ? 'verified' : null;
-    }
-
     /**
      * `api` means the provider itself refuses parallel tool calls, which is what
      * makes the sequential approval flow unbypassable. Only providers whose options

--- a/packages/Chat/src/Services/ModelRegistry.php
+++ b/packages/Chat/src/Services/ModelRegistry.php
@@ -18,18 +18,34 @@ final readonly class ModelRegistry
     /** @var array<string, float> */
     private array $multipliers;
 
+    /**
+     * The catalog as it stood when this instance was built.
+     *
+     * Held rather than re-read because this is a `readonly` singleton: a method
+     * that called `config()` again would answer from a newer catalog than the
+     * descriptors, rates and multipliers beside it were built from, and a model
+     * present in one but not the other prices its turns at 1x.
+     *
+     * @var list<array<string, mixed>>
+     */
+    private array $entries;
+
+    /** @var list<array{id:string,label:string,provider:?string,model:?string,min_plan:string,credit_multiplier:int|float,supports_tools:bool,write_guard:string,self_hosted:bool}> */
+    private array $custom;
+
     public function __construct()
     {
         /** @var list<array<string, mixed>> $entries */
         $entries = config('chat.models', []);
 
-        $custom = $this->customFromConfig();
+        $this->entries = $entries;
+        $this->custom = $this->customFromConfig();
 
         $enabled = array_values(array_filter($entries, self::identified(...)));
 
         $this->models = [
             ...array_map(ModelDescriptor::fromEntry(...), $enabled),
-            ...array_map(ModelDescriptor::fromConfig(...), $custom),
+            ...array_map(ModelDescriptor::fromConfig(...), $this->custom),
         ];
 
         // Every entry, disabled ones included. A retired model still has to be priced
@@ -39,7 +55,7 @@ final readonly class ModelRegistry
         $rates = [];
         $multipliers = [];
 
-        foreach ([...$entries, ...$custom] as $entry) {
+        foreach ([...$entries, ...$this->custom] as $entry) {
             $model = $entry['model'] ?? null;
 
             if (! is_string($model)) {
@@ -177,18 +193,15 @@ final readonly class ModelRegistry
      */
     public function autoChain(): array
     {
-        /** @var list<array<string, mixed>> $entries */
-        $entries = config('chat.models', []);
-
         $chosen = array_filter(
-            $entries,
+            $this->entries,
             static fn (array $entry): bool => ($entry['auto'] ?? false) === true
                 && self::identified($entry),
         );
 
         return [
             ...array_map(ModelDescriptor::fromEntry(...), array_values($chosen)),
-            ...array_map(ModelDescriptor::fromConfig(...), $this->customFromConfig()),
+            ...array_map(ModelDescriptor::fromConfig(...), $this->custom),
         ];
     }
 

--- a/packages/Chat/src/Services/ModelRegistry.php
+++ b/packages/Chat/src/Services/ModelRegistry.php
@@ -12,15 +12,42 @@ final readonly class ModelRegistry
     /** @var list<ModelDescriptor> */
     private array $models;
 
+    /** @var array<string, array{input_per_mtok: float, output_per_mtok: float}> */
+    private array $rates;
+
     public function __construct()
     {
-        /** @var list<array{id:string,label:string,provider:?string,model:?string,min_plan:string,credit_multiplier:int|float,supports_tools:bool,write_guard:string,self_hosted:bool}> $curated */
-        $curated = config('chat.models', []);
+        /** @var list<array<string, mixed>> $entries */
+        $entries = config('chat.models', []);
 
-        $this->models = array_map(
-            ModelDescriptor::fromConfig(...),
-            [...$curated, ...$this->customFromConfig()],
-        );
+        $enabled = array_values(array_filter(
+            $entries,
+            static fn (array $entry): bool => ($entry['enabled'] ?? true) === true,
+        ));
+
+        $this->models = [
+            ...array_map(ModelDescriptor::fromEntry(...), $enabled),
+            ...array_map(ModelDescriptor::fromConfig(...), $this->customFromConfig()),
+        ];
+
+        // Every entry, disabled ones included: a retired model still has to be
+        // priced, because ai_credit_transactions rows keep naming it.
+        $rates = [];
+
+        foreach ($entries as $entry) {
+            $model = $entry['model'] ?? null;
+            $input = $entry['input_per_mtok'] ?? null;
+            $output = $entry['output_per_mtok'] ?? null;
+
+            if (is_string($model) && is_numeric($input) && is_numeric($output)) {
+                $rates[$model] = [
+                    'input_per_mtok' => (float) $input,
+                    'output_per_mtok' => (float) $output,
+                ];
+            }
+        }
+
+        $this->rates = $rates;
     }
 
     /** @return list<ModelDescriptor> */
@@ -103,16 +130,39 @@ final readonly class ModelRegistry
         return $ids;
     }
 
-    /** @return list<ModelDescriptor> */
+    /**
+     * Auto's failover order: the entries flagged `auto`, in list order, then every
+     * env-derived self-hosted model.
+     *
+     * Self-hosted models are appended rather than stored because they used to sit
+     * at the tail of `chat.auto_chain`, and that tail is what makes Auto usable on
+     * an install with no cloud keys at all.
+     *
+     * @return list<ModelDescriptor>
+     */
     public function autoChain(): array
     {
-        /** @var list<string> $ids */
-        $ids = config('chat.auto_chain', []);
+        /** @var list<array<string, mixed>> $entries */
+        $entries = config('chat.models', []);
 
-        return array_values(array_filter(array_map(
-            $this->find(...),
-            $ids,
-        )));
+        $chosen = array_filter(
+            $entries,
+            static fn (array $entry): bool => ($entry['auto'] ?? false) === true
+                && ($entry['enabled'] ?? true) === true,
+        );
+
+        return [
+            ...array_map(ModelDescriptor::fromEntry(...), array_values($chosen)),
+            ...array_map(ModelDescriptor::fromConfig(...), $this->customFromConfig()),
+        ];
+    }
+
+    /**
+     * @return array{input_per_mtok: float, output_per_mtok: float}|null
+     */
+    public function ratesFor(string $model): ?array
+    {
+        return $this->rates[$model] ?? null;
     }
 
     public function multiplierFor(string $modelId): float
@@ -126,8 +176,49 @@ final readonly class ModelRegistry
         return 1.0;
     }
 
-    /** @return list<array{id:string,label:string,provider:?string,model:?string,min_plan:string,credit_multiplier:int|float,supports_tools:bool,write_guard:string,self_hosted:bool}> */
+    /**
+     * Self-hosted models, built from env on every read.
+     *
+     * They are deliberately not stored: `.env` stays their single source of truth,
+     * so OLLAMA_MODEL and SELF_HOSTED_AI_MODELS keep taking effect without a deploy
+     * and without anyone editing the panel. Ollama keeps the bare `ollama` id it has
+     * always had, because that id is what a user's saved preference stores.
+     *
+     * @return list<array{id:string,label:string,provider:?string,model:?string,min_plan:string,credit_multiplier:int|float,supports_tools:bool,write_guard:string,self_hosted:bool}>
+     */
     private function customFromConfig(): array
+    {
+        return [...$this->ollamaFromEnv(), ...$this->customEndpointFromEnv()];
+    }
+
+    /**
+     * @return list<array{id:string,label:string,provider:?string,model:?string,min_plan:string,credit_multiplier:int|float,supports_tools:bool,write_guard:string,self_hosted:bool}>
+     */
+    private function ollamaFromEnv(): array
+    {
+        $model = config('chat.ollama.model');
+
+        if (! is_string($model) || $model === '') {
+            return [];
+        }
+
+        return [[
+            'id' => 'ollama',
+            'label' => 'Ollama',
+            'provider' => 'ollama',
+            'model' => $model,
+            'min_plan' => Plan::Free->value,
+            'credit_multiplier' => 1.0,
+            'supports_tools' => true,
+            'write_guard' => 'prompt',
+            'self_hosted' => true,
+        ]];
+    }
+
+    /**
+     * @return list<array{id:string,label:string,provider:?string,model:?string,min_plan:string,credit_multiplier:int|float,supports_tools:bool,write_guard:string,self_hosted:bool}>
+     */
+    private function customEndpointFromEnv(): array
     {
         $url = config('chat.self_hosted.url');
         $models = config('chat.self_hosted.models');

--- a/packages/Chat/src/Services/ModelRegistry.php
+++ b/packages/Chat/src/Services/ModelRegistry.php
@@ -95,6 +95,26 @@ final readonly class ModelRegistry
     }
 
     /**
+     * What the product offers, whether or not this install holds the key.
+     *
+     * `available()` answers a different question — servable HERE — and the public
+     * pricing and AI pages must not be answering that one. A rotated key is an
+     * outage, not a change to what a plan includes, and routing marketing copy
+     * through it renders "Every plan can use  and any self-hosted model you connect
+     * yourself" with a hole where the name belongs. `supports_tools` still applies:
+     * a model AiModelResolver::pick() can never select must never be advertised.
+     *
+     * @return list<ModelDescriptor>
+     */
+    public function offered(): array
+    {
+        return array_values(array_filter(
+            $this->models,
+            static fn (ModelDescriptor $m): bool => ! $m->selfHosted && $m->supportsTools,
+        ));
+    }
+
+    /**
      * Voice input is servable on this install: the feature is switched on and
      * the transcription provider is configured. Same availability shape the
      * model picker uses for a cloud provider (ModelDescriptor::isAvailable()),

--- a/packages/Chat/src/Services/ModelRegistry.php
+++ b/packages/Chat/src/Services/ModelRegistry.php
@@ -25,10 +25,7 @@ final readonly class ModelRegistry
 
         $custom = $this->customFromConfig();
 
-        $enabled = array_values(array_filter(
-            $entries,
-            static fn (array $entry): bool => ($entry['enabled'] ?? true) === true,
-        ));
+        $enabled = array_values(array_filter($entries, self::identified(...)));
 
         $this->models = [
             ...array_map(ModelDescriptor::fromEntry(...), $enabled),
@@ -186,13 +183,31 @@ final readonly class ModelRegistry
         $chosen = array_filter(
             $entries,
             static fn (array $entry): bool => ($entry['auto'] ?? false) === true
-                && ($entry['enabled'] ?? true) === true,
+                && self::identified($entry),
         );
 
         return [
             ...array_map(ModelDescriptor::fromEntry(...), array_values($chosen)),
             ...array_map(ModelDescriptor::fromConfig(...), $this->customFromConfig()),
         ];
+    }
+
+    /**
+     * A row the catalog can offer. The model tag is the entry's identity, so a row
+     * without one is not a model missing its tag, it is not a model — and offering
+     * it would put an empty id in the picker and in `Rule::in()`.
+     *
+     * Pricing deliberately does not go through here: `$rates` and `$multipliers`
+     * are built over every entry, disabled ones included, because a retired model
+     * still has to price the transactions that name it.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    private static function identified(array $entry): bool
+    {
+        return ($entry['enabled'] ?? true) === true
+            && is_string($entry['model'] ?? null)
+            && $entry['model'] !== '';
     }
 
     /**

--- a/packages/Chat/src/Services/ModelRegistry.php
+++ b/packages/Chat/src/Services/ModelRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\Chat\Services;
 
 use App\Enums\Plan;
+use Relaticle\Chat\Support\CatalogEntry;
 use Relaticle\Chat\Support\ModelDescriptor;
 
 final readonly class ModelRegistry
@@ -19,14 +20,14 @@ final readonly class ModelRegistry
     private array $multipliers;
 
     /**
-     * The catalog as it stood when this instance was built.
+     * The catalog as it stood when this instance was built, parsed once.
      *
      * Held rather than re-read because this is a `readonly` singleton: a method
      * that called `config()` again would answer from a newer catalog than the
      * descriptors, rates and multipliers beside it were built from, and a model
      * present in one but not the other prices its turns at 1x.
      *
-     * @var list<array<string, mixed>>
+     * @var list<CatalogEntry>
      */
     private array $entries;
 
@@ -35,16 +36,17 @@ final readonly class ModelRegistry
 
     public function __construct()
     {
-        /** @var list<array<string, mixed>> $entries */
-        $entries = config('chat.models', []);
+        /** @var list<array<string, mixed>> $stored */
+        $stored = config('chat.models', []);
 
-        $this->entries = $entries;
+        $this->entries = array_values(array_filter(array_map(CatalogEntry::fromArray(...), $stored)));
         $this->custom = $this->customFromConfig();
 
-        $enabled = array_values(array_filter($entries, self::identified(...)));
-
         $this->models = [
-            ...array_map(ModelDescriptor::fromEntry(...), $enabled),
+            ...array_map(
+                ModelDescriptor::fromCatalogEntry(...),
+                array_values(array_filter($this->entries, static fn (CatalogEntry $entry): bool => $entry->enabled)),
+            ),
             ...array_map(ModelDescriptor::fromConfig(...), $this->custom),
         ];
 
@@ -55,26 +57,18 @@ final readonly class ModelRegistry
         $rates = [];
         $multipliers = [];
 
-        foreach ([...$entries, ...$this->custom] as $entry) {
-            $model = $entry['model'] ?? null;
+        foreach ($this->entries as $entry) {
+            $rate = $entry->rate();
 
-            if (! is_string($model)) {
-                continue;
+            if ($rate !== null) {
+                $rates[$entry->model] = $rate;
             }
 
-            $input = $entry['input_per_mtok'] ?? null;
-            $output = $entry['output_per_mtok'] ?? null;
+            $multipliers[$entry->model] = $entry->creditMultiplier;
+        }
 
-            if (is_numeric($input) && is_numeric($output)) {
-                $rates[$model] = [
-                    'input_per_mtok' => (float) $input,
-                    'output_per_mtok' => (float) $output,
-                ];
-            }
-
-            if (is_numeric($entry['credit_multiplier'] ?? null)) {
-                $multipliers[$model] = (float) $entry['credit_multiplier'];
-            }
+        foreach ($this->custom as $entry) {
+            $multipliers[(string) $entry['model']] = (float) $entry['credit_multiplier'];
         }
 
         $this->rates = $rates;
@@ -195,32 +189,13 @@ final readonly class ModelRegistry
     {
         $chosen = array_filter(
             $this->entries,
-            static fn (array $entry): bool => ($entry['auto'] ?? false) === true
-                && self::identified($entry),
+            static fn (CatalogEntry $entry): bool => $entry->auto && $entry->enabled,
         );
 
         return [
-            ...array_map(ModelDescriptor::fromEntry(...), array_values($chosen)),
+            ...array_map(ModelDescriptor::fromCatalogEntry(...), array_values($chosen)),
             ...array_map(ModelDescriptor::fromConfig(...), $this->custom),
         ];
-    }
-
-    /**
-     * A row the catalog can offer. The model tag is the entry's identity, so a row
-     * without one is not a model missing its tag, it is not a model — and offering
-     * it would put an empty id in the picker and in `Rule::in()`.
-     *
-     * Pricing deliberately does not go through here: `$rates` and `$multipliers`
-     * are built over every entry, disabled ones included, because a retired model
-     * still has to price the transactions that name it.
-     *
-     * @param  array<string, mixed>  $entry
-     */
-    private static function identified(array $entry): bool
-    {
-        return ($entry['enabled'] ?? true) === true
-            && is_string($entry['model'] ?? null)
-            && $entry['model'] !== '';
     }
 
     /**

--- a/packages/Chat/src/Services/ModelRegistry.php
+++ b/packages/Chat/src/Services/ModelRegistry.php
@@ -15,10 +15,15 @@ final readonly class ModelRegistry
     /** @var array<string, array{input_per_mtok: float, output_per_mtok: float}> */
     private array $rates;
 
+    /** @var array<string, float> */
+    private array $multipliers;
+
     public function __construct()
     {
         /** @var list<array<string, mixed>> $entries */
         $entries = config('chat.models', []);
+
+        $custom = $this->customFromConfig();
 
         $enabled = array_values(array_filter(
             $entries,
@@ -27,27 +32,40 @@ final readonly class ModelRegistry
 
         $this->models = [
             ...array_map(ModelDescriptor::fromEntry(...), $enabled),
-            ...array_map(ModelDescriptor::fromConfig(...), $this->customFromConfig()),
+            ...array_map(ModelDescriptor::fromConfig(...), $custom),
         ];
 
-        // Every entry, disabled ones included: a retired model still has to be
-        // priced, because ai_credit_transactions rows keep naming it.
+        // Every entry, disabled ones included. A retired model still has to be priced
+        // for the spend widget AND charged at the multiplier it was retired on: a turn
+        // enqueued before the catalog changed settles after it, and reading this off
+        // the picker instead would silently re-price that turn at 1x.
         $rates = [];
+        $multipliers = [];
 
-        foreach ($entries as $entry) {
+        foreach ([...$entries, ...$custom] as $entry) {
             $model = $entry['model'] ?? null;
+
+            if (! is_string($model)) {
+                continue;
+            }
+
             $input = $entry['input_per_mtok'] ?? null;
             $output = $entry['output_per_mtok'] ?? null;
 
-            if (is_string($model) && is_numeric($input) && is_numeric($output)) {
+            if (is_numeric($input) && is_numeric($output)) {
                 $rates[$model] = [
                     'input_per_mtok' => (float) $input,
                     'output_per_mtok' => (float) $output,
                 ];
             }
+
+            if (is_numeric($entry['credit_multiplier'] ?? null)) {
+                $multipliers[$model] = (float) $entry['credit_multiplier'];
+            }
         }
 
         $this->rates = $rates;
+        $this->multipliers = $multipliers;
     }
 
     /** @return list<ModelDescriptor> */
@@ -165,15 +183,9 @@ final readonly class ModelRegistry
         return $this->rates[$model] ?? null;
     }
 
-    public function multiplierFor(string $modelId): float
+    public function multiplierFor(string $model): float
     {
-        foreach ($this->models as $model) {
-            if ($model->model === $modelId) {
-                return $model->creditMultiplier;
-            }
-        }
-
-        return 1.0;
+        return $this->multipliers[$model] ?? 1.0;
     }
 
     /**

--- a/packages/Chat/src/Services/ProviderModelCatalog.php
+++ b/packages/Chat/src/Services/ProviderModelCatalog.php
@@ -18,6 +18,10 @@ use Illuminate\Support\Facades\Http;
  * reached yields an empty list, and the page falls back to whatever is already
  * saved. Never let this throw into a form render: an unreachable vendor must not
  * take the settings page down with it.
+ *
+ * Only a real listing is cached. A vendor having a bad minute must not blank the
+ * model picker for a day, which is the same reason ModelProbe never caches a
+ * failure: an empty list is what we could not learn, not what the provider offers.
  */
 final readonly class ProviderModelCatalog
 {
@@ -32,11 +36,20 @@ final readonly class ProviderModelCatalog
             return [];
         }
 
-        return Cache::remember(
-            $this->cacheKey($provider),
-            self::TTL_SECONDS,
-            fn (): array => rescue(fn (): array => $this->fetch($provider), [], report: false),
-        );
+        $cached = Cache::get($this->cacheKey($provider));
+
+        if (is_array($cached)) {
+            /** @var array<string, int> $cached */
+            return $cached;
+        }
+
+        $models = rescue(fn (): array => $this->fetch($provider), [], report: false);
+
+        if ($models !== []) {
+            Cache::put($this->cacheKey($provider), $models, self::TTL_SECONDS);
+        }
+
+        return $models;
     }
 
     public function forget(string $provider): void

--- a/packages/Chat/src/Services/ProviderModelCatalog.php
+++ b/packages/Chat/src/Services/ProviderModelCatalog.php
@@ -14,6 +14,10 @@ use Illuminate\Support\Facades\Http;
  * sysadmin model catalog offers real names instead of a free-text box where a
  * typo becomes a production 404.
  *
+ * Each id carries the vendor's own display name when the vendor publishes one
+ * (Anthropic sends `display_name`; OpenAI's listing has no such field), which is
+ * what spares an operator from typing the one user-facing string in the catalog.
+ *
  * A provider without a key, without a listing endpoint, or that simply cannot be
  * reached yields an empty list, and the page falls back to whatever is already
  * saved. Never let this throw into a form render: an unreachable vendor must not
@@ -28,7 +32,9 @@ final readonly class ProviderModelCatalog
     private const int TTL_SECONDS = 86400;
 
     /**
-     * @return array<string, int> model id => release timestamp, 0 when unknown
+     * @return array<string, array{label: string, released_at: int}> model id => the
+     *                                                               vendor's display name (the id itself when it publishes none) and its
+     *                                                               release timestamp, 0 when unknown
      */
     public function __invoke(string $provider): array
     {
@@ -39,7 +45,7 @@ final readonly class ProviderModelCatalog
         $cached = Cache::get($this->cacheKey($provider));
 
         if (is_array($cached)) {
-            /** @var array<string, int> $cached */
+            /** @var array<string, array{label: string, released_at: int}> $cached */
             return $cached;
         }
 
@@ -59,11 +65,13 @@ final readonly class ProviderModelCatalog
 
     private function cacheKey(string $provider): string
     {
-        return "chat:model-catalog:{$provider}";
+        // Versioned: a payload cached in the old id => timestamp shape would be read
+        // back as one carrying labels and blow up in the form.
+        return "chat:model-catalog:v2:{$provider}";
     }
 
     /**
-     * @return array<string, int>
+     * @return array<string, array{label: string, released_at: int}>
      */
     private function fetch(string $provider): array
     {
@@ -87,9 +95,26 @@ final readonly class ProviderModelCatalog
 
         return collect($rows)
             ->filter(fn (array $row): bool => is_string($row['id'] ?? null))
-            ->mapWithKeys(fn (array $row): array => [(string) $row['id'] => $this->releasedAt($row)])
-            ->sortDesc()
+            ->mapWithKeys(fn (array $row): array => [(string) $row['id'] => [
+                'label' => $this->displayName($row),
+                'released_at' => $this->releasedAt($row),
+            ]])
+            ->sortByDesc(fn (array $row): int => $row['released_at'])
             ->all();
+    }
+
+    /**
+     * The vendor's own name for the model, falling back to the tag. A catalog entry
+     * has exactly one user-facing string and this is where it comes from, so an
+     * operator adding a model does not have to invent "Sonnet 5" by hand.
+     *
+     * @param  array<string, mixed>  $row
+     */
+    private function displayName(array $row): string
+    {
+        $name = $row['display_name'] ?? null;
+
+        return is_string($name) && $name !== '' ? $name : (string) $row['id'];
     }
 
     /**

--- a/packages/Chat/src/Services/ProviderModelCatalog.php
+++ b/packages/Chat/src/Services/ProviderModelCatalog.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Services;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Model ids straight from a provider's own listing endpoint, newest first, so the
+ * sysadmin model catalog offers real names instead of a free-text box where a
+ * typo becomes a production 404.
+ *
+ * A provider without a key, without a listing endpoint, or that simply cannot be
+ * reached yields an empty list, and the page falls back to whatever is already
+ * saved. Never let this throw into a form render: an unreachable vendor must not
+ * take the settings page down with it.
+ */
+final readonly class ProviderModelCatalog
+{
+    private const int TTL_SECONDS = 86400;
+
+    /**
+     * @return array<string, int> model id => release timestamp, 0 when unknown
+     */
+    public function __invoke(string $provider): array
+    {
+        if (blank(config("ai.providers.{$provider}.key"))) {
+            return [];
+        }
+
+        return Cache::remember(
+            $this->cacheKey($provider),
+            self::TTL_SECONDS,
+            fn (): array => rescue(fn (): array => $this->fetch($provider), [], report: false),
+        );
+    }
+
+    public function forget(string $provider): void
+    {
+        Cache::forget($this->cacheKey($provider));
+    }
+
+    private function cacheKey(string $provider): string
+    {
+        return "chat:model-catalog:{$provider}";
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function fetch(string $provider): array
+    {
+        $key = (string) config("ai.providers.{$provider}.key");
+
+        $response = match ($provider) {
+            'anthropic' => $this->client()
+                ->withHeaders(['x-api-key' => $key, 'anthropic-version' => '2023-06-01'])
+                ->get('https://api.anthropic.com/v1/models', ['limit' => 100]),
+            'openai' => $this->client()->withToken($key)
+                ->get(rtrim((string) config('ai.providers.openai.url', 'https://api.openai.com/v1'), '/').'/models'),
+            default => null,
+        };
+
+        if ($response === null) {
+            return [];
+        }
+
+        /** @var array<int, array<string, mixed>> $rows */
+        $rows = $response->throw()->json('data', []);
+
+        return collect($rows)
+            ->filter(fn (array $row): bool => is_string($row['id'] ?? null))
+            ->mapWithKeys(fn (array $row): array => [(string) $row['id'] => $this->releasedAt($row)])
+            ->sortDesc()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     */
+    private function releasedAt(array $row): int
+    {
+        $created = $row['created'] ?? $row['created_at'] ?? null;
+
+        return match (true) {
+            is_int($created) => $created,
+            is_string($created) => rescue(fn (): int => Date::parse($created)->getTimestamp(), 0, report: false),
+            default => 0,
+        };
+    }
+
+    private function client(): PendingRequest
+    {
+        return Http::timeout(10)->acceptJson();
+    }
+}

--- a/packages/Chat/src/Settings/ChatSettings.php
+++ b/packages/Chat/src/Settings/ChatSettings.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+/**
+ * The chat model catalog, editable at runtime from the sysadmin panel.
+ *
+ * `models` is the whole catalog: each entry carries its own Auto membership, its
+ * own price, and the capabilities a probe measured. The list order is the Auto
+ * order. Self-hosted models are NOT here; they stay env-driven and are merged into
+ * ModelRegistry at read time, so `.env` remains their single source of truth.
+ *
+ * `toConfig()` is pushed into `config()` at boot (ChatServiceProvider), so every
+ * existing reader — ModelRegistry, AiModelResolver, the sysadmin spend widget,
+ * CrmAssistant::anthropicEffort() — keeps reading config and needs no changes.
+ * The config values remain the seed defaults and the fallback when the table is
+ * not there yet.
+ *
+ * Not `readonly`: spatie/laravel-settings hydrates and re-assigns these.
+ */
+final class ChatSettings extends Settings
+{
+    /** @phpstan-var list<array<string, mixed>> */
+    public array $models;
+
+    public string $anthropic_effort;
+
+    public static function group(): string
+    {
+        return 'chat';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toConfig(): array
+    {
+        return [
+            'chat.models' => $this->models,
+            'chat.anthropic_effort' => $this->anthropic_effort,
+        ];
+    }
+}

--- a/packages/Chat/src/Support/CatalogEntry.php
+++ b/packages/Chat/src/Support/CatalogEntry.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Support;
+
+use App\Enums\Plan;
+
+/**
+ * One row of the runtime-editable model catalog.
+ *
+ * The catalog is stored as plain arrays (spatie/laravel-settings owns the row's
+ * JSON), and that shape used to be re-derived, with independently chosen
+ * defaults, in eight places: ModelDescriptor, three passes inside ModelRegistry,
+ * the panel's normalise / verify / badge paths, and the provider health check.
+ * Those derivations drifted apart, and the drift shipped: the panel wrote back a
+ * capabilities record it had read off the form, and models silently stopped
+ * being served. This is the one place the array shape is understood.
+ *
+ * Identity is the provider's own model tag, because that is what is already
+ * persisted everywhere it matters (`ai_credit_transactions.model`, a user's
+ * saved preference, `?model=`). An entry therefore needs nothing but a tag to
+ * exist: `provider` is nullable and `enabled` is free to be false, because a
+ * retired row with neither still has to price the transactions that name it.
+ * Servability is a separate question, and `isServable()` is where it is asked.
+ */
+final readonly class CatalogEntry
+{
+    public function __construct(
+        public string $model,
+        public string $label,
+        public ?string $provider,
+        public Plan $minPlan,
+        public float $creditMultiplier,
+        public ?float $inputPerMtok,
+        public ?float $outputPerMtok,
+        public bool $auto,
+        public bool $enabled,
+        public ?Measurement $measurement,
+    ) {}
+
+    /**
+     * Null when the row names no model, which is not a model missing its tag: it
+     * is not a model. Offering it would put an empty id in the picker and in
+     * `Rule::in()`.
+     *
+     * Every scalar fails closed rather than throwing, because the settings row is
+     * editable outside the panel: an unreadable plan becomes the most restrictive
+     * one instead of handing an expensive model to every workspace, and a missing
+     * multiplier becomes full price instead of `(float) null`, which is free.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    public static function fromArray(array $entry): ?self
+    {
+        $model = $entry['model'] ?? null;
+
+        if (! is_string($model) || $model === '') {
+            return null;
+        }
+
+        $provider = $entry['provider'] ?? null;
+        $label = $entry['label'] ?? null;
+
+        return new self(
+            model: $model,
+            label: is_string($label) && $label !== '' ? $label : $model,
+            provider: is_string($provider) && $provider !== '' ? $provider : null,
+            minPlan: self::plan($entry['min_plan'] ?? null),
+            creditMultiplier: is_numeric($entry['credit_multiplier'] ?? null) ? (float) $entry['credit_multiplier'] : 1.0,
+            inputPerMtok: is_numeric($entry['input_per_mtok'] ?? null) ? (float) $entry['input_per_mtok'] : null,
+            outputPerMtok: is_numeric($entry['output_per_mtok'] ?? null) ? (float) $entry['output_per_mtok'] : null,
+            // Cast rather than compare: a Filament toggle hands back "1", and pint's
+            // strict_comparison fixer rewrites any `==` put here.
+            auto: (bool) ($entry['auto'] ?? false),
+            enabled: (bool) ($entry['enabled'] ?? true),
+            measurement: Measurement::fromEntry($entry),
+        );
+    }
+
+    /**
+     * The stored shape, key order included.
+     *
+     * The order is load-bearing: ManageAiSettings diffs the whole catalog with
+     * `===` to decide whether a save changed anything, and a reordered array is
+     * not identical to itself. Reordering here would make every no-op save write
+     * an activity row.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'label' => $this->label,
+            'provider' => $this->provider,
+            'model' => $this->model,
+            'min_plan' => $this->minPlan->value,
+            'credit_multiplier' => $this->creditMultiplier,
+            'input_per_mtok' => $this->inputPerMtok,
+            'output_per_mtok' => $this->outputPerMtok,
+            'auto' => $this->auto,
+            'enabled' => $this->enabled,
+            'capabilities' => $this->measurement?->toCapabilities(),
+            'verified_at' => $this->measurement?->verifiedAt,
+        ];
+    }
+
+    public function withMeasurement(?Measurement $measurement): self
+    {
+        return new self(
+            model: $this->model,
+            label: $this->label,
+            provider: $this->provider,
+            minPlan: $this->minPlan,
+            creditMultiplier: $this->creditMultiplier,
+            inputPerMtok: $this->inputPerMtok,
+            outputPerMtok: $this->outputPerMtok,
+            auto: $this->auto,
+            enabled: $this->enabled,
+            measurement: $measurement,
+        );
+    }
+
+    /**
+     * Offered to users at all: switched on, named a provider, and measured as
+     * able to call tools. A model AiModelResolver::pick() can never select must
+     * never reach a picker, a plan gate or the public pricing copy.
+     */
+    public function isServable(): bool
+    {
+        return $this->enabled
+            && $this->provider !== null
+            && $this->measurement instanceof Measurement
+            && $this->measurement->supportsTools;
+    }
+
+    /**
+     * Whether this pairing is worth an API call on save. A disabled row is served
+     * to nobody, and a row already carrying a measurement is the status quo.
+     */
+    public function needsProbe(): bool
+    {
+        return $this->enabled && ! $this->measurement instanceof Measurement;
+    }
+
+    public function pairing(): ?string
+    {
+        return $this->provider === null ? null : "{$this->provider}|{$this->model}";
+    }
+
+    /**
+     * @return array{input_per_mtok: float, output_per_mtok: float}|null
+     */
+    public function rate(): ?array
+    {
+        if ($this->inputPerMtok === null || $this->outputPerMtok === null) {
+            return null;
+        }
+
+        return [
+            'input_per_mtok' => $this->inputPerMtok,
+            'output_per_mtok' => $this->outputPerMtok,
+        ];
+    }
+
+    private static function plan(mixed $plan): Plan
+    {
+        if ($plan instanceof Plan) {
+            return $plan;
+        }
+
+        return Plan::tryFrom(is_string($plan) ? $plan : '') ?? Plan::Pro;
+    }
+}

--- a/packages/Chat/src/Support/Measurement.php
+++ b/packages/Chat/src/Support/Measurement.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Support;
+
+use Relaticle\Chat\Enums\WriteGuard;
+
+/**
+ * What a probe learned about a catalog entry, or nothing at all.
+ *
+ * Absence is the point. "Nobody has measured this pairing" and "the provider
+ * will not serve tools on it" are different claims with different consequences,
+ * and the catalog used to carry them as two loose fields (`capabilities`,
+ * `verified_at`) that could disagree: a `verified_at` with no capabilities beside
+ * it says a probe ran and measured nothing, which never happens. One nullable
+ * object makes that unrepresentable.
+ *
+ * `verifiedAt` is nullable inside a present measurement because a config-seeded
+ * entry declares capabilities no probe on THIS install has confirmed. That is a
+ * weaker claim than a measured one, and the panel's Verified column says so.
+ *
+ * Kept as a string rather than a date: the settings row is editable outside the
+ * panel, and an unparseable timestamp must not take a page down.
+ */
+final readonly class Measurement
+{
+    public function __construct(
+        public bool $supportsTools,
+        public WriteGuard $writeGuard,
+        public ?string $verifiedAt = null,
+    ) {}
+
+    /**
+     * Reads a stored entry's measurement, or null when it carries none.
+     *
+     * Fails closed on an unreadable guard: claiming `api` without proof would
+     * tell the write path the provider refuses parallel tool calls when it may
+     * not.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    public static function fromEntry(array $entry): ?self
+    {
+        $capabilities = $entry['capabilities'] ?? null;
+
+        if (! is_array($capabilities) || $capabilities === []) {
+            return null;
+        }
+
+        $verifiedAt = $entry['verified_at'] ?? null;
+
+        return new self(
+            supportsTools: ($capabilities['supports_tools'] ?? false) === true,
+            writeGuard: WriteGuard::tryFrom((string) ($capabilities['write_guard'] ?? '')) ?? WriteGuard::Prompt,
+            verifiedAt: is_string($verifiedAt) && $verifiedAt !== '' ? $verifiedAt : null,
+        );
+    }
+
+    /**
+     * @return array{supports_tools: bool, write_guard: string}
+     */
+    public function toCapabilities(): array
+    {
+        return [
+            'supports_tools' => $this->supportsTools,
+            'write_guard' => $this->writeGuard->value,
+        ];
+    }
+}

--- a/packages/Chat/src/Support/ModelDescriptor.php
+++ b/packages/Chat/src/Support/ModelDescriptor.php
@@ -40,6 +40,35 @@ final readonly class ModelDescriptor
     }
 
     /**
+     * A descriptor for a stored catalog entry.
+     *
+     * `selfHosted` is false by construction: self-hosted models are never stored,
+     * they are merged from env by ModelRegistry.
+     *
+     * A missing capability record means nobody has probed this entry yet, so it
+     * gets the weaker guard. Claiming `api` without proof would tell the write path
+     * the provider refuses parallel tool calls when it may not.
+     *
+     * @param  array<string, mixed>  $entry
+     */
+    public static function fromEntry(array $entry): self
+    {
+        $capabilities = is_array($entry['capabilities'] ?? null) ? $entry['capabilities'] : [];
+
+        return new self(
+            id: (string) $entry['key'],
+            label: (string) $entry['label'],
+            provider: isset($entry['provider']) ? (string) $entry['provider'] : null,
+            model: isset($entry['model']) ? (string) $entry['model'] : null,
+            minPlan: Plan::from((string) $entry['min_plan']),
+            creditMultiplier: (float) $entry['credit_multiplier'],
+            supportsTools: ($capabilities['supports_tools'] ?? false) === true,
+            writeGuard: WriteGuard::from((string) ($capabilities['write_guard'] ?? WriteGuard::Prompt->value)),
+            selfHosted: false,
+        );
+    }
+
+    /**
      * Servable on this install: tool-capable, has a model tag, and its provider
      * connection is configured. Cloud providers need a key; self-hosted providers
      * need a base URL.

--- a/packages/Chat/src/Support/ModelDescriptor.php
+++ b/packages/Chat/src/Support/ModelDescriptor.php
@@ -52,25 +52,23 @@ final readonly class ModelDescriptor
      * they are merged from env by ModelRegistry, and they keep the env-derived ids
      * they have always had because no operator types those either.
      *
-     * A missing capability record means nobody has probed this entry yet, so it
-     * gets the weaker guard. Claiming `api` without proof would tell the write path
-     * the provider refuses parallel tool calls when it may not.
-     *
-     * @param  array<string, mixed>  $entry
+     * An unmeasured entry gets the weaker guard. Claiming `api` without proof
+     * would tell the write path the provider refuses parallel tool calls when it
+     * may not.
      */
-    public static function fromEntry(array $entry): self
+    public static function fromCatalogEntry(CatalogEntry $entry): self
     {
-        $capabilities = is_array($entry['capabilities'] ?? null) ? $entry['capabilities'] : [];
+        $measurement = $entry->measurement;
 
         return new self(
-            id: (string) $entry['model'],
-            label: (string) $entry['label'],
-            provider: isset($entry['provider']) ? (string) $entry['provider'] : null,
-            model: isset($entry['model']) ? (string) $entry['model'] : null,
-            minPlan: Plan::from((string) $entry['min_plan']),
-            creditMultiplier: (float) $entry['credit_multiplier'],
-            supportsTools: ($capabilities['supports_tools'] ?? false) === true,
-            writeGuard: WriteGuard::from((string) ($capabilities['write_guard'] ?? WriteGuard::Prompt->value)),
+            id: $entry->model,
+            label: $entry->label,
+            provider: $entry->provider,
+            model: $entry->model,
+            minPlan: $entry->minPlan,
+            creditMultiplier: $entry->creditMultiplier,
+            supportsTools: $measurement instanceof Measurement && $measurement->supportsTools,
+            writeGuard: $measurement instanceof Measurement ? $measurement->writeGuard : WriteGuard::Prompt,
             selfHosted: false,
         );
     }

--- a/packages/Chat/src/Support/ModelDescriptor.php
+++ b/packages/Chat/src/Support/ModelDescriptor.php
@@ -42,8 +42,15 @@ final readonly class ModelDescriptor
     /**
      * A descriptor for a stored catalog entry.
      *
+     * The provider's own model tag is the id. A stored entry carries no separate
+     * identifier: one that an operator types is one an operator can mistype or
+     * rename, and the tag is already the identity everywhere it is persisted
+     * (`ai_credit_transactions.model`, `ModelRegistry::ratesFor()`). Retagging a
+     * row is therefore a new model by construction, which is what it is.
+     *
      * `selfHosted` is false by construction: self-hosted models are never stored,
-     * they are merged from env by ModelRegistry.
+     * they are merged from env by ModelRegistry, and they keep the env-derived ids
+     * they have always had because no operator types those either.
      *
      * A missing capability record means nobody has probed this entry yet, so it
      * gets the weaker guard. Claiming `api` without proof would tell the write path
@@ -56,7 +63,7 @@ final readonly class ModelDescriptor
         $capabilities = is_array($entry['capabilities'] ?? null) ? $entry['capabilities'] : [];
 
         return new self(
-            id: (string) $entry['key'],
+            id: (string) $entry['model'],
             label: (string) $entry['label'],
             provider: isset($entry['provider']) ? (string) $entry['provider'] : null,
             model: isset($entry['model']) ? (string) $entry['model'] : null,

--- a/packages/SystemAdmin/resources/views/filament/pages/manage-ai-settings.blade.php
+++ b/packages/SystemAdmin/resources/views/filament/pages/manage-ai-settings.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->form }}
+</x-filament-panels::page>

--- a/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
+++ b/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
@@ -8,7 +8,6 @@ use App\Enums\Plan;
 use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Hidden;
-use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
@@ -18,12 +17,15 @@ use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Form;
+use Filament\Schemas\Components\Icon;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Date;
 use Laravel\Ai\Enums\Lab;
 use Relaticle\Chat\Services\ModelProbe;
 use Relaticle\Chat\Services\ProviderModelCatalog;
@@ -140,9 +142,9 @@ final class ManageAiSettings extends Page
                                     Hidden::make('output_per_mtok'),
                                     Toggle::make('auto')->inline(false),
                                     Toggle::make('enabled')->inline(false),
-                                    Placeholder::make('measured')
-                                        ->hiddenLabel()
-                                        ->content(fn (Get $get): string => $this->capabilitySummary($get('capabilities'), (bool) $get('enabled'))),
+                                    Icon::make(fn (Get $get): Heroicon => $this->capabilityBadge($get)['icon'])
+                                        ->color(fn (Get $get): string => $this->capabilityBadge($get)['color'])
+                                        ->tooltip(fn (Get $get): string => $this->capabilityBadge($get)['tooltip']),
                                 ])
                                 // How a model is presented and priced is set once and then
                                 // rarely touched, while the rest of the row is what an
@@ -448,18 +450,55 @@ final class ManageAiSettings extends Page
     }
 
     /**
-     * `on save` is a promise only an enabled row keeps: verified() skips disabled
-     * entries, so a retired row would sit there claiming a probe that never runs.
+     * The Verified column: an icon an operator can scan a whole catalog down, and a
+     * tooltip carrying the detail the column has no room for. Filament renders that
+     * tooltip as the icon's visually-hidden text too, so the meaning is not
+     * hover-only.
+     *
+     * Four states, because they are four different claims: this install watched the
+     * provider accept a real request, the row only declares what it inherited from
+     * the config seed, the provider will not serve tools so ModelRegistry hides the
+     * row from every picker, or nothing has been measured yet. That last one is a
+     * promise only an enabled row keeps, since verified() skips disabled entries.
+     *
+     * @return array{icon: Heroicon, color: string, tooltip: string}
      */
-    private function capabilitySummary(mixed $capabilities, bool $enabled): string
+    private function capabilityBadge(Get $get): array
     {
+        $capabilities = $get('capabilities');
+
         if (! is_array($capabilities) || $capabilities === []) {
-            return $enabled ? 'on save' : 'not probed';
+            return (bool) $get('enabled')
+                ? ['icon' => Heroicon::OutlinedClock, 'color' => 'warning', 'tooltip' => 'Not measured yet. Saving probes this model against its provider.']
+                : ['icon' => Heroicon::OutlinedMinusCircle, 'color' => 'gray', 'tooltip' => 'Disabled, so it is never probed and never served.'];
         }
 
-        $tools = ($capabilities['supports_tools'] ?? false) === true ? 'tools' : 'no tools';
+        $guard = is_string($capabilities['write_guard'] ?? null) ? $capabilities['write_guard'] : 'prompt';
 
-        return $tools.' · '.($capabilities['write_guard'] ?? 'prompt');
+        if (($capabilities['supports_tools'] ?? false) !== true) {
+            return ['icon' => Heroicon::OutlinedExclamationTriangle, 'color' => 'danger', 'tooltip' => "No tool calls, so this model is offered to nobody. Write guard: {$guard}."];
+        }
+
+        $measured = $this->verifiedAgo($get('verified_at'));
+
+        if ($measured === null) {
+            return ['icon' => Heroicon::OutlinedCheckCircle, 'color' => 'gray', 'tooltip' => "Declares tool calls and the {$guard} write guard, but no probe has run on this install."];
+        }
+
+        return ['icon' => Heroicon::OutlinedCheckBadge, 'color' => 'success', 'tooltip' => "The provider accepted a real request {$measured}. Tool calls, {$guard} write guard."];
+    }
+
+    /**
+     * A stored timestamp is written by verified(), but the settings row is editable
+     * outside the panel, and an unparseable one must not take the page down.
+     */
+    private function verifiedAgo(mixed $verifiedAt): ?string
+    {
+        if (! is_string($verifiedAt) || $verifiedAt === '') {
+            return null;
+        }
+
+        return rescue(fn (): string => Date::parse($verifiedAt)->diffForHumans(), null, report: false);
     }
 
     /**

--- a/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
+++ b/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
@@ -1,0 +1,549 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Pages\Settings;
+
+use App\Enums\Plan;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Repeater\TableColumn;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Form;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\Width;
+use Illuminate\Support\Facades\Artisan;
+use Relaticle\Chat\Services\ModelProbe;
+use Relaticle\Chat\Services\ProviderModelCatalog;
+use Relaticle\Chat\Settings\ChatSettings;
+use UnitEnum;
+
+/**
+ * The model catalog, editable without a deploy.
+ *
+ * A vendor retiring a model or shipping a new one is not a code change, but it
+ * used to need one. The safety this buys back is ModelProbe: nothing can be saved
+ * until the provider has accepted a real request built the way a real turn builds
+ * it. That gate is the whole point of the page — see RELATICLE-CRM-6D, where a
+ * request the app happily built was rejected by the provider on every single turn.
+ *
+ * @property-read Schema $form
+ */
+final class ManageAiSettings extends Page
+{
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-cpu-chip';
+
+    protected static string|UnitEnum|null $navigationGroup = 'AI';
+
+    protected static ?string $navigationLabel = 'Model Catalog';
+
+    protected static ?string $title = 'AI Model Catalog';
+
+    protected static ?int $navigationSort = 10;
+
+    protected static ?string $slug = 'ai-models';
+
+    protected string $view = 'system-admin::filament.pages.manage-ai-settings';
+
+    /** @var array<string, mixed>|null */
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $settings = resolve(ChatSettings::class);
+
+        $this->form->fill([
+            'models' => $settings->models,
+            'anthropic_effort' => $settings->anthropic_effort,
+        ]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Form::make([
+                    Section::make('Models')
+                        ->description('What the model picker offers. Drag to set the Auto order. Capabilities are measured by a real request to the provider, never typed.')
+                        ->schema([
+                            Repeater::make('models')
+                                ->hiddenLabel()
+                                ->reorderableWithDragAndDrop()
+                                // A table, not stacked cards: the catalog is read as a
+                                // comparison (which provider serves it, which one Auto
+                                // reaches first, which ones are on) and rows make that
+                                // legible in a way one card per model does not.
+                                ->table([
+                                    TableColumn::make('Key')->markAsRequired(),
+                                    TableColumn::make('Provider')->markAsRequired(),
+                                    TableColumn::make('Model')->markAsRequired(),
+                                    TableColumn::make('Auto'),
+                                    TableColumn::make('On'),
+                                    TableColumn::make('Verified'),
+                                ])
+                                ->schema([
+                                    TextInput::make('key')
+                                        ->required()
+                                        ->distinct(),
+                                    Select::make('provider')
+                                        ->options(fn (Get $get): array => $this->providerOptions($get('provider')))
+                                        ->required()
+                                        ->live(),
+                                    // Suggests from the provider's live list, but keeps whatever is
+                                    // already stored: a Select that dropped the current value would
+                                    // invalidate every entry the moment a provider is unreachable
+                                    // or its key is absent on this install.
+                                    Select::make('model')
+                                        ->options(fn (Get $get): array => $this->modelOptions($get('provider'), $get('model')))
+                                        ->searchable()
+                                        ->required()
+                                        // Required fields have nothing to clear, and the clear
+                                        // button overflows the column into Auto.
+                                        ->selectablePlaceholder(false)
+                                        ->live()
+                                        ->afterStateUpdated(function (Set $set, Get $get, mixed $state): void {
+                                            if (is_string($state) && $state !== '' && blank($get('label'))) {
+                                                $set('label', $state);
+                                            }
+                                        })
+                                        ->helperText(fn (Get $get): ?string => $this->unlistedNote($get('provider'), $get('model')))
+                                        // An inline style, not a Tailwind class: this file is
+                                        // outside the sysadmin theme's JIT scan paths, so a
+                                        // utility class here compiles to nothing. Without a floor
+                                        // the table wraps model ids onto three lines.
+                                        ->extraAttributes(['style' => 'min-width: 11rem']),
+                                    // Hidden, not absent: a table repeater renders Hidden
+                                    // components without giving them a column, and a field
+                                    // missing from the schema is dropped from getState() —
+                                    // so leaving these out would silently discard every
+                                    // label, plan and price on the next save.
+                                    Hidden::make('label'),
+                                    // A row whose modal was never opened must not hand an
+                                    // expensive model to every free workspace.
+                                    Hidden::make('min_plan')->default(Plan::Pro->value),
+                                    // Without a default a row saved before its modal was
+                                    // opened charges nothing: `(float) null` is 0.0.
+                                    Hidden::make('credit_multiplier')->default(1.0),
+                                    Hidden::make('input_per_mtok'),
+                                    Hidden::make('output_per_mtok'),
+                                    Toggle::make('auto')->inline(false),
+                                    Toggle::make('enabled')->inline(false),
+                                    Placeholder::make('measured')
+                                        ->hiddenLabel()
+                                        ->content(fn (Get $get): string => $this->capabilitySummary($get('capabilities'))),
+                                ])
+                                // How a model is presented and priced is set once and then
+                                // rarely touched, while the rest of the row is what an
+                                // operator scans. It lives behind a gear so the table stays
+                                // readable.
+                                ->extraItemActions([
+                                    Action::make('configure')
+                                        ->icon('heroicon-o-cog-6-tooth')
+                                        ->color('gray')
+                                        ->modalHeading('Model configuration')
+                                        ->modalDescription('How this model is named in the picker, who may reach it, and what a turn on it costs.')
+                                        ->modalWidth(Width::Medium)
+                                        ->schema([
+                                            TextInput::make('label')
+                                                ->label('Label')
+                                                ->required()
+                                                ->helperText('The name users see in the model picker.'),
+                                            Select::make('min_plan')
+                                                ->label('Minimum plan')
+                                                ->options(Plan::class)
+                                                ->required()
+                                                ->selectablePlaceholder(false),
+                                            TextInput::make('credit_multiplier')
+                                                ->label('Credit multiplier')
+                                                ->numeric()
+                                                ->required()
+                                                ->minValue(0)
+                                                ->helperText('Charged to the workspace per turn, before tool-call bonuses.'),
+                                            TextInput::make('input_per_mtok')
+                                                ->label('Input $ / Mtok')
+                                                ->numeric()
+                                                ->minValue(0)
+                                                ->helperText('Vendor list price. Feeds the sysadmin spend widget only.'),
+                                            TextInput::make('output_per_mtok')
+                                                ->label('Output $ / Mtok')
+                                                ->numeric()
+                                                ->minValue(0),
+                                        ])
+                                        ->fillForm(fn (array $arguments, Repeater $component): array => collect($component->getItemState($arguments['item']))
+                                            ->only(['label', 'min_plan', 'credit_multiplier', 'input_per_mtok', 'output_per_mtok'])
+                                            ->all())
+                                        ->action(function (array $arguments, array $data, Repeater $component): void {
+                                            $state = $component->getState();
+                                            $state[$arguments['item']] = [...$state[$arguments['item']], ...$data];
+
+                                            $component->state($state);
+                                        }),
+                                ])
+                                ->addActionLabel('Add a model'),
+                        ]),
+                    Section::make('Tuning')
+                        ->description('Anthropic removed temperature and top_p on Opus 4.7 and every model since, so effort is the only quality-versus-cost dial those models expose.')
+                        ->schema([
+                            Select::make('anthropic_effort')
+                                ->label('Anthropic reasoning effort')
+                                ->options([
+                                    'low' => 'Low',
+                                    'medium' => 'Medium',
+                                    'high' => 'High (provider default)',
+                                    'xhigh' => 'Extra high',
+                                    'max' => 'Max',
+                                ])
+                                ->required(),
+                        ]),
+                ])
+                    ->livewireSubmitHandler('save')
+                    ->footer([
+                        Actions::make([
+                            Action::make('save')->label('Verify and save')->submit('save')->keyBindings(['mod+s']),
+                        ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    /**
+     * @return array<Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('refreshModelLists')
+                ->label('Refresh model lists')
+                ->icon('heroicon-o-arrow-path')
+                ->color('gray')
+                ->action(function (): void {
+                    $catalog = resolve(ProviderModelCatalog::class);
+
+                    foreach (array_keys($this->providerOptions()) as $provider) {
+                        $catalog->forget($provider);
+                    }
+
+                    Notification::make()->title('Model lists refreshed')->success()->send();
+                }),
+        ];
+    }
+
+    /**
+     * Every cloud model in the submitted catalog has to be accepted by its own
+     * provider before any of it is written. A pass is cached by ModelProbe, so an
+     * unchanged row costs nothing and only a genuinely new pairing spends a call.
+     */
+    public function save(): void
+    {
+        /** @var array<string, mixed> $data */
+        $data = $this->form->getState();
+
+        /** @var list<array<string, mixed>> $submitted */
+        $submitted = $data['models'] ?? [];
+
+        [$models, $failure] = $this->verified($this->normalizeModels($submitted));
+
+        if ($failure !== null) {
+            Notification::make()
+                ->title('The provider rejected this model')
+                ->body($failure)
+                ->danger()
+                ->persistent()
+                ->send();
+
+            return;
+        }
+
+        $settings = resolve(ChatSettings::class);
+        $before = $settings->toConfig();
+        $settings->models = $models;
+        $settings->anthropic_effort = (string) ($data['anthropic_effort'] ?? 'high');
+        $settings->save();
+
+        config($settings->toConfig());
+
+        $this->recordActivity($before, $settings);
+
+        // Chat runs entirely in queued jobs, and a worker holds the config it
+        // booted with. Without this the save looks applied in the panel and
+        // changes nothing about what users actually get until the next deploy.
+        Artisan::call('queue:restart');
+
+        Notification::make()
+            ->title('Saved')
+            ->body('Workers are restarting; the next chat turn uses the new catalog.')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Who changed which model dial, and to what.
+     *
+     * This is the one control in the panel that changes what every workspace's
+     * assistant does, and it takes effect on the next turn rather than at the next
+     * deploy, so git history will not answer "what changed at 09:00 on Tuesday".
+     * Only the keys that actually moved are recorded; a save that touched nothing
+     * writes nothing.
+     *
+     * @param  array<string, mixed>  $before
+     */
+    private function recordActivity(array $before, ChatSettings $settings): void
+    {
+        $after = $settings->toConfig();
+
+        // Numbers are compared as floats because a whole float survives the settings
+        // row's JSON round trip as an int: `1.0` going out and `1` coming back describe
+        // the same catalog. Without this every no-op save logs a change, and the audit
+        // trail is noise exactly when someone needs to read it.
+        $changed = collect($after)
+            ->reject(fn (mixed $value, string $key): bool => self::comparable($value) === self::comparable($before[$key] ?? null))
+            ->keys()
+            ->all();
+
+        if ($changed === []) {
+            return;
+        }
+
+        activity((string) config('activitylog.default_log_name'))
+            ->causedBy(auth('sysadmin')->user())
+            ->withProperties([
+                'changed' => $changed,
+                'old' => collect($before)->only($changed)->all(),
+                'attributes' => collect($after)->only($changed)->all(),
+            ])
+            ->event('chat_settings_updated')
+            ->log('chat_settings_updated');
+    }
+
+    private static function comparable(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_map(self::comparable(...), $value);
+        }
+
+        return is_int($value) || is_float($value) ? (float) $value : $value;
+    }
+
+    /**
+     * Probes every newly introduced (provider, model) pairing and writes back what
+     * the provider reported.
+     *
+     * Capabilities are never taken from the form. A model the provider will not
+     * serve must not be storable as enabled and tool-capable, which is exactly how
+     * Opus 4.7 went down in production (Sentry RELATICLE-CRM-6D).
+     *
+     * Only NEW pairings are probed. Verifying the whole catalog on every save would
+     * mean one provider with a stale key blocks edits to unrelated entries,
+     * including the effort dial. What is already stored is the status quo whether
+     * or not it still works; this gate stops a bad pairing being introduced, it is
+     * not a continuous audit.
+     *
+     * @param  list<array<string, mixed>>  $models
+     * @return array{0: list<array<string, mixed>>, 1: string|null}
+     */
+    private function verified(array $models): array
+    {
+        $probe = resolve(ModelProbe::class);
+        $known = $this->pairings(resolve(ChatSettings::class)->models);
+        $verified = [];
+
+        foreach ($models as $entry) {
+            $provider = $entry['provider'] ?? null;
+            $name = $entry['model'] ?? null;
+
+            // A disabled entry is not served to anyone, so it does not earn an API
+            // call. Retired models kept only for pricing history land here.
+            if (($entry['enabled'] ?? true) !== true) {
+                $verified[] = $entry;
+
+                continue;
+            }
+
+            if (! is_string($provider) || ! is_string($name) || $name === '') {
+                $verified[] = $entry;
+
+                continue;
+            }
+
+            if (in_array("{$provider}|{$name}", $known, true)) {
+                $verified[] = $entry;
+
+                continue;
+            }
+
+            if (blank(config("ai.providers.{$provider}.key"))) {
+                return [[], "{$name}: no API key is configured for {$provider}."];
+            }
+
+            $report = $probe($provider, $name);
+
+            if ($report['ok'] === false) {
+                return [[], "{$name}: ".($report['error'] ?? 'unknown error')];
+            }
+
+            $entry['capabilities'] = [
+                'supports_tools' => $report['supports_tools'],
+                'write_guard' => $report['write_guard'],
+            ];
+            $entry['verified_at'] = now()->toIso8601String();
+
+            $verified[] = $entry;
+        }
+
+        return [$verified, null];
+    }
+
+    /**
+     * Form state is not config-shaped. A Select bound to an enum hands back a Plan
+     * instance, a numeric TextInput hands back a string, and a toggle can hand back
+     * "1" — all of which get JSON-encoded into the settings row as-is and then blow
+     * up in ModelDescriptor::fromEntry(), which type-hints the primitives a PHP
+     * config file used to supply. Coerce here, at the one boundary where the panel
+     * writes the catalog.
+     *
+     * @param  list<array<string, mixed>>  $models
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeModels(array $models): array
+    {
+        return collect($models)
+            ->map(fn (array $model): array => [
+                ...$model,
+                'min_plan' => $this->plan($model['min_plan'] ?? null)->value,
+                'credit_multiplier' => is_numeric($model['credit_multiplier'] ?? null) ? (float) $model['credit_multiplier'] : 1.0,
+                'input_per_mtok' => is_numeric($model['input_per_mtok'] ?? null) ? (float) $model['input_per_mtok'] : null,
+                'output_per_mtok' => is_numeric($model['output_per_mtok'] ?? null) ? (float) $model['output_per_mtok'] : null,
+                // Cast rather than compare: a Filament toggle can hand back "1", and
+                // pint's strict_comparison fixer rewrites any `==` put here.
+                'auto' => (bool) ($model['auto'] ?? false),
+                'enabled' => (bool) ($model['enabled'] ?? true),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Fails closed: an entry with no readable plan is stored as the most
+     * restrictive one rather than becoming free for every workspace.
+     */
+    private function plan(mixed $plan): Plan
+    {
+        if ($plan instanceof Plan) {
+            return $plan;
+        }
+
+        return Plan::tryFrom(is_string($plan) ? $plan : '') ?? Plan::Pro;
+    }
+
+    private function capabilitySummary(mixed $capabilities): string
+    {
+        if (! is_array($capabilities) || $capabilities === []) {
+            return 'on save';
+        }
+
+        $tools = ($capabilities['supports_tools'] ?? false) === true ? 'tools' : 'no tools';
+
+        return $tools.' · '.($capabilities['write_guard'] ?? 'prompt');
+    }
+
+    /**
+     * Flags a stored model the provider is not currently listing, which is normal
+     * for an install without that provider's key and suspicious otherwise.
+     */
+    private function unlistedNote(mixed $provider, mixed $model): ?string
+    {
+        if (! is_string($provider) || ! is_string($model) || $model === '') {
+            return null;
+        }
+
+        $catalog = resolve(ProviderModelCatalog::class)($provider);
+
+        // Say nothing when the provider gave us no list at all: that means this
+        // install has no key for it, not that the model is wrong.
+        if ($catalog === [] || array_key_exists($model, $catalog)) {
+            return null;
+        }
+
+        return 'not listed by the provider';
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $models
+     * @return list<string>
+     */
+    private function pairings(array $models): array
+    {
+        return collect($models)
+            ->filter(fn (mixed $model): bool => is_array($model) && is_string($model['provider'] ?? null) && is_string($model['model'] ?? null))
+            ->map(fn (array $model): string => "{$model['provider']}|{$model['model']}")
+            ->values()
+            ->all();
+    }
+
+    /**
+     * The providers this install can actually reach, plus whatever a stored row
+     * already names.
+     *
+     * A provider with no API key can serve nothing — save() rejects every model
+     * under one — so offering it is offering a dead end. The merge of the current
+     * value is load-bearing for the same reason as in modelOptions(): a Select
+     * silently drops a value missing from its options, so a row naming a provider
+     * that is keyed in production but not here would blank itself on render.
+     *
+     * @return array<string, string>
+     */
+    private function providerOptions(mixed $current = null): array
+    {
+        /** @var array<string, array<string, mixed>> $providers */
+        $providers = config('ai.providers', []);
+
+        $options = collect($providers)
+            ->filter(fn (array $connection): bool => filled($connection['key'] ?? null))
+            ->keys()
+            ->mapWithKeys(fn (string $provider): array => [$provider => str($provider)->headline()->toString()])
+            ->all();
+
+        if (is_string($current) && $current !== '' && ! array_key_exists($current, $options)) {
+            $options[$current] = str($current)->headline()->toString().' (no API key)';
+        }
+
+        return $options;
+    }
+
+    /**
+     * The provider's live list, with whatever is already stored merged in.
+     *
+     * The merge is load-bearing: a Select silently drops a value that is not among
+     * its options, so without it every entry goes invalid the moment a provider is
+     * unreachable or its key is absent on this install.
+     *
+     * @return array<string, string>
+     */
+    private function modelOptions(mixed $provider, mixed $current = null): array
+    {
+        $options = [];
+
+        if (is_string($provider) && $provider !== '') {
+            foreach (array_keys(resolve(ProviderModelCatalog::class)($provider)) as $id) {
+                $options[$id] = $id;
+            }
+        }
+
+        if (is_string($current) && $current !== '' && ! array_key_exists($current, $options)) {
+            $options[$current] = $current;
+        }
+
+        return $options;
+    }
+}

--- a/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
+++ b/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
@@ -344,18 +344,21 @@ final class ManageAiSettings extends Page
     }
 
     /**
-     * Probes every newly introduced (provider, model) pairing and writes back what
-     * the provider reported.
+     * Probes every (provider, model) pairing nothing has measured yet and writes
+     * back what the provider reported.
      *
-     * Capabilities are never taken from the form. A model the provider will not
-     * serve must not be storable as enabled and tool-capable, which is exactly how
-     * Opus 4.7 went down in production (Sentry RELATICLE-CRM-6D).
+     * Capabilities are never taken from the form, they are taken from the stored
+     * catalog or from a probe. The form is redrawn from whatever the operator last
+     * saw and a re-added row carries none at all, so trusting it would store an
+     * enabled model as tool-incapable and drop it out of every picker — the silent
+     * failure this gate exists to stop (Sentry RELATICLE-CRM-6D).
      *
-     * Only NEW pairings are probed. Verifying the whole catalog on every save would
-     * mean one provider with a stale key blocks edits to unrelated entries,
-     * including the effort dial. What is already stored is the status quo whether
-     * or not it still works; this gate stops a bad pairing being introduced, it is
-     * not a continuous audit.
+     * A pairing already carrying a measurement is skipped. Re-verifying the whole
+     * catalog on every save would mean one provider with a stale key blocks edits to
+     * unrelated entries, including the effort dial. What is already measured is the
+     * status quo whether or not it still works; this gate stops an UNMEASURED model
+     * being served, it is not a continuous audit. Switching a retired row back on is
+     * therefore a probe, because nothing ever measured it.
      *
      * @param  list<array<string, mixed>>  $models
      * @return array{0: list<array<string, mixed>>, 1: string|null}
@@ -363,12 +366,24 @@ final class ManageAiSettings extends Page
     private function verified(array $models): array
     {
         $probe = resolve(ModelProbe::class);
-        $known = $this->pairings(resolve(ChatSettings::class)->models);
+        $stored = $this->storedByPairing(resolve(ChatSettings::class)->models);
         $verified = [];
 
         foreach ($models as $entry) {
             $provider = $entry['provider'] ?? null;
             $name = $entry['model'] ?? null;
+
+            if (! is_string($provider) || ! is_string($name) || $name === '') {
+                $verified[] = $entry;
+
+                continue;
+            }
+
+            $measured = $stored["{$provider}|{$name}"] ?? [];
+            $capabilities = $measured['capabilities'] ?? null;
+
+            $entry['capabilities'] = is_array($capabilities) && $capabilities !== [] ? $capabilities : null;
+            $entry['verified_at'] = $entry['capabilities'] === null ? null : ($measured['verified_at'] ?? null);
 
             // A disabled entry is not served to anyone, so it does not earn an API
             // call. Retired models kept only for pricing history land here.
@@ -378,13 +393,7 @@ final class ManageAiSettings extends Page
                 continue;
             }
 
-            if (! is_string($provider) || ! is_string($name) || $name === '') {
-                $verified[] = $entry;
-
-                continue;
-            }
-
-            if (in_array("{$provider}|{$name}", $known, true)) {
+            if ($entry['capabilities'] !== null) {
                 $verified[] = $entry;
 
                 continue;
@@ -546,15 +555,17 @@ final class ManageAiSettings extends Page
     }
 
     /**
+     * The stored catalog keyed by pairing, which is what makes a measurement
+     * survive an operator deleting a row and adding it straight back.
+     *
      * @param  array<int, array<string, mixed>>  $models
-     * @return list<string>
+     * @return array<string, array<string, mixed>>
      */
-    private function pairings(array $models): array
+    private function storedByPairing(array $models): array
     {
         return collect($models)
             ->filter(fn (mixed $model): bool => is_array($model) && is_string($model['provider'] ?? null) && is_string($model['model'] ?? null))
-            ->map(fn (array $model): string => "{$model['provider']}|{$model['model']}")
-            ->values()
+            ->keyBy(fn (array $model): string => "{$model['provider']}|{$model['model']}")
             ->all();
     }
 

--- a/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
+++ b/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
@@ -24,6 +24,7 @@ use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
 use Illuminate\Support\Facades\Artisan;
+use Laravel\Ai\Enums\Lab;
 use Relaticle\Chat\Services\ModelProbe;
 use Relaticle\Chat\Services\ProviderModelCatalog;
 use Relaticle\Chat\Settings\ChatSettings;
@@ -141,7 +142,7 @@ final class ManageAiSettings extends Page
                                     Toggle::make('enabled')->inline(false),
                                     Placeholder::make('measured')
                                         ->hiddenLabel()
-                                        ->content(fn (Get $get): string => $this->capabilitySummary($get('capabilities'))),
+                                        ->content(fn (Get $get): string => $this->capabilitySummary($get('capabilities'), (bool) $get('enabled'))),
                                 ])
                                 // How a model is presented and priced is set once and then
                                 // rarely touched, while the rest of the row is what an
@@ -446,10 +447,14 @@ final class ManageAiSettings extends Page
         return Plan::tryFrom(is_string($plan) ? $plan : '') ?? Plan::Pro;
     }
 
-    private function capabilitySummary(mixed $capabilities): string
+    /**
+     * `on save` is a promise only an enabled row keeps: verified() skips disabled
+     * entries, so a retired row would sit there claiming a probe that never runs.
+     */
+    private function capabilitySummary(mixed $capabilities, bool $enabled): string
     {
         if (! is_array($capabilities) || $capabilities === []) {
-            return 'on save';
+            return $enabled ? 'on save' : 'not probed';
         }
 
         $tools = ($capabilities['supports_tools'] ?? false) === true ? 'tools' : 'no tools';
@@ -492,6 +497,16 @@ final class ManageAiSettings extends Page
     }
 
     /**
+     * laravel/ai already spells every provider it supports, on the enum case name:
+     * `OpenAI`, `DeepSeek`, `xAI`. `headline()` renders those as `Openai`, `Deepseek`,
+     * `Xai`, so ask the enum first and fall back for a provider it does not know.
+     */
+    private function providerLabel(string $provider): string
+    {
+        return Lab::tryFrom($provider)?->name ?? str($provider)->headline()->toString();
+    }
+
+    /**
      * The providers this install can actually reach, plus whatever a stored row
      * already names.
      *
@@ -511,11 +526,11 @@ final class ManageAiSettings extends Page
         $options = collect($providers)
             ->filter(fn (array $connection): bool => filled($connection['key'] ?? null))
             ->keys()
-            ->mapWithKeys(fn (string $provider): array => [$provider => str($provider)->headline()->toString()])
+            ->mapWithKeys(fn (string $provider): array => [$provider => $this->providerLabel($provider)])
             ->all();
 
         if (is_string($current) && $current !== '' && ! array_key_exists($current, $options)) {
-            $options[$current] = str($current)->headline()->toString().' (no API key)';
+            $options[$current] = $this->providerLabel($current).' (no API key)';
         }
 
         return $options;

--- a/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
+++ b/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
@@ -88,7 +88,7 @@ final class ManageAiSettings extends Page
                                 // reaches first, which ones are on) and rows make that
                                 // legible in a way one card per model does not.
                                 ->table([
-                                    TableColumn::make('Key')->markAsRequired(),
+                                    TableColumn::make('Label')->markAsRequired(),
                                     TableColumn::make('Provider')->markAsRequired(),
                                     TableColumn::make('Model')->markAsRequired(),
                                     TableColumn::make('Auto'),
@@ -96,9 +96,12 @@ final class ManageAiSettings extends Page
                                     TableColumn::make('Verified'),
                                 ])
                                 ->schema([
-                                    TextInput::make('key')
+                                    // The one string a user ever reads. It is filled from the
+                                    // provider's own listing when the model is chosen, so this
+                                    // is an override rather than a thing to invent.
+                                    TextInput::make('label')
                                         ->required()
-                                        ->distinct(),
+                                        ->extraAttributes(['style' => 'min-width: 9rem']),
                                     Select::make('provider')
                                         ->options(fn (Get $get): array => $this->providerOptions($get('provider')))
                                         ->required()
@@ -111,13 +114,19 @@ final class ManageAiSettings extends Page
                                         ->options(fn (Get $get): array => $this->modelOptions($get('provider'), $get('model')))
                                         ->searchable()
                                         ->required()
+                                        // The tag is the entry's identity, and prices and
+                                        // multipliers are keyed by it across the whole
+                                        // catalog, disabled rows included. Two rows naming
+                                        // one tag would silently let the later row price
+                                        // the earlier one's transactions.
+                                        ->distinct()
                                         // Required fields have nothing to clear, and the clear
                                         // button overflows the column into Auto.
                                         ->selectablePlaceholder(false)
                                         ->live()
                                         ->afterStateUpdated(function (Set $set, Get $get, mixed $state): void {
                                             if (is_string($state) && $state !== '' && blank($get('label'))) {
-                                                $set('label', $state);
+                                                $set('label', $this->listedLabel($get('provider'), $state));
                                             }
                                         })
                                         ->helperText(fn (Get $get): ?string => $this->unlistedNote($get('provider'), $get('model')))
@@ -130,8 +139,8 @@ final class ManageAiSettings extends Page
                                     // components without giving them a column, and a field
                                     // missing from the schema is dropped from getState() —
                                     // so leaving these out would silently discard every
-                                    // label, plan and price on the next save.
-                                    Hidden::make('label'),
+                                    // plan and price on the next save.
+                                    //
                                     // A row whose modal was never opened must not hand an
                                     // expensive model to every free workspace.
                                     Hidden::make('min_plan')->default(Plan::Pro->value),
@@ -155,13 +164,9 @@ final class ManageAiSettings extends Page
                                         ->icon('heroicon-o-cog-6-tooth')
                                         ->color('gray')
                                         ->modalHeading('Model configuration')
-                                        ->modalDescription('How this model is named in the picker, who may reach it, and what a turn on it costs.')
+                                        ->modalDescription('Who may reach this model and what a turn on it costs.')
                                         ->modalWidth(Width::Medium)
                                         ->schema([
-                                            TextInput::make('label')
-                                                ->label('Label')
-                                                ->required()
-                                                ->helperText('The name users see in the model picker.'),
                                             Select::make('min_plan')
                                                 ->label('Minimum plan')
                                                 ->options(Plan::class)
@@ -184,7 +189,7 @@ final class ManageAiSettings extends Page
                                                 ->minValue(0),
                                         ])
                                         ->fillForm(fn (array $arguments, Repeater $component): array => collect($component->getItemState($arguments['item']))
-                                            ->only(['label', 'min_plan', 'credit_multiplier', 'input_per_mtok', 'output_per_mtok'])
+                                            ->only(['min_plan', 'credit_multiplier', 'input_per_mtok', 'output_per_mtok'])
                                             ->all())
                                         ->action(function (array $arguments, array $data, Repeater $component): void {
                                             $state = $component->getState();
@@ -499,6 +504,24 @@ final class ManageAiSettings extends Page
         }
 
         return rescue(fn (): string => Date::parse($verifiedAt)->diffForHumans(), null, report: false);
+    }
+
+    /**
+     * The vendor's own name for a model it lists, or the tag when it publishes none
+     * (OpenAI) or cannot be reached. Never blank: `label` is required, and a blank
+     * one would fail validation on a row the operator never typed into.
+     */
+    private function listedLabel(mixed $provider, string $model): string
+    {
+        if (! is_string($provider) || $provider === '') {
+            return $model;
+        }
+
+        $listed = resolve(ProviderModelCatalog::class)($provider)[$model] ?? null;
+
+        return is_array($listed) && is_string($listed['label'] ?? null) && $listed['label'] !== ''
+            ? $listed['label']
+            : $model;
     }
 
     /**

--- a/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
+++ b/packages/SystemAdmin/src/Filament/Pages/Settings/ManageAiSettings.php
@@ -27,9 +27,12 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Date;
 use Laravel\Ai\Enums\Lab;
+use Relaticle\Chat\Enums\WriteGuard;
 use Relaticle\Chat\Services\ModelProbe;
 use Relaticle\Chat\Services\ProviderModelCatalog;
 use Relaticle\Chat\Settings\ChatSettings;
+use Relaticle\Chat\Support\CatalogEntry;
+use Relaticle\Chat\Support\Measurement;
 use UnitEnum;
 
 /**
@@ -260,7 +263,7 @@ final class ManageAiSettings extends Page
         /** @var list<array<string, mixed>> $submitted */
         $submitted = $data['models'] ?? [];
 
-        [$models, $failure] = $this->verified($this->normalizeModels($submitted));
+        [$models, $failure] = $this->verified($this->parseModels($submitted));
 
         if ($failure !== null) {
             Notification::make()
@@ -360,107 +363,59 @@ final class ManageAiSettings extends Page
      * being served, it is not a continuous audit. Switching a retired row back on is
      * therefore a probe, because nothing ever measured it.
      *
-     * @param  list<array<string, mixed>>  $models
+     * @param  list<CatalogEntry>  $entries
      * @return array{0: list<array<string, mixed>>, 1: string|null}
      */
-    private function verified(array $models): array
+    private function verified(array $entries): array
     {
         $probe = resolve(ModelProbe::class);
         $stored = $this->storedByPairing(resolve(ChatSettings::class)->models);
         $verified = [];
 
-        foreach ($models as $entry) {
-            $provider = $entry['provider'] ?? null;
-            $name = $entry['model'] ?? null;
+        foreach ($entries as $entry) {
+            $pairing = $entry->pairing();
 
-            if (! is_string($provider) || ! is_string($name) || $name === '') {
-                $verified[] = $entry;
+            $entry = $entry->withMeasurement($pairing === null ? null : ($stored[$pairing] ?? null));
 
-                continue;
-            }
-
-            $measured = $stored["{$provider}|{$name}"] ?? [];
-            $capabilities = $measured['capabilities'] ?? null;
-
-            $entry['capabilities'] = is_array($capabilities) && $capabilities !== [] ? $capabilities : null;
-            $entry['verified_at'] = $entry['capabilities'] === null ? null : ($measured['verified_at'] ?? null);
-
-            // A disabled entry is not served to anyone, so it does not earn an API
-            // call. Retired models kept only for pricing history land here.
-            if (($entry['enabled'] ?? true) !== true) {
-                $verified[] = $entry;
+            if (! $entry->needsProbe() || $pairing === null) {
+                $verified[] = $entry->toArray();
 
                 continue;
             }
 
-            if ($entry['capabilities'] !== null) {
-                $verified[] = $entry;
-
-                continue;
+            if (blank(config("ai.providers.{$entry->provider}.key"))) {
+                return [[], "{$entry->model}: no API key is configured for {$entry->provider}."];
             }
 
-            if (blank(config("ai.providers.{$provider}.key"))) {
-                return [[], "{$name}: no API key is configured for {$provider}."];
-            }
-
-            $report = $probe($provider, $name);
+            $report = $probe((string) $entry->provider, $entry->model);
 
             if ($report['ok'] === false) {
-                return [[], "{$name}: ".($report['error'] ?? 'unknown error')];
+                return [[], "{$entry->model}: ".($report['error'] ?? 'unknown error')];
             }
 
-            $entry['capabilities'] = [
-                'supports_tools' => $report['supports_tools'],
-                'write_guard' => $report['write_guard'],
-            ];
-            $entry['verified_at'] = now()->toIso8601String();
-
-            $verified[] = $entry;
+            $verified[] = $entry->withMeasurement(new Measurement(
+                supportsTools: $report['supports_tools'],
+                writeGuard: WriteGuard::from($report['write_guard']),
+                verifiedAt: now()->toIso8601String(),
+            ))->toArray();
         }
 
         return [$verified, null];
     }
 
     /**
-     * Form state is not config-shaped. A Select bound to an enum hands back a Plan
+     * Form state is not catalog-shaped. A Select bound to an enum hands back a Plan
      * instance, a numeric TextInput hands back a string, and a toggle can hand back
-     * "1" — all of which get JSON-encoded into the settings row as-is and then blow
-     * up in ModelDescriptor::fromEntry(), which type-hints the primitives a PHP
-     * config file used to supply. Coerce here, at the one boundary where the panel
-     * writes the catalog.
+     * "1". CatalogEntry is where that becomes a catalog row, with every scalar
+     * failing closed, so the panel no longer keeps its own coercion rules beside
+     * the ones every reader already applies.
      *
      * @param  list<array<string, mixed>>  $models
-     * @return list<array<string, mixed>>
+     * @return list<CatalogEntry>
      */
-    private function normalizeModels(array $models): array
+    private function parseModels(array $models): array
     {
-        return collect($models)
-            ->map(fn (array $model): array => [
-                ...$model,
-                'min_plan' => $this->plan($model['min_plan'] ?? null)->value,
-                'credit_multiplier' => is_numeric($model['credit_multiplier'] ?? null) ? (float) $model['credit_multiplier'] : 1.0,
-                'input_per_mtok' => is_numeric($model['input_per_mtok'] ?? null) ? (float) $model['input_per_mtok'] : null,
-                'output_per_mtok' => is_numeric($model['output_per_mtok'] ?? null) ? (float) $model['output_per_mtok'] : null,
-                // Cast rather than compare: a Filament toggle can hand back "1", and
-                // pint's strict_comparison fixer rewrites any `==` put here.
-                'auto' => (bool) ($model['auto'] ?? false),
-                'enabled' => (bool) ($model['enabled'] ?? true),
-            ])
-            ->values()
-            ->all();
-    }
-
-    /**
-     * Fails closed: an entry with no readable plan is stored as the most
-     * restrictive one rather than becoming free for every workspace.
-     */
-    private function plan(mixed $plan): Plan
-    {
-        if ($plan instanceof Plan) {
-            return $plan;
-        }
-
-        return Plan::tryFrom(is_string($plan) ? $plan : '') ?? Plan::Pro;
+        return array_values(array_filter(array_map(CatalogEntry::fromArray(...), $models)));
     }
 
     /**
@@ -479,21 +434,24 @@ final class ManageAiSettings extends Page
      */
     private function capabilityBadge(Get $get): array
     {
-        $capabilities = $get('capabilities');
+        $measurement = Measurement::fromEntry([
+            'capabilities' => $get('capabilities'),
+            'verified_at' => $get('verified_at'),
+        ]);
 
-        if (! is_array($capabilities) || $capabilities === []) {
+        if (! $measurement instanceof Measurement) {
             return (bool) $get('enabled')
                 ? ['icon' => Heroicon::OutlinedClock, 'color' => 'warning', 'tooltip' => 'Not measured yet. Saving probes this model against its provider.']
                 : ['icon' => Heroicon::OutlinedMinusCircle, 'color' => 'gray', 'tooltip' => 'Disabled, so it is never probed and never served.'];
         }
 
-        $guard = is_string($capabilities['write_guard'] ?? null) ? $capabilities['write_guard'] : 'prompt';
+        $guard = $measurement->writeGuard->value;
 
-        if (($capabilities['supports_tools'] ?? false) !== true) {
+        if (! $measurement->supportsTools) {
             return ['icon' => Heroicon::OutlinedExclamationTriangle, 'color' => 'danger', 'tooltip' => "No tool calls, so this model is offered to nobody. Write guard: {$guard}."];
         }
 
-        $measured = $this->verifiedAgo($get('verified_at'));
+        $measured = $this->verifiedAgo($measurement->verifiedAt);
 
         if ($measured === null) {
             return ['icon' => Heroicon::OutlinedCheckCircle, 'color' => 'gray', 'tooltip' => "Declares tool calls and the {$guard} write guard, but no probe has run on this install."];
@@ -555,17 +513,19 @@ final class ManageAiSettings extends Page
     }
 
     /**
-     * The stored catalog keyed by pairing, which is what makes a measurement
-     * survive an operator deleting a row and adding it straight back.
+     * The measurements already on record, keyed by pairing. This is what makes a
+     * measurement survive an operator deleting a row and adding it straight back.
      *
      * @param  array<int, array<string, mixed>>  $models
-     * @return array<string, array<string, mixed>>
+     * @return array<string, Measurement>
      */
     private function storedByPairing(array $models): array
     {
         return collect($models)
-            ->filter(fn (mixed $model): bool => is_array($model) && is_string($model['provider'] ?? null) && is_string($model['model'] ?? null))
-            ->keyBy(fn (array $model): string => "{$model['provider']}|{$model['model']}")
+            ->map(fn (mixed $model): ?CatalogEntry => is_array($model) ? CatalogEntry::fromArray($model) : null)
+            ->filter(fn (?CatalogEntry $entry): bool => $entry?->pairing() !== null && $entry->measurement instanceof Measurement)
+            ->keyBy(fn (CatalogEntry $entry): string => (string) $entry->pairing())
+            ->map(fn (CatalogEntry $entry): Measurement => $entry->measurement)
             ->all();
     }
 

--- a/packages/SystemAdmin/src/Filament/Widgets/AiSpendStatsWidget.php
+++ b/packages/SystemAdmin/src/Filament/Widgets/AiSpendStatsWidget.php
@@ -9,6 +9,7 @@ use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Relaticle\Chat\Enums\AiCreditType;
 use Relaticle\Chat\Models\AiCreditTransaction;
+use Relaticle\Chat\Services\ModelRegistry;
 use Relaticle\SystemAdmin\Filament\Widgets\Concerns\HasPeriodComparison;
 
 final class AiSpendStatsWidget extends StatsOverviewWidget
@@ -68,8 +69,9 @@ final class AiSpendStatsWidget extends StatsOverviewWidget
             ? "{$topModelRow->model} ({$topModelRow->total})"
             : '—';
 
-        /** @var array<string, array{input_per_mtok: float, output_per_mtok: float}> $rates */
-        $rates = config('chat.model_costs', []);
+        // Rates live on the catalog entry now, disabled ones included, so a model
+        // that was retired from the picker still prices its historical rows.
+        $registry = resolve(ModelRegistry::class);
         $totalCost = 0.0;
         $unpriced = [];
 
@@ -84,13 +86,9 @@ final class AiSpendStatsWidget extends StatsOverviewWidget
                 continue;
             }
 
-            $rate = $rates[$row->model] ?? null;
+            $rate = $registry->ratesFor((string) $row->model);
 
-            if (
-                ! is_array($rate)
-                || ! is_numeric($rate['input_per_mtok'] ?? null)
-                || ! is_numeric($rate['output_per_mtok'] ?? null)
-            ) {
+            if ($rate === null) {
                 $unpriced[] = $row->model;
 
                 continue;

--- a/packages/SystemAdmin/src/SystemAdminPanelProvider.php
+++ b/packages/SystemAdmin/src/SystemAdminPanelProvider.php
@@ -66,6 +66,8 @@ final class SystemAdminPanelProvider extends PanelProvider
 
     public function boot(): void
     {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'system-admin');
+
         // Blog MCP requests are not Filament panel requests, so the panel-scoped
         // policy discovery in AppServiceProvider never sees them.
         foreach (self::BLOG_MODEL_POLICIES as $model => $policy) {

--- a/rector.php
+++ b/rector.php
@@ -19,6 +19,7 @@ use RectorLaravel\Rector\Class_\TimeoutPropertyToTimeoutAttributeRector;
 use RectorLaravel\Rector\Class_\TriesPropertyToTriesAttributeRector;
 use RectorLaravel\Rector\Class_\UniqueForPropertyToUniqueForAttributeRector;
 use RectorLaravel\Rector\Class_\UseForwardsCallsTraitRector;
+use RectorLaravel\Rector\Coalesce\ApplyDefaultInsteadOfNullCoalesceRector;
 use RectorLaravel\Rector\Empty_\EmptyToBlankAndFilledFuncRector;
 use RectorLaravel\Rector\MethodCall\EloquentWhereTypeHintClosureParameterRector;
 use RectorLaravel\Set\LaravelSetList;
@@ -71,6 +72,12 @@ return RectorConfig::configure()
         ArrowFunctionDelegatingCallToFirstClassCallableRector::class => [
             // class_exists has optional bool param that conflicts with Collection::first signature
             __DIR__.'/app/Providers/AppServiceProvider.php',
+        ],
+        // spatie/laravel-settings ships `repositories.database.table` as null, so the
+        // key EXISTS and config()'s default argument is never reached. Rewriting the
+        // `??` to that default hands the migration null and it runs `create table ""`.
+        ApplyDefaultInsteadOfNullCoalesceRector::class => [
+            __DIR__.'/database/migrations/2026_08_27_120000_create_settings_table.php',
         ],
         AddHasFactoryToModelsRector::class => [
             __DIR__.'/app/Models/PersonalAccessToken.php',

--- a/resources/views/ai.blade.php
+++ b/resources/views/ai.blade.php
@@ -12,6 +12,29 @@
     $freeCloudModels = $toolCapableCloudModels->where('min_plan', 'free')->pluck('label')->join(', ', ' and ');
     $paidCloudModels = $toolCapableCloudModels->where('min_plan', 'pro')->pluck('label')->join(', ', ' and ');
 
+    // Independent sentences rather than one with two holes in it: the catalog is editable at
+    // runtime, and a tier with no model rendered " is free on every plan".
+    $selfHostedNote = __('A self-hosted install supplies its own provider key, so you choose the model and pay the provider directly, or run a local one.');
+
+    $whichModelsAnswer = trim(implode(' ', array_filter([
+        $freeCloudModels === ''
+            ? __('Every plan can use any self-hosted model you connect yourself.')
+            : __(':freeModels on every plan.', ['freeModels' => $freeCloudModels]),
+        $paidCloudModels === ''
+            ? ''
+            : __('A paid plan additionally unlocks :paidModels, which cost more credits per reply.', ['paidModels' => $paidCloudModels]),
+        $selfHostedNote,
+    ])));
+
+    $modelChoiceLine = trim(implode(' ', array_filter([
+        $freeCloudModels === ''
+            ? __('Any self-hosted model you connect is free on every plan.')
+            : __(':freeModels is free on every plan.', ['freeModels' => $freeCloudModels]),
+        $paidCloudModels === ''
+            ? ''
+            : __('Switch to :paidModels on a paid plan when a harder question calls for it.', ['paidModels' => $paidCloudModels]),
+    ])));
+
     $billingActive = \Laravel\Pennant\Feature::active(\App\Features\Billing::class);
     $freeCredits = number_format(\App\Enums\Plan::Free->credits());
     $proCredits = number_format(\App\Enums\Plan::Pro->credits());
@@ -60,10 +83,7 @@
         ],
         [
             __('Which models power :name?', ['name' => $assistantName]),
-            __(
-                ':freeModels on every plan. A paid plan additionally unlocks :paidModels, which cost more credits per reply. A self-hosted install supplies its own provider key, so you choose the model and pay the provider directly, or run a local one.',
-                ['freeModels' => $freeCloudModels, 'paidModels' => $paidCloudModels]
-            ),
+            $whichModelsAnswer,
         ],
         [
             $includedPlanQuestion,
@@ -344,7 +364,7 @@
                             {{ __('Transparent credits, your choice of model') }}
                         </h3>
                         <p class="text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
-                            {{ __(':freeModels is free on every plan. Switch to :paidModels on a paid plan when a harder question calls for it.', ['freeModels' => $freeCloudModels, 'paidModels' => $paidCloudModels]) }}
+                            {{ $modelChoiceLine }}
                         </p>
                     </div>
                 </div>

--- a/resources/views/ai.blade.php
+++ b/resources/views/ai.blade.php
@@ -1,11 +1,10 @@
 @php
     $assistantName = (string) config('chat.assistant_name');
 
-    // Through the registry, not the raw catalog: it drops models this install cannot
-    // serve (no provider key) and ones a probe measured as unable to call tools, so the
-    // page never names a model the assistant could not actually run.
-    $toolCapableCloudModels = collect(resolve(\Relaticle\Chat\Services\ModelRegistry::class)->available())
-        ->reject(fn (\Relaticle\Chat\Support\ModelDescriptor $model): bool => $model->selfHosted)
+    // offered(), not available(): this page describes what a plan includes, so it must
+    // not change because this install is missing a provider key. It still drops models
+    // a probe measured as unable to call tools, which the assistant could never run.
+    $toolCapableCloudModels = collect(resolve(\Relaticle\Chat\Services\ModelRegistry::class)->offered())
         ->map(fn (\Relaticle\Chat\Support\ModelDescriptor $model): array => [
             'label' => $model->displayLabel(),
             'min_plan' => $model->minPlan->value,

--- a/resources/views/ai.blade.php
+++ b/resources/views/ai.blade.php
@@ -1,8 +1,15 @@
 @php
     $assistantName = (string) config('chat.assistant_name');
 
-    $toolCapableCloudModels = collect(config('chat.models', []))
-        ->filter(fn (array $model): bool => ($model['supports_tools'] ?? false) === true && ($model['self_hosted'] ?? false) === false);
+    // Through the registry, not the raw catalog: it drops models this install cannot
+    // serve (no provider key) and ones a probe measured as unable to call tools, so the
+    // page never names a model the assistant could not actually run.
+    $toolCapableCloudModels = collect(resolve(\Relaticle\Chat\Services\ModelRegistry::class)->available())
+        ->reject(fn (\Relaticle\Chat\Support\ModelDescriptor $model): bool => $model->selfHosted)
+        ->map(fn (\Relaticle\Chat\Support\ModelDescriptor $model): array => [
+            'label' => $model->displayLabel(),
+            'min_plan' => $model->minPlan->value,
+        ]);
     $freeCloudModels = $toolCapableCloudModels->where('min_plan', 'free')->pluck('label')->join(', ', ' and ');
     $paidCloudModels = $toolCapableCloudModels->where('min_plan', 'pro')->pluck('label')->join(', ', ' and ');
 

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -41,14 +41,14 @@
                 // max(1, ceil(multiplier + toolCalls * toolBonus)).
                 $opusReplies = intdiv((int) \App\Enums\Plan::Pro->credits(), 3);
 
-                // Read through the registry rather than the raw catalog so this list can never
-                // name a model the app won't actually serve: ModelRegistry::available() drops
-                // the entries whose measured capabilities say they cannot call tools (both
-                // Gemini models today) and the ones whose provider has no key on this install.
-                // AiModelResolver::pick() can never select those, so the page must not claim a
-                // plan "unlocks" them even though they sit in the catalog with a real price.
-                $toolCapableCloudModels = collect(resolve(\Relaticle\Chat\Services\ModelRegistry::class)->available())
-                    ->reject(fn (\Relaticle\Chat\Support\ModelDescriptor $model): bool => $model->selfHosted)
+                // offered(), not available(): this list can never name a model the app won't
+                // serve, because it drops the entries whose measured capabilities say they
+                // cannot call tools (both Gemini models today) and AiModelResolver::pick()
+                // can never select those. It deliberately does NOT drop models whose provider
+                // has no key on this install: what Cloud Pro includes is not a function of
+                // whether the web host currently holds an Anthropic key, and filtering on
+                // that renders these sentences with a hole where the model names belong.
+                $toolCapableCloudModels = collect(resolve(\Relaticle\Chat\Services\ModelRegistry::class)->offered())
                     ->map(fn (\Relaticle\Chat\Support\ModelDescriptor $model): array => [
                         'label' => $model->displayLabel(),
                         'min_plan' => $model->minPlan->value,

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -35,11 +35,6 @@
                 $proRateLimit = \App\Enums\Plan::Pro->rateLimit();
                 $trialDays = \App\Actions\Billing\StartProTrial::TRIAL_DAYS;
 
-                // Sourced from packages/Chat/config/chat.php's model catalog ('credit_multiplier'
-                // per model) and 'tool_call_credit_bonus'. Settlement formula verified in
-                // packages/Chat/src/Services/CreditService.php::calculateCredits():
-                // max(1, ceil(multiplier + toolCalls * toolBonus)).
-                $opusReplies = intdiv((int) \App\Enums\Plan::Pro->credits(), 3);
 
                 // offered(), not available(): this list can never name a model the app won't
                 // serve, because it drops the entries whose measured capabilities say they
@@ -56,13 +51,41 @@
                     ]);
                 $freeCloudModels = $toolCapableCloudModels->where('min_plan', 'free')->pluck('label')->join(', ', ' and ');
                 $paidCloudModels = $toolCapableCloudModels->where('min_plan', 'pro')->pluck('label')->join(', ', ' and ');
-                $multiplierOneModels = $toolCapableCloudModels->where('credit_multiplier', 1.0)->pluck('label')->join(', ', ' and ');
-                $multiplierOneHalfModels = $toolCapableCloudModels->where('credit_multiplier', 1.5)->pluck('label')->join(', ', ' and ');
-                $multiplierThreeModels = $toolCapableCloudModels->where('credit_multiplier', 3.0)->pluck('label')->join(', ', ' and ');
+
+                // Grouped, not three hardcoded tiers. The catalog is editable at runtime, so
+                // asking for the 1.0 / 1.5 / 3.0 buckets by name printed "3x for )" the moment
+                // an operator retired the only 3x model, and silently omitted any model priced
+                // at a fourth multiplier. Self-hosted models ride the 1x bucket because
+                // ModelRegistry gives them that multiplier.
+                $multiplierClauses = $toolCapableCloudModels
+                    ->groupBy(fn (array $model): string => rtrim(rtrim(number_format($model['credit_multiplier'], 2, '.', ''), '0'), '.'))
+                    ->map(fn (\Illuminate\Support\Collection $group): string => $group->pluck('label')->join(', ', ' and '));
+
+                $multiplierClauses->put('1', $multiplierClauses->has('1')
+                    ? __(':models and self-hosted models', ['models' => $multiplierClauses->get('1')])
+                    : __('self-hosted models'));
+
+                $creditMultiplierList = $multiplierClauses
+                    ->sortKeys(SORT_NUMERIC)
+                    ->map(fn (string $models, string $multiplier): string => __(':multiplierx for :models', ['multiplier' => $multiplier, 'models' => $models]))
+                    ->join('; ');
+
+                // The worked example names the cheapest and dearest models the catalog
+                // actually offers, so retiring either cannot leave the sentence describing a
+                // model nobody can pick.
+                $sortedByCost = $toolCapableCloudModels->sortBy('credit_multiplier')->values();
+                $cheapestModel = $sortedByCost->first()['label'] ?? __('a 1x model');
+                $dearestEntry = $sortedByCost->last() ?? ['label' => __('a higher-multiplier model'), 'credit_multiplier' => 1.0];
+                $dearestReplyCost = max(1, (int) ceil($dearestEntry['credit_multiplier'] + 1.0));
 
                 $creditFaqAnswer = __(
-                    'Credit cost depends on the model and how much work a reply does — it is not flat. Each message costs its model\'s credit multiplier (1x for :oneX and self-hosted models; 1.5x for :oneFiveX; 3x for :threeX), plus 0.5 credits for every tool call the assistant makes while answering — searching, creating, or updating a record — rounded up to the next whole credit with a 1-credit minimum. A simple Sonnet 5 reply with no tool calls costs 1 credit; an Opus 5 reply that touches two records costs 4. Using the REST API or the MCP server directly, outside the built-in chat, never touches your credit balance.',
-                    ['oneX' => $multiplierOneModels, 'oneFiveX' => $multiplierOneHalfModels, 'threeX' => $multiplierThreeModels]
+                    'Credit cost depends on the model and how much work a reply does — it is not flat. Each message costs its model\'s credit multiplier (:multipliers), plus 0.5 credits for every tool call the assistant makes while answering — searching, creating, or updating a record — rounded up to the next whole credit with a 1-credit minimum. A simple reply from :cheapestModel with no tool calls costs 1 credit; a reply from :dearestModel that touches two records costs :dearestCost. Using the REST API or the MCP server directly, outside the built-in chat, never touches your credit balance.',
+                    [
+                        'multipliers' => $creditMultiplierList,
+                        'cheapestModel' => $cheapestModel,
+                        'dearestModel' => $dearestEntry['label'],
+                        'dearestCost' => $dearestReplyCost,
+                    ]
                 );
 
                 // "Cloud Pro" is the billing-on marketing name only — under billing-off there is
@@ -74,10 +97,17 @@
                 // No Enterprise plan card or checkout path exists anywhere in the codebase, so
                 // whether it's an actual purchasable offering isn't something the code can confirm
                 // — it's mentioned nowhere in this page's visible copy for that reason.
-                $modelsUnlockAnswer = __(
-                    'Every plan can use :freeModels and any self-hosted model you connect yourself. :paidPlan additionally unlocks :paidModels — the models with a higher credit multiplier.',
-                    ['freeModels' => $freeCloudModels, 'paidModels' => $paidCloudModels, 'paidPlan' => $paidPlanLabel]
-                );
+                // Two independent sentences rather than one with two holes in it: a catalog
+                // with no free-tier model rendered "Every plan can use  and any self-hosted
+                // model you connect yourself", which is the failure this shape removes.
+                $modelsUnlockAnswer = trim(implode(' ', array_filter([
+                    $freeCloudModels === ''
+                        ? __('Every plan can use any self-hosted model you connect yourself.')
+                        : __('Every plan can use :freeModels and any self-hosted model you connect yourself.', ['freeModels' => $freeCloudModels]),
+                    $paidCloudModels === ''
+                        ? ''
+                        : __(':paidPlan additionally unlocks :paidModels — the models with a higher credit multiplier.', ['paidModels' => $paidCloudModels, 'paidPlan' => $paidPlanLabel]),
+                ])));
 
                 $rateLimitAnswer = __(
                     'Yes — a per-minute cap shared across the whole workspace, not per person: :free messages/minute on Free, :pro/minute on :paidPlan. It exists to stop runaway usage, not to constrain normal work.',
@@ -93,11 +123,16 @@
                     $hostedPriceCell = __('$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)');
                     $hostedUpdatesCell = __('Managed by Relaticle — no self-hosted maintenance required');
                     $hostedPlanAnswer = __(
-                        'Cloud Pro is :price and includes unlimited users and records, every supported AI model from Sonnet 5 up to Opus 5, the REST API, the 37-tool MCP server, and email support. Each workspace gets a :credits-credit monthly AI allowance; how far it goes depends on the model and how many tool calls each reply makes (see "What counts as an AI credit?" below). As a reference point, :credits credits covers roughly :credits simple Sonnet 5 replies, or around :opusReplies Opus 5 replies before tool calls. New workspaces start on a :days-day trial automatically, with no card required.',
+                        'Cloud Pro is :price and includes unlimited users and records, every supported AI model from :cheapestModel up to :dearestModel, the REST API, the 37-tool MCP server, and email support. Each workspace gets a :credits-credit monthly AI allowance; how far it goes depends on the model and how many tool calls each reply makes (see "What counts as an AI credit?" below). As a reference point, :credits credits covers roughly :credits simple :cheapestModel replies, or around :dearestReplies :dearestModel replies before tool calls. New workspaces start on a :days-day trial automatically, with no card required.',
                         [
                             'price' => '$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)',
                             'credits' => $proCredits,
-                            'opusReplies' => number_format($opusReplies),
+                            'cheapestModel' => $cheapestModel,
+                            'dearestModel' => $dearestEntry['label'],
+                            // Settlement formula, packages/Chat/src/Services/CreditService.php
+                            // ::calculateCredits(): max(1, ceil(multiplier + toolCalls * toolBonus)).
+                            // Before tool calls that is just the multiplier.
+                            'dearestReplies' => number_format(intdiv((int) \App\Enums\Plan::Pro->credits(), max(1, (int) ceil($dearestEntry['credit_multiplier'])))),
                             'days' => $trialDays,
                         ]
                     );

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -41,14 +41,19 @@
                 // max(1, ceil(multiplier + toolCalls * toolBonus)).
                 $opusReplies = intdiv((int) \App\Enums\Plan::Pro->credits(), 3);
 
-                // Filtered from config rather than hardcoded so this list can never name a model
-                // the app won't actually serve. Gemini 3 Flash and Gemini 3.1 Pro carry
-                // 'supports_tools' => false in chat.php, which makes ModelDescriptor::isAvailable()
-                // (packages/Chat/src/Support/ModelDescriptor.php:49) return false unconditionally —
-                // AiModelResolver::pick() can never select them, so they must not appear here even
-                // though they're in the catalog with real min_plan/credit_multiplier values.
-                $toolCapableCloudModels = collect(config('chat.models', []))
-                    ->filter(fn (array $model): bool => ($model['supports_tools'] ?? false) === true && ($model['self_hosted'] ?? false) === false);
+                // Read through the registry rather than the raw catalog so this list can never
+                // name a model the app won't actually serve: ModelRegistry::available() drops
+                // the entries whose measured capabilities say they cannot call tools (both
+                // Gemini models today) and the ones whose provider has no key on this install.
+                // AiModelResolver::pick() can never select those, so the page must not claim a
+                // plan "unlocks" them even though they sit in the catalog with a real price.
+                $toolCapableCloudModels = collect(resolve(\Relaticle\Chat\Services\ModelRegistry::class)->available())
+                    ->reject(fn (\Relaticle\Chat\Support\ModelDescriptor $model): bool => $model->selfHosted)
+                    ->map(fn (\Relaticle\Chat\Support\ModelDescriptor $model): array => [
+                        'label' => $model->displayLabel(),
+                        'min_plan' => $model->minPlan->value,
+                        'credit_multiplier' => $model->creditMultiplier,
+                    ]);
                 $freeCloudModels = $toolCapableCloudModels->where('min_plan', 'free')->pluck('label')->join(', ', ' and ');
                 $paidCloudModels = $toolCapableCloudModels->where('min_plan', 'pro')->pluck('label')->join(', ', ' and ');
                 $multiplierOneModels = $toolCapableCloudModels->where('credit_multiplier', 1.0)->pluck('label')->join(', ', ' and ');
@@ -56,7 +61,7 @@
                 $multiplierThreeModels = $toolCapableCloudModels->where('credit_multiplier', 3.0)->pluck('label')->join(', ', ' and ');
 
                 $creditFaqAnswer = __(
-                    'Credit cost depends on the model and how much work a reply does — it is not flat. Each message costs its model\'s credit multiplier (1x for :oneX and self-hosted models; 1.5x for :oneFiveX; 3x for :threeX), plus 0.5 credits for every tool call the assistant makes while answering — searching, creating, or updating a record — rounded up to the next whole credit with a 1-credit minimum. A simple Sonnet 4.6 reply with no tool calls costs 1 credit; an Opus 4.7 reply that touches two records costs 4. Using the REST API or the MCP server directly, outside the built-in chat, never touches your credit balance.',
+                    'Credit cost depends on the model and how much work a reply does — it is not flat. Each message costs its model\'s credit multiplier (1x for :oneX and self-hosted models; 1.5x for :oneFiveX; 3x for :threeX), plus 0.5 credits for every tool call the assistant makes while answering — searching, creating, or updating a record — rounded up to the next whole credit with a 1-credit minimum. A simple Sonnet 5 reply with no tool calls costs 1 credit; an Opus 5 reply that touches two records costs 4. Using the REST API or the MCP server directly, outside the built-in chat, never touches your credit balance.',
                     ['oneX' => $multiplierOneModels, 'oneFiveX' => $multiplierOneHalfModels, 'threeX' => $multiplierThreeModels]
                 );
 
@@ -88,7 +93,7 @@
                     $hostedPriceCell = __('$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)');
                     $hostedUpdatesCell = __('Managed by Relaticle — no self-hosted maintenance required');
                     $hostedPlanAnswer = __(
-                        'Cloud Pro is :price and includes unlimited users and records, every supported AI model from Sonnet 4.6 up to Opus 4.7, the REST API, the 37-tool MCP server, and email support. Each workspace gets a :credits-credit monthly AI allowance; how far it goes depends on the model and how many tool calls each reply makes (see "What counts as an AI credit?" below). As a reference point, :credits credits covers roughly :credits simple Sonnet 4.6 replies, or around :opusReplies Opus 4.7 replies before tool calls. New workspaces start on a :days-day trial automatically, with no card required.',
+                        'Cloud Pro is :price and includes unlimited users and records, every supported AI model from Sonnet 5 up to Opus 5, the REST API, the 37-tool MCP server, and email support. Each workspace gets a :credits-credit monthly AI allowance; how far it goes depends on the model and how many tool calls each reply makes (see "What counts as an AI credit?" below). As a reference point, :credits credits covers roughly :credits simple Sonnet 5 replies, or around :opusReplies Opus 5 replies before tool calls. New workspaces start on a :days-day trial automatically, with no card required.',
                         [
                             'price' => '$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)',
                             'credits' => $proCredits,

--- a/tests/Feature/AI/CreditServiceTest.php
+++ b/tests/Feature/AI/CreditServiceTest.php
@@ -94,7 +94,7 @@ it('deducts credits and logs a transaction', function (): void {
 
 it('calculates credits with model multiplier', function (): void {
     $credits = $this->service->calculateCredits(
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-5',
         toolCallsCount: 0,
     );
 

--- a/tests/Feature/AI/CreditServiceTest.php
+++ b/tests/Feature/AI/CreditServiceTest.php
@@ -10,6 +10,7 @@ use Relaticle\Chat\Enums\AiCreditType;
 use Relaticle\Chat\Models\AiCreditBalance;
 use Relaticle\Chat\Services\CreditService;
 use Relaticle\Chat\Services\ModelRegistry;
+use Tests\Helpers\ChatCatalog;
 
 mutates(CreditService::class);
 
@@ -109,8 +110,8 @@ it('calculates credits with model multiplier', function (): void {
  */
 it('charges a retired model the multiplier it was retired on', function (): void {
     config()->set('chat.models', [
-        catalogEntry(),
-        catalogEntry([
+        ChatCatalog::entry(),
+        ChatCatalog::entry([
             'key' => 'retired:claude-opus-4-7',
             'model' => 'claude-opus-4-7',
             'credit_multiplier' => 3.0,

--- a/tests/Feature/AI/CreditServiceTest.php
+++ b/tests/Feature/AI/CreditServiceTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Relaticle\Chat\Enums\AiCreditType;
 use Relaticle\Chat\Models\AiCreditBalance;
 use Relaticle\Chat\Services\CreditService;
+use Relaticle\Chat\Services\ModelRegistry;
 
 mutates(CreditService::class);
 
@@ -99,6 +100,29 @@ it('calculates credits with model multiplier', function (): void {
     );
 
     expect($credits)->toBe(3);
+});
+
+/**
+ * A turn enqueued before a model was retired settles after it. Reading the multiplier
+ * off the picker instead of the whole catalog re-priced that settlement at 1x, silently
+ * undercharging every Opus turn still in flight across the change.
+ */
+it('charges a retired model the multiplier it was retired on', function (): void {
+    config()->set('chat.models', [
+        catalogEntry(),
+        catalogEntry([
+            'key' => 'retired:claude-opus-4-7',
+            'model' => 'claude-opus-4-7',
+            'credit_multiplier' => 3.0,
+            'enabled' => false,
+        ]),
+    ]);
+    app()->forgetInstance(ModelRegistry::class);
+
+    expect(resolve(CreditService::class)->calculateCredits(
+        model: 'claude-opus-4-7',
+        toolCallsCount: 0,
+    ))->toBe(3);
 });
 
 it('adds tool call bonus to credit calculation', function (): void {

--- a/tests/Feature/Chat/AiModelResolverTest.php
+++ b/tests/Feature/Chat/AiModelResolverTest.php
@@ -11,7 +11,7 @@ mutates(AiModelResolver::class, ModelRegistry::class);
 
 it('falls back to Sonnet when the users preference is not allowed by their plan', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
-    $user->ai_preferences = ['default_model' => 'claude-opus'];
+    $user->ai_preferences = ['default_model' => 'claude-opus-5'];
     $user->save();
     $user->refresh();
 
@@ -24,7 +24,7 @@ it('honors the users preference when their plan allows it', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
     $user->currentTeam->plan = Plan::Pro;
     $user->currentTeam->save();
-    $user->ai_preferences = ['default_model' => 'claude-opus'];
+    $user->ai_preferences = ['default_model' => 'claude-opus-5'];
     $user->save();
     $user->refresh();
 
@@ -36,7 +36,7 @@ it('honors the users preference when their plan allows it', function (): void {
 it('falls back to Sonnet when an override is disallowed by the plan', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
 
-    $resolved = resolve(AiModelResolver::class)->resolve($user, 'gpt-5-5');
+    $resolved = resolve(AiModelResolver::class)->resolve($user, 'gpt-5.5');
 
     expect($resolved['model'])->toBe('claude-sonnet-5');
 });
@@ -139,23 +139,23 @@ it('honors an Ollama default-model preference when configured', function (): voi
 it('labels explicit and auto resolutions', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
 
-    $explicit = resolve(AiModelResolver::class)->resolve($user, 'claude-sonnet');
+    $explicit = resolve(AiModelResolver::class)->resolve($user, 'claude-sonnet-5');
     $auto = resolve(AiModelResolver::class)->resolve($user, null);
 
     expect($explicit['source'])->toBe('explicit')
-        ->and($explicit['id'])->toBe('claude-sonnet')
+        ->and($explicit['id'])->toBe('claude-sonnet-5')
         ->and($auto['source'])->toBe('auto')
-        ->and($auto['id'])->toBe('claude-sonnet');
+        ->and($auto['id'])->toBe('claude-sonnet-5');
 });
 
 it('fails over to the next available chain entry', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
     $user->currentTeam->forceFill(['plan' => Plan::Pro])->save();
 
-    $next = resolve(AiModelResolver::class)->failoverNext($user, 'claude-sonnet');
+    $next = resolve(AiModelResolver::class)->failoverNext($user, 'claude-sonnet-5');
 
     expect($next)->not->toBeNull()
-        ->and($next['id'])->toBe('gpt-5-5')
+        ->and($next['id'])->toBe('gpt-5.5')
         ->and($next['provider'])->toBe('openai')
         ->and($next['source'])->toBe('auto');
 });

--- a/tests/Feature/Chat/AiModelResolverTest.php
+++ b/tests/Feature/Chat/AiModelResolverTest.php
@@ -17,7 +17,7 @@ it('falls back to Sonnet when the users preference is not allowed by their plan'
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, null);
 
-    expect($resolved['model'])->toBe('claude-sonnet-4-6');
+    expect($resolved['model'])->toBe('claude-sonnet-5');
 });
 
 it('honors the users preference when their plan allows it', function (): void {
@@ -30,7 +30,7 @@ it('honors the users preference when their plan allows it', function (): void {
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, null);
 
-    expect($resolved['model'])->toBe('claude-opus-4-7');
+    expect($resolved['model'])->toBe('claude-opus-5');
 });
 
 it('falls back to Sonnet when an override is disallowed by the plan', function (): void {
@@ -38,7 +38,7 @@ it('falls back to Sonnet when an override is disallowed by the plan', function (
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, 'gpt-5-5');
 
-    expect($resolved['model'])->toBe('claude-sonnet-4-6');
+    expect($resolved['model'])->toBe('claude-sonnet-5');
 });
 
 it('resolves Auto to Sonnet for any plan', function (): void {
@@ -46,7 +46,7 @@ it('resolves Auto to Sonnet for any plan', function (): void {
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, 'auto');
 
-    expect($resolved['model'])->toBe('claude-sonnet-4-6');
+    expect($resolved['model'])->toBe('claude-sonnet-5');
 });
 
 it('falls back to ClaudeSonnet when a Gemini model is requested', function (): void {
@@ -55,11 +55,11 @@ it('falls back to ClaudeSonnet when a Gemini model is requested', function (): v
     $user->currentTeam->forceFill(['plan' => Plan::Pro])->save();
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, 'gemini-3-flash');
-    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6']);
+    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-5']);
 });
 
 it('resolves an explicit Ollama request when Ollama is configured', function (): void {
-    config()->set('chat.models.6.model', 'qwen3:14b');
+    config()->set('chat.ollama.model', 'qwen3:14b');
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();
@@ -69,19 +69,19 @@ it('resolves an explicit Ollama request when Ollama is configured', function ():
 });
 
 it('falls back to Sonnet when Ollama is requested but not configured', function (): void {
-    config()->set('chat.models.6.model', null);
+    config()->set('chat.ollama.model', null);
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, 'ollama');
-    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6']);
+    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-5']);
 });
 
 it('resolves Auto to Ollama when no cloud provider is configured', function (): void {
     config()->set('ai.providers.anthropic.key', null);
     config()->set('ai.providers.openai.key', null);
-    config()->set('chat.models.6.model', 'qwen3:14b');
+    config()->set('chat.ollama.model', 'qwen3:14b');
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();
@@ -91,18 +91,18 @@ it('resolves Auto to Ollama when no cloud provider is configured', function (): 
 });
 
 it('resolves Auto to Sonnet when Anthropic is configured alongside Ollama', function (): void {
-    config()->set('chat.models.6.model', 'qwen3:14b');
+    config()->set('chat.ollama.model', 'qwen3:14b');
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, 'auto');
-    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6']);
+    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-5']);
 });
 
 it('falls back to an available plan-gated model when the plan allows no configured provider', function (): void {
     config()->set('ai.providers.anthropic.key', null);
-    config()->set('chat.models.6.model', null);
+    config()->set('chat.ollama.model', null);
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();
@@ -114,17 +114,17 @@ it('falls back to an available plan-gated model when the plan allows no configur
 it('falls back to Sonnet when no provider is configured at all', function (): void {
     config()->set('ai.providers.anthropic.key', null);
     config()->set('ai.providers.openai.key', null);
-    config()->set('chat.models.6.model', null);
+    config()->set('chat.ollama.model', null);
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();
 
     $resolved = resolve(AiModelResolver::class)->resolve($user, 'auto');
-    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6']);
+    expect($resolved)->toMatchArray(['provider' => 'anthropic', 'model' => 'claude-sonnet-5']);
 });
 
 it('honors an Ollama default-model preference when configured', function (): void {
-    config()->set('chat.models.6.model', 'llama3.1:70b');
+    config()->set('chat.ollama.model', 'llama3.1:70b');
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();

--- a/tests/Feature/Chat/AnthropicPromptCachingTest.php
+++ b/tests/Feature/Chat/AnthropicPromptCachingTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 use Illuminate\Events\Dispatcher;
 use Laravel\Ai\AiManager;
+use Laravel\Ai\Enums\Lab;
 use Laravel\Ai\Gateway\Anthropic\AnthropicGateway;
 use Laravel\Ai\Gateway\TextGenerationOptions;
 use Laravel\Ai\Messages\UserMessage;
+use Laravel\Ai\ToolChoice;
 use Relaticle\Chat\Agents\CrmAssistant;
+use Relaticle\Chat\Agents\ModelProbeAgent;
 
 /**
  * The cached-prefix saving depends on laravel/ai merging providerOptions over the
@@ -68,6 +71,63 @@ it('still forces one tool call per turn alongside the cached system blocks', fun
         'type' => 'auto',
         'disable_parallel_tool_use' => true,
     ]);
+});
+
+/**
+ * Anthropic removed sampling parameters on Opus 4.7 and every model after it, and
+ * rejects a request carrying one with `temperature is deprecated for this model`.
+ * A #[Temperature] attribute on the agent is enough to break every turn on those
+ * models, which is what took Opus 4.7 down in production (RELATICLE-CRM-6D).
+ */
+it('sends no sampling parameters, which the current Anthropic models reject', function (): void {
+    $body = anthropicRequestBodyFor(new CrmAssistant);
+
+    expect($body)->not->toHaveKey('temperature')
+        ->and($body)->not->toHaveKey('top_p');
+});
+
+it('sends the configured reasoning effort, the only quality dial these models still expose', function (): void {
+    config()->set('chat.anthropic_effort', 'low');
+
+    $body = anthropicRequestBodyFor(new CrmAssistant);
+
+    expect($body['output_config'])->toBe(['effort' => 'low']);
+});
+
+it('sends no effort at all when the configured value is not one Anthropic accepts', function (): void {
+    config()->set('chat.anthropic_effort', 'ludicrous');
+
+    $body = anthropicRequestBodyFor(new CrmAssistant);
+
+    expect($body)->not->toHaveKey('output_config');
+});
+
+/**
+ * ModelProbe only earns its place if it fails on the request CrmAssistant would
+ * really send. Sampling parameters are read off the agent running the prompt, so
+ * a probe agent that carried its own (absent) sampling config would sail through
+ * while production failed on every turn — which is exactly RELATICLE-CRM-6D, and
+ * exactly what the first version of this probe did.
+ */
+it('probes with the assistant\'s own sampling parameters, not its own', function (): void {
+    $assistant = new CrmAssistant;
+    $probe = new ModelProbeAgent($assistant);
+
+    $assistantOptions = TextGenerationOptions::forAgent($assistant);
+    $probeOptions = TextGenerationOptions::forAgent($probe);
+
+    expect($probeOptions->temperature)->toBe($assistantOptions->temperature)
+        ->and($probeOptions->topP)->toBe($assistantOptions->topP);
+});
+
+it('forbids the probe from calling a tool while still sending every tool schema', function (): void {
+    $probe = new ModelProbeAgent(new CrmAssistant);
+
+    $options = TextGenerationOptions::forAgent($probe);
+
+    expect($options->toolChoice?->mode)->toBe(ToolChoice::none)
+        ->and($probe->providerOptions(Lab::Anthropic))->not->toHaveKey('tool_choice')
+        ->and($probe->tools())->toHaveCount(count((new CrmAssistant)->tools()));
 });
 
 it('falls back to a plain string system prompt when caching is disabled', function (): void {

--- a/tests/Feature/Chat/AnthropicPromptCachingTest.php
+++ b/tests/Feature/Chat/AnthropicPromptCachingTest.php
@@ -127,7 +127,7 @@ it('forbids the probe from calling a tool while still sending every tool schema'
 
     expect($options->toolChoice?->mode)->toBe(ToolChoice::none)
         ->and($probe->providerOptions(Lab::Anthropic))->not->toHaveKey('tool_choice')
-        ->and($probe->tools())->toHaveCount(count((new CrmAssistant)->tools()));
+        ->and($probe->tools())->toHaveSameSize((new CrmAssistant)->tools());
 });
 
 it('falls back to a plain string system prompt when caching is disabled', function (): void {

--- a/tests/Feature/Chat/ChatCancellationTest.php
+++ b/tests/Feature/Chat/ChatCancellationTest.php
@@ -138,7 +138,7 @@ it('settles the reserved minimum (not refund) when a stream is cancelled mid-fli
         team: $team,
         message: 'Show me my deals',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         turnId: '01TURNCANCELAAAAAAAAAAAAAA',
     )->handle(resolve(CreditService::class));
 

--- a/tests/Feature/Chat/ChatCatalogShapeTest.php
+++ b/tests/Feature/Chat/ChatCatalogShapeTest.php
@@ -12,9 +12,9 @@ use Spatie\LaravelSettings\SettingsRepositories\SettingsRepository;
  * rather than merely unlikely.
  */
 it('seeds one catalog carrying Auto membership, price and probed capabilities', function (): void {
-    $sonnet = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+    $sonnet = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5');
 
-    expect($sonnet['model'])->toBe('claude-sonnet-5')
+    expect($sonnet)->not->toHaveKey('key')
         ->and($sonnet['auto'])->toBeTrue()
         ->and($sonnet['enabled'])->toBeTrue()
         // Compared numerically, not identically: JSON has a single number type, so a
@@ -30,17 +30,17 @@ it('seeds one catalog carrying Auto membership, price and probed capabilities', 
 it('keeps Auto order as list order', function (): void {
     $auto = collect(resolve(ChatSettings::class)->models)
         ->filter(fn (array $entry): bool => $entry['auto'] === true)
-        ->pluck('key')
+        ->pluck('model')
         ->values()
         ->all();
 
-    expect($auto)->toBe(['claude-sonnet', 'gpt-5-5']);
+    expect($auto)->toBe(['claude-sonnet-5', 'gpt-5.5']);
 });
 
 it('leaves self-hosted models out of settings so env stays their only source', function (): void {
-    $keys = collect(resolve(ChatSettings::class)->models)->pluck('key');
+    $tags = collect(resolve(ChatSettings::class)->models)->pluck('model');
 
-    expect($keys)->not->toContain('ollama');
+    expect($tags)->not->toContain('ollama');
 });
 
 it('keeps a retired model as a disabled entry so historical spend stays priced', function (): void {

--- a/tests/Feature/Chat/ChatCatalogShapeTest.php
+++ b/tests/Feature/Chat/ChatCatalogShapeTest.php
@@ -54,8 +54,8 @@ it('keeps a retired model as a disabled entry so historical spend stays priced',
 it('never creates the two folded settings keys', function (): void {
     $repository = resolve(SettingsRepository::class);
 
-    expect(property_exists(resolve(ChatSettings::class), 'auto_chain'))->toBeFalse()
-        ->and(property_exists(resolve(ChatSettings::class), 'model_costs'))->toBeFalse()
+    expect(resolve(ChatSettings::class))->not->toHaveProperty('auto_chain')
+        ->and(resolve(ChatSettings::class))->not->toHaveProperty('model_costs')
         ->and($repository->checkIfPropertyExists('chat', 'auto_chain'))->toBeFalse()
         ->and($repository->checkIfPropertyExists('chat', 'model_costs'))->toBeFalse();
 });

--- a/tests/Feature/Chat/ChatCatalogShapeTest.php
+++ b/tests/Feature/Chat/ChatCatalogShapeTest.php
@@ -59,3 +59,14 @@ it('never creates the two folded settings keys', function (): void {
         ->and($repository->checkIfPropertyExists('chat', 'auto_chain'))->toBeFalse()
         ->and($repository->checkIfPropertyExists('chat', 'model_costs'))->toBeFalse();
 });
+
+/**
+ * The package auto-discovers `app/Settings` only, and this class lives in a package.
+ * Unregistered it still resolves — the container autowires it and it loads itself —
+ * so nothing breaks loudly; it just gets no scoped binding, which means a fresh
+ * instance and a fresh query per resolve, on every request that boots Chat.
+ */
+it('registers the settings class so the container can scope it', function (): void {
+    expect(config('settings.settings'))->toContain(ChatSettings::class)
+        ->and(resolve(ChatSettings::class))->toBe(resolve(ChatSettings::class));
+});

--- a/tests/Feature/Chat/ChatCatalogShapeTest.php
+++ b/tests/Feature/Chat/ChatCatalogShapeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Chat\Settings\ChatSettings;
+use Spatie\LaravelSettings\SettingsRepositories\SettingsRepository;
+
+/**
+ * The catalog used to be three lists that had to agree with each other: `models`,
+ * a bare-id `auto_chain`, and a `model_costs` map keyed by model string. One list
+ * is what makes a dangling Auto id and an unpriced model structurally impossible
+ * rather than merely unlikely.
+ */
+it('seeds one catalog carrying Auto membership, price and probed capabilities', function (): void {
+    $sonnet = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+
+    expect($sonnet['model'])->toBe('claude-sonnet-5')
+        ->and($sonnet['auto'])->toBeTrue()
+        ->and($sonnet['enabled'])->toBeTrue()
+        // Compared numerically, not identically: JSON has a single number type, so a
+        // whole float comes back as an int. ModelRegistry::ratesFor() is where the
+        // float guarantee lives, and ModelRegistrySourcesTest asserts it there.
+        ->and($sonnet['input_per_mtok'])->toEqual(3.0)
+        ->and($sonnet['output_per_mtok'])->toEqual(15.0)
+        ->and($sonnet['capabilities']['supports_tools'])->toBeTrue()
+        ->and($sonnet)->not->toHaveKey('supports_tools')
+        ->and($sonnet)->not->toHaveKey('self_hosted');
+});
+
+it('keeps Auto order as list order', function (): void {
+    $auto = collect(resolve(ChatSettings::class)->models)
+        ->filter(fn (array $entry): bool => $entry['auto'] === true)
+        ->pluck('key')
+        ->values()
+        ->all();
+
+    expect($auto)->toBe(['claude-sonnet', 'gpt-5-5']);
+});
+
+it('leaves self-hosted models out of settings so env stays their only source', function (): void {
+    $keys = collect(resolve(ChatSettings::class)->models)->pluck('key');
+
+    expect($keys)->not->toContain('ollama');
+});
+
+it('keeps a retired model as a disabled entry so historical spend stays priced', function (): void {
+    $retired = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-opus-4-7');
+
+    expect($retired['enabled'])->toBeFalse()
+        ->and($retired['auto'])->toBeFalse()
+        ->and($retired['output_per_mtok'])->toEqual(25.0);
+});
+
+it('never creates the two folded settings keys', function (): void {
+    $repository = resolve(SettingsRepository::class);
+
+    expect(property_exists(resolve(ChatSettings::class), 'auto_chain'))->toBeFalse()
+        ->and(property_exists(resolve(ChatSettings::class), 'model_costs'))->toBeFalse()
+        ->and($repository->checkIfPropertyExists('chat', 'auto_chain'))->toBeFalse()
+        ->and($repository->checkIfPropertyExists('chat', 'model_costs'))->toBeFalse();
+});

--- a/tests/Feature/Chat/ChatControllerTest.php
+++ b/tests/Feature/Chat/ChatControllerTest.php
@@ -208,7 +208,7 @@ it('accepts known model override values on chat.send', function (): void {
 
     $createRes = $this->postJson(route('chat.conversations.create'), [
         'document' => ChatDocument::fromText('hello'),
-        'model' => 'claude-sonnet',
+        'model' => 'claude-sonnet-5',
     ])->assertOk();
     $conversationId = $createRes->json('conversation_id');
 
@@ -216,7 +216,7 @@ it('accepts known model override values on chat.send', function (): void {
 
     $this->postJson(route('chat.send', ['conversation' => $conversationId]), [
         'document' => ChatDocument::fromText('hello'),
-        'model' => 'claude-sonnet',
+        'model' => 'claude-sonnet-5',
     ])->assertOk();
 
     Queue::assertPushed(ProcessChatMessage::class);

--- a/tests/Feature/Chat/ChatModelsCommandTest.php
+++ b/tests/Feature/Chat/ChatModelsCommandTest.php
@@ -13,7 +13,7 @@ it('lists the model registry via artisan', function (): void {
     config()->set('chat.ollama.model', 'qwen3:8b');
 
     $this->artisan('chat:models')
-        ->expectsOutputToContain('claude-sonnet')
+        ->expectsOutputToContain('claude-sonnet-5')
         ->expectsOutputToContain('ollama')
         ->assertExitCode(0);
 });
@@ -24,7 +24,7 @@ it('verifies a cloud model against its provider and reports what it measured', f
 
     resolve(ModelProbe::class)->forget('anthropic', 'claude-sonnet-5');
 
-    $this->artisan('chat:models', ['--probe' => 'claude-sonnet'])
+    $this->artisan('chat:models', ['--probe' => 'claude-sonnet-5'])
         ->expectsOutputToContain('write_guard')
         ->assertExitCode(0);
 });
@@ -35,7 +35,7 @@ it('fails with the provider message when the model is rejected', function (): vo
 
     resolve(ModelProbe::class)->forget('anthropic', 'claude-sonnet-5');
 
-    $this->artisan('chat:models', ['--probe' => 'claude-sonnet'])
+    $this->artisan('chat:models', ['--probe' => 'claude-sonnet-5'])
         ->expectsOutputToContain('model: nope')
         ->assertExitCode(1);
 });

--- a/tests/Feature/Chat/ChatModelsCommandTest.php
+++ b/tests/Feature/Chat/ChatModelsCommandTest.php
@@ -2,19 +2,40 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Http;
 use Relaticle\Chat\Commands\ChatModelsCommand;
+use Relaticle\Chat\Services\ModelProbe;
 
 mutates(ChatModelsCommand::class);
 
 it('lists the model registry via artisan', function (): void {
+    // Ollama comes from env now, so it only appears once it is configured.
+    config()->set('chat.ollama.model', 'qwen3:8b');
+
     $this->artisan('chat:models')
         ->expectsOutputToContain('claude-sonnet')
         ->expectsOutputToContain('ollama')
         ->assertExitCode(0);
 });
 
-it('declines to probe a cloud model without throwing', function (): void {
+it('verifies a cloud model against its provider and reports what it measured', function (): void {
+    Http::preventStrayRequests();
+    Http::fake(['api.anthropic.com/*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []])]);
+
+    resolve(ModelProbe::class)->forget('anthropic', 'claude-sonnet-5');
+
     $this->artisan('chat:models', ['--probe' => 'claude-sonnet'])
-        ->expectsOutputToContain('only supported for self-hosted')
+        ->expectsOutputToContain('write_guard')
+        ->assertExitCode(0);
+});
+
+it('fails with the provider message when the model is rejected', function (): void {
+    Http::preventStrayRequests();
+    Http::fake(['api.anthropic.com/*' => Http::response(['error' => ['message' => 'model: nope']], 404)]);
+
+    resolve(ModelProbe::class)->forget('anthropic', 'claude-sonnet-5');
+
+    $this->artisan('chat:models', ['--probe' => 'claude-sonnet'])
+        ->expectsOutputToContain('model: nope')
         ->assertExitCode(1);
 });

--- a/tests/Feature/Chat/ChatQueueConnectionTest.php
+++ b/tests/Feature/Chat/ChatQueueConnectionTest.php
@@ -31,7 +31,7 @@ it('dispatches the chat turn on the redis-chat connection', function (): void {
         team: $user->currentTeam,
         message: 'hello',
         conversationId: (string) Str::uuid7(),
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     ));
 
     Queue::assertPushed(ProcessChatMessage::class, fn (ProcessChatMessage $job): bool => $job->connection === 'redis-chat' && $job->queue === 'chat');

--- a/tests/Feature/Chat/ConversationTitleGenerationTest.php
+++ b/tests/Feature/Chat/ConversationTitleGenerationTest.php
@@ -363,7 +363,7 @@ it('titles from the assistant reply when the opening message named nothing', fun
         team: $this->team,
         message: 'hey',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     ))->handle(resolve(CreditService::class));
 
     Queue::assertPushed(
@@ -385,7 +385,7 @@ it('does not re-title at turn end when the conversation already has a generated 
         team: $this->team,
         message: 'how is globex doing',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     ))->handle(resolve(CreditService::class));
 
     Queue::assertNotPushed(GenerateConversationTitle::class);
@@ -425,7 +425,7 @@ it('titles at turn end from what the user typed, not from the rows the system wr
         team: $this->team,
         message: 'how is globex doing',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     ))->handle(resolve(CreditService::class));
 
     Queue::assertPushed(

--- a/tests/Feature/Chat/CreditsUsedInvariantTest.php
+++ b/tests/Feature/Chat/CreditsUsedInvariantTest.php
@@ -71,7 +71,7 @@ it('reserve + settle + refund cycles move credits_used in lockstep with the chat
         team: $team,
         user: $user,
         type: AiCreditType::Chat,
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-5',
         inputTokens: 100,
         outputTokens: 200,
         resolutionKey: 'turn-success',

--- a/tests/Feature/Chat/MentionsMessagePersistenceTest.php
+++ b/tests/Feature/Chat/MentionsMessagePersistenceTest.php
@@ -43,7 +43,7 @@ it('writes a row to agent_conversation_message_mentions for each mention', funct
         team: $team,
         message: 'Tell me about @Acme_Corp',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [['type' => 'company', 'id' => (string) $company->id, 'label' => 'Acme Corp']],
     );
 
@@ -94,7 +94,7 @@ it('writes no mention rows when the mentions list is empty', function (): void {
         team: $team,
         message: 'plain message',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
     ))->handle(resolve(CreditService::class));
 

--- a/tests/Feature/Chat/MentionsPersistenceTest.php
+++ b/tests/Feature/Chat/MentionsPersistenceTest.php
@@ -46,7 +46,7 @@ it('persists a clean user message even when mentions are resolved', function ():
         team: $team,
         message: $cleanMessage,
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [
             ['type' => 'company', 'id' => (string) $company->id, 'label' => 'Acme Corp'],
         ],
@@ -96,7 +96,7 @@ it('still gives the LLM the mention context via the system prompt', function ():
         team: $team,
         message: 'Tell me about @Acme_Corp',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [
             ['type' => 'company', 'id' => (string) $company->id, 'label' => 'Acme Corp'],
         ],

--- a/tests/Feature/Chat/ModelGatePlanTest.php
+++ b/tests/Feature/Chat/ModelGatePlanTest.php
@@ -44,7 +44,7 @@ it('rejects an Opus request from a grandfathered Free user with a 403', function
 
     $response = $this->actingAs($user)->postJson("/chat/{$conversationId}", [
         'document' => ChatDocument::fromText('hi'),
-        'model' => 'claude-opus',
+        'model' => 'claude-opus-5',
     ]);
 
     $response->assertStatus(403);
@@ -84,7 +84,7 @@ it('allows an Opus request from a Pro user', function (): void {
 
     $response = $this->actingAs($user)->postJson("/chat/{$conversationId}", [
         'document' => ChatDocument::fromText('hi'),
-        'model' => 'claude-opus',
+        'model' => 'claude-opus-5',
     ]);
 
     $response->assertStatus(200);
@@ -150,7 +150,7 @@ it('allows a Free user to explicitly pick Sonnet', function (): void {
 
     $response = $this->actingAs($user)->postJson("/chat/{$conversationId}", [
         'document' => ChatDocument::fromText('hi'),
-        'model' => 'claude-sonnet',
+        'model' => 'claude-sonnet-5',
     ]);
 
     $response->assertStatus(200);
@@ -180,12 +180,12 @@ it('rejects a GPT-5 request from a Free user with a 403', function (): void {
 
     $response = $this->actingAs($user)->postJson("/chat/{$conversationId}", [
         'document' => ChatDocument::fromText('hi'),
-        'model' => 'gpt-5-5',
+        'model' => 'gpt-5.5',
     ]);
 
     $response->assertStatus(403);
     expect($response->json('error'))->toBe('model_not_allowed');
-    expect($response->json('requested_model'))->toBe('gpt-5-5');
+    expect($response->json('requested_model'))->toBe('gpt-5.5');
 });
 
 it('allows a Free user to pick Ollama when it is configured', function (): void {

--- a/tests/Feature/Chat/ModelGatePlanTest.php
+++ b/tests/Feature/Chat/ModelGatePlanTest.php
@@ -190,7 +190,7 @@ it('rejects a GPT-5 request from a Free user with a 403', function (): void {
 
 it('allows a Free user to pick Ollama when it is configured', function (): void {
     Queue::fake();
-    config()->set('chat.models.6.model', 'qwen3:14b');
+    config()->set('chat.ollama.model', 'qwen3:14b');
     app()->forgetInstance(ModelRegistry::class);
 
     $user = User::factory()->withPersonalTeam()->create();

--- a/tests/Feature/Chat/ModelPickerVisibilityTest.php
+++ b/tests/Feature/Chat/ModelPickerVisibilityTest.php
@@ -22,7 +22,7 @@ beforeEach(function (): void {
 });
 
 it('shows the Ollama model in the chat picker when configured', function (): void {
-    config()->set('chat.models.6.model', 'qwen3:14b');
+    config()->set('chat.ollama.model', 'qwen3:14b');
     app()->forgetInstance(ModelRegistry::class);
 
     Livewire::test(ChatInterface::class)
@@ -30,7 +30,7 @@ it('shows the Ollama model in the chat picker when configured', function (): voi
 });
 
 it('hides the Ollama model from the chat picker when not configured', function (): void {
-    config()->set('chat.models.6.model', null);
+    config()->set('chat.ollama.model', null);
     app()->forgetInstance(ModelRegistry::class);
 
     Livewire::test(ChatInterface::class)
@@ -42,12 +42,12 @@ it('hides cloud models whose provider key is not configured', function (): void 
     app()->forgetInstance(ModelRegistry::class);
 
     Livewire::test(ChatInterface::class)
-        ->assertSee('Sonnet 4.6', stripInitialData: false)
+        ->assertSee('Sonnet 5', stripInitialData: false)
         ->assertDontSee('GPT 5.5', stripInitialData: false);
 });
 
 it('shows the Ollama model on the dashboard picker when configured', function (): void {
-    config()->set('chat.models.6.model', 'qwen3:14b');
+    config()->set('chat.ollama.model', 'qwen3:14b');
     app()->forgetInstance(ModelRegistry::class);
 
     livewire(Dashboard::class)
@@ -55,7 +55,7 @@ it('shows the Ollama model on the dashboard picker when configured', function ()
 });
 
 it('hides the Ollama model from the dashboard picker when not configured', function (): void {
-    config()->set('chat.models.6.model', null);
+    config()->set('chat.ollama.model', null);
     app()->forgetInstance(ModelRegistry::class);
 
     livewire(Dashboard::class)
@@ -67,7 +67,7 @@ it('drives the chat picker from the model registry', function (): void {
     app()->forgetInstance(ModelRegistry::class);
 
     Livewire::test(ChatInterface::class)
-        ->assertSee('Sonnet 4.6', stripInitialData: false)   // anthropic key set in tests
+        ->assertSee('Sonnet 5', stripInitialData: false)   // anthropic key set in tests
         ->assertSee('Auto', stripInitialData: false)
         ->assertDontSee('GPT 5.5', stripInitialData: false)   // openai key nulled → hidden
         ->assertDontSee('Gemini 3 Flash', stripInitialData: false); // supports_tools=false → never shown

--- a/tests/Feature/Chat/ModelProbeTest.php
+++ b/tests/Feature/Chat/ModelProbeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Relaticle\Chat\Services\ModelProbe;
+
+mutates(ModelProbe::class);
+
+beforeEach(function (): void {
+    Http::preventStrayRequests();
+    resolve(ModelProbe::class)->forget('anthropic', 'claude-sonnet-5');
+});
+
+it('reports tool support and the api write guard when the provider accepts everything', function (): void {
+    Http::fake(['api.anthropic.com/*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []])]);
+
+    expect(resolve(ModelProbe::class)('anthropic', 'claude-sonnet-5'))
+        ->toBe(['ok' => true, 'error' => null, 'supports_tools' => true, 'write_guard' => 'api']);
+});
+
+/**
+ * The safe direction. Claiming `api` without proof tells the write path the provider
+ * refuses parallel tool calls, which is what the sequential approval flow leans on.
+ */
+it('claims nothing and surfaces the provider message when rejected', function (): void {
+    Http::fake(['api.anthropic.com/*' => Http::response([
+        'type' => 'error',
+        'error' => ['message' => '`temperature` is deprecated for this model.'],
+    ], 400)]);
+
+    $result = resolve(ModelProbe::class)('anthropic', 'claude-sonnet-5');
+
+    expect($result['ok'])->toBeFalse()
+        ->and($result['error'])->toContain('temperature')
+        ->and($result['supports_tools'])->toBeFalse()
+        ->and($result['write_guard'])->toBe('prompt');
+});
+
+it('does not re-send a request for a pairing that already passed', function (): void {
+    Http::fake(['api.anthropic.com/*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []])]);
+
+    $probe = resolve(ModelProbe::class);
+    $probe('anthropic', 'claude-sonnet-5');
+    $probe('anthropic', 'claude-sonnet-5');
+
+    Http::assertSentCount(1);
+});
+
+it('retries a failure rather than caching it', function (): void {
+    Http::fake(['api.anthropic.com/*' => Http::response(['error' => ['message' => 'overloaded']], 529)]);
+
+    $probe = resolve(ModelProbe::class);
+    $probe('anthropic', 'claude-sonnet-5');
+    $probe('anthropic', 'claude-sonnet-5');
+
+    expect(Http::recorded())->toHaveCount(2);
+});

--- a/tests/Feature/Chat/ModelRegistrySourcesTest.php
+++ b/tests/Feature/Chat/ModelRegistrySourcesTest.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
+use Relaticle\Chat\Enums\WriteGuard;
 use Relaticle\Chat\Services\ModelRegistry;
+use Relaticle\Chat\Support\CatalogEntry;
+use Relaticle\Chat\Support\Measurement;
 use Relaticle\Chat\Support\ModelDescriptor;
 use Tests\Helpers\ChatCatalog;
 
 mutates(ModelRegistry::class);
+mutates(CatalogEntry::class);
+mutates(Measurement::class);
 
 function freshRegistry(): ModelRegistry
 {
@@ -117,4 +122,26 @@ it('drops an entry that carries no model tag', function (): void {
     $ids = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->all());
 
     expect($ids)->toBe(['claude-sonnet-5']);
+});
+
+/**
+ * `api` means the provider itself refuses parallel tool calls, which is what makes
+ * the sequential approval flow unbypassable. A row whose guard cannot be read has
+ * proved nothing, so it gets the weaker one: asserting `api` without proof would
+ * tell the write path a guarantee the provider never gave.
+ */
+it('falls back to the weaker write guard when a stored one is unreadable', function (): void {
+    config()->set('chat.models', [ChatCatalog::entry([
+        'capabilities' => ['supports_tools' => true, 'write_guard' => 'totally-not-a-guard'],
+    ])]);
+
+    expect(freshRegistry()->find('claude-sonnet-5')?->writeGuard)->toBe(WriteGuard::Prompt);
+});
+
+it('keeps a stored write guard the enum does know', function (): void {
+    config()->set('chat.models', [ChatCatalog::entry([
+        'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'],
+    ])]);
+
+    expect(freshRegistry()->find('claude-sonnet-5')?->writeGuard)->toBe(WriteGuard::Api);
 });

--- a/tests/Feature/Chat/ModelRegistrySourcesTest.php
+++ b/tests/Feature/Chat/ModelRegistrySourcesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Relaticle\Chat\Services\ModelRegistry;
 use Relaticle\Chat\Support\ModelDescriptor;
+use Tests\Helpers\ChatCatalog;
 
 mutates(ModelRegistry::class);
 
@@ -16,8 +17,8 @@ function freshRegistry(): ModelRegistry
 
 it('excludes disabled entries from the catalog', function (): void {
     config()->set('chat.models', [
-        catalogEntry(),
-        catalogEntry(['key' => 'gone', 'enabled' => false]),
+        ChatCatalog::entry(),
+        ChatCatalog::entry(['key' => 'gone', 'enabled' => false]),
     ]);
 
     $ids = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->all());
@@ -27,7 +28,7 @@ it('excludes disabled entries from the catalog', function (): void {
 
 it('reads capabilities from the probe record, not from input', function (): void {
     config()->set('chat.models', [
-        catalogEntry(['capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt']]),
+        ChatCatalog::entry(['capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt']]),
     ]);
 
     $descriptor = freshRegistry()->find('claude-sonnet');
@@ -41,16 +42,16 @@ it('reads capabilities from the probe record, not from input', function (): void
  * weaker guard is the safe direction: the PendingAction approval gate still holds.
  */
 it('treats a missing capability record as the weaker guard', function (): void {
-    config()->set('chat.models', [catalogEntry(['capabilities' => null])]);
+    config()->set('chat.models', [ChatCatalog::entry(['capabilities' => null])]);
 
     expect(freshRegistry()->find('claude-sonnet')?->writeGuard->value)->toBe('prompt');
 });
 
 it('takes the auto chain from the entries in list order', function (): void {
     config()->set('chat.models', [
-        catalogEntry(['key' => 'first', 'auto' => true]),
-        catalogEntry(['key' => 'excluded', 'auto' => false]),
-        catalogEntry(['key' => 'second', 'auto' => true]),
+        ChatCatalog::entry(['key' => 'first', 'auto' => true]),
+        ChatCatalog::entry(['key' => 'excluded', 'auto' => false]),
+        ChatCatalog::entry(['key' => 'second', 'auto' => true]),
     ]);
     config()->set('chat.self_hosted.url');
     config()->set('chat.self_hosted.models');
@@ -67,7 +68,7 @@ it('takes the auto chain from the entries in list order', function (): void {
  * fall back to.
  */
 it('appends env self-hosted models to the end of the auto chain', function (): void {
-    config()->set('chat.models', [catalogEntry(['key' => 'cloud', 'auto' => true])]);
+    config()->set('chat.models', [ChatCatalog::entry(['key' => 'cloud', 'auto' => true])]);
     config()->set('chat.self_hosted.url', 'http://localhost:11434');
     config()->set('chat.self_hosted.models', 'qwen3:8b');
 
@@ -86,7 +87,7 @@ it('merges self-hosted models from env, never from settings', function (): void 
 
 it('prices a retired model from its disabled entry', function (): void {
     config()->set('chat.models', [
-        catalogEntry([
+        ChatCatalog::entry([
             'key' => 'retired:claude-opus-4-7',
             'model' => 'claude-opus-4-7',
             'enabled' => false,
@@ -100,7 +101,7 @@ it('prices a retired model from its disabled entry', function (): void {
 });
 
 it('reports no rates for a model that carries none', function (): void {
-    config()->set('chat.models', [catalogEntry(['input_per_mtok' => null, 'output_per_mtok' => null])]);
+    config()->set('chat.models', [ChatCatalog::entry(['input_per_mtok' => null, 'output_per_mtok' => null])]);
 
     expect(freshRegistry()->ratesFor('claude-sonnet-5'))->toBeNull();
 });

--- a/tests/Feature/Chat/ModelRegistrySourcesTest.php
+++ b/tests/Feature/Chat/ModelRegistrySourcesTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\Chat\Services\ModelRegistry;
+use Relaticle\Chat\Support\ModelDescriptor;
+
+mutates(ModelRegistry::class);
+
+function freshRegistry(): ModelRegistry
+{
+    app()->forgetInstance(ModelRegistry::class);
+
+    return resolve(ModelRegistry::class);
+}
+
+it('excludes disabled entries from the catalog', function (): void {
+    config()->set('chat.models', [
+        catalogEntry(),
+        catalogEntry(['key' => 'gone', 'enabled' => false]),
+    ]);
+
+    $ids = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->all());
+
+    expect($ids)->toContain('claude-sonnet')->not->toContain('gone');
+});
+
+it('reads capabilities from the probe record, not from input', function (): void {
+    config()->set('chat.models', [
+        catalogEntry(['capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt']]),
+    ]);
+
+    $descriptor = freshRegistry()->find('claude-sonnet');
+
+    expect($descriptor?->supportsTools)->toBeFalse()
+        ->and($descriptor?->writeGuard->value)->toBe('prompt');
+});
+
+/**
+ * An unprobed entry must not claim the provider enforces one write per turn. The
+ * weaker guard is the safe direction: the PendingAction approval gate still holds.
+ */
+it('treats a missing capability record as the weaker guard', function (): void {
+    config()->set('chat.models', [catalogEntry(['capabilities' => null])]);
+
+    expect(freshRegistry()->find('claude-sonnet')?->writeGuard->value)->toBe('prompt');
+});
+
+it('takes the auto chain from the entries in list order', function (): void {
+    config()->set('chat.models', [
+        catalogEntry(['key' => 'first', 'auto' => true]),
+        catalogEntry(['key' => 'excluded', 'auto' => false]),
+        catalogEntry(['key' => 'second', 'auto' => true]),
+    ]);
+    config()->set('chat.self_hosted.url');
+    config()->set('chat.self_hosted.models');
+
+    $chain = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->autoChain());
+
+    expect($chain)->toBe(['first', 'second']);
+});
+
+/**
+ * Self-hosted models used to sit in `auto_chain` as the last entry, which is what
+ * made Auto usable on an install with no cloud keys at all. They are no longer
+ * stored, so the chain has to append them itself or that install has nothing to
+ * fall back to.
+ */
+it('appends env self-hosted models to the end of the auto chain', function (): void {
+    config()->set('chat.models', [catalogEntry(['key' => 'cloud', 'auto' => true])]);
+    config()->set('chat.self_hosted.url', 'http://localhost:11434');
+    config()->set('chat.self_hosted.models', 'qwen3:8b');
+
+    $chain = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->autoChain());
+
+    expect($chain)->toBe(['cloud', 'selfhosted:qwen3:8b']);
+});
+
+it('merges self-hosted models from env, never from settings', function (): void {
+    config()->set('chat.models', []);
+    config()->set('chat.self_hosted.url', 'http://localhost:11434');
+    config()->set('chat.self_hosted.models', 'qwen3:8b');
+
+    expect(freshRegistry()->find('selfhosted:qwen3:8b')?->selfHosted)->toBeTrue();
+});
+
+it('prices a retired model from its disabled entry', function (): void {
+    config()->set('chat.models', [
+        catalogEntry([
+            'key' => 'retired:claude-opus-4-7',
+            'model' => 'claude-opus-4-7',
+            'enabled' => false,
+            'input_per_mtok' => 5,
+            'output_per_mtok' => 25,
+        ]),
+    ]);
+
+    expect(freshRegistry()->ratesFor('claude-opus-4-7'))
+        ->toBe(['input_per_mtok' => 5.0, 'output_per_mtok' => 25.0]);
+});
+
+it('reports no rates for a model that carries none', function (): void {
+    config()->set('chat.models', [catalogEntry(['input_per_mtok' => null, 'output_per_mtok' => null])]);
+
+    expect(freshRegistry()->ratesFor('claude-sonnet-5'))->toBeNull();
+});

--- a/tests/Feature/Chat/ModelRegistrySourcesTest.php
+++ b/tests/Feature/Chat/ModelRegistrySourcesTest.php
@@ -18,12 +18,12 @@ function freshRegistry(): ModelRegistry
 it('excludes disabled entries from the catalog', function (): void {
     config()->set('chat.models', [
         ChatCatalog::entry(),
-        ChatCatalog::entry(['key' => 'gone', 'enabled' => false]),
+        ChatCatalog::entry(['model' => 'claude-gone-1', 'enabled' => false]),
     ]);
 
     $ids = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->all());
 
-    expect($ids)->toContain('claude-sonnet')->not->toContain('gone');
+    expect($ids)->toContain('claude-sonnet-5')->not->toContain('claude-gone-1');
 });
 
 it('reads capabilities from the probe record, not from input', function (): void {
@@ -31,7 +31,7 @@ it('reads capabilities from the probe record, not from input', function (): void
         ChatCatalog::entry(['capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt']]),
     ]);
 
-    $descriptor = freshRegistry()->find('claude-sonnet');
+    $descriptor = freshRegistry()->find('claude-sonnet-5');
 
     expect($descriptor?->supportsTools)->toBeFalse()
         ->and($descriptor?->writeGuard->value)->toBe('prompt');
@@ -44,21 +44,21 @@ it('reads capabilities from the probe record, not from input', function (): void
 it('treats a missing capability record as the weaker guard', function (): void {
     config()->set('chat.models', [ChatCatalog::entry(['capabilities' => null])]);
 
-    expect(freshRegistry()->find('claude-sonnet')?->writeGuard->value)->toBe('prompt');
+    expect(freshRegistry()->find('claude-sonnet-5')?->writeGuard->value)->toBe('prompt');
 });
 
 it('takes the auto chain from the entries in list order', function (): void {
     config()->set('chat.models', [
-        ChatCatalog::entry(['key' => 'first', 'auto' => true]),
-        ChatCatalog::entry(['key' => 'excluded', 'auto' => false]),
-        ChatCatalog::entry(['key' => 'second', 'auto' => true]),
+        ChatCatalog::entry(['model' => 'claude-first-1', 'auto' => true]),
+        ChatCatalog::entry(['model' => 'claude-excluded-1', 'auto' => false]),
+        ChatCatalog::entry(['model' => 'claude-second-1', 'auto' => true]),
     ]);
     config()->set('chat.self_hosted.url');
     config()->set('chat.self_hosted.models');
 
     $chain = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->autoChain());
 
-    expect($chain)->toBe(['first', 'second']);
+    expect($chain)->toBe(['claude-first-1', 'claude-second-1']);
 });
 
 /**
@@ -68,13 +68,13 @@ it('takes the auto chain from the entries in list order', function (): void {
  * fall back to.
  */
 it('appends env self-hosted models to the end of the auto chain', function (): void {
-    config()->set('chat.models', [ChatCatalog::entry(['key' => 'cloud', 'auto' => true])]);
+    config()->set('chat.models', [ChatCatalog::entry(['model' => 'claude-cloud-1', 'auto' => true])]);
     config()->set('chat.self_hosted.url', 'http://localhost:11434');
     config()->set('chat.self_hosted.models', 'qwen3:8b');
 
     $chain = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->autoChain());
 
-    expect($chain)->toBe(['cloud', 'selfhosted:qwen3:8b']);
+    expect($chain)->toBe(['claude-cloud-1', 'selfhosted:qwen3:8b']);
 });
 
 it('merges self-hosted models from env, never from settings', function (): void {
@@ -88,7 +88,6 @@ it('merges self-hosted models from env, never from settings', function (): void 
 it('prices a retired model from its disabled entry', function (): void {
     config()->set('chat.models', [
         ChatCatalog::entry([
-            'key' => 'retired:claude-opus-4-7',
             'model' => 'claude-opus-4-7',
             'enabled' => false,
             'input_per_mtok' => 5,
@@ -104,4 +103,18 @@ it('reports no rates for a model that carries none', function (): void {
     config()->set('chat.models', [ChatCatalog::entry(['input_per_mtok' => null, 'output_per_mtok' => null])]);
 
     expect(freshRegistry()->ratesFor('claude-sonnet-5'))->toBeNull();
+});
+
+/**
+ * The model tag is the entry's identity, so a row without one cannot be offered:
+ * an empty id would reach the picker and `Rule::in()` on the send endpoint.
+ */
+it('drops an entry that carries no model tag', function (): void {
+    config()->set('chat.models', [ChatCatalog::entry(), ChatCatalog::entry(['model' => ''])]);
+    config()->set('chat.self_hosted.url');
+    config()->set('chat.self_hosted.models');
+
+    $ids = array_map(fn (ModelDescriptor $model): string => $model->id, freshRegistry()->all());
+
+    expect($ids)->toBe(['claude-sonnet-5']);
 });

--- a/tests/Feature/Chat/NextStepSuggestionTest.php
+++ b/tests/Feature/Chat/NextStepSuggestionTest.php
@@ -307,7 +307,7 @@ it('dispatches the suggester at the end of a turn with what the turn produced', 
         team: $this->team,
         message: 'how is acme doing',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     ))->handle(resolve(CreditService::class));
 
     Queue::assertPushed(
@@ -337,7 +337,7 @@ it('offers no steps on a turn that ends waiting for a decision', function (): vo
         team: $this->team,
         message: 'create a task to call acme',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     ))->handle(resolve(CreditService::class));
 
     expect(PendingAction::query()->where('conversation_id', $this->conversationId)

--- a/tests/Feature/Chat/PageContextBindingTest.php
+++ b/tests/Feature/Chat/PageContextBindingTest.php
@@ -151,7 +151,7 @@ it('persists the bound record as a page_context row on the user message', functi
         team: $this->team,
         message: 'summarize this',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
         pageContext: ['type' => 'company', 'id' => (string) $company->getKey(), 'label' => 'Acme'],
     ))->handle(resolve(CreditService::class));
@@ -190,7 +190,7 @@ it('carries no page_context row on a second message in the same conversation onc
         team: $this->team,
         message: 'summarize this',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
         pageContext: ['type' => 'company', 'id' => (string) $company->getKey(), 'label' => 'Acme'],
         turnId: 'turn-1',
@@ -204,7 +204,7 @@ it('carries no page_context row on a second message in the same conversation onc
         team: $this->team,
         message: 'and what else can you tell me',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
         pageContext: null,
         turnId: 'turn-2',
@@ -253,7 +253,7 @@ it('writes both a mention row and a page_context row when a message has each', f
         team: $this->team,
         message: 'Tell me about @Widgets_Inc',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [['type' => 'company', 'id' => (string) $mentioned->getKey(), 'label' => 'Widgets Inc']],
         pageContext: ['type' => 'company', 'id' => (string) $viewed->getKey(), 'label' => 'Acme'],
     ))->handle(resolve(CreditService::class));
@@ -288,7 +288,7 @@ it('binds the job\'s team onto the agent so the workspace_state block can resolv
         team: $this->team,
         message: 'hello',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
         pageContext: null,
     ))->handle(resolve(CreditService::class));
@@ -306,7 +306,7 @@ it('writes no page_context row when no record is bound', function (): void {
         team: $this->team,
         message: 'hello',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
         pageContext: null,
     ))->handle(resolve(CreditService::class));
@@ -432,7 +432,7 @@ it('collapses a record referenced across multiple prior turns into a single ledg
         team: $this->team,
         message: 'what else can you tell me',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     );
 
     $ledger = runAndCaptureLedger($job);
@@ -471,7 +471,7 @@ it('caps the ledger at 10 distinct records without duplicate rows wasting a slot
         team: $this->team,
         message: 'anything',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     );
 
     $ledger = runAndCaptureLedger($job);
@@ -516,7 +516,7 @@ it('exempts the conversation\'s oldest page_context record from ledger eviction'
         team: $this->team,
         message: 'anything',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     );
 
     $ledger = runAndCaptureLedger($job);
@@ -543,7 +543,7 @@ it('includes a record that was only ever bound as page context, never a typed me
         team: $this->team,
         message: 'anything',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     );
 
     $ledger = runAndCaptureLedger($job);
@@ -583,7 +583,7 @@ it('scopes the ledger to its own conversation and excludes records referenced in
         team: $this->team,
         message: 'anything',
         conversationId: $this->conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     );
 
     $ledger = runAndCaptureLedger($job);

--- a/tests/Feature/Chat/ProcessChatMessageDocumentMaterializationTest.php
+++ b/tests/Feature/Chat/ProcessChatMessageDocumentMaterializationTest.php
@@ -46,7 +46,7 @@ it('materializes the assistant message document at stream end', function (): voi
         team: $this->team,
         message: 'Show me my deals',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
     )->handle(resolve(CreditService::class));
 
@@ -89,7 +89,7 @@ it('records turn duration in assistant message meta', function (): void {
         team: $this->team,
         message: 'Show me my deals',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         mentions: [],
     )->handle(resolve(CreditService::class));
 

--- a/tests/Feature/Chat/ProcessChatMessageFailureTest.php
+++ b/tests/Feature/Chat/ProcessChatMessageFailureTest.php
@@ -291,7 +291,7 @@ it('redispatches once on a terminal pre-stream failure when resolution was auto'
         team: $team,
         message: 'hello',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'id' => 'claude-sonnet-5', 'source' => 'auto'],
         turnId: $turnId,
     );
 
@@ -339,7 +339,7 @@ it('does not fail over for an explicit model pick', function (): void {
         team: $team,
         message: 'hello',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'explicit'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'id' => 'claude-sonnet-5', 'source' => 'explicit'],
         turnId: $turnId,
     );
 
@@ -375,7 +375,7 @@ it('does not fail over once the stream has already broadcast an event', function
         team: $team,
         message: 'hello',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'id' => 'claude-sonnet-5', 'source' => 'auto'],
         turnId: $turnId,
     );
 
@@ -413,7 +413,7 @@ it('refunds the reservation when the job dies before it ever runs', function ():
         team: $team,
         message: 'hello',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'id' => 'claude-sonnet-5', 'source' => 'auto'],
         turnId: $turnId,
     );
 
@@ -448,7 +448,7 @@ it('reports a pre-model failure to the exception handler instead of only a bread
         team: $team,
         message: 'hello',
         conversationId: $conversationId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-5', 'id' => 'claude-sonnet-5', 'source' => 'auto'],
         turnId: (string) Str::ulid(),
     );
 

--- a/tests/Feature/Chat/ProcessChatMessageSettlementTest.php
+++ b/tests/Feature/Chat/ProcessChatMessageSettlementTest.php
@@ -77,7 +77,7 @@ it('settles the reserved minimum when the turn already streamed before failing',
 
     $job = new ProcessChatMessage(
         user: $user, team: $team, message: 'hi', conversationId: 'c-2',
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         turnId: $turnId,
     );
 
@@ -131,7 +131,7 @@ it('bills a turn that streamed even though the queue hands failed() a fresh inst
 
     $job = new ProcessChatMessage(
         user: $user, team: $team, message: 'hi', conversationId: 'c-3',
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         turnId: $turnId,
     );
 

--- a/tests/Feature/Chat/ProcessChatMessageTest.php
+++ b/tests/Feature/Chat/ProcessChatMessageTest.php
@@ -38,7 +38,7 @@ it('broadcasts a stream.failed event when the job fails', function (): void {
         team: $team,
         message: 'hello',
         conversationId: 'conv-123',
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     );
 
     $job->failed(new RuntimeException('boom'));
@@ -66,7 +66,7 @@ it('refunds the reservation when the job fails without ever streaming', function
         team: $team,
         message: 'hello',
         conversationId: 'conv-123',
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
     );
 
     $job->failed(new RuntimeException('boom'));
@@ -114,7 +114,7 @@ it('refunds the reservation and stops when hosted access expires in the queue', 
         team: $team,
         message: 'hello',
         conversationId: 'conv-paused',
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         turnId: 'turn-paused',
     );
 

--- a/tests/Feature/Chat/ProposalContinuationTest.php
+++ b/tests/Feature/Chat/ProposalContinuationTest.php
@@ -239,7 +239,7 @@ it('clears the continuation flag when the resumed turn dies before it stores any
         team: $team,
         message: TurnContinuationService::PROMPT,
         conversationId: $this->convId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         turnId: (string) Str::ulid(),
         isContinuation: true,
     );
@@ -276,7 +276,7 @@ it('leaves the next job on the worker to store its own question as the user type
             team: $team,
             message: TurnContinuationService::PROMPT,
             conversationId: $this->convId,
-            resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+            resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
             turnId: (string) Str::ulid(),
             isContinuation: true,
         ))->handle(resolve(CreditService::class));
@@ -290,7 +290,7 @@ it('leaves the next job on the worker to store its own question as the user type
         team: $team,
         message: 'What did we agree with Acme?',
         conversationId: $this->convId,
-        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet', 'source' => 'auto'],
+        resolved: ['provider' => 'anthropic', 'model' => 'claude-sonnet-4-6', 'id' => 'claude-sonnet-4-6', 'source' => 'auto'],
         turnId: (string) Str::ulid(),
     ))->handle(resolve(CreditService::class));
 

--- a/tests/Feature/HealthChecks/ChatProviderCheckTest.php
+++ b/tests/Feature/HealthChecks/ChatProviderCheckTest.php
@@ -19,18 +19,21 @@ function chatProviderCatalogueEntry(
     string $model,
     string $minPlan = 'free',
     bool $supportsTools = true,
-    bool $selfHosted = false,
+    bool $enabled = true,
 ): array {
     return [
-        'id' => $model,
+        'key' => $model,
         'label' => $model,
         'provider' => $provider,
         'model' => $model,
         'min_plan' => $minPlan,
         'credit_multiplier' => 1.0,
-        'supports_tools' => $supportsTools,
-        'write_guard' => 'api',
-        'self_hosted' => $selfHosted,
+        'input_per_mtok' => 1.0,
+        'output_per_mtok' => 1.0,
+        'auto' => true,
+        'enabled' => $enabled,
+        'capabilities' => ['supports_tools' => $supportsTools, 'write_guard' => 'api'],
+        'verified_at' => null,
     ];
 }
 
@@ -200,10 +203,10 @@ it('registers one check per provider that has a key configured', function (): vo
 it('skips models chat can never select', function (): void {
     config()->set('chat.models', [
         chatProviderCatalogueEntry('gemini', 'gemini-3-flash', supportsTools: false),
-        chatProviderCatalogueEntry('ollama', 'llama', selfHosted: true),
+        chatProviderCatalogueEntry('mistral', 'retired-model', enabled: false),
     ]);
     config()->set('ai.providers.gemini.key', 'test-key');
-    config()->set('ai.providers.ollama.key', 'test-key');
+    config()->set('ai.providers.mistral.key', 'test-key');
 
     expect(ChatProviderCheck::forConfiguredProviders())->toBeEmpty();
 });

--- a/tests/Feature/Public/PricingPageTest.php
+++ b/tests/Feature/Public/PricingPageTest.php
@@ -133,7 +133,7 @@ it('discloses the real per-model credit multiplier instead of a flat allowance c
     $this->get('/pricing')
         ->assertOk()
         ->assertSee(__('What counts as an AI credit?'))
-        ->assertSee('3x for Opus 4.7', false)
+        ->assertSee('3x for Opus 5', false)
         ->assertSee('0.5 credits for every tool call')
         ->assertDontSee('One credit is used each time the built-in AI assistant sends a chat reply or generates a record summary.');
 });
@@ -182,8 +182,8 @@ it('never names a model the app cannot actually serve', function (): void {
         ->assertOk()
         ->assertDontSee('Gemini')
         ->assertSee(__('Which AI models does my plan unlock?'))
-        ->assertSee('Sonnet 4.6 and self-hosted models')
-        ->assertSee('Opus 4.7, GPT 5.5 and GPT 5.4');
+        ->assertSee('Sonnet 5 and self-hosted models')
+        ->assertSee('GPT 5.5, Opus 5 and GPT 5.4');
 });
 
 it('pins the exact membership of every model list derived from the chat catalog', function (): void {
@@ -198,11 +198,11 @@ it('pins the exact membership of every model list derived from the chat catalog'
     $this->get('/pricing')
         ->assertOk()
         // $freeCloudModels, via $modelsUnlockAnswer
-        ->assertSee('Every plan can use Sonnet 4.6 and any self-hosted model you connect yourself.')
+        ->assertSee('Every plan can use Sonnet 5 and any self-hosted model you connect yourself.')
         // $paidCloudModels, via $modelsUnlockAnswer
-        ->assertSee('Cloud Pro additionally unlocks Opus 4.7, GPT 5.5 and GPT 5.4 — the models with a higher credit multiplier.')
+        ->assertSee('Cloud Pro additionally unlocks GPT 5.5, Opus 5 and GPT 5.4 — the models with a higher credit multiplier.')
         // $multiplierOneModels, $multiplierOneHalfModels, $multiplierThreeModels, via $creditFaqAnswer
-        ->assertSee('1x for Sonnet 4.6 and self-hosted models; 1.5x for GPT 5.5 and GPT 5.4; 3x for Opus 4.7)', false);
+        ->assertSee('1x for Sonnet 5 and self-hosted models; 1.5x for GPT 5.5 and GPT 5.4; 3x for Opus 5)', false);
 });
 
 it('does not claim an unconfirmed Enterprise tier is a purchasable offering when billing is on', function (): void {

--- a/tests/Feature/Public/PricingPageTest.php
+++ b/tests/Feature/Public/PricingPageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Features\Billing as BillingFeature;
 use Laravel\Pennant\Feature;
+use Relaticle\Chat\Services\ModelRegistry;
 
 it('shows the legacy two-card page when billing is off', function (): void {
     Feature::define(BillingFeature::class, false);
@@ -203,6 +204,26 @@ it('pins the exact membership of every model list derived from the chat catalog'
         ->assertSee('Cloud Pro additionally unlocks GPT 5.5, Opus 5 and GPT 5.4 — the models with a higher credit multiplier.')
         // $multiplierOneModels, $multiplierOneHalfModels, $multiplierThreeModels, via $creditFaqAnswer
         ->assertSee('1x for Sonnet 5 and self-hosted models; 1.5x for GPT 5.5 and GPT 5.4; 3x for Opus 5)', false);
+});
+
+/**
+ * What a plan includes is not a function of whether the web host currently holds an
+ * Anthropic key. Reading these lists through ModelRegistry::available() made a key
+ * rotation render "Every plan can use  and any self-hosted model you connect
+ * yourself" — a public sentence with a hole in it, invisible to the rest of this
+ * suite because phpunit.xml sets a fake key for every provider.
+ */
+it('names the models a plan includes even when this install holds no provider key', function (): void {
+    Feature::define(BillingFeature::class, true);
+    config(['ai.providers.anthropic.key' => null, 'ai.providers.openai.key' => null]);
+    app()->forgetInstance(ModelRegistry::class);
+
+    $this->get('/pricing')
+        ->assertOk()
+        ->assertSee('Every plan can use Sonnet 5 and any self-hosted model you connect yourself.')
+        ->assertSee('Cloud Pro additionally unlocks GPT 5.5, Opus 5 and GPT 5.4', false)
+        ->assertSee('3x for Opus 5', false)
+        ->assertDontSee('Gemini');
 });
 
 it('does not claim an unconfirmed Enterprise tier is a purchasable offering when billing is on', function (): void {

--- a/tests/Feature/Public/PricingPageTest.php
+++ b/tests/Feature/Public/PricingPageTest.php
@@ -269,3 +269,114 @@ it('does not overstate the self-hoster\'s lever over the credit cap', function (
         ->assertSee("doesn't reset the current period's balance")
         ->assertDontSee('raising or removing that cap is a matter of updating your own workspace\'s plan; there is no separate self-hosted billing UI for it.');
 });
+
+/**
+ * The catalog is editable at runtime now, so the marketing copy has to survive a
+ * catalog these sentences were not written against. Asking for the 1.0 / 1.5 / 3.0
+ * buckets by name printed "3x for )" the moment an operator retired the only 3x
+ * model, and left a model priced at any other multiplier out of the sentence
+ * entirely.
+ *
+ * @param  list<array{model:string,label:string,min_plan:string,credit_multiplier:float}>  $models
+ */
+function catalogOf(array $models): void
+{
+    config(['chat.models' => array_map(fn (array $model): array => [
+        'label' => $model['label'],
+        'provider' => 'anthropic',
+        'model' => $model['model'],
+        'min_plan' => $model['min_plan'],
+        'credit_multiplier' => $model['credit_multiplier'],
+        'input_per_mtok' => 1.0,
+        'output_per_mtok' => 2.0,
+        'auto' => true,
+        'enabled' => true,
+        'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'],
+        'verified_at' => null,
+    ], $models)]);
+
+    app()->forgetInstance(ModelRegistry::class);
+}
+
+/** The shapes an empty interpolation leaves behind. */
+function assertNoCopyHoles(string $html): void
+{
+    expect($html)
+        ->not->toMatch('/\dx for\s*[;)]/')
+        ->not->toMatch('/can use\s+and\b/')
+        ->not->toMatch('/unlocks\s+—/')
+        ->not->toMatch('/from\s+up to\b/')
+        ->not->toMatch('/simple\s+replies\b/')
+        ->not->toMatch('/^\s*is free on every plan/m');
+}
+
+it('names every offered model in exactly one multiplier clause', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    catalogOf([
+        ['model' => 'a-1', 'label' => 'Alpha One', 'min_plan' => 'free', 'credit_multiplier' => 1.0],
+        ['model' => 'b-2', 'label' => 'Beta Two', 'min_plan' => 'pro', 'credit_multiplier' => 2.0],
+        ['model' => 'c-7', 'label' => 'Gamma Seven', 'min_plan' => 'pro', 'credit_multiplier' => 7.5],
+    ]);
+
+    $html = (string) $this->get('/pricing')->assertOk()->getContent();
+
+    assertNoCopyHoles($html);
+
+    // 2x and 7.5x are multipliers the old three-bucket copy could not express at all.
+    expect($html)->toContain('1x for Alpha One and self-hosted models')
+        ->toContain('2x for Beta Two')
+        ->toContain('7.5x for Gamma Seven');
+});
+
+it('leaves no hole when no model carries a given multiplier', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    catalogOf([
+        ['model' => 'a-1', 'label' => 'Alpha One', 'min_plan' => 'free', 'credit_multiplier' => 1.0],
+    ]);
+
+    $html = (string) $this->get('/pricing')->assertOk()->getContent();
+
+    assertNoCopyHoles($html);
+
+    expect($html)->not->toContain('3x for');
+});
+
+it('leaves no hole when the catalog offers nothing on the free plan', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    catalogOf([
+        ['model' => 'b-2', 'label' => 'Beta Two', 'min_plan' => 'pro', 'credit_multiplier' => 2.0],
+    ]);
+
+    $html = (string) $this->get('/pricing')->assertOk()->getContent();
+
+    assertNoCopyHoles($html);
+
+    expect($html)->toContain('Every plan can use any self-hosted model you connect yourself.');
+});
+
+it('leaves no hole when the catalog offers nothing on a paid plan', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    catalogOf([
+        ['model' => 'a-1', 'label' => 'Alpha One', 'min_plan' => 'free', 'credit_multiplier' => 1.0],
+    ]);
+
+    $html = (string) $this->get('/pricing')->assertOk()->getContent();
+
+    assertNoCopyHoles($html);
+
+    expect($html)->not->toContain('additionally unlocks');
+});
+
+it('keeps the shipped seed catalog free of copy holes on both public pages', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    config(['chat.models' => (require base_path('packages/Chat/config/chat.php'))['models']]);
+    app()->forgetInstance(ModelRegistry::class);
+
+    assertNoCopyHoles((string) $this->get('/pricing')->assertOk()->getContent());
+    assertNoCopyHoles((string) $this->get('/ai')->assertOk()->getContent());
+});

--- a/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
+++ b/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
@@ -75,7 +75,7 @@ it('retries a failed listing rather than caching the emptiness for a day', funct
     $catalog = resolve(ProviderModelCatalog::class);
 
     expect($catalog('anthropic'))->toBe([])
-        ->and($catalog('anthropic'))->toBe(['claude-sonnet-5' => 1769904000]);
+        ->and($catalog('anthropic'))->toBe(['claude-sonnet-5' => ['label' => 'claude-sonnet-5', 'released_at' => 1769904000]]);
 });
 
 it('does not re-fetch a listing it already has', function (): void {

--- a/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
+++ b/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Http;
 use Relaticle\Chat\Services\ProviderModelCatalog;
 use Relaticle\SystemAdmin\Filament\Pages\Settings\ManageAiSettings;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
+use Tests\Helpers\ChatCatalog;
 
 /**
  * The model field is a picker over the provider's own listing, not a free-text box,
@@ -33,7 +34,7 @@ it('flags a stored model id the provider is no longer listing', function (): voi
     ]])]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(['models' => [catalogEntry(['model' => 'claude-retired-0'])], 'anthropic_effort' => 'high'])
+        ->fillForm(['models' => [ChatCatalog::entry(['model' => 'claude-retired-0'])], 'anthropic_effort' => 'high'])
         ->assertSuccessful()
         ->assertSee('not listed by the provider');
 });
@@ -44,7 +45,7 @@ it('says nothing about a model the provider does list', function (): void {
     ]])]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(['models' => [catalogEntry(['model' => 'claude-sonnet-5'])], 'anthropic_effort' => 'high'])
+        ->fillForm(['models' => [ChatCatalog::entry(['model' => 'claude-sonnet-5'])], 'anthropic_effort' => 'high'])
         ->assertSuccessful()
         ->assertDontSee('not listed by the provider');
 });
@@ -57,7 +58,7 @@ it('says nothing when the provider returned no list at all', function (): void {
     Http::fake(['api.anthropic.com/v1/models*' => Http::response([], 500)]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(['models' => [catalogEntry(['model' => 'claude-retired-0'])], 'anthropic_effort' => 'high'])
+        ->fillForm(['models' => [ChatCatalog::entry(['model' => 'claude-retired-0'])], 'anthropic_effort' => 'high'])
         ->assertSuccessful()
         ->assertDontSee('not listed by the provider');
 });

--- a/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
+++ b/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Http;
+use Relaticle\SystemAdmin\Filament\Pages\Settings\ManageAiSettings;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+/**
+ * The model field is a picker over the provider's own listing, not a free-text box,
+ * so a typo cannot become a production 404. Nothing else reads ProviderModelCatalog's
+ * output, so stubbing it to an empty list passed the whole suite.
+ *
+ * Separate from ManageAiSettingsTest because that file's beforeEach stubs this exact
+ * URL with an empty list, and Http stubs are matched in registration order — a second
+ * fake for the same pattern is never reached, whatever you reset in between.
+ */
+beforeEach(function (): void {
+    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+    Http::preventStrayRequests();
+});
+
+/**
+ * A stored id the provider no longer lists is still offered — dropping it would blank
+ * the row — but it is called out so an operator sees the drift.
+ */
+it('flags a stored model id the provider is no longer listing', function (): void {
+    Http::fake(['api.anthropic.com/v1/models*' => Http::response(['data' => [
+        ['id' => 'claude-sonnet-5', 'created_at' => '2026-02-01T00:00:00Z'],
+    ]])]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(['models' => [catalogEntry(['model' => 'claude-retired-0'])], 'anthropic_effort' => 'high'])
+        ->assertSuccessful()
+        ->assertSee('not listed by the provider');
+});
+
+it('says nothing about a model the provider does list', function (): void {
+    Http::fake(['api.anthropic.com/v1/models*' => Http::response(['data' => [
+        ['id' => 'claude-sonnet-5', 'created_at' => '2026-02-01T00:00:00Z'],
+    ]])]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(['models' => [catalogEntry(['model' => 'claude-sonnet-5'])], 'anthropic_effort' => 'high'])
+        ->assertSuccessful()
+        ->assertDontSee('not listed by the provider');
+});
+
+/**
+ * An install without that provider's key gets no list at all, which means "we cannot
+ * tell", not "this model is wrong". Saying otherwise would flag every row.
+ */
+it('says nothing when the provider returned no list at all', function (): void {
+    Http::fake(['api.anthropic.com/v1/models*' => Http::response([], 500)]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(['models' => [catalogEntry(['model' => 'claude-retired-0'])], 'anthropic_effort' => 'high'])
+        ->assertSuccessful()
+        ->assertDontSee('not listed by the provider');
+});

--- a/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
+++ b/tests/Feature/SystemAdmin/AiModelCatalogListingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Http;
+use Relaticle\Chat\Services\ProviderModelCatalog;
 use Relaticle\SystemAdmin\Filament\Pages\Settings\ManageAiSettings;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
@@ -59,4 +60,31 @@ it('says nothing when the provider returned no list at all', function (): void {
         ->fillForm(['models' => [catalogEntry(['model' => 'claude-retired-0'])], 'anthropic_effort' => 'high'])
         ->assertSuccessful()
         ->assertDontSee('not listed by the provider');
+});
+
+/**
+ * A vendor having a bad minute must not blank the picker for a day. Same rule as
+ * ModelProbe: an empty list is what we could not learn, not what the provider offers.
+ */
+it('retries a failed listing rather than caching the emptiness for a day', function (): void {
+    Http::fakeSequence()
+        ->push([], 500)
+        ->push(['data' => [['id' => 'claude-sonnet-5', 'created_at' => '2026-02-01T00:00:00Z']]]);
+
+    $catalog = resolve(ProviderModelCatalog::class);
+
+    expect($catalog('anthropic'))->toBe([])
+        ->and($catalog('anthropic'))->toBe(['claude-sonnet-5' => 1769904000]);
+});
+
+it('does not re-fetch a listing it already has', function (): void {
+    Http::fake(['api.anthropic.com/v1/models*' => Http::response(['data' => [
+        ['id' => 'claude-sonnet-5', 'created_at' => '2026-02-01T00:00:00Z'],
+    ]])]);
+
+    $catalog = resolve(ProviderModelCatalog::class);
+    $catalog('anthropic');
+    $catalog('anthropic');
+
+    Http::assertSentCount(1);
 });

--- a/tests/Feature/SystemAdmin/AiSpendStatsWidgetTest.php
+++ b/tests/Feature/SystemAdmin/AiSpendStatsWidgetTest.php
@@ -9,6 +9,7 @@ use Relaticle\Chat\Models\AiCreditTransaction;
 use Relaticle\Chat\Services\ModelRegistry;
 use Relaticle\SystemAdmin\Filament\Widgets\AiSpendStatsWidget;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
+use Tests\Helpers\ChatCatalog;
 
 mutates(AiSpendStatsWidget::class);
 
@@ -104,7 +105,7 @@ it('respects the dashboard period filter', function (): void {
 
 it('reports period ai cost in dollars from token usage', function (): void {
     $this->travelTo(new DateTimeImmutable('2026-06-15 12:00:00', new DateTimeZone('UTC')));
-    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    config()->set('chat.models', [ChatCatalog::entry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
     app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
@@ -121,7 +122,7 @@ it('reports period ai cost in dollars from token usage', function (): void {
 });
 
 it('surfaces models with no configured rate as unpriced instead of silently treating them as free', function (): void {
-    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    config()->set('chat.models', [ChatCatalog::entry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
     app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
@@ -139,7 +140,7 @@ it('surfaces models with no configured rate as unpriced instead of silently trea
 });
 
 it('keeps the upper-bound caveat alongside the unpriced list in a mixed month', function (): void {
-    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    config()->set('chat.models', [ChatCatalog::entry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
     app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
@@ -167,7 +168,7 @@ it('keeps the upper-bound caveat alongside the unpriced list in a mixed month', 
 });
 
 it('treats a malformed rate entry as unpriced instead of coercing it to zero cost', function (): void {
-    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => null])]);
+    config()->set('chat.models', [ChatCatalog::entry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => null])]);
     app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
@@ -185,7 +186,7 @@ it('treats a malformed rate entry as unpriced instead of coercing it to zero cos
 });
 
 it('ignores zero-token settlement rows instead of listing them as unpriced models', function (): void {
-    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    config()->set('chat.models', [ChatCatalog::entry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
     app()->forgetInstance(ModelRegistry::class);
 
     // settleReservedMinimum() books cancelled and timed-out turns under this

--- a/tests/Feature/SystemAdmin/AiSpendStatsWidgetTest.php
+++ b/tests/Feature/SystemAdmin/AiSpendStatsWidgetTest.php
@@ -6,6 +6,7 @@ use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Date;
 use Relaticle\Chat\Enums\AiCreditType;
 use Relaticle\Chat\Models\AiCreditTransaction;
+use Relaticle\Chat\Services\ModelRegistry;
 use Relaticle\SystemAdmin\Filament\Widgets\AiSpendStatsWidget;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
@@ -103,7 +104,8 @@ it('respects the dashboard period filter', function (): void {
 
 it('reports period ai cost in dollars from token usage', function (): void {
     $this->travelTo(new DateTimeImmutable('2026-06-15 12:00:00', new DateTimeZone('UTC')));
-    config()->set('chat.model_costs', ['claude-sonnet-4-6' => ['input_per_mtok' => 3.00, 'output_per_mtok' => 15.00]]);
+    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
         'type' => AiCreditType::Chat,
@@ -119,7 +121,8 @@ it('reports period ai cost in dollars from token usage', function (): void {
 });
 
 it('surfaces models with no configured rate as unpriced instead of silently treating them as free', function (): void {
-    config()->set('chat.model_costs', ['claude-sonnet-4-6' => ['input_per_mtok' => 3.00, 'output_per_mtok' => 15.00]]);
+    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
         'type' => AiCreditType::Chat,
@@ -136,7 +139,8 @@ it('surfaces models with no configured rate as unpriced instead of silently trea
 });
 
 it('keeps the upper-bound caveat alongside the unpriced list in a mixed month', function (): void {
-    config()->set('chat.model_costs', ['claude-sonnet-4-6' => ['input_per_mtok' => 3.00, 'output_per_mtok' => 15.00]]);
+    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
         'type' => AiCreditType::Chat,
@@ -163,7 +167,8 @@ it('keeps the upper-bound caveat alongside the unpriced list in a mixed month', 
 });
 
 it('treats a malformed rate entry as unpriced instead of coercing it to zero cost', function (): void {
-    config()->set('chat.model_costs', ['claude-sonnet-4-6' => ['input_per_mtok' => 3.00]]);
+    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => null])]);
+    app()->forgetInstance(ModelRegistry::class);
 
     AiCreditTransaction::factory()->create([
         'type' => AiCreditType::Chat,
@@ -180,7 +185,8 @@ it('treats a malformed rate entry as unpriced instead of coercing it to zero cos
 });
 
 it('ignores zero-token settlement rows instead of listing them as unpriced models', function (): void {
-    config()->set('chat.model_costs', ['claude-sonnet-4-6' => ['input_per_mtok' => 3.00, 'output_per_mtok' => 15.00]]);
+    config()->set('chat.models', [catalogEntry(['model' => 'claude-sonnet-4-6', 'input_per_mtok' => 3.00, 'output_per_mtok' => 15.00])]);
+    app()->forgetInstance(ModelRegistry::class);
 
     // settleReservedMinimum() books cancelled and timed-out turns under this
     // synthetic model with zero tokens — they cost nothing to serve.
@@ -198,19 +204,18 @@ it('ignores zero-token settlement rows instead of listing them as unpriced model
         ->assertDontSee('Unpriced models');
 });
 
-it('has a configured cost rate for every hosted model the app can select', function (): void {
-    /** @var array<string, mixed> $rates */
-    $rates = config('chat.model_costs');
+it('has a cost rate on every catalog entry the app can select', function (): void {
+    $registry = resolve(ModelRegistry::class);
 
     $hostedModels = collect(config('chat.models'))
-        ->reject(fn (array $model): bool => (bool) ($model['self_hosted'] ?? false))
+        ->filter(fn (array $entry): bool => ($entry['enabled'] ?? true) === true)
         ->pluck('model')
         ->all();
 
     expect($hostedModels)->not->toBeEmpty();
 
     foreach ($hostedModels as $model) {
-        expect($rates)->toHaveKey($model);
+        expect($registry->ratesFor((string) $model))->not->toBeNull("{$model} has no rate");
     }
 });
 

--- a/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
+++ b/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
@@ -261,3 +261,28 @@ it('falls back to the most restrictive plan and a full-price multiplier when a r
     expect($descriptor?->minPlan)->toBe(Plan::Pro)
         ->and($descriptor?->creditMultiplier)->toEqual(1.0);
 });
+
+it('keeps probed capabilities when a save touches only the effort dial', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response([], 500),
+    ]);
+
+    $settings = resolve(ChatSettings::class);
+    $settings->models = [catalogEntry(['verified_at' => '2026-08-27T09:00:00+00:00'])];
+    $settings->save();
+
+    livewire(ManageAiSettings::class)
+        ->set('data.anthropic_effort', 'max')
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+
+    expect($entry['capabilities'])->toBe(['supports_tools' => true, 'write_guard' => 'api'])
+        ->and($entry['verified_at'])->toBe('2026-08-27T09:00:00+00:00');
+
+    app()->forgetInstance(ModelRegistry::class);
+
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet')?->supportsTools)->toBeTrue();
+});

--- a/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
+++ b/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
@@ -11,6 +11,7 @@ use Relaticle\Chat\Services\ModelRegistry;
 use Relaticle\Chat\Settings\ChatSettings;
 use Relaticle\SystemAdmin\Filament\Pages\Settings\ManageAiSettings;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
+use Tests\Helpers\ChatCatalog;
 
 mutates(ManageAiSettings::class);
 
@@ -33,7 +34,7 @@ beforeEach(function (): void {
 function catalogState(array $overrides = []): array
 {
     return array_merge([
-        'models' => [catalogEntry()],
+        'models' => [ChatCatalog::entry()],
         'anthropic_effort' => 'high',
     ], $overrides);
 }
@@ -54,7 +55,7 @@ it('offers only providers this install has a key for', function (): void {
     config(['ai.providers.gemini.key' => null]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(catalogState(['models' => [catalogEntry(['provider' => 'gemini', 'model' => 'gemini-3-flash'])]]))
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['provider' => 'gemini', 'model' => 'gemini-3-flash'])]]))
         ->assertSuccessful()
         ->assertSee('Gemini (no API key)')
         ->assertDontSee('Cohere');
@@ -92,7 +93,7 @@ it('refuses to store a model the provider rejects, and says why', function (): v
     $before = resolve(ChatSettings::class)->models;
 
     livewire(ManageAiSettings::class)
-        ->fillForm(catalogState(['models' => [catalogEntry(['model' => 'claude-imaginary'])]]))
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['model' => 'claude-imaginary'])]]))
         ->call('save')
         ->assertNotified();
 
@@ -150,7 +151,7 @@ it('carries Auto membership on the entry itself', function (): void {
     ]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(catalogState(['models' => [catalogEntry(['auto' => false])]]))
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['auto' => false])]]))
         ->call('save')
         ->assertHasNoFormErrors();
 
@@ -210,7 +211,7 @@ it('keeps what is edited through the modal rather than the table', function (): 
     ]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(catalogState(['models' => [catalogEntry([
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry([
             'label' => 'Sonnet 5 (fast)',
             'min_plan' => 'enterprise',
             'input_per_mtok' => 4.5,
@@ -245,7 +246,7 @@ it('falls back to the most restrictive plan and a full-price multiplier when a r
     ]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(catalogState(['models' => [catalogEntry(['min_plan' => null, 'credit_multiplier' => null])]]))
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['min_plan' => null, 'credit_multiplier' => null])]]))
         ->call('save')
         ->assertHasNoFormErrors();
 
@@ -269,7 +270,7 @@ it('keeps probed capabilities when a save touches only the effort dial', functio
     ]);
 
     $settings = resolve(ChatSettings::class);
-    $settings->models = [catalogEntry(['verified_at' => '2026-08-27T09:00:00+00:00'])];
+    $settings->models = [ChatCatalog::entry(['verified_at' => '2026-08-27T09:00:00+00:00'])];
     $settings->save();
 
     livewire(ManageAiSettings::class)
@@ -295,20 +296,61 @@ it('spells a provider the way its vendor does', function (): void {
     Http::fake(['api.openai.com/v1/models*' => Http::response(['data' => []])]);
 
     livewire(ManageAiSettings::class)
-        ->fillForm(catalogState(['models' => [catalogEntry(['provider' => 'openai', 'model' => 'gpt-5.5'])]]))
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['provider' => 'openai', 'model' => 'gpt-5.5'])]]))
         ->assertSuccessful()
         ->assertSee('OpenAI')
         ->assertDontSee('Openai');
 });
 
 /**
- * verified() skips disabled entries, so a retired row showing "on save" promises a
- * probe that never runs.
+ * The Verified column is an icon, and Filament renders its tooltip as the icon's
+ * visually-hidden text, so what an operator is told is assertable as rendered text.
+ *
+ * verified() skips disabled entries, so a retired row promising a probe on save
+ * promises one that never runs.
  */
 it('does not promise a probe on a row that will never be probed', function (): void {
     livewire(ManageAiSettings::class)
-        ->fillForm(catalogState(['models' => [catalogEntry(['capabilities' => null, 'enabled' => false])]]))
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['capabilities' => null, 'enabled' => false])]]))
         ->assertSuccessful()
-        ->assertSee('not probed')
-        ->assertDontSee('on save');
+        ->assertSee('Disabled, so it is never probed')
+        ->assertDontSee('Saving probes this model');
+});
+
+it('promises a probe on an enabled row nothing has measured yet', function (): void {
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['capabilities' => null])]]))
+        ->assertSuccessful()
+        ->assertSee('Saving probes this model');
+});
+
+/**
+ * The config seed declares capabilities for models nobody has probed here, and a
+ * column headed "Verified" must not launder that into a measurement.
+ */
+it('separates a capability this install measured from one the row merely declares', function (): void {
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['verified_at' => null])]]))
+        ->assertSuccessful()
+        ->assertSee('no probe has run on this install')
+        ->assertDontSee('accepted a real request');
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['verified_at' => now()->subHour()->toIso8601String()])]]))
+        ->assertSuccessful()
+        ->assertSee('accepted a real request 1 hour ago')
+        ->assertDontSee('no probe has run on this install');
+});
+
+/**
+ * ModelRegistry hides a row without tool support from every picker, so the column
+ * has to read as a problem rather than as a quieter kind of pass.
+ */
+it('flags a row the provider will not serve tools on', function (): void {
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry([
+            'capabilities' => ['supports_tools' => false, 'write_guard' => 'prompt'],
+        ])]]))
+        ->assertSuccessful()
+        ->assertSee('No tool calls, so this model is offered to nobody');
 });

--- a/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
+++ b/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
@@ -74,7 +74,7 @@ it('carries a saved model all the way into the request the assistant sends', fun
 
     app()->forgetInstance(ModelRegistry::class);
 
-    expect(resolve(ModelRegistry::class)->find('claude-sonnet')?->model)->toBe('claude-sonnet-5');
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet-5')?->model)->toBe('claude-sonnet-5');
 });
 
 /**
@@ -155,7 +155,7 @@ it('carries Auto membership on the entry itself', function (): void {
         ->call('save')
         ->assertHasNoFormErrors();
 
-    expect(collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet')['auto'])->toBeFalse();
+    expect(collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5')['auto'])->toBeFalse();
 });
 
 it('records who changed which dial, and to what', function (): void {
@@ -220,7 +220,7 @@ it('keeps what is edited through the modal rather than the table', function (): 
         ->call('save')
         ->assertHasNoFormErrors();
 
-    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5');
 
     expect($entry['label'])->toBe('Sonnet 5 (fast)')
         ->and($entry['min_plan'])->toBe('enterprise')
@@ -230,7 +230,7 @@ it('keeps what is edited through the modal rather than the table', function (): 
 
     app()->forgetInstance(ModelRegistry::class);
 
-    expect(resolve(ModelRegistry::class)->find('claude-sonnet')?->displayLabel())->toBe('Sonnet 5 (fast)');
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet-5')?->displayLabel())->toBe('Sonnet 5 (fast)');
 });
 
 /**
@@ -250,14 +250,14 @@ it('falls back to the most restrictive plan and a full-price multiplier when a r
         ->call('save')
         ->assertHasNoFormErrors();
 
-    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5');
 
     expect($entry['min_plan'])->toBe('pro')
         ->and($entry['credit_multiplier'])->toEqual(1.0);
 
     app()->forgetInstance(ModelRegistry::class);
 
-    $descriptor = resolve(ModelRegistry::class)->find('claude-sonnet');
+    $descriptor = resolve(ModelRegistry::class)->find('claude-sonnet-5');
 
     expect($descriptor?->minPlan)->toBe(Plan::Pro)
         ->and($descriptor?->creditMultiplier)->toEqual(1.0);
@@ -278,14 +278,14 @@ it('keeps probed capabilities when a save touches only the effort dial', functio
         ->call('save')
         ->assertHasNoFormErrors();
 
-    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5');
 
     expect($entry['capabilities'])->toBe(['supports_tools' => true, 'write_guard' => 'api'])
         ->and($entry['verified_at'])->toBe('2026-08-27T09:00:00+00:00');
 
     app()->forgetInstance(ModelRegistry::class);
 
-    expect(resolve(ModelRegistry::class)->find('claude-sonnet')?->supportsTools)->toBeTrue();
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet-5')?->supportsTools)->toBeTrue();
 });
 
 /**

--- a/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
+++ b/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Plan;
+use App\Models\ActivityLog\Activity;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Relaticle\Chat\Services\ModelRegistry;
+use Relaticle\Chat\Settings\ChatSettings;
+use Relaticle\SystemAdmin\Filament\Pages\Settings\ManageAiSettings;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+mutates(ManageAiSettings::class);
+
+beforeEach(function (): void {
+    $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+
+    // Rendering the page evaluates the model datalist, which lists models live from
+    // the provider. Nothing in this suite may reach the network.
+    Http::preventStrayRequests();
+    Http::fake(['api.anthropic.com/v1/models*' => Http::response(['data' => []])]);
+});
+
+/**
+ * The stored catalog, as the page's form state expects it.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function catalogState(array $overrides = []): array
+{
+    return array_merge([
+        'models' => [catalogEntry()],
+        'anthropic_effort' => 'high',
+    ], $overrides);
+}
+
+it('renders the catalog the app is actually running on', function (): void {
+    livewire(ManageAiSettings::class)
+        ->assertSuccessful()
+        ->assertFormSet(fn (array $state): bool => $state['anthropic_effort'] === config('chat.anthropic_effort'));
+});
+
+/**
+ * A provider with no API key can serve nothing — save() rejects every model under
+ * one — so offering it in the picker is offering a dead end. The exception is a
+ * provider a stored row already names: dropping it from the options would blank
+ * that row on render.
+ */
+it('offers only providers this install has a key for', function (): void {
+    config(['ai.providers.gemini.key' => null]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [catalogEntry(['provider' => 'gemini', 'model' => 'gemini-3-flash'])]]))
+        ->assertSuccessful()
+        ->assertSee('Gemini (no API key)')
+        ->assertDontSee('Cohere');
+});
+
+it('carries a saved model all the way into the request the assistant sends', function (): void {
+    Http::fake(['api.anthropic.com/*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []])]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['anthropic_effort' => 'low']))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(resolve(ChatSettings::class)->anthropic_effort)->toBe('low')
+        ->and(config('chat.anthropic_effort'))->toBe('low');
+
+    app()->forgetInstance(ModelRegistry::class);
+
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet')?->model)->toBe('claude-sonnet-5');
+});
+
+/**
+ * The gate the whole page exists for. A model the provider will not serve must
+ * never reach the catalog, because every turn that picks it fails outright
+ * (RELATICLE-CRM-6D).
+ */
+it('refuses to store a model the provider rejects, and says why', function (): void {
+    Http::fake([
+        'api.anthropic.com/*' => Http::response([
+            'type' => 'error',
+            'error' => ['type' => 'not_found_error', 'message' => 'model: claude-imaginary'],
+        ], 404),
+    ]);
+
+    $before = resolve(ChatSettings::class)->models;
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [catalogEntry(['model' => 'claude-imaginary'])]]))
+        ->call('save')
+        ->assertNotified();
+
+    expect(resolve(ChatSettings::class)->models)->toBe($before);
+});
+
+it('does not re-verify models that are already in the catalog', function (): void {
+    Http::fake(['api.anthropic.com/*' => Http::response([], 500)]);
+
+    $settings = resolve(ChatSettings::class);
+    $settings->models = catalogState()['models'];
+    $settings->save();
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['anthropic_effort' => 'max']))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(resolve(ChatSettings::class)->anthropic_effort)->toBe('max');
+
+    // The catalog's own /v1/models listing is expected; what must NOT happen is a
+    // /v1/messages probe against a pairing that is already live.
+    Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/v1/messages'));
+});
+
+/**
+ * Chat runs entirely in queued jobs and a worker holds the config it booted
+ * with, so a save that does not restart them changes nothing for users until the
+ * next deploy.
+ */
+it('restarts the queue workers so running jobs pick the change up', function (): void {
+    Http::fake(['api.anthropic.com/*' => Http::response([], 500)]);
+    Artisan::spy();
+
+    $settings = resolve(ChatSettings::class);
+    $settings->models = catalogState()['models'];
+    $settings->save();
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['anthropic_effort' => 'medium']))
+        ->call('save');
+
+    Artisan::shouldHaveReceived('call')->with('queue:restart')->once();
+});
+
+/**
+ * Auto membership is a flag on the entry, so the chain cannot name a model that is
+ * not in the catalog. This pins that the flag round-trips rather than that a
+ * dangling id is rejected: there is no longer an id to dangle.
+ */
+it('carries Auto membership on the entry itself', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []]),
+    ]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [catalogEntry(['auto' => false])]]))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet')['auto'])->toBeFalse();
+});
+
+it('records who changed which dial, and to what', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []]),
+    ]);
+
+    $settings = resolve(ChatSettings::class);
+    $settings->models = catalogState()['models'];
+    $settings->save();
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['anthropic_effort' => 'xhigh']))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    // TeamScope hides tenant-less rows; the sysadmin ActivityResource drops it too.
+    $activity = Activity::query()->withoutGlobalScopes()->where('event', 'chat_settings_updated')->sole();
+
+    expect($activity->properties['changed'])->toContain('chat.anthropic_effort')
+        ->and($activity->properties['attributes']['chat.anthropic_effort'])->toBe('xhigh')
+        ->and($activity->properties['old']['chat.anthropic_effort'])->not->toBe('xhigh')
+        ->and($activity->causer_id)->not->toBeNull();
+});
+
+it('writes no activity when a save changes nothing', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []]),
+    ]);
+
+    livewire(ManageAiSettings::class)->fillForm(catalogState())->call('save')->assertHasNoFormErrors();
+
+    $afterFirst = Activity::query()->withoutGlobalScopes()->where('event', 'chat_settings_updated')->count();
+
+    livewire(ManageAiSettings::class)->fillForm(catalogState())->call('save')->assertHasNoFormErrors();
+
+    expect(Activity::query()->withoutGlobalScopes()->where('event', 'chat_settings_updated')->count())
+        ->toBe($afterFirst);
+});
+
+/**
+ * The label, the plan gate and the prices live behind a per-row modal, so they are
+ * Hidden components in the repeater rather than columns. A field absent from the
+ * schema is dropped from getState(), which would silently wipe all of them on the
+ * next save.
+ */
+it('keeps what is edited through the modal rather than the table', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []]),
+    ]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [catalogEntry([
+            'label' => 'Sonnet 5 (fast)',
+            'min_plan' => 'enterprise',
+            'input_per_mtok' => 4.5,
+            'output_per_mtok' => 21.0,
+        ])]]))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+
+    expect($entry['label'])->toBe('Sonnet 5 (fast)')
+        ->and($entry['min_plan'])->toBe('enterprise')
+        ->and($entry['input_per_mtok'])->toEqual(4.5)
+        ->and($entry['output_per_mtok'])->toEqual(21.0)
+        ->and($entry['credit_multiplier'])->toEqual(1.0);
+
+    app()->forgetInstance(ModelRegistry::class);
+
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet')?->displayLabel())->toBe('Sonnet 5 (fast)');
+});
+
+/**
+ * A row added without ever opening its modal must fail closed. An unreadable plan
+ * stored as free would hand an expensive model to every workspace and an empty one
+ * crashes ModelDescriptor::fromEntry() on the next read; a null multiplier casts to
+ * 0.0 and the model runs free forever.
+ */
+it('falls back to the most restrictive plan and a full-price multiplier when a row carries neither', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []]),
+    ]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [catalogEntry(['min_plan' => null, 'credit_multiplier' => null])]]))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('key', 'claude-sonnet');
+
+    expect($entry['min_plan'])->toBe('pro')
+        ->and($entry['credit_multiplier'])->toEqual(1.0);
+
+    app()->forgetInstance(ModelRegistry::class);
+
+    $descriptor = resolve(ModelRegistry::class)->find('claude-sonnet');
+
+    expect($descriptor?->minPlan)->toBe(Plan::Pro)
+        ->and($descriptor?->creditMultiplier)->toEqual(1.0);
+});

--- a/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
+++ b/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
@@ -289,6 +289,120 @@ it('keeps probed capabilities when a save touches only the effort dial', functio
 });
 
 /**
+ * The measurement is the stored one, never the form's.
+ *
+ * A repeater row an operator deletes and adds straight back carries no
+ * `capabilities` at all, and the pairing is still stored, so the probe used to be
+ * skipped and the entry written back unmeasured — dropping the model out of every
+ * picker and off the public pricing page. That is the silent failure this page
+ * exists to prevent, arriving through the page itself.
+ */
+it('keeps a stored measurement when a row is deleted and added straight back', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response([], 500),
+    ]);
+
+    $settings = resolve(ChatSettings::class);
+    $settings->models = [ChatCatalog::entry(['verified_at' => '2026-08-27T09:00:00+00:00'])];
+    $settings->save();
+
+    $reAdded = ChatCatalog::entry();
+    unset($reAdded['capabilities'], $reAdded['verified_at']);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [$reAdded]]))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5');
+
+    expect($entry['capabilities'])->toBe(['supports_tools' => true, 'write_guard' => 'api'])
+        ->and($entry['verified_at'])->toBe('2026-08-27T09:00:00+00:00');
+
+    app()->forgetInstance(ModelRegistry::class);
+
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet-5')?->supportsTools)->toBeTrue();
+});
+
+/**
+ * A new row is added disabled, so its first save stores the pairing without probing
+ * it. Switching it on is therefore the moment it first becomes servable, and the
+ * pairing already being stored must not be what lets it skip the gate.
+ */
+it('probes a stored row that has never been measured when it is switched on', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []]),
+    ]);
+
+    $settings = resolve(ChatSettings::class);
+    $settings->models = [ChatCatalog::entry(['enabled' => false, 'capabilities' => null])];
+    $settings->save();
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['enabled' => true, 'capabilities' => null])]]))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5');
+
+    expect($entry['capabilities'])->toBe(['supports_tools' => true, 'write_guard' => 'api'])
+        ->and($entry['verified_at'])->not->toBeNull();
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/v1/messages'));
+});
+
+/**
+ * Capabilities carried in on the form state are the one thing that must never
+ * survive a retag: the row still shows the previous model's measurement, and the
+ * new pairing has none.
+ */
+it('probes a retagged row rather than inheriting the old tag\'s measurement', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response([
+            'type' => 'error',
+            'error' => ['type' => 'not_found_error', 'message' => 'model: claude-imaginary'],
+        ], 404),
+    ]);
+
+    $settings = resolve(ChatSettings::class);
+    $settings->models = [ChatCatalog::entry()];
+    $settings->save();
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['model' => 'claude-imaginary'])]]))
+        ->call('save')
+        ->assertNotified();
+
+    expect(collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-imaginary'))->toBeNull();
+});
+
+/**
+ * The provider dropdown is key-gated, so this branch is not reachable through the
+ * page today. It stays the server-side floor: a catalog edited outside the panel,
+ * or a key rotated away between render and save, must not store a model nothing
+ * can serve.
+ */
+it('refuses a new pairing under a provider this install has no key for', function (): void {
+    config(['ai.providers.gemini.key' => null]);
+
+    $before = resolve(ChatSettings::class)->models;
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry([
+            'provider' => 'gemini',
+            'model' => 'gemini-4-ultra',
+            'capabilities' => null,
+        ])]]))
+        ->call('save')
+        ->assertNotified();
+
+    expect(resolve(ChatSettings::class)->models)->toBe($before);
+});
+
+/**
  * `headline()` renders `openai` as `Openai`. laravel/ai already spells each provider
  * on its enum case name, so the panel does not have to keep its own list.
  */

--- a/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
+++ b/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
@@ -286,3 +286,29 @@ it('keeps probed capabilities when a save touches only the effort dial', functio
 
     expect(resolve(ModelRegistry::class)->find('claude-sonnet')?->supportsTools)->toBeTrue();
 });
+
+/**
+ * `headline()` renders `openai` as `Openai`. laravel/ai already spells each provider
+ * on its enum case name, so the panel does not have to keep its own list.
+ */
+it('spells a provider the way its vendor does', function (): void {
+    Http::fake(['api.openai.com/v1/models*' => Http::response(['data' => []])]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [catalogEntry(['provider' => 'openai', 'model' => 'gpt-5.5'])]]))
+        ->assertSuccessful()
+        ->assertSee('OpenAI')
+        ->assertDontSee('Openai');
+});
+
+/**
+ * verified() skips disabled entries, so a retired row showing "on save" promises a
+ * probe that never runs.
+ */
+it('does not promise a probe on a row that will never be probed', function (): void {
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [catalogEntry(['capabilities' => null, 'enabled' => false])]]))
+        ->assertSuccessful()
+        ->assertSee('not probed')
+        ->assertDontSee('on save');
+});

--- a/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
+++ b/tests/Feature/SystemAdmin/ManageAiSettingsTest.php
@@ -403,6 +403,32 @@ it('refuses a new pairing under a provider this install has no key for', functio
 });
 
 /**
+ * A Filament toggle submits "1", not `true`. CatalogEntry casts rather than
+ * compares for exactly that reason, and pint's `strict_comparison` fixer rewrites
+ * any `==` put there, so this pins the behaviour the comment defends.
+ */
+it('reads a toggle that submits a string rather than a boolean', function (): void {
+    Http::fake([
+        'api.anthropic.com/v1/models*' => Http::response(['data' => []]),
+        'api.anthropic.com/v1/messages*' => Http::response(['id' => 'msg_1', 'content' => [], 'usage' => []]),
+    ]);
+
+    livewire(ManageAiSettings::class)
+        ->fillForm(catalogState(['models' => [ChatCatalog::entry(['auto' => '1', 'enabled' => '1'])]]))
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $entry = collect(resolve(ChatSettings::class)->models)->firstWhere('model', 'claude-sonnet-5');
+
+    expect($entry['auto'])->toBeTrue()
+        ->and($entry['enabled'])->toBeTrue();
+
+    app()->forgetInstance(ModelRegistry::class);
+
+    expect(resolve(ModelRegistry::class)->find('claude-sonnet-5'))->not->toBeNull();
+});
+
+/**
  * `headline()` renders `openai` as `Openai`. laravel/ai already spells each provider
  * on its enum case name, so the panel does not have to keep its own list.
  */

--- a/tests/Feature/Teams/WorkspaceActivityLogTest.php
+++ b/tests/Feature/Teams/WorkspaceActivityLogTest.php
@@ -362,6 +362,12 @@ test('filtering on updated covers custom field edits too', function (): void {
     $company = Company::factory()->for($this->team)->create(['name' => 'Field Edited Co']);
     Company::factory()->for($this->team)->create(['name' => 'Untouched Co'])->delete();
 
+    // The custom-field edit is a later request, so it gets its own batch_uuid.
+    // Without this the whole test shares one, RequestActivityBatch being scoped to
+    // a request, and the edit collapses into the company's `created` row instead —
+    // which is what the page is supposed to do to a create that carried fields.
+    app()->forgetScopedInstances();
+
     activity()
         ->performedOn($company)
         ->causedBy($this->owner)

--- a/tests/Helpers/ChatCatalog.php
+++ b/tests/Helpers/ChatCatalog.php
@@ -7,10 +7,13 @@ namespace Tests\Helpers;
 /**
  * Fixtures for the chat model catalog, in the shape ChatSettings stores.
  *
- * One home for the entry shape: `key`, the measured `capabilities` record and the
- * per-million prices are restated by every suite that touches the catalog — the
- * registry, the credit maths, the sysadmin page and the spend widget — so a change
- * to the stored shape used to mean hunting all of them.
+ * One home for the entry shape: the identifying `model` tag, the measured
+ * `capabilities` record and the per-million prices are restated by every suite that
+ * touches the catalog — the registry, the credit maths, the sysadmin page and the
+ * spend widget — so a change to the stored shape used to mean hunting all of them.
+ *
+ * Override `model` to get a second, distinct entry: it is the identity, so two
+ * entries sharing it are one model as far as every reader is concerned.
  */
 final class ChatCatalog
 {
@@ -21,7 +24,6 @@ final class ChatCatalog
     public static function entry(array $overrides = []): array
     {
         return array_merge([
-            'key' => 'claude-sonnet',
             'label' => 'Sonnet 5',
             'provider' => 'anthropic',
             'model' => 'claude-sonnet-5',

--- a/tests/Helpers/ChatCatalog.php
+++ b/tests/Helpers/ChatCatalog.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+/**
+ * Fixtures for the chat model catalog, in the shape ChatSettings stores.
+ *
+ * One home for the entry shape: `key`, the measured `capabilities` record and the
+ * per-million prices are restated by every suite that touches the catalog — the
+ * registry, the credit maths, the sysadmin page and the spend widget — so a change
+ * to the stored shape used to mean hunting all of them.
+ */
+final class ChatCatalog
+{
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    public static function entry(array $overrides = []): array
+    {
+        return array_merge([
+            'key' => 'claude-sonnet',
+            'label' => 'Sonnet 5',
+            'provider' => 'anthropic',
+            'model' => 'claude-sonnet-5',
+            'min_plan' => 'free',
+            'credit_multiplier' => 1.0,
+            'input_per_mtok' => 3.0,
+            'output_per_mtok' => 15.0,
+            'auto' => true,
+            'enabled' => true,
+            'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'],
+            'verified_at' => null,
+        ], $overrides);
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,30 +45,6 @@ function livewire(string $component, array $params = []): Testable
 }
 
 /**
- * One catalog entry in the shape ChatSettings stores.
- *
- * @param  array<string, mixed>  $overrides
- * @return array<string, mixed>
- */
-function catalogEntry(array $overrides = []): array
-{
-    return array_merge([
-        'key' => 'claude-sonnet',
-        'label' => 'Sonnet 5',
-        'provider' => 'anthropic',
-        'model' => 'claude-sonnet-5',
-        'min_plan' => 'free',
-        'credit_multiplier' => 1.0,
-        'input_per_mtok' => 3.0,
-        'output_per_mtok' => 15.0,
-        'auto' => true,
-        'enabled' => true,
-        'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'],
-        'verified_at' => null,
-    ], $overrides);
-}
-
-/**
  * Invoke the chat conversation broadcast channel authorization callback.
  *
  * The conversation channel is registered on boot; if the broadcaster has not yet

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,6 +45,30 @@ function livewire(string $component, array $params = []): Testable
 }
 
 /**
+ * One catalog entry in the shape ChatSettings stores.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function catalogEntry(array $overrides = []): array
+{
+    return array_merge([
+        'key' => 'claude-sonnet',
+        'label' => 'Sonnet 5',
+        'provider' => 'anthropic',
+        'model' => 'claude-sonnet-5',
+        'min_plan' => 'free',
+        'credit_multiplier' => 1.0,
+        'input_per_mtok' => 3.0,
+        'output_per_mtok' => 15.0,
+        'auto' => true,
+        'enabled' => true,
+        'capabilities' => ['supports_tools' => true, 'write_guard' => 'api'],
+        'verified_at' => null,
+    ], $overrides);
+}
+
+/**
  * Invoke the chat conversation broadcast channel authorization callback.
  *
  * The conversation channel is registered on boot; if the broadcaster has not yet


### PR DESCRIPTION
The chat model catalog moves out of `packages/Chat/config/chat.php` and into settings, editable at `/sysadmin/ai-models`, so retiring a model or shipping a new one no longer needs a deploy; the config values stay as the seed and the fallback before the table exists. Nothing is stored unverified: every newly introduced provider/model pairing is probed with a real request built the way a turn builds one, and the capabilities that probe measures are what get saved, which is the gate that was missing when Anthropic removed `temperature` on Opus 4.7 and every turn on it failed (RELATICLE-CRM-6D, now fixed by dropping `#[Temperature]` for the `output_config.effort` dial the panel exposes).

Auto membership, the plan gate, the credit multiplier and the vendor prices now ride on the catalog entry itself, so the Auto chain can no longer name a model nobody offers and a retired model still prices the credit rows naming it; self-hosted models stay env-driven and are merged in at read time. Each save probes, restarts the queue workers (chat runs in queued jobs holding the config they booted with), and records what changed in the activity log.

Two consumers still read the old entry shape and had gone silently empty: the chat provider health check registered zero checks, and the pricing and AI pages rendered "Every plan can use  and any self-hosted model" — both now read through `ModelRegistry`.

Verified: full suite green (3556 passed, 0 failed), phpstan 0 errors, 100% type coverage, rector and pint clean; the panel, both marketing pages and a real save were walked in the browser.