### PR TITLE
fix(demo): store company logos on every demo:reset

### DIFF
--- a/app/Console/Commands/ResetDemoAccountCommand.php
+++ b/app/Console/Commands/ResetDemoAccountCommand.php
@@ -15,6 +15,7 @@ use App\Actions\People\CreatePeople;
 use App\Actions\Task\CreateTask;
 use App\Actions\Task\UpdateTask;
 use App\Enums\CreationSource;
+use App\Jobs\FetchFaviconForCompany;
 use App\Models\ActivityLog\Activity;
 use App\Models\Company;
 use App\Models\CustomField;
@@ -28,6 +29,7 @@ use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Carbon;
@@ -111,8 +113,10 @@ final class ResetDemoAccountCommand extends Command
         // team_id and creator_id from the authenticated user.
         Auth::setUser($user);
 
+        $seededCompanies = new EloquentCollection;
+
         try {
-            DB::transaction(function () use ($user, $team): void {
+            DB::transaction(function () use ($user, $team, &$seededCompanies): void {
                 $this->resetReviewerWorkspace($team);
 
                 throw_unless(
@@ -121,6 +125,8 @@ final class ResetDemoAccountCommand extends Command
                     'Reviewer workspace fixtures could not be generated.',
                 );
 
+                $seededCompanies = Company::query()->where('team_id', $team->getKey())->get();
+
                 $this->resetAiCredits($team);
                 $this->shapeOpportunities($user, $team);
                 $this->shapeTasks($user, $team);
@@ -128,6 +134,7 @@ final class ResetDemoAccountCommand extends Command
                 $this->ensureInactiveField($user, $team);
                 $this->recordCreationActivity($user, $team);
             });
+            $this->fetchCompanyLogos($seededCompanies);
         } finally {
             Auth::forgetUser();
             TenantContextService::setTenantId($previousTenantId);
@@ -137,6 +144,17 @@ final class ResetDemoAccountCommand extends Command
         $this->components->twoColumnDetail('Password', $password === null ? 'unchanged' : 'updated');
 
         return self::SUCCESS;
+    }
+
+    // OnboardSeed writes its fixtures with model events disabled, so the observer that
+    // normally queues a logo fetch never fires for them. Everything created afterwards
+    // goes through the actions, and the observer covers those.
+    /** @param  EloquentCollection<int, Company>  $companies */
+    private function fetchCompanyLogos(EloquentCollection $companies): void
+    {
+        $companies->each(function (Company $company): void {
+            dispatch(new FetchFaviconForCompany($company));
+        });
     }
 
     private function password(): ?string
@@ -216,6 +234,12 @@ final class ResetDemoAccountCommand extends Command
         DB::table('exports')->where('team_id', $teamId)->delete();
         DB::table('team_invitations')->where('team_id', $teamId)->delete();
         Activity::query()->withoutGlobalScopes()->where('team_id', $teamId)->delete();
+
+        Company::query()
+            ->where('team_id', $teamId)
+            ->each(function (Company $company): void {
+                $company->clearMediaCollection(Company::LOGO_MEDIA_COLLECTION);
+            });
 
         Model::withoutEvents(function () use ($teamId): void {
             Note::query()->withTrashed()->where('team_id', $teamId)->forceDelete();
@@ -510,7 +534,7 @@ final class ResetDemoAccountCommand extends Command
             'Webflow' => ['domain' => 'webflow.com', 'handle' => 'webflow-inc-', 'icp' => true],
             'Zapier' => ['domain' => 'zapier.com', 'handle' => 'zapier', 'icp' => true],
             'Intercom' => ['domain' => 'intercom.com', 'handle' => 'intercom', 'icp' => true],
-            'Segment' => ['domain' => 'segment.com', 'handle' => 'segmentio', 'icp' => false],
+            'Airtable' => ['domain' => 'airtable.com', 'handle' => 'airtable', 'icp' => true],
             'Amplitude' => ['domain' => 'amplitude.com', 'handle' => 'amplitude-analytics', 'icp' => true],
         ];
     }
@@ -544,7 +568,7 @@ final class ResetDemoAccountCommand extends Command
             'Peter Nowak' => ['company' => 'Zapier', 'title' => 'Head of Integrations', 'phone' => '+14155550130'],
             'Sana Iqbal' => ['company' => 'Intercom', 'title' => 'Director of Support Operations', 'phone' => '+14155550131'],
             'Niall Sweeney' => ['company' => 'Intercom', 'title' => 'Revenue Operations Analyst', 'phone' => '+14155550132'],
-            'Gabriel Ruiz' => ['company' => 'Segment', 'title' => 'Data Platform Manager', 'phone' => '+14155550133'],
+            'Gabriel Ruiz' => ['company' => 'Airtable', 'title' => 'Data Platform Manager', 'phone' => '+14155550133'],
             'Helena Roth' => ['company' => 'Amplitude', 'title' => 'VP Product Analytics', 'phone' => '+14155550134'],
             'Tomas Bergstrom' => ['company' => 'Amplitude', 'title' => 'Enterprise Account Executive', 'phone' => '+14155550135'],
         ];
@@ -593,7 +617,7 @@ final class ResetDemoAccountCommand extends Command
             'Send Amplitude case study' => ['company' => 'Amplitude', 'contact' => 'Helena Roth', 'opportunity' => 'Amplitude Product Insights', 'status' => 'To do', 'priority' => 'Low', 'due_in_days' => 12, 'assigned' => false, 'description' => 'Share the product analytics case study she asked for on the intro call.'],
             'Confirm Retool sandbox access' => ['company' => 'Retool', 'contact' => 'Hugo Marchand', 'opportunity' => 'Retool Internal Tools', 'status' => 'In progress', 'priority' => 'Medium', 'due_in_days' => 4, 'assigned' => true, 'description' => 'Their architect needs sandbox credentials before the technical review.'],
             'Follow up with Loom on renewal' => ['company' => 'Loom', 'contact' => 'Mei Tanaka', 'opportunity' => '', 'status' => 'To do', 'priority' => 'Medium', 'due_in_days' => 9, 'assigned' => true, 'description' => 'Renewal conversation opens next month; confirm the seat count first.'],
-            'Introduce Segment to data team' => ['company' => 'Segment', 'contact' => 'Gabriel Ruiz', 'opportunity' => '', 'status' => 'To do', 'priority' => 'Low', 'due_in_days' => 15, 'assigned' => false, 'description' => 'Warm introduction between their data platform manager and our engineers.'],
+            'Introduce Airtable to the data team' => ['company' => 'Airtable', 'contact' => 'Gabriel Ruiz', 'opportunity' => '', 'status' => 'To do', 'priority' => 'Low', 'due_in_days' => 15, 'assigned' => false, 'description' => 'Warm introduction between their data platform manager and our engineers.'],
             'Recap Webflow platform review' => ['company' => 'Webflow', 'contact' => 'Isaac Mbeki', 'opportunity' => '', 'status' => 'Done', 'priority' => 'Low', 'due_in_days' => -8, 'assigned' => true, 'description' => 'Platform review went well; they will revisit budget next quarter.'],
         ];
     }

--- a/app/Jobs/FetchFaviconForCompany.php
+++ b/app/Jobs/FetchFaviconForCompany.php
@@ -38,6 +38,10 @@ final class FetchFaviconForCompany implements ShouldBeUnique, ShouldQueue
                 ->where('code', CompanyField::DOMAINS->value)
                 ->first();
 
+            // Reading a value walks every custom field value on the company, and a company
+            // with more than one of them trips strict lazy loading outside production.
+            $this->company->load('customFieldValues.customField.options');
+
             $domains = $this->company->getCustomFieldValue($customFieldDomain);
             $domainName = is_array($domains) ? ($domains[0] ?? null) : $domains;
 

--- a/tests/Feature/Commands/ResetDemoAccountCommandTest.php
+++ b/tests/Feature/Commands/ResetDemoAccountCommandTest.php
@@ -9,6 +9,7 @@ use App\Actions\Opportunity\AggregateOpportunities;
 use App\Actions\Opportunity\UpdateOpportunity;
 use App\Actions\Task\UpdateTask;
 use App\Console\Commands\ResetDemoAccountCommand;
+use App\Jobs\FetchFaviconForCompany;
 use App\Mcp\Servers\RelaticleServer;
 use App\Mcp\Tools\AggregateOpportunitiesTool;
 use App\Mcp\Tools\FetchTool;
@@ -29,9 +30,11 @@ use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Services\Billing\HostedWorkspaceAccess;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\Testing\Fluent\AssertableJson;
 use Relaticle\Chat\Models\AiCreditBalance;
@@ -320,6 +323,33 @@ it('creates a deterministic reviewer workspace and safely refreshes it', functio
     ])->toBe($entityCounts)
         ->and(Hash::check($replacementPassword, (string) $reviewer->password))->toBeTrue()
         ->and(Company::query()->withoutGlobalScopes()->whereKey($otherCompany->getKey())->exists())->toBeTrue();
+});
+
+it('queues exactly one logo fetch per company, including the fixtures seeded without model events', function (): void {
+    Bus::fake([FetchFaviconForCompany::class]);
+
+    $this->artisan('demo:reset', ['--password' => 'runtime-secret-five'])->assertSuccessful();
+
+    Bus::assertDispatched(FetchFaviconForCompany::class, fn (FetchFaviconForCompany $job): bool => $job->company->name === 'Notion');
+    Bus::assertDispatchedTimes(FetchFaviconForCompany::class, 20);
+});
+
+it('removes stored logos before rebuilding the workspace', function (): void {
+    Storage::fake('public');
+
+    $this->artisan('demo:reset', ['--password' => 'runtime-secret-six'])->assertSuccessful();
+
+    $team = User::query()->where('email', ResetDemoAccountCommand::EMAIL)->firstOrFail()->personalTeam();
+    $company = Company::query()->where('team_id', $team->getKey())->where('name', 'Notion')->firstOrFail();
+    $company->addMediaFromString('logo-bytes')
+        ->usingFileName('logo.png')
+        ->toMediaCollection(Company::LOGO_MEDIA_COLLECTION);
+
+    expect(DB::table('media')->where('model_id', $company->getKey())->count())->toBe(1);
+
+    $this->artisan('demo:reset')->assertSuccessful();
+
+    expect(DB::table('media')->where('model_id', $company->getKey())->count())->toBe(0);
 });
 
 it('keeps the existing workspace slug when another team already holds the reviewer slug', function (): void {

--- a/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
+++ b/tests/Feature/Jobs/FetchFaviconForCompanyTest.php
@@ -117,3 +117,33 @@ test('downloads the favicon through the guarded client and stores it', function 
     Http::assertSent(fn ($request): bool => $request->url() === 'https://1.1.1.1/favicon.png');
     expect($company->fresh()->getMedia('logo'))->toHaveCount(1);
 });
+
+test('downloads the favicon when the company carries several custom field values', function (): void {
+    Storage::fake('public');
+
+    $company = Company::factory()->for($this->user->currentTeam)->create();
+
+    foreach ([CompanyField::DOMAINS->value => ['example.com'], CompanyField::LINKEDIN->value => 'www.linkedin.com/company/example'] as $code => $value) {
+        CustomFieldValue::forceCreate([
+            'tenant_id' => $this->user->currentTeam->getKey(),
+            'entity_type' => 'company',
+            'entity_id' => $company->getKey(),
+            'custom_field_id' => CustomField::query()->where('code', $code)->forEntity(Company::class)->firstOrFail()->getKey(),
+            'json_value' => $value,
+        ]);
+    }
+
+    $favicon = Mockery::mock(AshAllenDesign\FaviconFetcher\Favicon::class);
+    $favicon->shouldReceive('getFaviconUrl')->andReturn('https://1.1.1.1/favicon.png');
+    $favicon->shouldReceive('getIconSize')->andReturn(180);
+    $favicon->shouldReceive('getIconType')->andReturn('apple-touch-icon');
+
+    Favicon::shouldReceive('driver->fetch')->andReturn($favicon);
+
+    $pngBytes = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+    Http::fake(['https://1.1.1.1/favicon.png' => Http::response($pngBytes, 200)]);
+
+    (new FetchFaviconForCompany($company->fresh()))->handle();
+
+    expect($company->fresh()->getMedia('logo'))->toHaveCount(1);
+});


### PR DESCRIPTION
The reviewer workspace showed no company logos at all, and three separate causes were behind it. `FetchFaviconForCompany` read a custom field value without eager loading the values it walks, so any company carrying more than one custom field tripped strict lazy loading, the job swallowed the violation and stored nothing (every demo company has three, and the existing tests used companies with a single value, which never arms the check). OnboardSeed writes its fixtures with model events disabled, so the observer that queues the fetch never fired for Notion, Figma, Apple and Airbnb; `demo:reset` now queues those four itself after the rebuild commits and leaves everything it creates through the actions to the observer, which keeps it at exactly one fetch per company. The reset also force-deletes companies with events disabled, skipping media library's cleanup and orphaning a media row and file on every run, so logos are cleared before the wipe. Lastly `segment.com` redirects to `twilio.com` and pulled Twilio's logo, so that fixture is now Airtable; the other nineteen domains were checked and resolve to themselves.

Verified on the local app, not just in tests: after `QUEUE_CONNECTION=sync php artisan demo:reset` the workspace reports 20 companies, 20 with logos, exactly 20 media rows and 0 orphans, and the Companies table renders Notion's mark in the browser. Note `tests/Feature/Teams/WorkspaceActivityLogTest::filtering on updated covers custom field edits too` fails on `origin/main` (637d88c) with this branch stashed, so it is unrelated to these changes.