### PR TITLE
fix(marketing): quote one MCP tool count across the public pages

### DIFF
--- a/app/Support/CompetitorFacts.php
+++ b/app/Support/CompetitorFacts.php
@@ -55,4 +55,13 @@ final readonly class CompetitorFacts
 
         return $facts;
     }
+
+    // Read from the `ai` fact rather than a fresh literal, so no marketing surface
+    // can drift from the tool count the MCP server actually registers.
+    public static function mcpToolCount(): int
+    {
+        preg_match('/^(\d+)/', self::all()['relaticle']['ai'], $matches);
+
+        return (int) ($matches[1] ?? 0);
+    }
 }

--- a/resources/views/home/partials/community.blade.php
+++ b/resources/views/home/partials/community.blade.php
@@ -1,3 +1,7 @@
+@php
+    $mcpToolCount = \App\Support\CompetitorFacts::mcpToolCount();
+@endphp
+
 <section id="community" class="relative py-24 md:py-32 overflow-hidden bg-white dark:bg-gray-950">
     <div class="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgb(0_0_0/0.04)_1px,transparent_0)] dark:bg-[radial-gradient(circle_at_1px_1px,rgb(255_255_255/0.035)_1px,transparent_0)] bg-[size:24px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_50%,black_25%,transparent_100%)]"></div>
 
@@ -43,7 +47,7 @@
         <div class="max-w-3xl mx-auto">
             <div class="rounded-xl border border-gray-200/80 dark:border-white/[0.06] bg-gray-50/50 dark:bg-white/[0.015] overflow-hidden">
                 <div class="grid grid-cols-2 md:grid-cols-4 divide-x divide-gray-200/60 dark:divide-white/[0.04]">
-                    @foreach([['AGPL-3.0', 'Open Source'], ['2,000+', 'Automated Tests'], ['32', 'MCP Tools'], ['Free', 'Forever']] as $index => [$value, $label])
+                    @foreach([['AGPL-3.0', 'Open Source'], ['2,000+', 'Automated Tests'], [(string) $mcpToolCount, 'MCP Tools'], ['Free', 'Forever']] as $index => [$value, $label])
                         <div class="px-6 py-5 text-center @if($index >= 2) border-t border-gray-200/60 dark:border-white/[0.04] md:border-t-0 @endif">
                             <div class="text-lg font-semibold text-gray-900 dark:text-white tracking-tight">{{ $value }}</div>
                             <div class="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5 uppercase tracking-wider font-medium">{{ $label }}</div>

--- a/resources/views/home/partials/features.blade.php
+++ b/resources/views/home/partials/features.blade.php
@@ -2,6 +2,7 @@
     $cardBase = 'group feat-card rounded-xl border border-gray-200/80 dark:border-white/[0.06] bg-white dark:bg-white/[0.02] transition-all duration-300 hover:border-gray-300 dark:hover:border-white/[0.10] hover:shadow-sm';
     $cardTitle = 'font-display text-lg font-medium text-gray-900 dark:text-white mb-2';
     $cardDesc = 'text-[13px] leading-relaxed text-gray-500 dark:text-gray-400';
+    $mcpToolCount = \App\Support\CompetitorFacts::mcpToolCount();
 @endphp
 
 <section id="features" class="py-24 md:py-32 bg-gray-50 dark:bg-gray-950 relative overflow-hidden">
@@ -54,7 +55,7 @@
                         <div class="fn w-full bg-white dark:bg-gray-700 border border-primary/30 dark:border-primary/40 rounded-lg p-3 shadow-sm shadow-primary/5">
                             <div class="text-[10px] font-medium text-emerald-700 dark:text-emerald-400 mb-2">MCP Server · Connected</div>
                             <div class="flex gap-4 text-[11px]">
-                                <span class="text-gray-500 dark:text-gray-400"><span class="font-mono font-medium text-gray-800 dark:text-gray-200">32</span> tools</span>
+                                <span class="text-gray-500 dark:text-gray-400"><span class="font-mono font-medium text-gray-800 dark:text-gray-200">{{ $mcpToolCount }}</span> tools</span>
                                 <span class="text-gray-500 dark:text-gray-400">REST API <span class="font-mono font-medium text-gray-800 dark:text-gray-200">v1</span></span>
                                 <span class="text-gray-500 dark:text-gray-400">Schema <span class="font-mono font-medium text-emerald-700 dark:text-emerald-400">auto</span></span>
                             </div>
@@ -98,7 +99,7 @@
                                 <div class="bg-white dark:bg-gray-700 border border-primary/30 dark:border-primary/40 rounded-lg p-3 shadow-sm shadow-primary/5">
                                     <div class="text-[10px] font-medium text-emerald-700 dark:text-emerald-400 mb-2">Connected</div>
                                     <div class="space-y-1.5">
-                                        @foreach([['Tools', '32', ''], ['REST API', 'v1', ''], ['Schema', 'auto', 'text-emerald-700 dark:text-emerald-400']] as [$label, $val, $valClass])
+                                        @foreach([['Tools', (string) $mcpToolCount, ''], ['REST API', 'v1', ''], ['Schema', 'auto', 'text-emerald-700 dark:text-emerald-400']] as [$label, $val, $valClass])
                                             <div class="flex items-center justify-between text-[11px]">
                                                 <span class="text-gray-500 dark:text-gray-400">{{ $label }}</span>
                                                 <span class="font-mono font-medium {{ $valClass ?: 'text-gray-800 dark:text-gray-200' }}">{{ $val }}</span>

--- a/resources/views/press.blade.php
+++ b/resources/views/press.blade.php
@@ -1,11 +1,7 @@
 @php
     $facts = \App\Support\CompetitorFacts::all()['relaticle'];
 
-    // Derived from the facts file's `ai` field ("37 first-party MCP tools plus...")
-    // rather than a fresh literal, so this number can never drift from the one
-    // source of truth for public competitor/company claims.
-    preg_match('/^(\d+)/', $facts['ai'], $mcpToolMatch);
-    $mcpToolCount = (int) ($mcpToolMatch[1] ?? 0);
+    $mcpToolCount = \App\Support\CompetitorFacts::mcpToolCount();
 
     $starsAsOf = \Carbon\CarbonImmutable::parse($facts['stars_verified'])->format('F j, Y');
     $factsVerifiedAt = \Carbon\CarbonImmutable::parse($facts['verified'])->format('F j, Y');

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -1,3 +1,7 @@
+@php
+    $mcpToolCount = \App\Support\CompetitorFacts::mcpToolCount();
+@endphp
+
 <x-guest-layout
     title="Pricing - $19/mo flat, unlimited users - Relaticle"
     description="No per-seat pricing. One flat workspace plan at $19/mo billed yearly, with unlimited users and records. 14-day trial, no card. Self-host free forever."
@@ -208,7 +212,7 @@
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
                     @foreach([
                         ['ri-shield-check-line', '2,000+', 'Automated Tests'],
-                        ['ri-robot-2-line', '32', 'MCP Tools'],
+                        ['ri-robot-2-line', (string) $mcpToolCount, 'MCP Tools'],
                         ['ri-stack-line', '22', 'Field Types'],
                         ['ri-lock-line', '5-Layer', 'Authorization'],
                     ] as [$icon, $value, $label])

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\PrivacyPolicyController;
 use App\Http\Controllers\TermsOfServiceController;
+use App\Mcp\Servers\RelaticleServer;
 use App\Models\User;
+use App\Support\CompetitorFacts;
 use App\Support\DetectsPublicMarkdownRequest;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\URL;
@@ -195,6 +197,24 @@ describe('Pricing page', function () {
 
         $response->assertStatus(200);
         $response->assertSee('No per-seat pricing');
+    });
+});
+
+describe('MCP tool count', function () {
+    it('quotes the registered tool count on every marketing page that claims one', function (): void {
+        $registered = new ReflectionClass(RelaticleServer::class)->getDefaultProperties()['tools'];
+        $count = CompetitorFacts::mcpToolCount();
+
+        expect($count)->toBe(count($registered));
+
+        foreach (['/', '/pricing', '/press'] as $path) {
+            $text = preg_replace('/\s+/', ' ', strip_tags($this->get($path)->assertOk()->getContent()));
+
+            preg_match_all('/(\d+)[ -](?:first-party )?(?:MCP )?tools?\b/i', (string) $text, $matches);
+
+            expect($matches[1])->not->toBeEmpty()
+                ->and(array_values(array_unique($matches[1])))->toBe([(string) $count]);
+        }
     });
 });
 


### PR DESCRIPTION
## Why

The MCP server registers 37 tools on `main`, and production runs `main`. The hero, the FAQ, the meta description and the pricing plan bullet all say 37. Four stat literals were missed and still said 32, so relaticle.com contradicted itself on the same page:

- `/pricing` sells a "REST API and 37-tool MCP server" directly above a trust-signal tile reading **32 MCP Tools**.
- The homepage MCP mockups and the community stat band each carried their own `'32'`.

Four independent copies of one number is why it drifted, so this removes the copies rather than editing them.

## What

- `CompetitorFacts::mcpToolCount()` reads the count from Relaticle's own `ai` fact, which is already the single source of truth for public claims. The press page had this exact regex inline; it now calls the shared method.
- The homepage (2 spots), the community stat band and the pricing trust signals all render that value.
- A test asserts the facts entry equals the tool list `RelaticleServer` actually registers, then walks `/`, `/pricing` and `/press` and fails if any of them quotes a different count. Verified it goes red when the `'32'` literal is put back.

## Verification

- `vendor/bin/pint --dirty`, `vendor/bin/rector --dry-run`, `phpstan analyse`: clean.
- `composer test:type-coverage`: 100%.
- `pest tests/Feature/Public/ tests/Feature/Billing/BillingPageTest.php`: 182 passed, 701 assertions.

Worth deciding separately: both stat bands also claim "2,000+ Automated Tests", and test counts are on the launch campaign's banned-claims list because nobody re-checks them.