### PR TITLE
fix(mcp): oauth connector docs, public tool count, demo email domains

### DIFF
--- a/.claude/skills/ai-sdk-development/SKILL.md
+++ b/.claude/skills/ai-sdk-development/SKILL.md
@@ -450,9 +450,9 @@ Embeddings::for(['Hello'])->generate(
 );
 ```
 
-It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
+It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions`; the returned array is merged into the body.
 
-Transcription uploads standard multipart (`file` + `model` + optional `language`) and defaults to `response_format: json`. Because endpoints vary, provider options override the defaults — pass `response_format: 'verbose_json'` for segments, or use `diarize()` on servers that implement `diarized_json`:
+Transcription uploads standard multipart (`file` + `model` + optional `language`) and defaults to `response_format: json`. Because endpoints vary, provider options override the defaults. Pass `response_format: 'verbose_json'` for segments, or use `diarize()` on servers that implement `diarized_json`:
 
 ```php
 Transcription::fromDisk('recordings', $path)

--- a/packages/Documentation/resources/content/docs/guides/mcp.md
+++ b/packages/Documentation/resources/content/docs/guides/mcp.md
@@ -2,7 +2,7 @@
 title: MCP Server
 description: Connect AI assistants like Claude to your CRM.
 order: 2
-updated: "2026-08-26"
+updated: "2026-08-28"
 ---
 
 MCP (Model Context Protocol) lets AI assistants like Claude work directly with your Relaticle CRM data. Instead of copy-pasting between tools, your AI assistant can list companies, create tasks, update contacts, and more -- all from a natural conversation.
@@ -24,9 +24,11 @@ With the Relaticle MCP server, your AI assistant can:
 
 ---
 
-## Prerequisites
+## Connect to Relaticle
 
-Before connecting an AI assistant, you need an access token:
+Clients with OAuth support need only the MCP endpoint. ChatGPT and Claude open Relaticle's consent screen and let you choose one workspace.
+
+Clients without OAuth support need a personal access token:
 
 1. Log in to Relaticle
 2. Click your avatar in the top-right corner
@@ -34,7 +36,7 @@ Before connecting an AI assistant, you need an access token:
 4. Click **Create** and give your token a name
 5. Copy the token -- it won't be shown again
 
-The token scopes your access to the team you select when creating it. All MCP operations use that team's data.
+The token scopes your access to the workspace you select when creating it. All MCP operations use that workspace's data.
 
 ---
 
@@ -49,9 +51,9 @@ The MCP endpoint advertises OAuth metadata at:
 - `https://mcp.relaticle.com/.well-known/oauth-authorization-server`
 - `https://mcp.relaticle.com/.well-known/oauth-protected-resource`
 
-Clients that support Dynamic Client Registration (RFC 7591) — including Claude.ai, Claude Desktop, Claude Code, and ChatGPT custom connectors — register themselves automatically and walk you through a one-click consent flow. PKCE is required (`S256`).
+Clients that support Dynamic Client Registration (RFC 7591), including Claude.ai, Claude Desktop, Claude Code, and ChatGPT custom connectors, register themselves automatically and walk you through a one-click consent flow. PKCE is required (`S256`).
 
-At consent you pick **one workspace** for the connector. That choice is permanent for that connector: to point it at a different workspace, revoke it and connect again. Paused workspaces cannot be selected — subscribe first, or the connector would have no data to read.
+At consent you pick **one workspace** for the connector. That choice is permanent for that connector: to point it at a different workspace, revoke it and connect again. Paused workspaces cannot be selected. Subscribe first, or the connector would have no data to read.
 
 Access tokens last 30 days and refresh tokens 90 days; supported clients refresh silently in the background.
 
@@ -67,9 +69,23 @@ For Cursor, VS Code, MCP Inspector, or any client without OAuth support, create 
 
 ## Setup by Client
 
-The MCP server endpoint is `https://mcp.relaticle.com`. Replace `YOUR_TOKEN` in the examples below with the access token you created above.
+The MCP server endpoint is `https://mcp.relaticle.com`. ChatGPT and Claude use OAuth. The remaining examples use a personal access token.
 
-### Claude Desktop
+### ChatGPT
+
+1. Open **Settings → Security and login** and enable **Developer mode**.
+2. Open **ChatGPT Plugins** and select the plus button.
+3. Enter `Relaticle` and `https://mcp.relaticle.com`.
+4. Connect, sign in to Relaticle, and choose one workspace.
+
+### Claude
+
+1. Open **Customize → Connectors**.
+2. Select the plus button, then **Add custom connector**.
+3. Enter `Relaticle` and `https://mcp.relaticle.com`.
+4. Connect, sign in to Relaticle, and choose one workspace.
+
+### Claude Desktop with a personal access token
 
 Add this to your Claude Desktop configuration file (`claude_desktop_config.json`):
 
@@ -87,7 +103,7 @@ Add this to your Claude Desktop configuration file (`claude_desktop_config.json`
 }
 ```
 
-### Claude Code
+### Claude Code with a personal access token
 
 Add the server from your terminal:
 
@@ -98,7 +114,7 @@ claude mcp add relaticle \
   --header "Authorization: Bearer YOUR_TOKEN"
 ```
 
-### Cursor
+### Cursor with a personal access token
 
 Add this to your Cursor MCP configuration (`.cursor/mcp.json`):
 
@@ -116,7 +132,7 @@ Add this to your Cursor MCP configuration (`.cursor/mcp.json`):
 }
 ```
 
-### VS Code (GitHub Copilot)
+### VS Code with a personal access token
 
 Add this to your VS Code settings (`.vscode/mcp.json`):
 

--- a/packages/OnboardSeed/resources/fixtures/sales/people/brian.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/brian.yaml
@@ -2,7 +2,7 @@ name: Brian Chesky
 company: airbnb
 custom_fields:
   emails:
-    - brian@airbnb.com
+    - brian@airbnb.example
   phone_number: "+14155550100"
   job_title: CEO & Co-founder
   linkedin: www.linkedin.com/in/brianchesky/

--- a/packages/OnboardSeed/resources/fixtures/sales/people/dylan.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/dylan.yaml
@@ -2,7 +2,7 @@ name: Dylan Field
 company: figma
 custom_fields:
   emails:
-    - dylan@figma.com
+    - dylan@figma.example
   phone_number: "+14155550101"
   job_title: CEO
   linkedin: www.linkedin.com/in/dylanfield/

--- a/packages/OnboardSeed/resources/fixtures/sales/people/ivan.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/ivan.yaml
@@ -2,7 +2,7 @@ name: Ivan Zhao
 company: notion
 custom_fields:
   emails:
-    - ivan@notion.com
+    - ivan@notion.example
   phone_number: "+14155550102"
   job_title: Co-founder
   linkedin: www.linkedin.com/in/ivzhao/

--- a/packages/OnboardSeed/resources/fixtures/sales/people/tim.yaml
+++ b/packages/OnboardSeed/resources/fixtures/sales/people/tim.yaml
@@ -2,7 +2,7 @@ name: Tim Cook
 company: apple
 custom_fields:
   emails:
-    - tim@apple.com
+    - tim@apple.example
   phone_number: "+14155550103"
   job_title: CEO
   linkedin: www.linkedin.com/in/timcook/

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -208,7 +208,7 @@
                 <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
                     @foreach([
                         ['ri-shield-check-line', '2,000+', 'Automated Tests'],
-                        ['ri-robot-2-line', '32', 'MCP Tools'],
+                        ['ri-robot-2-line', '37', 'MCP Tools'],
                         ['ri-stack-line', '22', 'Field Types'],
                         ['ri-lock-line', '5-Layer', 'Authorization'],
                     ] as [$icon, $value, $label])

--- a/tests/Feature/Commands/GenerateSitemapCommandTest.php
+++ b/tests/Feature/Commands/GenerateSitemapCommandTest.php
@@ -100,7 +100,7 @@ it('adds developer guide urls with lastmod from front matter', function (): void
 
     expect($xml)->toContain('<loc>'.route('documentation.index').'</loc>')
         ->and($xml)->toMatch('#developers/self-hosting</loc>\s*<lastmod>2026-08-14#')
-        ->and($xml)->toMatch('#developers/mcp</loc>\s*<lastmod>2026-08-26#');
+        ->and($xml)->toMatch('#developers/mcp</loc>\s*<lastmod>2026-08-28#');
 });
 
 it('omits lastmod for a help page with no updated front matter', function (): void {

--- a/tests/Feature/Commands/ResetDemoAccountCommandTest.php
+++ b/tests/Feature/Commands/ResetDemoAccountCommandTest.php
@@ -212,11 +212,30 @@ it('creates a deterministic reviewer workspace and safely refreshes it', functio
     $notionOpportunity = Opportunity::query()->where('team_id', $team->getKey())->where('name', 'Notion API Integration')->firstOrFail();
     $notionTask = Task::query()->where('team_id', $team->getKey())->where('title', 'Integration meeting with Ivan')->firstOrFail();
     $notionNote = Note::query()->where('team_id', $team->getKey())->where('title', 'API integration possibilities')->firstOrFail();
+    $emailField = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $team->getKey())
+        ->where('entity_type', 'people')
+        ->where('code', 'emails')
+        ->firstOrFail();
+    $executiveEmails = People::query()
+        ->where('team_id', $team->getKey())
+        ->whereIn('name', ['Brian Chesky', 'Dylan Field', 'Ivan Zhao', 'Tim Cook'])
+        ->withCustomFieldValues()
+        ->get()
+        ->mapWithKeys(fn (People $person): array => [$person->name => $person->getCustomFieldValue($emailField)])
+        ->all();
 
     expect($ivan->company_id)->toBe($notion->getKey())
         ->and($notionOpportunity->company_id)->toBe($notion->getKey())
         ->and($notionTask->people()->whereKey($ivan->getKey())->exists())->toBeTrue()
-        ->and($notionNote->companies()->whereKey($notion->getKey())->exists())->toBeTrue();
+        ->and($notionNote->companies()->whereKey($notion->getKey())->exists())->toBeTrue()
+        ->and($executiveEmails)->toBe([
+            'Brian Chesky' => ['brian@airbnb.example'],
+            'Dylan Field' => ['dylan@figma.example'],
+            'Ivan Zhao' => ['ivan@notion.example'],
+            'Tim Cook' => ['tim@apple.example'],
+        ]);
 
     $statusField = CustomField::query()
         ->withoutGlobalScopes()

--- a/tests/Feature/Documentation/DocumentationHeadingsTest.php
+++ b/tests/Feature/Documentation/DocumentationHeadingsTest.php
@@ -55,3 +55,18 @@ it('states the actual MCP rate limits in the rendered guide as :format', functio
     'HTML' => [[], 'text/html'],
     'Markdown' => [['Accept' => 'text/markdown'], 'text/markdown'],
 ]);
+
+it('explains OAuth setup for ChatGPT and Claude in the rendered guide as :format', function (array $headers, string $contentType): void {
+    $response = $this->get('/developers/mcp', $headers)->assertOk();
+
+    expect($response->headers->get('Content-Type'))->toStartWith($contentType);
+
+    $response
+        ->assertSee('Clients with OAuth support need only the MCP endpoint.')
+        ->assertSee('ChatGPT')
+        ->assertSee('Claude')
+        ->assertDontSee('Before connecting an AI assistant, you need an access token:');
+})->with([
+    'HTML' => [[], 'text/html'],
+    'Markdown' => [['Accept' => 'text/markdown'], 'text/markdown'],
+]);

--- a/tests/Feature/Public/PricingPageTest.php
+++ b/tests/Feature/Public/PricingPageTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Features\Billing as BillingFeature;
 use Laravel\Pennant\Feature;
+use Symfony\Component\DomCrawler\Crawler;
 
 it('shows the legacy two-card page when billing is off', function (): void {
     Feature::define(BillingFeature::class, false);
@@ -31,6 +32,16 @@ it('shows the pro tier when billing is on', function (): void {
         ->assertDontSee('One workspace price as your team grows')
         ->assertDontSee('300 AI credits')
         ->assertDontSee('Generous free tier');
+});
+
+it('advertises all MCP tools in the feature metrics', function (): void {
+    $response = $this->get('/pricing')->assertOk();
+    $crawler = new Crawler((string) $response->getContent());
+    $toolCount = $crawler
+        ->filterXPath('//*[normalize-space(text())="MCP Tools"]/preceding-sibling::div[1]')
+        ->text();
+
+    expect($toolCount)->toBe('37');
 });
 
 it('emits product json-ld on the pricing page', function (): void {

--- a/tests/Feature/Teams/WorkspaceActivityLogTest.php
+++ b/tests/Feature/Teams/WorkspaceActivityLogTest.php
@@ -8,6 +8,7 @@ use App\Models\Company;
 use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
+use App\Support\ActivityLog\RequestActivityBatch;
 use Filament\Facades\Filament;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Url;
@@ -361,6 +362,7 @@ test('a custom field edit reads as an update, not its raw event name', function 
 test('filtering on updated covers custom field edits too', function (): void {
     $company = Company::factory()->for($this->team)->create(['name' => 'Field Edited Co']);
     Company::factory()->for($this->team)->create(['name' => 'Untouched Co'])->delete();
+    app()->forgetInstance(RequestActivityBatch::class);
 
     activity()
         ->performedOn($company)


### PR DESCRIPTION
Leads the MCP guide with OAuth: ChatGPT and Claude each get their own connector setup steps, and the personal access token sections are relabelled as the fallback for clients without OAuth support.

Corrects the pricing page MCP tool count from 32 to 37, and moves the demo executive fixtures onto `.example` domains so `demo:reset` never seeds a real corporate address.

Covered by tests for the rendered guide (HTML and markdown), the pricing metric, and the seeded fixture emails, plus an isolation fix for the workspace activity log test.

Replaces #565.