### PR TITLE
fix(import): reject impossible dates instead of importing a date nobody typed

### DIFF
--- a/packages/ImportWizard/src/Enums/DateFormat.php
+++ b/packages/ImportWizard/src/Enums/DateFormat.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use DateTimeImmutable;
 use DateTimeZone;
 use Filament\Support\Contracts\HasLabel;
+use Illuminate\Support\Facades\Date;
 
 /**
  * Supported date/datetime formats for CSV import parsing.
@@ -160,7 +161,7 @@ enum DateFormat: string implements HasLabel
             return null;
         }
 
-        return Carbon::instance($parsed);
+        return Date::instance($parsed);
     }
 
     /**

--- a/packages/ImportWizard/src/Enums/DateFormat.php
+++ b/packages/ImportWizard/src/Enums/DateFormat.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Relaticle\ImportWizard\Enums;
 
 use Carbon\Carbon;
+use DateTimeImmutable;
+use DateTimeZone;
 use Filament\Support\Contracts\HasLabel;
-use Illuminate\Support\Facades\Date;
 
 /**
  * Supported date/datetime formats for CSV import parsing.
@@ -19,6 +20,12 @@ enum DateFormat: string implements HasLabel
     case ISO = 'iso';
     case EUROPEAN = 'european';
     case AMERICAN = 'american';
+
+    /**
+     * `Y` matches a two-digit year, so without a floor `1/1/24` parses to 1 January 24 AD
+     * and imports as a plausible-looking date two thousand years out.
+     */
+    private const int MINIMUM_YEAR = 1000;
 
     public function getLabel(): string
     {
@@ -113,18 +120,47 @@ enum DateFormat: string implements HasLabel
         }
 
         foreach ($this->getParseFormats($withTime) as $format) {
-            try {
-                $date = Date::createFromFormat($format, $value, $withTime ? $timezone : null);
+            $date = $this->parseStrictly($format, $value, $withTime ? $timezone : null);
 
-                if ($date instanceof Carbon) {
-                    return $withTime && $timezone !== null ? $date->utc() : $date;
-                }
-            } catch (\Exception) {
-                continue;
+            if ($date instanceof Carbon) {
+                return $withTime && $timezone !== null ? $date->utc() : $date;
             }
         }
 
         return null;
+    }
+
+    /**
+     * `createFromFormat` overflows silently: `d/m/Y` turns 31/02/2024 into 2 March and
+     * `Y-m-d` turns 2024-02-31 into the same, so a typo imports as a real date nobody
+     * typed. The `!` prefix does not prevent it and `Carbon::hasFormat()` does not detect
+     * it either. `getLastErrors()` reports a warning for every overflow, so that is the
+     * gate. The `!` prefix is still used, to zero the fields the format does not carry
+     * rather than inheriting them from the current clock.
+     */
+    private function parseStrictly(string $format, string $value, ?string $timezone): ?Carbon
+    {
+        $parsed = DateTimeImmutable::createFromFormat(
+            '!'.$format,
+            $value,
+            $timezone !== null ? new DateTimeZone($timezone) : null,
+        );
+
+        if ($parsed === false) {
+            return null;
+        }
+
+        $errors = DateTimeImmutable::getLastErrors();
+
+        if ($errors !== false && ($errors['warning_count'] > 0 || $errors['error_count'] > 0)) {
+            return null;
+        }
+
+        if ((int) $parsed->format('Y') < self::MINIMUM_YEAR) {
+            return null;
+        }
+
+        return Carbon::instance($parsed);
     }
 
     /**
@@ -163,6 +199,10 @@ enum DateFormat: string implements HasLabel
                     'H:i:s d-m-Y',
                     'H:i d/m/Y',
                     'H:i d-m-Y',
+                    'H:i:s j F Y',
+                    'H:i:s j M Y',
+                    'H:i j F Y',
+                    'H:i j M Y',
                 ],
                 self::AMERICAN => [
                     'm/d/Y H:i:s',
@@ -175,6 +215,10 @@ enum DateFormat: string implements HasLabel
                     'H:i:s m-d-Y',
                     'H:i m/d/Y',
                     'H:i m-d-Y',
+                    'H:i:s F jS Y',
+                    'H:i:s F j, Y',
+                    'H:i F jS Y',
+                    'H:i F j, Y',
                 ],
             };
         }
@@ -190,12 +234,18 @@ enum DateFormat: string implements HasLabel
                 'j/n/Y',
                 'j-n-Y',
                 'j.n.Y',
+                'j F Y',
+                'j M Y',
             ],
             self::AMERICAN => [
                 'm/d/Y',
                 'm-d-Y',
                 'n/j/Y',
                 'n-j-Y',
+                'F jS Y',
+                'F j, Y',
+                'M jS Y',
+                'M j, Y',
             ],
         };
     }

--- a/tests/Feature/ImportWizard/Enums/DateFormatTest.php
+++ b/tests/Feature/ImportWizard/Enums/DateFormatTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Relaticle\ImportWizard\Enums\DateFormat;
+
+it('parses every example it advertises in the format picker', function (DateFormat $format, bool $withTime): void {
+    foreach ($format->getExamples($withTime) as $example) {
+        expect($format->parse($example, $withTime))
+            ->toBeInstanceOf(Carbon::class, "{$format->value} advertises '{$example}' but cannot parse it");
+    }
+})->with([
+    'iso date' => [DateFormat::ISO, false],
+    'iso datetime' => [DateFormat::ISO, true],
+    'european date' => [DateFormat::EUROPEAN, false],
+    'european datetime' => [DateFormat::EUROPEAN, true],
+    'american date' => [DateFormat::AMERICAN, false],
+    'american datetime' => [DateFormat::AMERICAN, true],
+]);
+
+it('rejects a calendar-impossible date instead of rolling it into the next month', function (DateFormat $format, string $cell): void {
+    expect($format->parse($cell))->toBeNull();
+})->with([
+    'european 31 February' => [DateFormat::EUROPEAN, '31/02/2024'],
+    'european month 45' => [DateFormat::EUROPEAN, '13/45/2024'],
+    'european all nines' => [DateFormat::EUROPEAN, '99/99/9999'],
+    'american 31 February' => [DateFormat::AMERICAN, '02/31/2024'],
+    'american month 13' => [DateFormat::AMERICAN, '13/01/2024'],
+    'iso 31 February' => [DateFormat::ISO, '2024-02-31'],
+    'iso month 13' => [DateFormat::ISO, '2024-13-01'],
+]);
+
+it('rejects a two-digit year rather than reading it as the first century', function (DateFormat $format, string $cell): void {
+    expect($format->parse($cell))->toBeNull();
+})->with([
+    'european' => [DateFormat::EUROPEAN, '1/1/24'],
+    'american' => [DateFormat::AMERICAN, '1/1/24'],
+    'iso' => [DateFormat::ISO, '24-01-01'],
+]);
+
+it('rejects free text and blanks', function (string $cell): void {
+    expect(DateFormat::EUROPEAN->parse($cell))->toBeNull();
+})->with(['Q/A', 'invalid-date', 'next tuesday', '', '   ']);
+
+it('reads an ambiguous date according to the chosen convention', function (): void {
+    expect(DateFormat::EUROPEAN->parse('3/4/2024')?->format('Y-m-d'))->toBe('2024-04-03')
+        ->and(DateFormat::AMERICAN->parse('3/4/2024')?->format('Y-m-d'))->toBe('2024-03-04')
+        ->and(DateFormat::ISO->parse('3/4/2024'))->toBeNull();
+});
+
+it('zeroes the time a date-only format does not carry', function (): void {
+    Carbon::setTestNow('2024-06-01 13:45:59');
+
+    expect(DateFormat::EUROPEAN->parse('15/05/2024')?->format('H:i:s'))->toBe('00:00:00');
+
+    Carbon::setTestNow();
+});
+
+it('zeroes the seconds a minute-precision format does not carry', function (): void {
+    Carbon::setTestNow('2024-06-01 13:45:59');
+
+    expect(DateFormat::EUROPEAN->parse('15/05/2024 16:00', withTime: true)?->format('H:i:s'))->toBe('16:00:00');
+
+    Carbon::setTestNow();
+});
+
+it('reads a naive datetime in the importer timezone and stores it as UTC', function (): void {
+    $parsed = DateFormat::ISO->parse('2024-05-15 16:00:00', withTime: true, timezone: 'America/New_York');
+
+    expect($parsed?->format('Y-m-d H:i:s'))->toBe('2024-05-15 20:00:00')
+        ->and($parsed?->timezoneName)->toBe('UTC');
+});
+
+it('leaves a datetime alone when no timezone is supplied', function (): void {
+    expect(DateFormat::ISO->parse('2024-05-15 16:00:00', withTime: true)?->format('Y-m-d H:i:s'))
+        ->toBe('2024-05-15 16:00:00');
+});
+
+it('ignores the timezone for a date, which has no time of day to convert', function (): void {
+    expect(DateFormat::ISO->parse('2024-05-15', timezone: 'America/New_York')?->format('Y-m-d'))
+        ->toBe('2024-05-15');
+});
+
+it('still parses every ordinary date it parsed before', function (DateFormat $format, string $cell, string $expected): void {
+    expect($format->parse($cell)?->format('Y-m-d'))->toBe($expected);
+})->with([
+    [DateFormat::ISO, '2024-05-15', '2024-05-15'],
+    [DateFormat::EUROPEAN, '15/05/2024', '2024-05-15'],
+    [DateFormat::EUROPEAN, '15-05-2024', '2024-05-15'],
+    [DateFormat::EUROPEAN, '15.05.2024', '2024-05-15'],
+    [DateFormat::EUROPEAN, '5/5/2024', '2024-05-05'],
+    [DateFormat::AMERICAN, '05/15/2024', '2024-05-15'],
+    [DateFormat::AMERICAN, '05-15-2024', '2024-05-15'],
+    [DateFormat::AMERICAN, '5/5/2024', '2024-05-05'],
+]);


### PR DESCRIPTION
## The bug

`DateFormat::parse()` used `createFromFormat` without checking whether the date it produced was the date the user typed. PHP overflows silently, so an impossible date became a real one:

```
EUROPEAN  31/02/2024  ->  2024-03-02   (31 February became 2 March)
EUROPEAN  13/45/2024  ->  2027-09-13   (month 45 became September 2027)
EUROPEAN  99/99/9999  ->  10007-06-07
ISO       2024-02-31  ->  2024-03-02
ISO       2024-13-01  ->  2025-01-01
ANY       1/1/24      ->  0024-01-01   (`Y` matches a two-digit year)
```

Every one of those imported cleanly. `ColumnValidator` saw a `Carbon` instance and passed the cell, the review step previewed the wrong date, and `ExecuteImportJob` wrote it. The row counted as successful.

This is the failure mode `ExecuteImportJob::formatValue()` already has a comment about, for a different cause: "Silently dropping data the user handed us is worse than refusing the row." Silently *changing* it is worse still, because nothing downstream can tell.

## The fix

`parse()` now runs each candidate format through `parseStrictly()`, which rejects on `DateTimeImmutable::getLastErrors()` reporting any warning or error, and rejects any year below 1000.

Two approaches that look like they should work and do not, recorded so nobody retries them:

- **The `!` format prefix.** `!Y-m-d` still turns `2024-02-31` into 2 March. It only zeroes fields the format does not carry.
- **`Carbon::hasFormat()`.** Returns `true` for `2024-02-31`. It catches an out-of-range month but not a calendar-invalid day.

`getLastErrors()` is the only reliable gate. The `!` prefix is still applied, for its actual purpose: a date-only cell now yields midnight instead of inheriting the current wall clock.

Because `parse()` is the single choke point for `ColumnValidator`, `ImportDateRule`, `ReviewStep` and `ExecuteImportJob`, all four paths are fixed by this one change. An impossible date is now caught at validation, shown as invalid in the review step, and if it somehow reaches the job it raises the existing `UnparsableDateException`, which surfaces the column and the offending value on the failed row.

## The picker advertised four formats it could not parse

Auditing every example against its own parser turned up a second bug:

```
european  date  15 May 2024              *** REJECTED ***
european  time  21:30:02 15 May 2024     *** REJECTED ***
american  date  May 15th 2024            *** REJECTED ***
american  time  21:30:02 May 15th 2024   *** REJECTED ***
```

`getExamples()` feeds `toOptions()`, which is what the user reads when choosing a date format. It promised textual months that `getParseFormats()` did not accept, so anyone who followed the on-screen example had their rows rejected.

Added the textual formats rather than editing the examples, since accepting them is what the UI already promised. Textual months are unambiguous, so this only widens what is accepted and cannot change how an existing cell is read.

The new test asserts this class of mismatch cannot come back: it iterates every case and every advertised example and requires the parser to accept it.

## Behavior change

Rows carrying an impossible date now fail instead of importing a date nobody typed. That is the intent. The failure names the column and the value, and the row is preserved for correction and re-upload.

No date that parses correctly today changes. The full existing ImportWizard suite passes, and the new test pins every ordinary date form per convention.

## Verification

- 35 new tests in `tests/Feature/ImportWizard/Enums/DateFormatTest.php`, covering the advertised-examples contract, calendar-impossible dates, two-digit years, free text, the ambiguous `3/4/2024` reading per convention, midnight and zero-second normalisation, and the timezone contract.
- The timezone behaviour is the riskiest part of this change, since it swaps `Date::createFromFormat` for the native parser. It is pinned directly: a naive `2024-05-15 16:00:00` with importer timezone `America/New_York` still yields `2024-05-15 20:00:00` UTC, and a date-only cell still ignores the timezone.
- `tests/Feature/ImportWizard`: 359 passed, 1 skipped.
- PHPStan and Pint clean.
