### PR TITLE
fix(mcp): fit the registry description inside its 100-char limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.relaticle/crm",
   "title": "Relaticle",
-  "description": "Open-source CRM with 37 MCP tools for companies, people, opportunities, tasks, notes, schemas, activity, and pipeline analysis.",
+  "description": "Open-source CRM your AI agents can write to: companies, people, deals, tasks, notes, pipeline.",
   "version": "${VERSION}",
   "remotes": [
     {

--- a/tests/Feature/Mcp/RegistryManifestTest.php
+++ b/tests/Feature/Mcp/RegistryManifestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+function registryManifest(): array
+{
+    return json_decode((string) file_get_contents(base_path('server.json')), true, flags: JSON_THROW_ON_ERROR);
+}
+
+it('keeps every published field inside the registry schema length limits', function (string $field, int $limit): void {
+    expect(mb_strlen((string) registryManifest()[$field]))->toBeLessThanOrEqual($limit);
+})->with([
+    'description' => ['description', 100],
+    'title' => ['title', 100],
+    'name' => ['name', 200],
+]);
+
+it('leaves the version placeholder for the publish workflow to substitute', function (): void {
+    expect(registryManifest()['version'])->toBe('${VERSION}');
+});
+
+it('points the registry at the production MCP endpoint over streamable http', function (): void {
+    expect(registryManifest()['remotes'])->toBe([
+        ['type' => 'streamable-http', 'url' => 'https://mcp.relaticle.com'],
+    ]);
+});


### PR DESCRIPTION
The v3.5.2 release published, but `Publish to MCP Registry` failed:

```
422 Unprocessable Entity
"expected length <= 100", location: body.description
value: "Open-source CRM with 37 MCP tools for companies, people, opportunities,
        tasks, notes, schemas, activity, and pipeline analysis."
```

That description is 127 characters. `ServerDetail.properties.description` in the [published schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) caps it at 100.

## Root cause

#549 rewrote the description when it raised the tool count:

| | description | length |
|---|---|---|
| before #549 | `Open-source CRM your AI agents can write to: 32 MCP tools for companies, people, deals, and tasks.` | 98 |
| after #549 | the 127-char version above | 127 |

v3.5.1 predates #549 and published cleanly. v3.5.2 is the first release to carry the long description, and the first to fail. The registry limit did not change; our description grew past it.

**Consequence:** `registry.modelcontextprotocol.io` still lists `com.relaticle/crm` **3.5.1** as `isLatest`, describing 32 tools.

## Change

New description, 94 characters, with no tool count in it. A count in this field has to be re-verified on every release and is wrong for self-hosters between releases, and the object list already carries the breadth:

```
Open-source CRM your AI agents can write to: companies, people, deals, tasks, notes, pipeline.
```

## Why a test

The old failure mode only surfaced at publish time, which is after the tag is public and the release notes are out. `RegistryManifestTest` covers the schema length limits, the `${VERSION}` placeholder the workflow substitutes, and the remote endpoint, so a manifest that cannot publish fails on the PR instead.

Verified in both directions: restoring the 127-char description fails the test (4 passed, 1 failed), and the shipped description passes (5 passed, 8 assertions).

## Follow-up, not in this PR

The registry needs a republish to pick this up. Either re-run the workflow against a new tag, or cut the next release.