### PR TITLE
fix(onboarding): unstrand the workspace wizard and polish the signup flow

### DIFF
--- a/app/Filament/Pages/CreateTeam.php
+++ b/app/Filament/Pages/CreateTeam.php
@@ -269,7 +269,9 @@ final class CreateTeam extends RegisterTenant
                     ->live()
                     // Stale sub-options from the previous use case are invisible yet
                     // fail validation silently, stranding the wizard on this step.
-                    ->afterStateUpdated(fn (Set $set): mixed => $set('onboarding_context', [])),
+                    ->afterStateUpdated(function (Set $set): void {
+                        $set('onboarding_context', []);
+                    }),
 
                 ToggleButtons::make('onboarding_context')
                     ->label(__('filament/pages/teams.create_team.form.use_case_context_label'))

--- a/app/Filament/Pages/CreateTeam.php
+++ b/app/Filament/Pages/CreateTeam.php
@@ -18,7 +18,6 @@ use Filament\Facades\Filament;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Repeater;
-use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
@@ -191,6 +190,7 @@ final class CreateTeam extends RegisterTenant
         return Step::make(__('filament/pages/teams.create_team.steps.workspace'))
             ->schema([
                 Placeholder::make('workspace_heading')
+                    ->label(__('filament/pages/teams.create_team.headings.workspace'))
                     ->hiddenLabel()
                     ->content($this->stepHeading(__('filament/pages/teams.create_team.headings.workspace')))
                     ->dehydrated(false),
@@ -203,6 +203,7 @@ final class CreateTeam extends RegisterTenant
         return Step::make(__('filament/pages/teams.create_team.steps.attribution'))
             ->schema([
                 Placeholder::make('attribution_heading')
+                    ->label(__('filament/pages/teams.create_team.headings.attribution'))
                     ->hiddenLabel()
                     ->content($this->stepHeading(
                         __('filament/pages/teams.create_team.headings.attribution'),
@@ -211,6 +212,7 @@ final class CreateTeam extends RegisterTenant
                     ->dehydrated(false),
 
                 ToggleButtons::make('onboarding_referral_source')
+                    ->label(__('filament/pages/teams.create_team.headings.attribution'))
                     ->hiddenLabel()
                     ->options(
                         collect(OnboardingReferralSource::cases())
@@ -236,6 +238,7 @@ final class CreateTeam extends RegisterTenant
             ->key('onboarding-use-case')
             ->schema([
                 Placeholder::make('use_case_heading')
+                    ->label(__('filament/pages/teams.create_team.headings.use_case'))
                     ->hiddenLabel()
                     ->content($this->stepHeading(
                         __('filament/pages/teams.create_team.headings.use_case'),
@@ -263,7 +266,10 @@ final class CreateTeam extends RegisterTenant
                             ->all()
                     )
                     ->inline()
-                    ->live(),
+                    ->live()
+                    // Stale sub-options from the previous use case are invisible yet
+                    // fail validation silently, stranding the wizard on this step.
+                    ->afterStateUpdated(fn (Set $set): mixed => $set('onboarding_context', [])),
 
                 ToggleButtons::make('onboarding_context')
                     ->label(__('filament/pages/teams.create_team.form.use_case_context_label'))
@@ -293,6 +299,7 @@ final class CreateTeam extends RegisterTenant
         return Step::make(__('filament/pages/teams.create_team.steps.invite'))
             ->schema([
                 Placeholder::make('invite_heading')
+                    ->label(__('filament/pages/teams.create_team.headings.invite'))
                     ->hiddenLabel()
                     ->content($this->stepHeading(
                         __('filament/pages/teams.create_team.headings.invite'),
@@ -301,6 +308,7 @@ final class CreateTeam extends RegisterTenant
                     ->dehydrated(false),
 
                 Placeholder::make('invite_subheading')
+                    ->label(__('filament/pages/teams.create_team.headings.invite_subheading'))
                     ->hiddenLabel()
                     ->content(new HtmlString(
                         '<p class="text-sm font-medium text-gray-700 dark:text-gray-300">'
@@ -309,22 +317,25 @@ final class CreateTeam extends RegisterTenant
                     ))
                     ->dehydrated(false),
 
+                // A grid, not the repeater table: its fixed role column left the
+                // email input ~10 characters wide on phones. The grid stacks below sm.
                 Repeater::make('invites')
                     ->hiddenLabel()
-                    ->table([
-                        TableColumn::make(__('filament/pages/teams.create_team.form.invite_table_column_email')),
-                        TableColumn::make(__('filament/pages/teams.create_team.form.invite_table_column_role'))
-                            ->width('140px'),
-                    ])
+                    ->columns(['default' => 1, 'sm' => 3])
                     ->schema([
                         TextInput::make('email')
+                            ->label(__('filament/pages/teams.create_team.form.invite_email_label'))
+                            ->hiddenLabel()
                             ->email()
                             ->placeholder(__('filament/pages/teams.create_team.form.invite_email_placeholder'))
                             // Drives the submit label below: "Send invites" only once
                             // there is actually something to send.
-                            ->live(onBlur: true),
+                            ->live(onBlur: true)
+                            ->columnSpan(['default' => 1, 'sm' => 2]),
 
                         Select::make('role')
+                            ->label(__('filament/pages/teams.create_team.form.invite_role_label'))
+                            ->hiddenLabel()
                             ->options([
                                 TeamRole::Editor->value => __('filament/pages/teams.create_team.form.invite_role_member'),
                                 TeamRole::Admin->value => __('filament/pages/teams.create_team.form.invite_role_admin'),
@@ -428,10 +439,10 @@ final class CreateTeam extends RegisterTenant
 
         return [
             TextInput::make('name')
-                ->label(__('filament/pages/teams.create_team.form.company_name.label'))
+                ->label(__('filament/pages/teams.create_team.form.workspace_name.label'))
                 ->required()
                 ->maxLength(255)
-                ->placeholder(__('filament/pages/teams.create_team.form.company_name.placeholder'))
+                ->placeholder(__('filament/pages/teams.create_team.form.workspace_name.placeholder'))
                 ->autofocus()
                 ->live(onBlur: true)
                 ->afterStateUpdated(function (Get $get, Set $set, ?string $state): void {

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -75,6 +75,12 @@ final class Dashboard extends Page
         $user = Filament::auth()->user();
         $firstName = explode(' ', $user->name)[0];
 
+        // The browser reports its timezone only after the first render, so the
+        // local hour is unknown on the very first visit: greet without the clock.
+        if ($user->timezone === null) {
+            return __('Welcome, :name.', ['name' => $firstName]);
+        }
+
         $hour = Date::now($user->effectiveTimezone())->hour;
 
         return match (true) {

--- a/app/Livewire/App/Teams/AddTeamMember.php
+++ b/app/Livewire/App/Teams/AddTeamMember.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\App\Teams;
 
 use App\Actions\Jetstream\InviteTeamMember;
+use App\Enums\TeamRole;
 use App\Livewire\BaseLivewireComponent;
 use App\Models\Team;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
@@ -35,7 +36,7 @@ final class AddTeamMember extends BaseLivewireComponent
     {
         $this->team = $team;
 
-        $this->form->fill($this->team->only(['name']));
+        $this->form->fill();
     }
 
     public function form(Schema $schema): Schema
@@ -49,6 +50,7 @@ final class AddTeamMember extends BaseLivewireComponent
                     ->description(__('teams.sections.add_team_member.description'))
                     ->schema([
                         TextEntry::make('addTeamMemberNotice')
+                            ->label(__('teams.sections.add_team_member.title'))
                             ->hiddenLabel()
                             ->state(fn (): string => __('teams.sections.add_team_member.notice')),
                         TextInput::make('email')
@@ -64,6 +66,9 @@ final class AddTeamMember extends BaseLivewireComponent
                                     Radio::make('role')
                                         ->hiddenLabel()
                                         ->required()
+                                        // Least privilege, matching the
+                                        // onboarding wizard's default.
+                                        ->default(TeamRole::Editor->value)
                                         ->in($roles->pluck('key'))
                                         ->options($roles->pluck('name', 'key'))
                                         ->descriptions($roles->pluck('description', 'key')),
@@ -110,7 +115,7 @@ final class AddTeamMember extends BaseLivewireComponent
 
         $this->sendNotification(__('teams.notifications.team_invitation_sent.success'));
 
-        $this->form->fill($this->team->only(['name']));
+        $this->form->fill();
 
         $this->dispatch('teamInvitationSent');
     }

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -361,22 +361,22 @@ final class AppPanelProvider extends PanelProvider
                 },
             );
 
+        // Hidden without a bound tenant: the old panel-root fallback sent these
+        // to the dashboard, silently abandoning the create-workspace wizard.
         $accountMenuItems = [
             Action::make('settings')
                 ->label(__('filament/panel.user_menu.settings'))
                 ->icon('heroicon-m-cog-6-tooth')
-                ->url(fn (): string => $this->shouldRegisterMenuItem()
-                    ? url(Settings::getUrl())
-                    : url($panel->getPath())),
+                ->visible(fn (): bool => $this->shouldRegisterMenuItem())
+                ->url(fn (): string => url(Settings::getUrl())),
         ];
 
         if (Features::hasApiFeatures()) {
             $accountMenuItems[] = Action::make('api_tokens')
                 ->label(__('access-tokens.user_menu'))
                 ->icon('heroicon-o-key')
-                ->url(fn (): string => $this->shouldRegisterMenuItem()
-                    ? url(AccessTokens::getUrl())
-                    : url($panel->getPath()));
+                ->visible(fn (): bool => $this->shouldRegisterMenuItem())
+                ->url(fn (): string => url(AccessTokens::getUrl()));
         }
 
         $panel->userMenuItems([

--- a/lang/en/filament/pages/teams.php
+++ b/lang/en/filament/pages/teams.php
@@ -38,8 +38,8 @@ return [
             'invite_subheading' => 'Invite your team to collaborate',
         ],
         'form' => [
-            'company_name' => [
-                'label' => 'Company name',
+            'workspace_name' => [
+                'label' => 'Workspace name',
                 'placeholder' => 'Acme Corp',
             ],
             'workspace_handle' => [
@@ -53,8 +53,8 @@ return [
             'invite_email_placeholder' => 'name@company.com',
             'invite_role_member' => 'Member',
             'invite_role_admin' => 'Admin',
-            'invite_table_column_email' => 'Email',
-            'invite_table_column_role' => 'Role',
+            'invite_email_label' => 'Email',
+            'invite_role_label' => 'Role',
         ],
         'notifications' => [
             'workspace_created' => [
@@ -63,7 +63,7 @@ return [
             ],
             'invite_link_copied' => [
                 'title' => 'Invite link copied',
-                'body' => 'Share this link with your teammates. Anyone with the link can join this team.',
+                'body' => 'Share this link with your teammates. Anyone with the link can join this workspace.',
             ],
             'complete_previous_steps' => [
                 'title' => 'Complete the previous steps first',

--- a/resources/views/components/onboarding/wizard.blade.php
+++ b/resources/views/components/onboarding/wizard.blade.php
@@ -35,6 +35,14 @@
             })"
     x-on:next-wizard-step.window="if ($event.detail.key === @js($key)) goToNextStep()"
     x-on:go-to-wizard-step.window="$event.detail.key === @js($key) && goToStep($event.detail.step)"
+    {{-- Enter advances the step; on the last one it submits via requestSubmit
+         so native validation still runs. Without this the wizard was mouse-only. --}}
+    x-on:keydown.enter="
+        if ($event.target.matches('input:not([type=checkbox]):not([type=radio])')) {
+            $event.preventDefault()
+            isLastStep() ? $el.closest('form').requestSubmit() : requestNextStep()
+        }
+    "
     wire:ignore.self
     x-effect="window.dispatchEvent(new CustomEvent('onboarding-step-changed', { detail: { index: getStepIndex(step) } }))"
     {{-- x-effect only re-runs when the step changes, so a listener that mounts mid-wizard

--- a/tests/Browser/Chat/DashboardTest.php
+++ b/tests/Browser/Chat/DashboardTest.php
@@ -51,7 +51,7 @@ it('uses a white composer surface in light mode', function (): void {
 });
 
 it('shows greeting on the dashboard', function (): void {
-    $user = User::factory()->withTeam()->create();
+    $user = User::factory()->withTeam()->create(['timezone' => 'UTC']);
     $team = $user->ownedTeams()->first();
 
     $this->visit('/app/login')

--- a/tests/Feature/Filament/App/Pages/DashboardGreetingTest.php
+++ b/tests/Feature/Filament/App/Pages/DashboardGreetingTest.php
@@ -31,14 +31,16 @@ it('shows good evening for a Los Angeles user at 9pm local time', function (): v
     Livewire::test(Dashboard::class)->assertSee('Good evening');
 });
 
-it('falls back to app timezone when user has no timezone set', function (): void {
+it('greets without a time of day while the timezone is still unknown', function (): void {
     $this->travelTo(new DateTimeImmutable('2026-04-19 10:00:00', new DateTimeZone('UTC')));
 
-    $user = User::factory()->withPersonalTeam()->create(['timezone' => null]);
+    $user = User::factory()->withPersonalTeam()->create(['name' => 'Casey Lee', 'timezone' => null]);
     $this->actingAs($user);
     Filament::setTenant($user->currentTeam);
 
-    Livewire::test(Dashboard::class)->assertSee('Good morning');
+    Livewire::test(Dashboard::class)
+        ->assertSee('Welcome, Casey.')
+        ->assertDontSee('Good morning');
 });
 
 it('greets a fresh seeded workspace by the clock, with no assistant message in the greeting slot', function (): void {

--- a/tests/Feature/Onboarding/CreateTeamWizardTest.php
+++ b/tests/Feature/Onboarding/CreateTeamWizardTest.php
@@ -51,7 +51,13 @@ it('resolves every wizard heading from translations', function (): void {
         ->assertSee(__('filament/pages/teams.create_team.headings.invite'))
         ->assertSee(__('filament/pages/teams.create_team.headings.invite_description'))
         ->assertSee(__('filament/pages/teams.create_team.headings.invite_subheading'))
-        ->assertDontSee('filament/pages/teams.create_team.headings');
+        ->assertDontSee('filament/pages/teams.create_team.headings')
+        ->assertDontSee('Workspace heading')
+        ->assertDontSee('Attribution heading')
+        ->assertDontSee('Use case heading')
+        ->assertDontSee('Invite heading')
+        ->assertDontSee('Invite subheading')
+        ->assertDontSee('Onboarding referral source');
 });
 
 it('renders wizard for users who already have a team', function (): void {
@@ -108,6 +114,56 @@ it('creates a team with onboarding fields', function (): void {
     expect($team)->not->toBeNull()
         ->and($team->slug)->toBe('acme-corp')
         ->and($team->onboarding_use_case)->toBe(OnboardingUseCase::Sales);
+});
+
+it('hides the account menu links while no workspace is bound, instead of sending them to the dashboard', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    $this->get('/app/new')
+        ->assertSuccessful()
+        ->assertDontSee(__('filament/panel.user_menu.settings'))
+        ->assertDontSee(__('access-tokens.user_menu'));
+});
+
+it('shows the account menu links inside a workspace', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+
+    $this->actingAs($user);
+
+    $this->get('/app/'.$user->currentTeam->slug)
+        ->assertSuccessful()
+        ->assertSee(__('filament/panel.user_menu.settings'))
+        ->assertSee(__('access-tokens.user_menu'));
+});
+
+it('clears the sub-options when the use case changes, so a switch can never strand the wizard', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    livewire(CreateTeam::class)
+        ->fillForm([
+            'name' => 'Switcher Co',
+            'onboarding_use_case' => OnboardingUseCase::Sales->value,
+            'onboarding_context' => ['outbound'],
+        ])
+        ->fillForm([
+            'onboarding_use_case' => OnboardingUseCase::Recruiting->value,
+        ])
+        ->assertFormSet(['onboarding_context' => []])
+        ->fillForm([
+            'onboarding_context' => ['applications'],
+        ])
+        ->call('register')
+        ->assertHasNoFormErrors();
+
+    $team = Team::query()->where('name', 'Switcher Co')->first();
+
+    expect($team)->not->toBeNull()
+        ->and($team->onboarding_use_case)->toBe(OnboardingUseCase::Recruiting)
+        ->and($team->onboarding_context)->toBe(['applications']);
 });
 
 it('automatically starts one 14-day Cloud Pro trial after hosted onboarding', function (): void {

--- a/tests/Feature/Onboarding/CreateTeamWizardTest.php
+++ b/tests/Feature/Onboarding/CreateTeamWizardTest.php
@@ -60,6 +60,21 @@ it('resolves every wizard heading from translations', function (): void {
         ->assertDontSee('Onboarding referral source');
 });
 
+it('resolves every wizard form label from translations', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user);
+
+    livewire(CreateTeam::class)
+        ->assertSuccessful()
+        ->assertSee(__('filament/pages/teams.create_team.form.workspace_name.label'))
+        ->assertSee(__('filament/pages/teams.create_team.form.workspace_handle.label'))
+        ->assertSee(__('filament/pages/teams.create_team.form.use_case_label'))
+        ->assertSee(__('filament/pages/teams.create_team.form.invite_email_label'))
+        ->assertSee(__('filament/pages/teams.create_team.form.invite_role_label'))
+        ->assertDontSee('filament/pages/teams.create_team.form');
+});
+
 it('renders wizard for users who already have a team', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
 

--- a/tests/Feature/Teams/InviteTeamMemberTest.php
+++ b/tests/Feature/Teams/InviteTeamMemberTest.php
@@ -29,6 +29,17 @@ beforeEach(function () {
     Filament::setTenant($this->team);
 });
 
+test('an invite with only an email defaults to the editor role', function () {
+    livewire(AddTeamMember::class, ['team' => $this->team])
+        ->assertFormSet(['role' => 'editor'])
+        ->fillForm(['email' => 'default-role@example.com'])
+        ->call('addTeamMember', $this->team);
+
+    $invitation = $this->team->fresh()->teamInvitations->sole();
+    expect($invitation->email)->toBe('default-role@example.com')
+        ->and($invitation->role)->toBe('editor');
+});
+
 test('team members can be invited to team', function () {
     livewire(AddTeamMember::class, ['team' => $this->team])
         ->fillForm([

--- a/tests/Feature/Teams/TeamSettingsInvitationFlowTest.php
+++ b/tests/Feature/Teams/TeamSettingsInvitationFlowTest.php
@@ -89,7 +89,7 @@ test('inviting keeps the admin on the members tab and refreshes the pending list
         ->assertDispatched('teamInvitationSent')
         ->assertSchemaStateSet([
             'email' => null,
-            'role' => null,
+            'role' => 'editor',
         ]);
 
     livewire(PendingTeamInvitations::class, ['team' => $this->team])


### PR DESCRIPTION
An end-to-end audit of register → workspace creation → first onboarding found ten issues; this fixes the eight actionable ones and records reasons for the two accepted. The blocker: switching the use case on step 3 left the previous sub-options in form state (invisible, invalid, and failing validation under an indexed error key the field never renders), so Continue silently did nothing with no discoverable escape — the field now clears its sub-options on change, and a blocked Continue shows a real error.

Also fixed: the wizard's user menu no longer sends "Settings"/"Access Tokens" to the dashboard while no tenant is bound (they are hidden instead), the invite repeater stacks rather than pinning a fixed role column (email input 78px → 278px at a 390px viewport), hidden-label fields carry translated labels instead of announcing raw field keys to screen readers, Enter advances the wizard and submits on the last step through `requestSubmit` so native validation still runs, the dashboard greets without a time of day until the browser has reported the user's timezone, the members-page invite form defaults to the Editor role (its `fill()` was passing a payload matching no field, which suppressed every default), and copy now reads "Workspace name" and "join this workspace" instead of a third and fourth noun for the same entity.

Every fix carries a regression test through its real entry point. The greeting change also required correcting a browser assertion that had encoded the old UTC-fallback behavior, and a mutation audit over the branch's own production hunks surfaced one uncovered hunk (a translation key that would have rendered raw), now tested.

Gates green: pint, rector, phpstan, 100% type coverage, full non-TIA Pest (3867 tests) and the browser suite (114 tests).