### PR TITLE
Move record-creation policy to workspace settings

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -29,6 +29,7 @@ use Laravel\Jetstream\Events\TeamUpdated;
 use Laravel\Jetstream\Team as JetstreamTeam;
 use Relaticle\Chat\Models\AgentConversation;
 use Relaticle\Chat\Models\AiCreditBalance;
+use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\ImportWizard\Models\Import;
 use Spatie\Onboard\Concerns\GetsOnboarded;
@@ -40,6 +41,8 @@ use Spatie\Sluggable\SlugOptions;
  * @property string $name
  * @property string $slug
  * @property EmailPrivacyTier|null $default_email_sharing_tier
+ * @property ContactCreationMode $contact_creation_mode
+ * @property bool $auto_create_companies
  * @property Plan $plan
  * @property ?string $invite_link_token
  * @property ?Carbon $invite_link_token_expires_at
@@ -61,6 +64,8 @@ use Spatie\Sluggable\SlugOptions;
     'slug',
     'personal_team',
     'default_email_sharing_tier',
+    'contact_creation_mode',
+    'auto_create_companies',
     'onboarding_use_case',
     'onboarding_context',
     'onboarding_referral_source',
@@ -169,6 +174,8 @@ final class Team extends JetstreamTeam implements HasAvatar, Onboardable
         return [
             'personal_team' => 'boolean',
             'default_email_sharing_tier' => EmailPrivacyTier::class,
+            'contact_creation_mode' => ContactCreationMode::class,
+            'auto_create_companies' => 'boolean',
             'plan' => Plan::class,
             'onboarding_use_case' => OnboardingUseCase::class,
             'onboarding_context' => 'array',

--- a/database/factories/ConnectedAccountFactory.php
+++ b/database/factories/ConnectedAccountFactory.php
@@ -7,7 +7,6 @@ namespace Database\Factories;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -19,6 +18,9 @@ final class ConnectedAccountFactory extends Factory
 {
     protected $model = ConnectedAccount::class;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function definition(): array
     {
         return [
@@ -31,8 +33,6 @@ final class ConnectedAccountFactory extends Factory
             'access_token' => 'fake-token',
             'is_default' => false,
             'status' => EmailAccountStatus::ACTIVE,
-            'contact_creation_mode' => ContactCreationMode::None,
-            'auto_create_companies' => false,
         ];
     }
 
@@ -62,20 +62,6 @@ final class ConnectedAccountFactory extends Factory
         return $this->state(fn (): array => [
             'status' => EmailAccountStatus::ERROR,
             'last_error' => 'Token refresh failed',
-        ]);
-    }
-
-    public function withAutoCreateCompanies(): static
-    {
-        return $this->state(fn (): array => [
-            'auto_create_companies' => true,
-        ]);
-    }
-
-    public function withContactCreation(ContactCreationMode $mode = ContactCreationMode::All): static
-    {
-        return $this->state(fn (): array => [
-            'contact_creation_mode' => $mode,
         ]);
     }
 

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 
 /**
  * @extends Factory<Team>
@@ -28,6 +29,8 @@ final class TeamFactory extends Factory
             'user_id' => User::factory(),
             'personal_team' => true,
             'plan' => Plan::default()->value,
+            'contact_creation_mode' => ContactCreationMode::Bidirectional,
+            'auto_create_companies' => true,
         ];
     }
 

--- a/database/migrations/2026_08_29_065101_add_contact_creation_settings_to_teams_table.php
+++ b/database/migrations/2026_08_29_065101_add_contact_creation_settings_to_teams_table.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table): void {
+            $table->string('contact_creation_mode', 20)
+                ->default('bidirectional')
+                ->after('default_email_sharing_tier');
+            $table->boolean('auto_create_companies')
+                ->default(true)
+                ->after('contact_creation_mode');
+        });
+    }
+};

--- a/database/migrations/2026_08_29_065102_backfill_team_contact_creation_settings.php
+++ b/database/migrations/2026_08_29_065102_backfill_team_contact_creation_settings.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement(<<<'SQL'
+            UPDATE teams AS t
+            SET
+                contact_creation_mode = src.contact_creation_mode,
+                auto_create_companies = src.auto_create_companies
+            FROM (
+                SELECT DISTINCT ON (ca.team_id)
+                    ca.team_id,
+                    ca.contact_creation_mode,
+                    ca.auto_create_companies
+                FROM connected_accounts AS ca
+                INNER JOIN teams AS owner ON ca.team_id = owner.id
+                WHERE ca.deleted_at IS NULL
+                ORDER BY ca.team_id, (ca.user_id = owner.user_id) DESC, ca.created_at ASC
+            ) AS src
+            WHERE t.id = src.team_id
+            SQL);
+    }
+};

--- a/database/migrations/2026_08_29_065103_drop_contact_creation_columns_from_connected_accounts_table.php
+++ b/database/migrations/2026_08_29_065103_drop_contact_creation_columns_from_connected_accounts_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->dropColumn(['contact_creation_mode', 'auto_create_companies']);
+        });
+    }
+};

--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -34,14 +34,6 @@ return [
             'label' => 'Sync sent',
             'helper_text' => 'Sync emails you send from this account.',
         ],
-        'contact_creation_mode' => [
-            'label' => 'Auto-create contacts',
-            'helper_text' => 'When to create Person records from participants.',
-        ],
-        'auto_create_companies' => [
-            'label' => 'Auto-create companies',
-            'helper_text' => 'Creates companies from business domains only.',
-        ],
         'hourly_send_limit' => [
             'label' => 'Hourly send limit',
             'placeholder' => 'Default: :default',

--- a/lang/en/filament/pages/email-privacy-settings.php
+++ b/lang/en/filament/pages/email-privacy-settings.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 return [
     'title' => 'Workspace Privacy',
     'navigation_label' => 'Workspace Privacy',
+    'tabs' => [
+        'aria' => 'Workspace email settings',
+        'visibility' => 'Email visibility',
+        'record_creation' => 'Record creation',
+    ],
     'actions' => [
         'save' => 'Save',
     ],
@@ -26,6 +31,29 @@ return [
         'domains_label' => 'Domains',
         'domains_placeholder' => 'e.g. acme.com',
         'domains_after_label' => 'All emails from these domains will be protected.',
+    ],
+    'record_creation' => [
+        'heading' => 'Automatic record creation',
+        'description' => 'Applies to every connected mailbox and calendar in the workspace, including forwarding. Changes affect newly synced emails and events.',
+        'recommended' => 'Recommended',
+        'modes' => [
+            'all' => [
+                'label' => 'All contacts',
+                'description' => 'Records will be created for all contacts who appear in the emails and calendar events of your workspace members.',
+            ],
+            'bidirectional' => [
+                'label' => 'Selective contact creation',
+                'description' => 'Records will only be created for contacts who receive emails from your workspace members, or appear in their calendar events.',
+            ],
+            'none' => [
+                'label' => 'None',
+                'description' => 'No records will automatically be created. Email and calendar events will still be linked with records created manually.',
+            ],
+        ],
+        'companies' => [
+            'label' => 'Automatically create company records',
+            'description' => 'Company records will be automatically created based on the domain in a person\'s email address.',
+        ],
     ],
     'notifications' => [
         'saved' => 'Privacy settings saved.',

--- a/packages/EmailIntegration/resources/css/email-integration.css
+++ b/packages/EmailIntegration/resources/css/email-integration.css
@@ -35,7 +35,8 @@
         @apply ring-2 ring-primary-600/40 dark:ring-primary-500/40;
     }
 
-    &:has(input:checked) {
+    &:has(input:checked),
+    &:has([role='switch'][aria-checked='true']) {
         @apply border-primary-600 bg-primary-50 dark:border-primary-500 dark:bg-primary-500/10;
 
         & .ei-sharing-card-icon {

--- a/packages/EmailIntegration/resources/views/filament/pages/workspace-email-settings.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/workspace-email-settings.blade.php
@@ -1,7 +1,27 @@
 <x-filament-panels::page>
+    <x-filament::tabs :label="__('filament/pages/email-privacy-settings.tabs.aria')" class="ei-tabs-segmented mb-6">
+        <x-filament::tabs.item
+            :active="$tab === 'visibility'"
+            :icon="\Filament\Support\Icons\Heroicon::OutlinedEye"
+            wire:click="setTab('visibility')"
+        >
+            {{ __('filament/pages/email-privacy-settings.tabs.visibility') }}
+        </x-filament::tabs.item>
+
+        <x-filament::tabs.item
+            :active="$tab === 'record_creation'"
+            :icon="\Filament\Support\Icons\Heroicon::OutlinedUserPlus"
+            wire:click="setTab('record_creation')"
+        >
+            {{ __('filament/pages/email-privacy-settings.tabs.record_creation') }}
+        </x-filament::tabs.item>
+    </x-filament::tabs>
+
     {{ $this->form }}
 
-    <div class="mt-6">
-        {{ $this->saveAction }}
-    </div>
+    @if ($tab === 'visibility')
+        <div class="mt-6">
+            {{ $this->saveAction }}
+        </div>
+    @endif
 </x-filament-panels::page>

--- a/packages/EmailIntegration/resources/views/forms/company-creation-card.blade.php
+++ b/packages/EmailIntegration/resources/views/forms/company-creation-card.blade.php
@@ -1,0 +1,31 @@
+@php
+    $statePath = $getStatePath();
+    $toggleState = '$wire.$entangle(\''.$statePath.'\', true)';
+@endphp
+
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+    <div
+        class="ei-sharing-card"
+        x-on:click="if (! $event.target.closest('.fi-toggle')) $refs.companyToggle.click()"
+    >
+        <span class="ei-sharing-card-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 transition dark:bg-white/10 dark:text-gray-400">
+            <x-filament::icon icon="heroicon-o-building-office-2" class="h-5 w-5" />
+        </span>
+
+        <span class="min-w-0 flex-1">
+            <span class="ei-sharing-card-title block text-sm font-medium text-gray-950 dark:text-white">
+                {{ __('filament/pages/email-privacy-settings.record_creation.companies.label') }}
+            </span>
+            <span class="mt-0.5 block text-sm text-gray-600 dark:text-gray-400">
+                {{ __('filament/pages/email-privacy-settings.record_creation.companies.description') }}
+            </span>
+        </span>
+
+        <x-filament::toggle
+            x-ref="companyToggle"
+            class="mt-1 shrink-0"
+            :state="$toggleState"
+            :aria-label="__('filament/pages/email-privacy-settings.record_creation.companies.label')"
+        />
+    </div>
+</x-dynamic-component>

--- a/packages/EmailIntegration/resources/views/forms/contact-creation-cards.blade.php
+++ b/packages/EmailIntegration/resources/views/forms/contact-creation-cards.blade.php
@@ -1,0 +1,46 @@
+@php
+    use Relaticle\EmailIntegration\Enums\ContactCreationMode;
+
+    $statePath = $getStatePath();
+
+    $options = array_map(fn (ContactCreationMode $mode): array => [
+        'value' => $mode->value,
+        'icon' => $mode->getIcon(),
+        'label' => $mode->getLabel(),
+        'description' => $mode->getDescription(),
+        'recommended' => $mode->isRecommended(),
+    ], ContactCreationMode::cases());
+@endphp
+
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+    <div class="space-y-2" role="radiogroup" aria-label="{{ $ariaLabel }}">
+        @foreach ($options as $option)
+            <label class="ei-sharing-card">
+                <span class="ei-sharing-card-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 transition dark:bg-white/10 dark:text-gray-400">
+                    <x-filament::icon :icon="$option['icon']" class="h-5 w-5" />
+                </span>
+
+                <span class="min-w-0 flex-1">
+                    <span class="ei-sharing-card-title flex flex-wrap items-center gap-2 text-sm font-medium text-gray-950 dark:text-white">
+                        {{ $option['label'] }}
+                        @if ($option['recommended'])
+                            <x-filament::badge color="success" size="sm">
+                                {{ __('filament/pages/email-privacy-settings.record_creation.recommended') }}
+                            </x-filament::badge>
+                        @endif
+                    </span>
+                    <span class="mt-0.5 block text-sm text-gray-600 dark:text-gray-400">
+                        {{ $option['description'] }}
+                    </span>
+                </span>
+
+                <input
+                    type="radio"
+                    value="{{ $option['value'] }}"
+                    wire:model.live="{{ $statePath }}"
+                    class="fi-radio-input mt-1 shrink-0"
+                />
+            </label>
+        @endforeach
+    </div>
+</x-dynamic-component>

--- a/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
@@ -6,7 +6,6 @@ namespace Relaticle\EmailIntegration\Actions;
 
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Data\ConnectAccountData;
-use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 final readonly class ConnectAccountAction
@@ -24,8 +23,6 @@ final readonly class ConnectAccountAction
                 'token_expires_at' => $data->tokenExpiresAt,
                 'status' => 'active',
                 'last_error' => null,
-                'auto_create_companies' => true,
-                'contact_creation_mode' => ContactCreationMode::Bidirectional,
                 'capabilities' => [
                     'email' => true,
                     'calendar' => $data->hasCalendar,

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -60,7 +60,7 @@ final readonly class LinkEmailAction
                 $company = $this->domainMatcher->firstMatching($domain, $teamId);
 
                 // 2. Auto-create Company when no existing record found.
-                if (! $company && ! $isAutomatedSender && $connectedAccount?->auto_create_companies) {
+                if (! $company && ! $isAutomatedSender && $team?->auto_create_companies) {
                     $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
                 }
 
@@ -85,7 +85,7 @@ final readonly class LinkEmailAction
                 ->first();
 
             // 4. Auto-create Person when no existing record found, passing resolved company_id.
-            if (! $person && ! $isAutomatedSender && $connectedAccount && $this->shouldCreatePerson($connectedAccount, $participant->email_address)) {
+            if (! $person && ! $isAutomatedSender && $connectedAccount && $team && $this->shouldCreatePerson($team, $connectedAccount, $participant->email_address)) {
                 $person = $this->autoCreatePerson->execute(
                     $participant->name ?? '',
                     $participant->email_address,
@@ -128,16 +128,16 @@ final readonly class LinkEmailAction
 
     /**
      * Determine whether a new Person should be created for the given email address,
-     * based on the account's contact_creation_mode setting.
+     * based on the workspace contact_creation_mode setting.
      *
      * - All:           always create when the address is unknown
      * - Bidirectional: only create when the connected account has exchanged email in
      *                  BOTH directions with this address
-     * - None:          never create (default)
+     * - None:          never create
      */
-    private function shouldCreatePerson(ConnectedAccount $account, string $emailAddress): bool
+    private function shouldCreatePerson(Team $team, ConnectedAccount $account, string $emailAddress): bool
     {
-        return match ($account->contact_creation_mode) {
+        return match ($team->contact_creation_mode) {
             ContactCreationMode::All => true,
             ContactCreationMode::Bidirectional => $this->hasBidirectionalHistory($account, $emailAddress),
             ContactCreationMode::None => false,

--- a/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
@@ -7,6 +7,7 @@ namespace Relaticle\EmailIntegration\Actions;
 use App\Models\Company;
 use App\Models\Opportunity;
 use App\Models\People;
+use App\Models\Team;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -43,7 +44,7 @@ final readonly class LinkMeetingAction
             if ($domain && $skippedDomains->doesntContain($domain)) {
                 $company = $this->domainMatcher->firstMatching($domain, $teamId);
 
-                if (! $company && $account?->auto_create_companies) {
+                if (! $company && $team?->auto_create_companies) {
                     $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
                 }
 
@@ -62,7 +63,7 @@ final readonly class LinkMeetingAction
                 )
                 ->first();
 
-            if (! $person && $account && $this->shouldCreatePerson($account, $attendee->email_address, $meeting)) {
+            if (! $person && $account && $team && $this->shouldCreatePerson($team, $account, $attendee->email_address, $meeting)) {
                 $person = $this->autoCreatePerson->execute(
                     $attendee->name ?? '',
                     $attendee->email_address,
@@ -95,9 +96,9 @@ final readonly class LinkMeetingAction
         }
     }
 
-    private function shouldCreatePerson(ConnectedAccount $account, string $emailAddress, Meeting $currentMeeting): bool
+    private function shouldCreatePerson(Team $team, ConnectedAccount $account, string $emailAddress, Meeting $currentMeeting): bool
     {
-        return match ($account->contact_creation_mode) {
+        return match ($team->contact_creation_mode) {
             ContactCreationMode::All => true,
             ContactCreationMode::Bidirectional => $this->hasPriorMeetingWith($account, $emailAddress, $currentMeeting),
             ContactCreationMode::None => false,

--- a/packages/EmailIntegration/src/Actions/UpdateConnectedAccountSettingsAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateConnectedAccountSettingsAction.php
@@ -16,8 +16,6 @@ final readonly class UpdateConnectedAccountSettingsAction
         $account->update([
             'sync_inbox' => $data['sync_inbox'],
             'sync_sent' => $data['sync_sent'],
-            'contact_creation_mode' => $data['contact_creation_mode'],
-            'auto_create_companies' => $data['auto_create_companies'],
             'hourly_send_limit' => filled($data['hourly_send_limit'] ?? null) ? (int) $data['hourly_send_limit'] : null,
             'daily_send_limit' => filled($data['daily_send_limit'] ?? null) ? (int) $data['daily_send_limit'] : null,
         ]);

--- a/packages/EmailIntegration/src/Actions/UpdateTeamContactCreationSettingsAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateTeamContactCreationSettingsAction.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Enums\ContactCreationMode;
+
+final readonly class UpdateTeamContactCreationSettingsAction
+{
+    public function execute(
+        Team $team,
+        User $actor,
+        ContactCreationMode $contactCreationMode,
+        bool $autoCreateCompanies,
+    ): void {
+        abort_unless(
+            $actor->ownsTeam($team) || $actor->hasTeamRole($team, TeamRole::Admin->value),
+            403,
+        );
+
+        $team->update([
+            'contact_creation_mode' => $contactCreationMode,
+            'auto_create_companies' => $autoCreateCompanies,
+        ]);
+    }
+}

--- a/packages/EmailIntegration/src/Enums/ContactCreationMode.php
+++ b/packages/EmailIntegration/src/Enums/ContactCreationMode.php
@@ -4,33 +4,48 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Enums;
 
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
+use Filament\Support\Icons\Heroicon;
 
-enum ContactCreationMode: string implements HasLabel
+enum ContactCreationMode: string implements HasDescription, HasIcon, HasLabel
 {
-    /**
-     * Automatically create a Person record for every new email address
-     * encountered during sync, regardless of direction.
-     */
     case All = 'all';
 
-    /**
-     * Only create a Person record when the connected account has exchanged
-     * email in both directions with the address (sent AND received).
-     */
     case Bidirectional = 'bidirectional';
 
-    /**
-     * Never auto-create Person records. Only link emails to existing records.
-     */
     case None = 'none';
 
     public function getLabel(): string
     {
         return match ($this) {
-            self::All => 'All contacts',
-            self::Bidirectional => 'Bidirectional only',
-            self::None => 'Never',
+            self::All => __('filament/pages/email-privacy-settings.record_creation.modes.all.label'),
+            self::Bidirectional => __('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.label'),
+            self::None => __('filament/pages/email-privacy-settings.record_creation.modes.none.label'),
         };
     }
-}
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::All => __('filament/pages/email-privacy-settings.record_creation.modes.all.description'),
+            self::Bidirectional => __('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.description'),
+            self::None => __('filament/pages/email-privacy-settings.record_creation.modes.none.description'),
+        };
+    }
+
+    public function getIcon(): Heroicon
+    {
+        return match ($this) {
+            self::All => Heroicon::OutlinedUserGroup,
+            self::Bidirectional => Heroicon::OutlinedUserPlus,
+            self::None => Heroicon::OutlinedNoSymbol,
+        };
+    }
+
+    public function isRecommended(): bool
+    {
+        return $this === self::Bidirectional;
+    }
+};

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountSettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountSettingsPage.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Pages;
 
-use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Field;
-use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\RichEditor;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -38,7 +35,6 @@ use Relaticle\EmailIntegration\Actions\DeleteSignatureAction;
 use Relaticle\EmailIntegration\Actions\UpdateConnectedAccountSettingsAction;
 use Relaticle\EmailIntegration\Actions\UpdateSignatureAction;
 use Relaticle\EmailIntegration\Actions\UpdateUserEmailPrivacySettingsAction;
-use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Clusters\EmailSettings;
@@ -94,8 +90,6 @@ final class EmailAccountSettingsPage extends Page implements HasSchemas
         $this->form->fill([
             'sync_inbox' => $this->account()->sync_inbox,
             'sync_sent' => $this->account()->sync_sent,
-            'contact_creation_mode' => $this->account()->contact_creation_mode->value,
-            'auto_create_companies' => $this->account()->auto_create_companies,
             'hourly_send_limit' => $this->account()->hourly_send_limit,
             'daily_send_limit' => $this->account()->daily_send_limit,
             'default_email_sharing_tier' => $user->default_email_sharing_tier->value ?? '',
@@ -179,20 +173,6 @@ final class EmailAccountSettingsPage extends Page implements HasSchemas
             Toggle::make('sync_sent')
                 ->label($this->labelWithInfo(__('filament/pages/email-accounts.settings.sync_sent.label'), __('filament/pages/email-accounts.settings.sync_sent.helper_text')))
                 ->inlineLabel(),
-
-            Toggle::make('auto_create_companies')
-                ->label($this->labelWithInfo(__('filament/pages/email-accounts.settings.auto_create_companies.label'), __('filament/pages/email-accounts.settings.auto_create_companies.helper_text')))
-                ->inlineLabel(),
-
-            Select::make('contact_creation_mode')
-                ->label($this->labelWithInfo(
-                    __('filament/pages/email-accounts.settings.contact_creation_mode.label'),
-                    __('filament/pages/email-accounts.settings.contact_creation_mode.helper_text'),
-                ))
-                ->options(ContactCreationMode::class)
-                ->selectablePlaceholder(false)
-                ->inlineLabel()
-                ->required(),
 
             Grid::make(2)
                 ->schema([

--- a/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
@@ -20,7 +20,9 @@ use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Laravel\Pennant\Feature;
+use Relaticle\EmailIntegration\Actions\UpdateTeamContactCreationSettingsAction;
 use Relaticle\EmailIntegration\Actions\UpdateTeamEmailPrivacySettingsAction;
+use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ProtectedRecipient;
 
@@ -30,9 +32,10 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
     use InteractsWithSchemas;
 
     /**
-     * Workspace-wide privacy settings may only be viewed and changed by the team
-     * owner or an admin. Mirrors the write guard in
-     * {@see UpdateTeamEmailPrivacySettingsAction}; other roles use the
+     * Workspace-wide privacy and record-creation settings may only be viewed
+     * and changed by the team owner or an admin. Mirrors the write guards in
+     * {@see UpdateTeamEmailPrivacySettingsAction} and
+     * {@see UpdateTeamContactCreationSettingsAction}; other roles use the
      * per-user "My Email Privacy" page instead.
      *
      * @param  array<string, mixed>  $parameters
@@ -84,6 +87,12 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
     /** @var array<int, string> */
     public array $protected_domains = [];
 
+    public string $contact_creation_mode = 'bidirectional';
+
+    public bool $auto_create_companies = true;
+
+    public string $tab = 'visibility';
+
     public function mount(): void
     {
         /** @var User $user */
@@ -92,10 +101,32 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
 
         $this->default_email_sharing_tier = ($team->default_email_sharing_tier ?? EmailPrivacyTier::METADATA_ONLY)->value;
 
+        $this->contact_creation_mode = ($team->contact_creation_mode ?? ContactCreationMode::Bidirectional)->value;
+        $this->auto_create_companies = $team->auto_create_companies;
+
         $rows = ProtectedRecipient::query()->where('team_id', $team->getKey())->get();
 
         $this->protected_emails = $rows->where('type', 'email')->pluck('value')->values()->all();
         $this->protected_domains = $rows->where('type', 'domain')->pluck('value')->values()->all();
+    }
+
+    public function setTab(string $tab): void
+    {
+        if (! in_array($tab, ['visibility', 'record_creation'], true)) {
+            return;
+        }
+
+        $this->tab = $tab;
+    }
+
+    public function updatedContactCreationMode(): void
+    {
+        $this->persistContactCreationSettings();
+    }
+
+    public function updatedAutoCreateCompanies(): void
+    {
+        $this->persistContactCreationSettings();
     }
 
     public function saveAction(): Action
@@ -114,6 +145,8 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
                     $this->protected_domains,
                 );
 
+                $this->persistContactCreationSettings();
+
                 Notification::make()
                     ->success()
                     ->title(__('filament/pages/email-privacy-settings.notifications.saved'))
@@ -124,32 +157,69 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
     public function form(Schema $schema): Schema
     {
         return $schema->schema([
-            Grid::make(2)->schema([
-                Section::make(__('filament/pages/email-privacy-settings.workspace_default.heading'))
-                    ->description(__('filament/pages/email-privacy-settings.workspace_default.description'))
-                    ->schema([
-                        ViewField::make('default_email_sharing_tier')
-                            ->label(__('filament/pages/email-privacy-settings.workspace_default.tier_label'))
-                            ->view('email-integration::forms.sharing-tier-cards')
-                            ->viewData([
-                                'ariaLabel' => __('filament/pages/email-privacy-settings.workspace_default.tier_label'),
-                            ]),
-                    ])->compact(),
+            Grid::make(2)
+                ->visible(fn (): bool => $this->tab === 'visibility')
+                ->schema([
+                    Section::make(__('filament/pages/email-privacy-settings.workspace_default.heading'))
+                        ->description(__('filament/pages/email-privacy-settings.workspace_default.description'))
+                        ->schema([
+                            ViewField::make('default_email_sharing_tier')
+                                ->label(__('filament/pages/email-privacy-settings.workspace_default.tier_label'))
+                                ->view('email-integration::forms.sharing-tier-cards')
+                                ->viewData([
+                                    'ariaLabel' => __('filament/pages/email-privacy-settings.workspace_default.tier_label'),
+                                ]),
+                        ])->compact(),
 
-                Section::make(__('filament/pages/email-privacy-settings.privacy_protections.heading'))
-                    ->description(__('filament/pages/email-privacy-settings.privacy_protections.description'))
-                    ->compact()
-                    ->schema([
-                        TagsInput::make('protected_emails')
-                            ->label(__('filament/pages/email-privacy-settings.protected_recipients.emails_label'))
-                            ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.emails_placeholder'))
-                            ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.emails_after_label')),
-                        TagsInput::make('protected_domains')
-                            ->label(__('filament/pages/email-privacy-settings.protected_recipients.domains_label'))
-                            ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.domains_placeholder'))
-                            ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.domains_after_label')),
-                    ]),
-            ]),
+                    Section::make(__('filament/pages/email-privacy-settings.privacy_protections.heading'))
+                        ->description(__('filament/pages/email-privacy-settings.privacy_protections.description'))
+                        ->compact()
+                        ->schema([
+                            TagsInput::make('protected_emails')
+                                ->label(__('filament/pages/email-privacy-settings.protected_recipients.emails_label'))
+                                ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.emails_placeholder'))
+                                ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.emails_after_label')),
+                            TagsInput::make('protected_domains')
+                                ->label(__('filament/pages/email-privacy-settings.protected_recipients.domains_label'))
+                                ->placeholder(__('filament/pages/email-privacy-settings.protected_recipients.domains_placeholder'))
+                                ->afterLabel(__('filament/pages/email-privacy-settings.protected_recipients.domains_after_label')),
+                        ]),
+                ]),
+
+            Section::make(__('filament/pages/email-privacy-settings.record_creation.heading'))
+                ->description(__('filament/pages/email-privacy-settings.record_creation.description'))
+                ->compact()
+                ->visible(fn (): bool => $this->tab === 'record_creation')
+                ->schema([
+                    ViewField::make('contact_creation_mode')
+                        ->hiddenLabel()
+                        ->view('email-integration::forms.contact-creation-cards')
+                        ->viewData([
+                            'ariaLabel' => __('filament/pages/email-privacy-settings.record_creation.heading'),
+                        ]),
+                    ViewField::make('auto_create_companies')
+                        ->hiddenLabel()
+                        ->view('email-integration::forms.company-creation-card'),
+                ]),
         ]);
+    }
+
+    private function persistContactCreationSettings(): void
+    {
+        $mode = ContactCreationMode::tryFrom($this->contact_creation_mode);
+
+        if ($mode === null) {
+            return;
+        }
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        resolve(UpdateTeamContactCreationSettingsAction::class)->execute(
+            $user->currentTeam,
+            $user,
+            $mode,
+            $this->auto_create_companies,
+        );
     }
 }

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -19,7 +19,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
-use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
@@ -39,8 +38,6 @@ use Relaticle\EmailIntegration\Observers\ConnectedAccountObserver;
  * @property string $access_token
  * @property string|null $refresh_token
  * @property Carbon|null $token_expires_at
- * @property ContactCreationMode $contact_creation_mode
- * @property bool $auto_create_companies
  * @property int|null $hourly_send_limit
  * @property int|null $daily_send_limit
  */
@@ -77,8 +74,6 @@ final class ConnectedAccount extends Model
         'last_error',
         'sync_inbox',
         'sync_sent',
-        'contact_creation_mode',
-        'auto_create_companies',
         'daily_send_limit',
         'hourly_send_limit',
     ];
@@ -92,8 +87,6 @@ final class ConnectedAccount extends Model
         'is_default' => 'boolean',
         'sync_inbox' => 'boolean',
         'sync_sent' => 'boolean',
-        'contact_creation_mode' => ContactCreationMode::class,
-        'auto_create_companies' => 'boolean',
         'capabilities' => 'array',
         'access_token' => 'encrypted',
         'refresh_token' => 'encrypted',

--- a/tests/Feature/CalendarIntegration/LinkMeetingCompanyTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingCompanyTest.php
@@ -16,7 +16,7 @@ use Relaticle\EmailIntegration\Models\MeetingAttendee;
 mutates(LinkMeetingAction::class);
 
 it('auto-links a meeting to a company by attendee email domain', function (): void {
-    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create(['auto_create_companies' => true]));
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
     $meeting = Meeting::factory()->create([
         'team_id' => $account->team_id,
         'connected_account_id' => $account->getKey(),
@@ -36,7 +36,7 @@ it('auto-links a meeting to a company by attendee email domain', function (): vo
 });
 
 it('skips company creation for public domains', function (): void {
-    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create(['auto_create_companies' => true]));
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
     $meeting = Meeting::factory()->create([
         'team_id' => $account->team_id,
         'connected_account_id' => $account->getKey(),
@@ -61,8 +61,8 @@ it('does not downgrade an existing manual company link to auto', function (): vo
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
-        'auto_create_companies' => false,
     ]));
+    $team->update(['auto_create_companies' => false]);
 
     $domainsField = CustomField::query()
         ->where('tenant_id', $account->team_id)

--- a/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
@@ -39,8 +39,8 @@ it('matches an existing person by email custom-field value', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
+    $team->update(['contact_creation_mode' => ContactCreationMode::None]);
 
     $person = People::factory()->for($team)->create();
     savePersonEmail($person, 'guest@acme.com');
@@ -82,8 +82,8 @@ it('auto-creates a person when contact_creation_mode=All', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
-        'contact_creation_mode' => ContactCreationMode::All,
     ]));
+    $team->update(['contact_creation_mode' => ContactCreationMode::All]);
 
     $meeting = Meeting::factory()->create([
         'team_id' => $account->team_id,
@@ -109,8 +109,8 @@ it('skips person creation when contact_creation_mode=None', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
+    $team->update(['contact_creation_mode' => ContactCreationMode::None]);
 
     $meeting = Meeting::factory()->create([
         'team_id' => $account->team_id,
@@ -135,8 +135,8 @@ it('requires prior meeting with the address for Bidirectional mode', function ()
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
-        'contact_creation_mode' => ContactCreationMode::Bidirectional,
     ]));
+    $team->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
 
     // First meeting — no existing prior → skipped
     $m1 = Meeting::factory()->create(['team_id' => $account->team_id, 'connected_account_id' => $account->getKey()]);
@@ -164,9 +164,11 @@ it('increments meeting_count metrics on matched records', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
+    ]));
+    $team->update([
         'contact_creation_mode' => ContactCreationMode::All,
         'auto_create_companies' => true,
-    ]));
+    ]);
 
     $meeting = Meeting::factory()->create([
         'team_id' => $account->team_id,
@@ -194,9 +196,11 @@ it('does not double-count metrics when a meeting is re-linked on re-sync', funct
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
+    ]));
+    $team->update([
         'contact_creation_mode' => ContactCreationMode::All,
         'auto_create_companies' => true,
-    ]));
+    ]);
 
     $meeting = Meeting::factory()->create([
         'team_id' => $account->team_id,
@@ -225,9 +229,11 @@ it('never regresses last_meeting_at when an older meeting is linked after a newe
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $team->id,
         'user_id' => $user->id,
+    ]));
+    $team->update([
         'contact_creation_mode' => ContactCreationMode::All,
         'auto_create_companies' => true,
-    ]));
+    ]);
 
     $recent = Meeting::factory()->create([
         'team_id' => $account->team_id,

--- a/tests/Feature/EmailIntegration/EmailAccountSettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountSettingsPageTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountSettingsPage;
@@ -45,13 +44,17 @@ it('fills the form from the account, the user tier and the existing blocklist', 
     expect($data['blocklist_domains'])->toContain('spammy.com');
 });
 
+it('does not expose workspace record creation controls on a personal account', function (): void {
+    livewire(EmailAccountSettingsPage::class, ['account' => $this->account->id])
+        ->assertDontSee(__('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.label'))
+        ->assertDontSee(__('filament/pages/email-privacy-settings.record_creation.companies.label'));
+});
+
 it('saves account settings, the sharing tier and the blocklist together', function (): void {
     livewire(EmailAccountSettingsPage::class, ['account' => $this->account->id])
         ->fillForm([
             'sync_inbox' => false,
             'sync_sent' => true,
-            'contact_creation_mode' => ContactCreationMode::All->value,
-            'auto_create_companies' => true,
             'hourly_send_limit' => 25,
             'daily_send_limit' => 100,
             'default_email_sharing_tier' => EmailPrivacyTier::FULL->value,
@@ -64,8 +67,6 @@ it('saves account settings, the sharing tier and the blocklist together', functi
     expect($this->account->fresh())
         ->sync_inbox->toBeFalse()
         ->sync_sent->toBeTrue()
-        ->contact_creation_mode->toBe(ContactCreationMode::All)
-        ->auto_create_companies->toBeTrue()
         ->hourly_send_limit->toBe(25)
         ->daily_send_limit->toBe(100);
 

--- a/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 use App\Models\User;
 use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Actions\UpdateTeamContactCreationSettingsAction;
 use Relaticle\EmailIntegration\Actions\UpdateTeamEmailPrivacySettingsAction;
+use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Pages\EmailPrivacySettingsPage;
 use Relaticle\EmailIntegration\Models\ProtectedRecipient;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-mutates(EmailPrivacySettingsPage::class, UpdateTeamEmailPrivacySettingsAction::class);
+mutates(EmailPrivacySettingsPage::class, UpdateTeamEmailPrivacySettingsAction::class, UpdateTeamContactCreationSettingsAction::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -169,4 +171,63 @@ it('denies a non-admin member access to the workspace privacy page', function ()
     Filament::setTenant($this->team);
 
     expect(EmailPrivacySettingsPage::canAccess())->toBeFalse();
+});
+
+it('shows record creation mode descriptions and the recommended badge', function (): void {
+    livewire(EmailPrivacySettingsPage::class)
+        ->call('setTab', 'record_creation')
+        ->assertSee(__('filament/pages/email-privacy-settings.tabs.record_creation'))
+        ->assertSee(__('filament/pages/email-privacy-settings.record_creation.modes.all.description'))
+        ->assertSee(__('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.description'))
+        ->assertSee(__('filament/pages/email-privacy-settings.record_creation.modes.none.description'))
+        ->assertSee(__('filament/pages/email-privacy-settings.record_creation.recommended'))
+        ->assertSee(__('filament/pages/email-privacy-settings.record_creation.companies.label'));
+});
+
+it('pre-fills record creation settings from the team on mount', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::None,
+        'auto_create_companies' => false,
+    ]);
+
+    livewire(EmailPrivacySettingsPage::class)
+        ->assertSet('contact_creation_mode', ContactCreationMode::None->value)
+        ->assertSet('auto_create_companies', false);
+});
+
+it('autosaves contact_creation_mode for every mailbox on the team', function (): void {
+    livewire(EmailPrivacySettingsPage::class)
+        ->call('setTab', 'record_creation')
+        ->set('contact_creation_mode', ContactCreationMode::All->value);
+
+    expect($this->team->fresh()->contact_creation_mode)->toBe(ContactCreationMode::All);
+});
+
+it('autosaves auto_create_companies for the workspace', function (): void {
+    livewire(EmailPrivacySettingsPage::class)
+        ->call('setTab', 'record_creation')
+        ->set('auto_create_companies', false);
+
+    expect($this->team->fresh()->auto_create_companies)->toBeFalse();
+});
+
+it('renders a switch for automatic company creation', function (): void {
+    livewire(EmailPrivacySettingsPage::class)
+        ->call('setTab', 'record_creation')
+        ->assertSeeHtml('role="switch"')
+        ->assertDontSeeHtml('fi-checkbox-input');
+});
+
+it('forbids a non-admin member from changing record creation settings', function (): void {
+    $member = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($member, ['role' => 'editor']);
+
+    expect(fn () => resolve(UpdateTeamContactCreationSettingsAction::class)->execute(
+        $this->team,
+        $member,
+        ContactCreationMode::All,
+        false,
+    ))->toThrow(HttpException::class);
+
+    expect($this->team->fresh()->contact_creation_mode)->toBe(ContactCreationMode::Bidirectional);
 });

--- a/tests/Feature/EmailIntegration/EmailSignaturesPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailSignaturesPageTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Models\User;
 use Filament\Facades\Filament;
-use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
 use Relaticle\EmailIntegration\Filament\Pages\EmailSignaturesPage;
@@ -28,7 +27,6 @@ function foreignAccount(string $accountId, string $email): ConnectedAccount
         'display_name' => 'Other Sender',
         'access_token' => 'fake-token',
         'status' => EmailAccountStatus::ACTIVE,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
 }
 
@@ -47,7 +45,6 @@ beforeEach(function (): void {
         'display_name' => 'Test Sender',
         'access_token' => 'fake-token',
         'status' => EmailAccountStatus::ACTIVE,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
 });
 
@@ -84,7 +81,6 @@ it('preselects the default account, not merely the oldest, when opening the crea
         'is_default' => true,
         'access_token' => 'fake-token-default',
         'status' => EmailAccountStatus::ACTIVE,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
 
     livewire(EmailSignaturesPage::class)
@@ -244,7 +240,6 @@ it('does not delete another user\'s signature', function (): void {
         'display_name' => 'Other Sender',
         'access_token' => 'fake-token-2',
         'status' => EmailAccountStatus::ACTIVE,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
 
     $otherSignature = EmailSignature::factory()->create([
@@ -282,7 +277,6 @@ it('shows only the authenticated user\'s signatures on mount', function (): void
         'display_name' => 'Other',
         'access_token' => 'fake-token-3',
         'status' => EmailAccountStatus::ACTIVE,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
 
     $otherSignature = EmailSignature::factory()->create([
@@ -313,7 +307,6 @@ it('excludes another user\'s signatures even when in the same team', function ()
         'display_name' => 'Teammate',
         'access_token' => 'fake-token-4',
         'status' => EmailAccountStatus::ACTIVE,
-        'contact_creation_mode' => ContactCreationMode::None,
     ]));
 
     $teammateSignature = EmailSignature::factory()->create([

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -238,6 +238,8 @@ it('updates participant contact_id when linked to a person', function (): void {
 });
 
 it('does not auto-create companies when auto_create_companies is false', function (): void {
+    $this->team->update(['auto_create_companies' => false]);
+
     $email = makeLinkEmail();
 
     EmailParticipant::factory()->from()->create([
@@ -253,7 +255,7 @@ it('does not auto-create companies when auto_create_companies is false', functio
 });
 
 it('auto-creates a company when auto_create_companies is true', function (): void {
-    $this->account->update(['auto_create_companies' => true]);
+    $this->team->update(['auto_create_companies' => true]);
 
     $email = makeLinkEmail();
 
@@ -268,7 +270,7 @@ it('auto-creates a company when auto_create_companies is true', function (): voi
 });
 
 it('derives the company name from the registrable domain, not a mail subdomain', function (): void {
-    $this->account->update(['auto_create_companies' => true]);
+    $this->team->update(['auto_create_companies' => true]);
 
     $email = makeLinkEmail();
 
@@ -284,7 +286,7 @@ it('derives the company name from the registrable domain, not a mail subdomain',
 });
 
 it('derives the company name from the registrable label across TLD shapes', function (string $address, string $expected): void {
-    $this->account->update(['auto_create_companies' => true]);
+    $this->team->update(['auto_create_companies' => true]);
 
     $email = makeLinkEmail();
 
@@ -307,7 +309,7 @@ it('derives the company name from the registrable label across TLD shapes', func
 ]);
 
 it('does not auto-create a company for a no-reply / automated sender', function (): void {
-    $this->account->update(['auto_create_companies' => true]);
+    $this->team->update(['auto_create_companies' => true]);
 
     $email = makeLinkEmail();
 
@@ -324,7 +326,7 @@ it('does not auto-create a company for a no-reply / automated sender', function 
 });
 
 it('does not auto-create a person for a no-reply / automated sender', function (): void {
-    $this->account->update(['contact_creation_mode' => ContactCreationMode::All]);
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::All]);
 
     $email = makeLinkEmail();
 
@@ -342,7 +344,7 @@ it('does not auto-create a person for a no-reply / automated sender', function (
 });
 
 it('seeds an auto-created company with a protocol-less domain and ICP set to false', function (): void {
-    $this->account->update(['auto_create_companies' => true]);
+    $this->team->update(['auto_create_companies' => true]);
 
     $email = makeLinkEmail();
 
@@ -444,6 +446,8 @@ it('creates distinct companies for same-named domains with different TLDs and pr
 });
 
 it('does not auto-create a person when contact_creation_mode is None', function (): void {
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::None]);
+
     $countBefore = People::where('team_id', $this->team->id)->count();
 
     $email = makeLinkEmail();
@@ -459,7 +463,7 @@ it('does not auto-create a person when contact_creation_mode is None', function 
 });
 
 it('auto-creates a person when contact_creation_mode is All', function (): void {
-    $this->account->update(['contact_creation_mode' => ContactCreationMode::All]);
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::All]);
 
     $email = makeLinkEmail();
 
@@ -475,7 +479,7 @@ it('auto-creates a person when contact_creation_mode is All', function (): void 
 });
 
 it('creates distinct people for participants sharing a display name but different emails', function (): void {
-    $this->account->update(['contact_creation_mode' => ContactCreationMode::All]);
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::All]);
 
     $email = makeLinkEmail();
 
@@ -496,7 +500,7 @@ it('creates distinct people for participants sharing a display name but differen
 });
 
 it('does not duplicate a person when the same address appears on multiple participants', function (): void {
-    $this->account->update(['contact_creation_mode' => ContactCreationMode::All]);
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::All]);
 
     $email = makeLinkEmail();
 
@@ -517,7 +521,7 @@ it('does not duplicate a person when the same address appears on multiple partic
 });
 
 it('does not auto-create a person when Bidirectional and only one direction exists', function (): void {
-    $this->account->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
 
     // Only inbound email — no outbound yet
     $inboundEmail = makeLinkEmail(['direction' => EmailDirection::INBOUND]);
@@ -543,7 +547,7 @@ it('does not auto-create a person when Bidirectional and only one direction exis
 });
 
 it('auto-creates a person when Bidirectional and both directions exist', function (): void {
-    $this->account->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
 
     $address = 'bidirectional@bidirectional.com';
 

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -52,7 +52,7 @@ it('stores an azure connected account and flips calendar capability when Graph c
 
     expect($account->hasCalendar())->toBeTrue()
         ->and($account->capabilities['email'])->toBeTrue()
-        ->and($account->contact_creation_mode)->toBe(ContactCreationMode::Bidirectional);
+        ->and($user->currentTeam->fresh()->contact_creation_mode)->toBe(ContactCreationMode::Bidirectional);
 
     Bus::assertDispatched(InitialCalendarSyncJob::class, fn (InitialCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
 });


### PR DESCRIPTION
## Summary
- Move contact-creation mode and auto-create-companies from each mailbox onto the team, with an Attio-style Record creation tab on workspace Email and Calendar (radio cards, recommended Selective, company toggle).
- Admins own the policy; sync (`LinkEmailAction` / `LinkMeetingAction`) reads the team instead of account columns, and those per-account fields are dropped after a backfill.
- Personal account Settings no longer exposes these controls.

## Test plan
- [ ] Migrate, then as an owner/admin open Workspace Settings → Email and Calendar → Record creation; confirm the three modes, Recommended badge, and company switch autosave.
- [ ] Confirm a non-admin cannot open the page or change the action.
- [ ] Confirm personal mailbox Settings has no record-creation fields.
- [ ] With workspace All / None / Selective (current Bidirectional semantics), confirm the next email/meeting sync follows the team setting.