### PR TITLE
fix(chat): restore in-flight turn state on page reload

### DIFF
--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -350,7 +350,12 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
         }
 
         this.beforeUnloadHandler = (e) => {
-            if (!this.isStreaming) return;
+            // A streaming turn is reload-safe (TurnPresence restores it), so
+            // only undelivered input warrants the prompt: a send the server
+            // has not accepted yet, or a message queued behind the stream.
+            const undelivered = this.queuedSend
+                || this.messages.some((m) => m.role === 'user' && m.sendState === 'sending');
+            if (!undelivered) return;
             // Browsers show their own generic prompt; custom strings are ignored.
             e.preventDefault();
             e.returnValue = '';

--- a/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/chat-interface.blade.php
@@ -1,5 +1,5 @@
 <div
-    x-data="chatInterface(@js($conversationId), @js(route('chat.send')), @js($initialMessage), @js($messages), @js(auth()->id()), @js($hasMoreMessages), @js($initialModel ?? auth()->user()?->ai_preferences['default_model'] ?? 'auto'), @js($initialPrompt ?? null))"
+    x-data="chatInterface(@js($conversationId), @js(route('chat.send')), @js($initialMessage), @js($messages), @js(auth()->id()), @js($hasMoreMessages), @js($initialModel ?? auth()->user()?->ai_preferences['default_model'] ?? 'auto'), @js($initialPrompt ?? null), @js($turnInFlight))"
     x-on:keydown="onChatRootKeydown($event)"
     x-on:chat:focus-editor.window="if ($event.detail?.context === @js($context ?? 'conversation')) localEditor()?.focus()"
     x-on:chat:editor-arrow-up.window="if ($event.detail?.context === @js($context ?? 'conversation')) maybeEditLastUserMessage()"
@@ -29,7 +29,7 @@
 
 @script
 <script>
-Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, initialMessages, userId, initialHasMoreMessages, initialModel, initialPrompt) => ({
+Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, initialMessages, userId, initialHasMoreMessages, initialModel, initialPrompt, turnInFlight) => ({
     ...window.ChatModules.transcriptModule({
         messagesUrl: @js(url('/chat/messages')),
         {{-- Templated on the conversation id for the same reason the switcher's
@@ -250,6 +250,16 @@ Alpine.data('chatInterface', (initialConversationId, sendUrl, initialMessage, in
 
         if (this.conversationId) {
             this.subscribeToConversation(this.conversationId);
+        }
+
+        // A turn is mid-flight server-side (reload during a running turn): show
+        // it as one from the first paint, exactly as the chat:resuming handler
+        // does for a resume this tab never sent. The watchdog bounds a job that
+        // died without broadcasting; stream_end/failure clear it as usual.
+        if (turnInFlight && this.conversationId) {
+            this.isStreaming = true;
+            this.currentToolStatus = null;
+            this.startStreamTimeout();
         }
 
         // Land at the latest message when reopening an existing conversation.

--- a/packages/Chat/resources/views/livewire/chat/partials/_composer.blade.php
+++ b/packages/Chat/resources/views/livewire/chat/partials/_composer.blade.php
@@ -33,7 +33,11 @@
                  the decision buttons pinned. Scrolling here instead would push
                  Approve below the fold on any plan taller than the dock. --}}
             <div class="flex max-h-[55vh] min-h-0 flex-col">
-                <livewire:chat.proposal-card :context="$context ?? 'conversation'" wire:key="proposal-dock-{{ $context ?? 'conversation' }}" />
+                <livewire:chat.proposal-card
+                    :context="$context ?? 'conversation'"
+                    :initial-pending-action-id="$initialProposalId ?? null"
+                    wire:key="proposal-dock-{{ $context ?? 'conversation' }}"
+                />
             </div>
         </div>
 

--- a/packages/Chat/src/Http/Controllers/ChatController.php
+++ b/packages/Chat/src/Http/Controllers/ChatController.php
@@ -41,6 +41,7 @@ use Relaticle\Chat\Support\ModelDescriptor;
 use Relaticle\Chat\Support\RecordReferenceResolver;
 use Relaticle\Chat\Support\TitleSanitizer;
 use Relaticle\Chat\Support\TranscriptScope;
+use Relaticle\Chat\Support\TurnPresence;
 
 final readonly class ChatController
 {
@@ -192,6 +193,15 @@ final readonly class ChatController
         $pageContext = $this->resolvePageContext($validated['page_context'] ?? null, $user);
 
         $this->maybeTitleConversation($conversation, $parsed['text'], $resolved['provider'], $pageContext);
+
+        TurnPresence::begin(
+            $conversation,
+            turnId: $turnId,
+            message: $parsed['text'],
+            document: $validated['document'],
+            mentions: $parsed['mentions'],
+            pageContext: $pageContext,
+        );
 
         dispatch(new ProcessChatMessage(
             user: $user,

--- a/packages/Chat/src/Jobs/ProcessChatMessage.php
+++ b/packages/Chat/src/Jobs/ProcessChatMessage.php
@@ -49,6 +49,7 @@ use Relaticle\Chat\Support\ConversationTitleGate;
 use Relaticle\Chat\Support\ProviderRateGate;
 use Relaticle\Chat\Support\ProviderStreamError;
 use Relaticle\Chat\Support\StreamEventBroadcaster;
+use Relaticle\Chat\Support\TurnPresence;
 use Relaticle\CustomFields\Services\TenantContextService;
 use Throwable;
 
@@ -139,6 +140,7 @@ final class ProcessChatMessage implements ShouldQueue
                 conversationId: $this->conversationId,
                 message: __('billing.access.paused_chat'),
             ));
+            TurnPresence::clear($this->conversationId, $this->turnId);
 
             return;
         }
@@ -174,6 +176,7 @@ final class ProcessChatMessage implements ShouldQueue
                 conversationId: $this->conversationId,
             );
             $this->releaseAuth();
+            TurnPresence::clear($this->conversationId, $this->turnId);
 
             return;
         }
@@ -233,6 +236,7 @@ final class ProcessChatMessage implements ShouldQueue
                 message: 'The assistant could not start. Please try again.',
             ));
             $this->releaseAuth();
+            TurnPresence::clear($this->conversationId, $this->turnId);
 
             return;
         }
@@ -305,6 +309,7 @@ final class ProcessChatMessage implements ShouldQueue
                     conversationId: $this->conversationId,
                     message: 'Generation stopped.',
                 ));
+                TurnPresence::clear($this->conversationId, $this->turnId);
 
                 return;
             }
@@ -342,6 +347,12 @@ final class ProcessChatMessage implements ShouldQueue
                 $this->materializeAssistantDocument($streamedResponse, $startedAt);
                 $this->maybeTitleFromTurn($streamedResponse);
                 $this->suggestNextSteps($streamedResponse);
+
+                // Both rows are persisted by now (RememberConversation's own
+                // then() ran before this one), so a reload can rebuild the turn
+                // from the database. Any throw above lands in failed(), which
+                // clears too.
+                TurnPresence::clear($this->conversationId, $this->turnId);
             });
         } catch (Throwable $e) {
             // Rate-limit, overloaded, dropped-connection and provider stream errors are
@@ -536,6 +547,10 @@ final class ProcessChatMessage implements ShouldQueue
             conversationId: $this->conversationId,
             message: $this->failureMessage($exception),
         ));
+
+        // Last, after persistFailedTurn: a reload landing mid-failed() must
+        // never find the marker gone AND the rows unpersisted at once.
+        TurnPresence::clear($this->conversationId, $this->turnId);
     }
 
     private function failureMessage(?Throwable $exception): string

--- a/packages/Chat/src/Livewire/Chat/ChatInterface.php
+++ b/packages/Chat/src/Livewire/Chat/ChatInterface.php
@@ -6,6 +6,7 @@ namespace Relaticle\Chat\Livewire\Chat;
 
 use App\Livewire\BaseLivewireComponent;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Renderless;
@@ -15,8 +16,10 @@ use Relaticle\Chat\Enums\PendingActionStatus;
 use Relaticle\Chat\Models\PendingAction;
 use Relaticle\Chat\Support\DisplayBlocks;
 use Relaticle\Chat\Support\NextSteps;
+use Relaticle\Chat\Support\RecordReferenceResolver;
 use Relaticle\Chat\Support\TitleSanitizer;
 use Relaticle\Chat\Support\TranscriptScope;
+use Relaticle\Chat\Support\TurnPresence;
 
 final class ChatInterface extends BaseLivewireComponent
 {
@@ -36,6 +39,14 @@ final class ChatInterface extends BaseLivewireComponent
 
     public bool $hasMoreMessages = false;
 
+    /**
+     * A turn is running (or queued) for this conversation right now. Nothing
+     * about it is persisted until its stream settles, so without this flag a
+     * reload mid-turn renders an idle-looking page: the client uses it to show
+     * the streaming state and arm the watchdog from the first paint.
+     */
+    public bool $turnInFlight = false;
+
     public string $context = 'conversation';
 
     public ?string $pageContextType = null;
@@ -53,7 +64,7 @@ final class ChatInterface extends BaseLivewireComponent
     private const int MAX_PROMPT_LENGTH = 5000;
 
     /**
-     * @var array<int, array{id?: string, role: string, content: string, created_at?: ?string, pending_actions?: array<int, mixed>, mentions?: list<array{type: string, id: string, label: string}>}>
+     * @var array<int, array{id?: string, role: string, content: string, created_at?: ?string, document?: array<string, mixed>, pending_actions?: array<int, mixed>, display_blocks?: list<array<string, mixed>>, next_steps?: list<array{label: string, prompt: string}>, feedback?: array{rating: string, category: ?string}|null, mentions?: list<array{type: string, id: string, label: string, url?: ?string}>, page_context?: array{type: string, id: string, label: string, url?: ?string}|null}>
      */
     public array $messages = [];
 
@@ -88,7 +99,133 @@ final class ChatInterface extends BaseLivewireComponent
             );
             $this->oldestMessageId = $this->messages === [] ? null : ($this->messages[0]['id'] ?? null);
             $this->hasMoreMessages = count($this->messages) === self::PAGE_SIZE;
+            $this->appendInFlightTurnState($this->conversationId);
         }
+    }
+
+    /**
+     * Restore what a reload would otherwise lose about a turn that has not
+     * persisted yet: the user's own just-sent message (nothing reaches the
+     * database before the stream settles) and any proposals the turn already
+     * created. Without this, refreshing mid-turn shows an idle page with the
+     * sent message gone and 25 pending proposals invisible until the next
+     * broadcast happens to arrive.
+     */
+    private function appendInFlightTurnState(string $conversationId): void
+    {
+        $presence = TurnPresence::current($conversationId);
+
+        if ($presence !== null && $this->turnAlreadyPersisted($presence['started_at'])) {
+            $presence = null;
+        }
+
+        if ($presence !== null) {
+            $this->turnInFlight = true;
+
+            if ($presence['kind'] === 'message') {
+                $this->messages[] = $this->inFlightUserMessage($presence);
+            }
+        }
+
+        // Same merge stream_end reconciliation does, at mount: a still-pending
+        // proposal whose carrying assistant message is not persisted yet (the
+        // turn is mid-stream) must still dock, or the reloaded page hides a
+        // decision that other tabs are already showing.
+        $missing = $this->missingPendingCards($conversationId);
+
+        if ($missing !== []) {
+            $this->messages[] = [
+                'role' => 'assistant',
+                'content' => '',
+                'created_at' => now()->toISOString(),
+                'pending_actions' => $missing,
+                'display_blocks' => [],
+                'next_steps' => [],
+                'feedback' => null,
+                'mentions' => [],
+                'page_context' => null,
+            ];
+        }
+    }
+
+    /**
+     * The marker outlives persistence for a moment (it is cleared after the
+     * rows are written), so a user message stored at or after the turn began
+     * means the reload can rebuild everything from the database already.
+     */
+    private function turnAlreadyPersisted(string $startedAt): bool
+    {
+        $started = Date::parse($startedAt);
+
+        foreach ($this->messages as $message) {
+            if ($message['role'] !== 'user') {
+                continue;
+            }
+
+            $createdAt = $message['created_at'] ?? null;
+
+            if (is_string($createdAt) && Date::parse($createdAt)->gte($started)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The in-flight user message, shaped like a ListConversationMessages row so
+     * the client renders it exactly as the persisted one will after the turn.
+     *
+     * @param  array{kind: string, message: string, document: array<string, mixed>, mentions: list<array{type: string, id: string, label: string}>, page_context: array{type: string, id: string, label: string}|null, started_at: string}  $presence
+     * @return array{role: string, content: string, created_at: string, document: array<string, mixed>, pending_actions: array<int, mixed>, display_blocks: list<array<string, mixed>>, next_steps: list<array{label: string, prompt: string}>, feedback: null, mentions: list<array{type: string, id: string, label: string, url: ?string}>, page_context: array{type: string, id: string, label: string, url: ?string}|null}
+     */
+    private function inFlightUserMessage(array $presence): array
+    {
+        $resolver = resolve(RecordReferenceResolver::class);
+
+        $pageContext = $presence['page_context'];
+
+        return [
+            'role' => 'user',
+            'content' => $presence['message'],
+            'document' => $presence['document'],
+            'created_at' => $presence['started_at'],
+            'pending_actions' => [],
+            'display_blocks' => [],
+            'next_steps' => [],
+            'feedback' => null,
+            'mentions' => array_map(static fn (array $mention): array => [
+                ...$mention,
+                'url' => $resolver->urlFor($mention['type'], $mention['id']),
+            ], $presence['mentions']),
+            'page_context' => $pageContext === null ? null : [
+                ...$pageContext,
+                'url' => $resolver->urlFor($pageContext['type'], $pageContext['id']),
+            ],
+        ];
+    }
+
+    /**
+     * Still-pending proposal cards not carried by any loaded message.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function missingPendingCards(string $conversationId): array
+    {
+        $known = [];
+
+        foreach ($this->messages as $message) {
+            foreach ($message['pending_actions'] ?? [] as $action) {
+                if (is_array($action) && isset($action['pending_action_id'])) {
+                    $known[(string) $action['pending_action_id']] = true;
+                }
+            }
+        }
+
+        return array_values(array_filter(
+            $this->pendingActionCards($conversationId),
+            static fn (array $card): bool => ! isset($known[(string) $card['pending_action_id']]),
+        ));
     }
 
     /**
@@ -241,6 +378,29 @@ final class ChatInterface extends BaseLivewireComponent
 
     public function render(): View
     {
-        return view('chat::livewire.chat.chat-interface');
+        return view('chat::livewire.chat.chat-interface', [
+            // Lets the docked ProposalCard render WITH the page instead of
+            // arriving a Livewire round trip after Alpine boots: the reloaded
+            // page used to show dead air where the decision was.
+            'initialProposalId' => $this->firstPendingCardId(),
+        ]);
+    }
+
+    /**
+     * The id the dock anchors on at first paint: the earliest still-pending
+     * card in transcript order, matching what the client's own
+     * syncActiveProposal() will dispatch a moment later.
+     */
+    private function firstPendingCardId(): ?string
+    {
+        foreach ($this->messages as $message) {
+            foreach ($message['pending_actions'] ?? [] as $action) {
+                if (is_array($action) && ($action['status'] ?? null) === 'pending' && isset($action['pending_action_id'])) {
+                    return (string) $action['pending_action_id'];
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/packages/Chat/src/Livewire/Chat/ChatInterface.php
+++ b/packages/Chat/src/Livewire/Chat/ChatInterface.php
@@ -125,11 +125,7 @@ final class ChatInterface extends BaseLivewireComponent
 
         $presence = TurnPresence::current($conversationId);
 
-        if ($presence !== null && $this->turnAlreadyPersisted($presence['started_at'])) {
-            $presence = null;
-        }
-
-        if ($presence !== null) {
+        if ($presence !== null && ! $this->turnAlreadyPersisted($presence['started_at'])) {
             $this->turnInFlight = true;
 
             if ($presence['kind'] === 'message') {

--- a/packages/Chat/src/Livewire/Chat/ChatInterface.php
+++ b/packages/Chat/src/Livewire/Chat/ChatInterface.php
@@ -113,6 +113,16 @@ final class ChatInterface extends BaseLivewireComponent
      */
     private function appendInFlightTurnState(string $conversationId): void
     {
+        // $conversationId is a route parameter, so it names any conversation the
+        // caller cares to type. Neither source below is scoped on its own: the
+        // marker is keyed by conversation id alone, and the cards query trusted
+        // its previous caller to have verified ownership first. An empty
+        // transcript is not that verification, it is what a foreign id also
+        // returns.
+        if (resolve(FindConversation::class)->execute($this->authUser(), $conversationId) === null) {
+            return;
+        }
+
         $presence = TurnPresence::current($conversationId);
 
         if ($presence !== null && $this->turnAlreadyPersisted($presence['started_at'])) {
@@ -316,16 +326,23 @@ final class ChatInterface extends BaseLivewireComponent
 
     /**
      * Still-pending (and not-yet-expired) proposal cards for this conversation,
-     * shaped exactly as the live `.tool_result` payload the client renders. Used
-     * only for reconciliation, so the conversation ownership is already verified
-     * by latestAssistantMessage()'s scoped query before this runs.
+     * shaped exactly as the live `.tool_result` payload the client renders.
+     *
+     * Scoped to the authed participant in its own right, matching the filter
+     * ListConversationMessages applies to the same rows. Every caller does
+     * verify the conversation, but leaning on that precondition is how a
+     * route-supplied id once reached these payloads.
      *
      * @return list<array<string, mixed>>
      */
     private function pendingActionCards(string $conversationId): array
     {
+        $user = $this->authUser();
+
         $actions = PendingAction::query()
             ->where('conversation_id', $conversationId)
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $user->current_team_id)
             ->where('status', PendingActionStatus::Pending)
             ->where('expires_at', '>', now())
             ->oldest()

--- a/packages/Chat/src/Livewire/Chat/ProposalCard.php
+++ b/packages/Chat/src/Livewire/Chat/ProposalCard.php
@@ -95,9 +95,29 @@ final class ProposalCard extends BaseLivewireComponent
     /** @var array<string, mixed> */
     public array $data = [];
 
-    public function mount(string $context = 'conversation'): void
+    /**
+     * $initialPendingActionId lets the dock render its card in the same request
+     * that renders the page, instead of empty-until-set-active: the client's
+     * init dispatch of proposal:set-active still runs and re-anchors moments
+     * later, so a stale or wrong id self-corrects. loadStep() scopes it to the
+     * authed user, so the value can only ever name a proposal of their own.
+     */
+    public function mount(string $context = 'conversation', ?string $initialPendingActionId = null): void
     {
         $this->context = $context;
+
+        if ($initialPendingActionId === null) {
+            return;
+        }
+
+        $pendingAction = $this->loadStep($initialPendingActionId);
+
+        if (! $pendingAction instanceof PendingAction) {
+            return;
+        }
+
+        $this->pendingActionId = (string) $pendingAction->getKey();
+        $this->focusFirstPendingStep($pendingAction);
     }
 
     public function form(Schema $schema): Schema

--- a/packages/Chat/src/Services/TurnContinuationService.php
+++ b/packages/Chat/src/Services/TurnContinuationService.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Relaticle\Chat\Enums\PendingActionStatus;
 use Relaticle\Chat\Jobs\ProcessChatMessage;
 use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Support\TurnPresence;
 
 /**
  * Resumes the assistant after the user decides a proposal.
@@ -91,6 +92,8 @@ final readonly class TurnContinuationService
 
             return false;
         }
+
+        TurnPresence::begin($conversationId, turnId: $turnId, message: '', isContinuation: true);
 
         dispatch(new ProcessChatMessage(
             user: $user,

--- a/packages/Chat/src/Support/TurnPresence.php
+++ b/packages/Chat/src/Support/TurnPresence.php
@@ -20,8 +20,8 @@ use Illuminate\Support\Facades\Cache;
  * Written where the turn is dispatched (ChatController::send,
  * TurnContinuationService::resume) and cleared on every terminal path of
  * ProcessChatMessage. Retries, releases and the failover re-dispatch keep it:
- * the turn is still alive. The TTL is only the dead-worker backstop — a job
- * killed hard enough to skip failed() — sized past the job's worst case
+ * the turn is still alive. The TTL is only the dead-worker backstop (a job
+ * killed hard enough to skip failed()), sized past the job's worst case
  * (retryUntil + timeout), after which the client watchdog's timeout error has
  * long since told the user the turn is gone.
  */

--- a/packages/Chat/src/Support/TurnPresence.php
+++ b/packages/Chat/src/Support/TurnPresence.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\Chat\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * The in-flight turn marker: what a reload must still know about a turn that
+ * has not persisted yet.
+ *
+ * Nothing about a running turn reaches the database until the stream's then()
+ * callback writes the user and assistant rows together, so for the whole turn
+ * (queue wait included) a reload would otherwise render the conversation as if
+ * the send never happened: the user's own message gone, no streaming
+ * indicator, proposals invisible until the next broadcast. ChatInterface reads
+ * this at mount to restore that state.
+ *
+ * Written where the turn is dispatched (ChatController::send,
+ * TurnContinuationService::resume) and cleared on every terminal path of
+ * ProcessChatMessage. Retries, releases and the failover re-dispatch keep it:
+ * the turn is still alive. The TTL is only the dead-worker backstop — a job
+ * killed hard enough to skip failed() — sized past the job's worst case
+ * (retryUntil + timeout), after which the client watchdog's timeout error has
+ * long since told the user the turn is gone.
+ */
+final readonly class TurnPresence
+{
+    private const int TTL_SECONDS = 360;
+
+    /**
+     * @param  array<string, mixed>  $document
+     * @param  list<array{type: string, id: string, label: string}>  $mentions
+     * @param  array{type: string, id: string, label: string}|null  $pageContext
+     */
+    public static function begin(
+        string $conversationId,
+        string $turnId,
+        string $message,
+        array $document = ['type' => 'doc', 'content' => []],
+        array $mentions = [],
+        ?array $pageContext = null,
+        bool $isContinuation = false,
+    ): void {
+        Cache::put(self::key($conversationId), [
+            'turn_id' => $turnId,
+            'kind' => $isContinuation ? 'continuation' : 'message',
+            // A continuation runs on a synthetic prompt the transcript never
+            // shows, so nothing worth rendering is stored for it.
+            'message' => $isContinuation ? '' : $message,
+            'document' => $isContinuation ? ['type' => 'doc', 'content' => []] : $document,
+            'mentions' => $isContinuation ? [] : $mentions,
+            'page_context' => $isContinuation ? null : $pageContext,
+            'started_at' => now()->toISOString(),
+        ], self::TTL_SECONDS);
+    }
+
+    /**
+     * Scoped to the clearing turn: a newer send overwrites the marker before
+     * the older job ends (two tabs racing), and the older job's cleanup must
+     * not blank a turn that is still waiting behind WithoutOverlapping.
+     */
+    public static function clear(string $conversationId, string $turnId): void
+    {
+        $current = self::current($conversationId);
+
+        if ($current !== null && $current['turn_id'] !== $turnId) {
+            return;
+        }
+
+        Cache::forget(self::key($conversationId));
+    }
+
+    /**
+     * @return array{turn_id: string, kind: string, message: string, document: array<string, mixed>, mentions: list<array{type: string, id: string, label: string}>, page_context: array{type: string, id: string, label: string}|null, started_at: string}|null
+     */
+    public static function current(string $conversationId): ?array
+    {
+        /** @var array{turn_id: string, kind: string, message: string, document: array<string, mixed>, mentions: list<array{type: string, id: string, label: string}>, page_context: array{type: string, id: string, label: string}|null, started_at: string}|null $value */
+        $value = Cache::get(self::key($conversationId));
+
+        return is_array($value) ? $value : null;
+    }
+
+    private static function key(string $conversationId): string
+    {
+        return "chat:turn-inflight:{$conversationId}";
+    }
+}

--- a/tests/Feature/Chat/ProcessChatMessageTest.php
+++ b/tests/Feature/Chat/ProcessChatMessageTest.php
@@ -12,6 +12,7 @@ use Relaticle\Chat\Events\ChatStreamFailed;
 use Relaticle\Chat\Jobs\ProcessChatMessage;
 use Relaticle\Chat\Models\AiCreditBalance;
 use Relaticle\Chat\Services\CreditService;
+use Relaticle\Chat\Support\TurnPresence;
 
 function seedConversation(User $user, string $conversationId): void
 {
@@ -118,7 +119,11 @@ it('refunds the reservation and stops when hosted access expires in the queue', 
         turnId: 'turn-paused',
     );
 
+    TurnPresence::begin('conv-paused', turnId: 'turn-paused', message: 'hello');
+
     $job->handle($credits);
+
+    expect(TurnPresence::current('conv-paused'))->toBeNull();
 
     Event::assertDispatched(ChatStreamFailed::class, fn (ChatStreamFailed $event): bool => $event->conversationId === 'conv-paused'
         && $event->message === __('billing.access.paused_chat'));

--- a/tests/Feature/Chat/TurnPresenceTest.php
+++ b/tests/Feature/Chat/TurnPresenceTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Task\CreateTask;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Relaticle\Chat\Enums\PendingActionOperation;
+use Relaticle\Chat\Enums\PendingActionStatus;
+use Relaticle\Chat\Jobs\ProcessChatMessage;
+use Relaticle\Chat\Livewire\Chat\ChatInterface;
+use Relaticle\Chat\Livewire\Chat\ProposalCard;
+use Relaticle\Chat\Models\AiCreditBalance;
+use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Support\TurnPresence;
+use Tests\Helpers\ChatDocument;
+
+mutates(TurnPresence::class, ChatInterface::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withPersonalTeam()->create();
+    $this->team = $this->user->currentTeam;
+    $this->actingAs($this->user);
+
+    AiCreditBalance::query()->updateOrCreate(['team_id' => $this->team->getKey()], [
+        'team_id' => $this->team->getKey(),
+        'credits_remaining' => 100,
+        'credits_used' => 0,
+        'period_starts_at' => now()->startOfMonth(),
+        'period_ends_at' => now()->endOfMonth(),
+    ]);
+});
+
+function turnPresenceSeedConversation(User $user): string
+{
+    $conversationId = (string) Str::uuid7();
+    DB::table('agent_conversations')->insert([
+        'id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => (string) $user->getKey(),
+        'team_id' => $user->currentTeam->getKey(),
+        'title' => 'T',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $conversationId;
+}
+
+/** @param array<string, mixed> $overrides */
+function turnPresenceSeedMessage(User $user, string $conversationId, array $overrides = []): void
+{
+    DB::table('agent_conversation_messages')->insert(array_merge([
+        'id' => (string) Str::ulid(),
+        'conversation_id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => (string) $user->getKey(),
+        'agent' => 'Relaticle\\Chat\\Agents\\CrmAssistant',
+        'role' => 'user',
+        'content' => 'earlier message',
+        'document' => ChatDocument::emptyJson(),
+        'attachments' => '[]',
+        'tool_calls' => '[]',
+        'tool_results' => '[]',
+        'usage' => '{}',
+        'meta' => '{}',
+        'created_at' => now()->subMinutes(5),
+        'updated_at' => now()->subMinutes(5),
+    ], $overrides));
+}
+
+function turnPresenceSeedPendingAction(User $user, string $conversationId): string
+{
+    $pending = PendingAction::query()->create([
+        'team_id' => $user->currentTeam->getKey(),
+        'user_id' => $user->getKey(),
+        'conversation_id' => $conversationId,
+        'action_class' => CreateTask::class,
+        'operation' => PendingActionOperation::Create,
+        'entity_type' => 'task',
+        'action_data' => ['title' => 'Follow up'],
+        'display_data' => ['title' => 'Create Task', 'summary' => 'Create task "Follow up"'],
+        'status' => PendingActionStatus::Pending,
+        'expires_at' => now()->addMinutes(15),
+    ]);
+
+    return (string) $pending->getKey();
+}
+
+it('marks the turn in flight when a message is sent', function (): void {
+    Queue::fake();
+    $conversationId = turnPresenceSeedConversation($this->user);
+
+    $this->postJson(route('chat.send'), [
+        'document' => ChatDocument::fromText('update categories for all contacts'),
+        'conversation_id' => $conversationId,
+    ])->assertOk();
+
+    Queue::assertPushed(ProcessChatMessage::class);
+
+    $presence = TurnPresence::current($conversationId);
+
+    expect($presence)->not->toBeNull()
+        ->and($presence['kind'])->toBe('message')
+        ->and($presence['message'])->toBe('update categories for all contacts');
+});
+
+it('restores the in-flight user message and streaming flag on reload', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+    turnPresenceSeedMessage($this->user, $conversationId);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-a', message: 'random');
+
+    $component = Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->assertSet('turnInFlight', true);
+
+    $messages = $component->get('messages');
+    $last = end($messages);
+
+    expect($last['role'])->toBe('user')
+        ->and($last['content'])->toBe('random');
+});
+
+it('docks proposals whose carrying assistant message is not persisted yet', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+    turnPresenceSeedMessage($this->user, $conversationId);
+    $pendingId = turnPresenceSeedPendingAction($this->user, $conversationId);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-a', message: 'random');
+
+    $messages = Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->get('messages');
+
+    $last = end($messages);
+
+    expect($last['role'])->toBe('assistant')
+        ->and($last['pending_actions'][0]['pending_action_id'])->toBe($pendingId)
+        ->and($last['pending_actions'][0]['status'])->toBe('pending');
+});
+
+it('skips the injection once the turn is persisted but the marker lingers', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-a', message: 'random');
+
+    turnPresenceSeedMessage($this->user, $conversationId, [
+        'content' => 'random',
+        'created_at' => now()->addSecond(),
+        'updated_at' => now()->addSecond(),
+    ]);
+
+    $component = Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->assertSet('turnInFlight', false);
+
+    expect($component->get('messages'))->toHaveCount(1);
+});
+
+it('shows a continuation turn without injecting a user bubble', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+    turnPresenceSeedMessage($this->user, $conversationId, ['role' => 'assistant', 'content' => 'Created it.']);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-a', message: '', isContinuation: true);
+
+    $component = Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->assertSet('turnInFlight', true);
+
+    $messages = $component->get('messages');
+
+    expect($messages)->toHaveCount(1)
+        ->and($messages[0]['role'])->toBe('assistant');
+});
+
+it('clears the marker when the job fails for good', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-a', message: 'doomed');
+
+    $job = new ProcessChatMessage(
+        user: $this->user,
+        team: $this->team,
+        message: 'doomed',
+        conversationId: $conversationId,
+        resolved: ['provider' => 'anthropic', 'model' => 'x', 'id' => 'x', 'source' => 'auto'],
+        turnId: 'turn-a',
+    );
+    $job->failed(null);
+
+    expect(TurnPresence::current($conversationId))->toBeNull();
+});
+
+it('keeps a newer turn marker when an older turn ends', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-b', message: 'newer send');
+
+    TurnPresence::clear($conversationId, 'turn-a');
+
+    expect(TurnPresence::current($conversationId)['message'] ?? null)->toBe('newer send');
+});
+
+it('anchors the dock server-side from the initial pending action id', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+    $pendingId = turnPresenceSeedPendingAction($this->user, $conversationId);
+
+    Livewire::test(ProposalCard::class, ['context' => 'conversation', 'initialPendingActionId' => $pendingId])
+        ->assertSet('pendingActionId', $pendingId)
+        ->assertSee('Follow up');
+});
+
+it('ignores an initial pending action id belonging to another user', function (): void {
+    $other = User::factory()->withPersonalTeam()->create();
+    $conversationId = turnPresenceSeedConversation($other);
+    $foreignId = turnPresenceSeedPendingAction($other, $conversationId);
+
+    Livewire::test(ProposalCard::class, ['context' => 'conversation', 'initialPendingActionId' => $foreignId])
+        ->assertSet('pendingActionId', null);
+});

--- a/tests/Feature/Chat/TurnPresenceTest.php
+++ b/tests/Feature/Chat/TurnPresenceTest.php
@@ -218,3 +218,36 @@ it('ignores an initial pending action id belonging to another user', function ()
     Livewire::test(ProposalCard::class, ['context' => 'conversation', 'initialPendingActionId' => $foreignId])
         ->assertSet('pendingActionId', null);
 });
+
+it('never leaks another team conversation in-flight turn on mount', function (): void {
+    $victim = User::factory()->withPersonalTeam()->create();
+    $conversationId = turnPresenceSeedConversation($victim);
+    $pendingId = turnPresenceSeedPendingAction($victim, $conversationId);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-a', message: 'victim secret prompt');
+
+    $component = Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->assertSet('turnInFlight', false)
+        ->assertSet('messages', [])
+        ->assertDontSee($pendingId)
+        ->assertDontSee('victim secret prompt');
+
+    expect($component->get('messages'))->toBe([]);
+});
+
+it('never leaks a teammate conversation in-flight turn on mount', function (): void {
+    $teammate = User::factory()->create();
+    $this->team->users()->attach($teammate, ['role' => 'editor']);
+    $teammate->forceFill(['current_team_id' => $this->team->getKey()])->save();
+
+    $conversationId = turnPresenceSeedConversation($teammate);
+    $pendingId = turnPresenceSeedPendingAction($teammate, $conversationId);
+
+    TurnPresence::begin($conversationId, turnId: 'turn-a', message: 'teammate secret prompt');
+
+    Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->assertSet('turnInFlight', false)
+        ->assertSet('messages', [])
+        ->assertDontSee($pendingId)
+        ->assertDontSee('teammate secret prompt');
+});

--- a/tests/Feature/Chat/TurnPresenceTest.php
+++ b/tests/Feature/Chat/TurnPresenceTest.php
@@ -15,10 +15,11 @@ use Relaticle\Chat\Livewire\Chat\ChatInterface;
 use Relaticle\Chat\Livewire\Chat\ProposalCard;
 use Relaticle\Chat\Models\AiCreditBalance;
 use Relaticle\Chat\Models\PendingAction;
+use Relaticle\Chat\Services\TurnContinuationService;
 use Relaticle\Chat\Support\TurnPresence;
 use Tests\Helpers\ChatDocument;
 
-mutates(TurnPresence::class, ChatInterface::class);
+mutates(TurnPresence::class, ChatInterface::class, TurnContinuationService::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withPersonalTeam()->create();
@@ -250,4 +251,39 @@ it('never leaks a teammate conversation in-flight turn on mount', function (): v
         ->assertSet('messages', [])
         ->assertDontSee($pendingId)
         ->assertDontSee('teammate secret prompt');
+});
+
+it('marks a continuation turn in flight when the assistant resumes', function (): void {
+    Queue::fake();
+    $conversationId = turnPresenceSeedConversation($this->user);
+
+    $resumed = resolve(TurnContinuationService::class)
+        ->resume($this->user, $conversationId, 'resolved-turn-a');
+
+    expect($resumed)->toBeTrue();
+
+    Queue::assertPushed(ProcessChatMessage::class);
+
+    $presence = TurnPresence::current($conversationId);
+
+    expect($presence)->not->toBeNull()
+        ->and($presence['kind'])->toBe('continuation')
+        ->and($presence['message'])->toBe('');
+});
+
+it('hands the dock the first pending card id at render', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+    turnPresenceSeedMessage($this->user, $conversationId);
+    $pendingId = turnPresenceSeedPendingAction($this->user, $conversationId);
+
+    Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->assertViewHas('initialProposalId', $pendingId);
+});
+
+it('hands the dock no card id when nothing is pending', function (): void {
+    $conversationId = turnPresenceSeedConversation($this->user);
+    turnPresenceSeedMessage($this->user, $conversationId);
+
+    Livewire::test(ChatInterface::class, ['conversationId' => $conversationId])
+        ->assertViewHas('initialProposalId', null);
 });


### PR DESCRIPTION
Nothing about a running chat turn is persisted until the stream settles, so reloading mid-turn rendered an idle page: the just-sent user message gone, no streaming indicator, and already-created proposals invisible until the job's next broadcast arrived seconds later (reported on a 25-card batch turn in production).

A new `TurnPresence` cache marker records the dispatched turn (send and continuation paths) and is cleared, scoped to its own turn id, on every terminal path of `ProcessChatMessage`. `ChatInterface::mount` rebuilds the in-flight user bubble from the marker, tells the client to show the streaming state and arm the watchdog, and docks still-pending proposals that no persisted message carries yet. `ProposalCard` now takes an initial pending action id so the docked card renders with the page instead of one Livewire round trip after Alpine boots.

Verified in the real stack (redis worker, Reverb, live Anthropic turns): mid-turn reload restores message, indicator and card at first paint; success, timeout and failure paths all clean the marker up. Covered by `tests/Feature/Chat/TurnPresenceTest.php` plus the full chat feature suite (1120 passing).