### PR TITLE
Create people on outbound email and first meetings

### DIFF
--- a/app/ActivityLog/AppEventPalette.php
+++ b/app/ActivityLog/AppEventPalette.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\ActivityLog;
 
-enum AppEventPalette: string
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum AppEventPalette: string implements HasIcon, HasLabel
 {
     case EmailSent = 'email_sent';
     case EmailReceived = 'email_received';
     case NoteCreated = 'note_created';
     case TaskCreated = 'task_created';
 
-    public function icon(): string
+    public function getIcon(): string
     {
         return match ($this) {
             self::EmailSent, self::EmailReceived => 'ri-mail-line',
@@ -20,7 +23,7 @@ enum AppEventPalette: string
         };
     }
 
-    public function label(): string
+    public function getLabel(): string
     {
         return (string) __("activity-log.events.{$this->value}.label");
     }

--- a/app/ActivityLog/MeetingEventPalette.php
+++ b/app/ActivityLog/MeetingEventPalette.php
@@ -19,7 +19,11 @@ enum MeetingEventPalette: string
 
     public function label(): string
     {
-        return (string) __("activity-log.events.{$this->value}.label");
+        $events = __('activity-log.events');
+        $event = is_array($events) ? ($events[$this->value] ?? null) : null;
+        $label = is_array($event) ? ($event['label'] ?? null) : null;
+
+        return is_string($label) ? $label : $this->value;
     }
 
     public function badge(): null

--- a/app/ActivityLog/MeetingEventPalette.php
+++ b/app/ActivityLog/MeetingEventPalette.php
@@ -4,20 +4,24 @@ declare(strict_types=1);
 
 namespace App\ActivityLog;
 
-enum MeetingEventPalette: string
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+use Filament\Support\Icons\Heroicon;
+
+enum MeetingEventPalette: string implements HasIcon, HasLabel
 {
     case MeetingCreated = 'meeting.created';
     case MeetingCancelled = 'meeting.cancelled';
 
-    public function icon(): string
+    public function getIcon(): Heroicon
     {
         return match ($this) {
-            self::MeetingCreated => 'heroicon-o-calendar',
-            self::MeetingCancelled => 'heroicon-o-calendar-days',
+            self::MeetingCreated => Heroicon::OutlinedCalendar,
+            self::MeetingCancelled => Heroicon::OutlinedCalendarDays,
         };
     }
 
-    public function label(): string
+    public function getLabel(): string
     {
         $events = __('activity-log.events');
         $event = is_array($events) ? ($events[$this->value] ?? null) : null;

--- a/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
+++ b/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\CompanyResource\Pages;
 
+use App\Features\EmailIntegration;
 use App\Filament\Components\Infolists\AvatarName;
 use App\Filament\Resources\CompanyResource;
+use App\Filament\Resources\CompanyResource\RelationManagers\MeetingsRelationManager;
 use App\Filament\Resources\CompanyResource\RelationManagers\NotesRelationManager;
 use App\Filament\Resources\CompanyResource\RelationManagers\PeopleRelationManager;
 use App\Filament\Resources\CompanyResource\RelationManagers\TasksRelationManager;
@@ -21,6 +23,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
+use Laravel\Pennant\Feature;
 use Relaticle\ActivityLog\Filament\RelationManagers\ActivityLogRelationManager;
 use Relaticle\CustomFields\Facades\CustomFields;
 
@@ -35,6 +38,7 @@ final class ViewCompany extends ViewRecord
                 ->label(__('filament/resources/company.pages.view.actions.view_emails.label'))
                 ->icon('heroicon-o-envelope')
                 ->color('gray')
+                ->visible(fn (): bool => Feature::active(EmailIntegration::class))
                 ->url(fn (): string => CompanyResource::getUrl('emails', ['record' => $this->getRecord()])),
             EditAction::make()->icon('heroicon-o-pencil-square')->label(__('filament/resources/company.pages.view.actions.edit.label')),
             ActionGroup::make([
@@ -160,6 +164,7 @@ final class ViewCompany extends ViewRecord
             PeopleRelationManager::class,
             TasksRelationManager::class,
             NotesRelationManager::class,
+            MeetingsRelationManager::class,
             ActivityLogRelationManager::class,
         ];
     }

--- a/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\OpportunityResource\Pages;
 
+use App\Features\EmailIntegration;
 use App\Filament\Resources\CompanyResource;
 use App\Filament\Resources\OpportunityResource;
 use App\Filament\Resources\PeopleResource;
@@ -19,6 +20,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
+use Laravel\Pennant\Feature;
 use Relaticle\CustomFields\Facades\CustomFields;
 
 final class ViewOpportunity extends ViewRecord
@@ -32,6 +34,7 @@ final class ViewOpportunity extends ViewRecord
                 ->label(__('filament/resources/opportunity.pages.view.actions.view_emails.label'))
                 ->icon('heroicon-o-envelope')
                 ->color('gray')
+                ->visible(fn (): bool => Feature::active(EmailIntegration::class))
                 ->url(fn (): string => OpportunityResource::getUrl('emails', ['record' => $this->getRecord()])),
             EditAction::make()->icon('heroicon-o-pencil-square')->label(__('filament/resources/opportunity.pages.view.actions.edit.label')),
             ActionGroup::make([

--- a/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
+++ b/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\PeopleResource\Pages;
 
+use App\Features\EmailIntegration;
 use App\Filament\Resources\CompanyResource;
 use App\Filament\Resources\PeopleResource;
 use App\Models\People;
@@ -20,6 +21,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\TextSize;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
+use Laravel\Pennant\Feature;
 use Relaticle\CustomFields\Facades\CustomFields;
 
 final class ViewPeople extends ViewRecord
@@ -33,6 +35,7 @@ final class ViewPeople extends ViewRecord
                 ->label(__('filament/resources/person.pages.view.actions.view_emails.label'))
                 ->icon('heroicon-o-envelope')
                 ->color('gray')
+                ->visible(fn (): bool => Feature::active(EmailIntegration::class))
                 ->url(fn (): string => PeopleResource::getUrl('emails', ['record' => $this->getRecord()])),
             EditAction::make()->icon('heroicon-o-pencil-square')->label(__('filament/resources/person.pages.view.actions.edit.label')),
             ActionGroup::make([

--- a/app/Jobs/SendEmailJob.php
+++ b/app/Jobs/SendEmailJob.php
@@ -78,7 +78,7 @@ final class SendEmailJob implements ShouldQueue
         /** @var Email|null $email */
         $email = Email::query()->find($this->emailId);
 
-        if ($email === null) {
+        if ($email === null || $email->status === EmailStatus::SENT) {
             return;
         }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Features\EmailIntegration;
 use App\Http\Controllers\Billing\StripeWebhookController;
 use App\Http\Middleware\DenyIndexingOnSecondaryHosts;
 use App\Http\Middleware\RedirectToPrimaryHost;
@@ -20,6 +21,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
+use Laravel\Pennant\Feature;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
@@ -182,29 +184,31 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('notifications:send-task-digest')->hourly()->withoutOverlapping()->onOneServer();
         $schedule->command('notifications:send-setup-nudge')->hourly()->withoutOverlapping()->onOneServer();
 
-        // TODO::Separate it in different command class
-        $schedule->call(function (): void {
-            ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
-                ->whereNotNull('sync_cursor')
-                ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalEmailSyncJob($account)));
-        })
-            ->everyFiveMinutes()
-            ->name('email:incremental-sync')
-            ->withoutOverlapping();
+        if (Feature::active(EmailIntegration::class)) {
+            // TODO::Separate it in different command class
+            $schedule->call(function (): void {
+                ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
+                    ->whereNotNull('sync_cursor')
+                    ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalEmailSyncJob($account)));
+            })
+                ->everyFiveMinutes()
+                ->name('email:incremental-sync')
+                ->withoutOverlapping();
 
-        $schedule->call(function (): void {
-            ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
-                ->whereJsonContains('capabilities->calendar', true)
-                ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalCalendarSyncJob($account)));
-        })
-            ->everyFiveMinutes()
-            ->name('calendar:incremental-sync')
-            ->withoutOverlapping();
+            $schedule->call(function (): void {
+                ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
+                    ->whereJsonContains('capabilities->calendar', true)
+                    ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalCalendarSyncJob($account)));
+            })
+                ->everyFiveMinutes()
+                ->name('calendar:incremental-sync')
+                ->withoutOverlapping();
 
-        $schedule->command('email:dispatch-outbox')
-            ->everyMinute()
-            ->name('email:dispatch-outbox')
-            ->withoutOverlapping();
+            $schedule->command('email:dispatch-outbox')
+                ->everyMinute()
+                ->name('email:dispatch-outbox')
+                ->withoutOverlapping();
+        }
 
         if (config('app.health_checks_enabled')) {
             $schedule->command(RunHealthChecksCommand::class)->everyMinute();

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -29,7 +29,7 @@ final class TeamFactory extends Factory
             'user_id' => User::factory(),
             'personal_team' => true,
             'plan' => Plan::default()->value,
-            'contact_creation_mode' => ContactCreationMode::Bidirectional,
+            'contact_creation_mode' => ContactCreationMode::Selective,
             'auto_create_companies' => true,
         ];
     }

--- a/database/migrations/2026_08_29_090210_rename_bidirectional_contact_creation_mode_to_selective.php
+++ b/database/migrations/2026_08_29_090210_rename_bidirectional_contact_creation_mode_to_selective.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('teams')
+            ->where('contact_creation_mode', 'bidirectional')
+            ->update(['contact_creation_mode' => 'selective']);
+
+        DB::statement("ALTER TABLE teams ALTER COLUMN contact_creation_mode SET DEFAULT 'selective'");
+    }
+};

--- a/lang/en/filament/pages/email-privacy-settings.php
+++ b/lang/en/filament/pages/email-privacy-settings.php
@@ -41,7 +41,7 @@ return [
                 'label' => 'All contacts',
                 'description' => 'Records will be created for all contacts who appear in the emails and calendar events of your workspace members.',
             ],
-            'bidirectional' => [
+            'selective' => [
                 'label' => 'Selective contact creation',
                 'description' => 'Records will only be created for contacts who receive emails from your workspace members, or appear in their calendar events.',
             ],

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -14,7 +14,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
-use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 use Relaticle\EmailIntegration\Support\AutomatedSenderMatcher;
@@ -85,7 +84,7 @@ final readonly class LinkEmailAction
                 ->first();
 
             // 4. Auto-create Person when no existing record found, passing resolved company_id.
-            if (! $person && ! $isAutomatedSender && $connectedAccount && $team && $this->shouldCreatePerson($team, $connectedAccount, $participant->email_address)) {
+            if (! $person && ! $isAutomatedSender && $connectedAccount && $team && $this->shouldCreatePerson($team, $participant->email_address)) {
                 $person = $this->autoCreatePerson->execute(
                     $participant->name ?? '',
                     $participant->email_address,
@@ -130,35 +129,34 @@ final readonly class LinkEmailAction
      * Determine whether a new Person should be created for the given email address,
      * based on the workspace contact_creation_mode setting.
      *
-     * - All:           always create when the address is unknown
-     * - Bidirectional: only create when the connected account has exchanged email in
-     *                  BOTH directions with this address
-     * - None:          never create
+     * - All:        always create when the address is unknown
+     * - Selective:  create when any workspace mailbox has sent to this address
+     * - None:       never create
      */
-    private function shouldCreatePerson(Team $team, ConnectedAccount $account, string $emailAddress): bool
+    private function shouldCreatePerson(Team $team, string $emailAddress): bool
     {
         return match ($team->contact_creation_mode) {
             ContactCreationMode::All => true,
-            ContactCreationMode::Bidirectional => $this->hasBidirectionalHistory($account, $emailAddress),
+            ContactCreationMode::Selective => $this->hasTeamOutboundHistory($team, $emailAddress),
             ContactCreationMode::None => false,
         };
     }
 
     /**
-     * Returns true if the account already has at least one stored email in each
-     * direction involving the given address.
+     * True when any connected mailbox on this team has an outbound email involving
+     * the address. The email currently being linked already exists in the table,
+     * so the first send is enough — a reply is not required.
      */
-    private function hasBidirectionalHistory(ConnectedAccount $account, string $emailAddress): bool
+    private function hasTeamOutboundHistory(Team $team, string $emailAddress): bool
     {
-        $directions = Email::query()->where('connected_account_id', $account->getKey())
-            ->whereHas('participants', fn (Builder $participantQuery) => $participantQuery->where('email_address', $emailAddress))
-            ->distinct()
-            ->pluck('direction');
-
-        $values = $directions->map(fn (mixed $direction): mixed => $direction instanceof EmailDirection ? $direction->value : $direction);
-
-        return $values->contains(EmailDirection::INBOUND->value)
-            && $values->contains(EmailDirection::OUTBOUND->value);
+        return Email::query()
+            ->where('team_id', $team->getKey())
+            ->where('direction', EmailDirection::OUTBOUND)
+            ->whereHas(
+                'participants',
+                fn (Builder $participantQuery) => $participantQuery->where('email_address', $emailAddress),
+            )
+            ->exists();
     }
 
     /**

--- a/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
-use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
@@ -63,7 +62,7 @@ final readonly class LinkMeetingAction
                 )
                 ->first();
 
-            if (! $person && $account && $team && $this->shouldCreatePerson($team, $account, $attendee->email_address, $meeting)) {
+            if (! $person && $account && $team && $this->shouldCreatePerson($team)) {
                 $person = $this->autoCreatePerson->execute(
                     $attendee->name ?? '',
                     $attendee->email_address,
@@ -96,22 +95,12 @@ final readonly class LinkMeetingAction
         }
     }
 
-    private function shouldCreatePerson(Team $team, ConnectedAccount $account, string $emailAddress, Meeting $currentMeeting): bool
+    private function shouldCreatePerson(Team $team): bool
     {
         return match ($team->contact_creation_mode) {
-            ContactCreationMode::All => true,
-            ContactCreationMode::Bidirectional => $this->hasPriorMeetingWith($account, $emailAddress, $currentMeeting),
+            ContactCreationMode::All, ContactCreationMode::Selective => true,
             ContactCreationMode::None => false,
         };
-    }
-
-    private function hasPriorMeetingWith(ConnectedAccount $account, string $emailAddress, Meeting $currentMeeting): bool
-    {
-        return Meeting::query()
-            ->where('connected_account_id', $account->getKey())
-            ->where('id', '!=', $currentMeeting->getKey())
-            ->whereHas('attendees', fn (Builder $q) => $q->where('email_address', $emailAddress))
-            ->exists();
     }
 
     /**

--- a/packages/EmailIntegration/src/Enums/ContactCreationMode.php
+++ b/packages/EmailIntegration/src/Enums/ContactCreationMode.php
@@ -13,7 +13,7 @@ enum ContactCreationMode: string implements HasDescription, HasIcon, HasLabel
 {
     case All = 'all';
 
-    case Bidirectional = 'bidirectional';
+    case Selective = 'selective';
 
     case None = 'none';
 
@@ -21,7 +21,7 @@ enum ContactCreationMode: string implements HasDescription, HasIcon, HasLabel
     {
         return match ($this) {
             self::All => __('filament/pages/email-privacy-settings.record_creation.modes.all.label'),
-            self::Bidirectional => __('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.label'),
+            self::Selective => __('filament/pages/email-privacy-settings.record_creation.modes.selective.label'),
             self::None => __('filament/pages/email-privacy-settings.record_creation.modes.none.label'),
         };
     }
@@ -30,7 +30,7 @@ enum ContactCreationMode: string implements HasDescription, HasIcon, HasLabel
     {
         return match ($this) {
             self::All => __('filament/pages/email-privacy-settings.record_creation.modes.all.description'),
-            self::Bidirectional => __('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.description'),
+            self::Selective => __('filament/pages/email-privacy-settings.record_creation.modes.selective.description'),
             self::None => __('filament/pages/email-privacy-settings.record_creation.modes.none.description'),
         };
     }
@@ -39,13 +39,13 @@ enum ContactCreationMode: string implements HasDescription, HasIcon, HasLabel
     {
         return match ($this) {
             self::All => Heroicon::OutlinedUserGroup,
-            self::Bidirectional => Heroicon::OutlinedUserPlus,
+            self::Selective => Heroicon::OutlinedUserPlus,
             self::None => Heroicon::OutlinedNoSymbol,
         };
     }
 
     public function isRecommended(): bool
     {
-        return $this === self::Bidirectional;
+        return $this === self::Selective;
     }
-};
+}

--- a/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
@@ -87,7 +87,7 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
     /** @var array<int, string> */
     public array $protected_domains = [];
 
-    public string $contact_creation_mode = 'bidirectional';
+    public string $contact_creation_mode = 'selective';
 
     public bool $auto_create_companies = true;
 
@@ -101,7 +101,7 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
 
         $this->default_email_sharing_tier = ($team->default_email_sharing_tier ?? EmailPrivacyTier::METADATA_ONLY)->value;
 
-        $this->contact_creation_mode = ($team->contact_creation_mode ?? ContactCreationMode::Bidirectional)->value;
+        $this->contact_creation_mode = ($team->contact_creation_mode ?? ContactCreationMode::Selective)->value;
         $this->auto_create_companies = $team->auto_create_companies;
 
         $rows = ProtectedRecipient::query()->where('team_id', $team->getKey())->get();

--- a/resources/views/activity-log/entries/app-event.blade.php
+++ b/resources/views/activity-log/entries/app-event.blade.php
@@ -1,6 +1,6 @@
 @php
     $causerName = $entry->causer?->name ?? null;
-    $fallbackTitle = $palette->label();
+    $fallbackTitle = $palette->getLabel();
     $title = $entry->title ?? $fallbackTitle;
     $description = $entry->description
         ?? ($causerName
@@ -16,7 +16,7 @@
 >
     <div class="flex justify-center pt-0.5">
         <span class="flex h-6 w-6 items-center justify-center rounded-full bg-primary-50 text-primary-600 ring-1 ring-primary-100 dark:bg-primary-500/10 dark:text-primary-300 dark:ring-primary-500/20">
-            <x-filament::icon :icon="$palette->icon()" class="h-3.5 w-3.5" />
+            <x-filament::icon :icon="$palette->getIcon()" class="h-3.5 w-3.5" />
         </span>
     </div>
 

--- a/tests/Feature/ActivityLog/MeetingTimelineActivityTest.php
+++ b/tests/Feature/ActivityLog/MeetingTimelineActivityTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\ActivityLog\MeetingEventPalette;
+use App\ActivityLog\MeetingEventRenderer;
+use Carbon\CarbonImmutable;
+use Relaticle\ActivityLog\Timeline\TimelineEntry;
+
+mutates(MeetingEventRenderer::class);
+mutates(MeetingEventPalette::class);
+
+it('renders meeting.created with the defined activity-log label, not a dotted lookup miss', function (): void {
+    $html = app(MeetingEventRenderer::class)->render(new TimelineEntry(
+        id: 'meeting-created',
+        type: 'activity_log',
+        event: 'meeting.created',
+        occurredAt: CarbonImmutable::now(),
+        dedupKey: 'meeting-created',
+        sourcePriority: 0,
+    ))->render();
+
+    expect($html)
+        ->toContain(__('activity-log.events')['meeting.created']['label'])
+        ->not->toContain('activity-log.events.meeting.created.label');
+});
+
+it('renders meeting.cancelled with the defined activity-log label, not a dotted lookup miss', function (): void {
+    $html = app(MeetingEventRenderer::class)->render(new TimelineEntry(
+        id: 'meeting-cancelled',
+        type: 'activity_log',
+        event: 'meeting.cancelled',
+        occurredAt: CarbonImmutable::now(),
+        dedupKey: 'meeting-cancelled',
+        sourcePriority: 0,
+    ))->render();
+
+    expect($html)
+        ->toContain(__('activity-log.events')['meeting.cancelled']['label'])
+        ->not->toContain('activity-log.events.meeting.cancelled.label');
+});

--- a/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
@@ -127,7 +127,7 @@ it('skips person creation when contact_creation_mode=None', function (): void {
     expect(People::query()->where('team_id', $team->id)->count())->toBe(0);
 });
 
-it('requires prior meeting with the address for Bidirectional mode', function (): void {
+it('auto-creates a person on the first meeting in Selective mode', function (): void {
     $user = User::factory()->withTeam()->create();
     $this->actingAs($user);
     $team = $user->currentTeam;
@@ -136,22 +136,14 @@ it('requires prior meeting with the address for Bidirectional mode', function ()
         'team_id' => $team->id,
         'user_id' => $user->id,
     ]));
-    $team->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
+    $team->update(['contact_creation_mode' => ContactCreationMode::Selective]);
 
-    // First meeting — no existing prior → skipped
-    $m1 = Meeting::factory()->create(['team_id' => $account->team_id, 'connected_account_id' => $account->getKey()]);
+    $meeting = Meeting::factory()->create(['team_id' => $account->team_id, 'connected_account_id' => $account->getKey()]);
     MeetingAttendee::factory()->create([
-        'meeting_id' => $m1->getKey(), 'email_address' => 'bi@acme.com', 'is_self' => false,
+        'meeting_id' => $meeting->getKey(), 'email_address' => 'new-guest@acme.com', 'is_self' => false,
     ]);
-    (app(LinkMeetingAction::class))->execute($m1->fresh());
-    expect(People::query()->where('team_id', $team->id)->count())->toBe(0);
+    (app(LinkMeetingAction::class))->execute($meeting->fresh());
 
-    // Second meeting with same address — prior exists → created
-    $m2 = Meeting::factory()->create(['team_id' => $account->team_id, 'connected_account_id' => $account->getKey()]);
-    MeetingAttendee::factory()->create([
-        'meeting_id' => $m2->getKey(), 'email_address' => 'bi@acme.com', 'is_self' => false,
-    ]);
-    (app(LinkMeetingAction::class))->execute($m2->fresh());
     expect(People::query()->where('team_id', $team->id)->count())->toBe(1);
 });
 

--- a/tests/Feature/Commands/EmailIntegrationScheduleTest.php
+++ b/tests/Feature/Commands/EmailIntegrationScheduleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Features\EmailIntegration;
+use Illuminate\Console\Scheduling\Schedule;
+use Laravel\Pennant\Feature;
+
+it('registers outbox and sync schedules when email integration is active', function (): void {
+    Feature::activate(EmailIntegration::class);
+    $this->app->forgetInstance(Schedule::class);
+
+    $this->artisan('schedule:list')
+        ->expectsOutputToContain('email:dispatch-outbox')
+        ->expectsOutputToContain('email:incremental-sync')
+        ->expectsOutputToContain('calendar:incremental-sync')
+        ->assertSuccessful();
+});
+
+it('does not register outbox or sync schedules when email integration is inactive', function (): void {
+    config()->set('relaticle.features.email_integration', false);
+    Feature::flushCache();
+    Feature::deactivate(EmailIntegration::class);
+    $this->app->forgetInstance(Schedule::class);
+
+    $this->artisan('schedule:list')
+        ->doesntExpectOutputToContain('email:dispatch-outbox')
+        ->doesntExpectOutputToContain('email:incremental-sync')
+        ->doesntExpectOutputToContain('calendar:incremental-sync')
+        ->assertSuccessful();
+});

--- a/tests/Feature/EmailIntegration/EmailAccountSettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountSettingsPageTest.php
@@ -46,7 +46,7 @@ it('fills the form from the account, the user tier and the existing blocklist', 
 
 it('does not expose workspace record creation controls on a personal account', function (): void {
     livewire(EmailAccountSettingsPage::class, ['account' => $this->account->id])
-        ->assertDontSee(__('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.label'))
+        ->assertDontSee(__('filament/pages/email-privacy-settings.record_creation.modes.selective.label'))
         ->assertDontSee(__('filament/pages/email-privacy-settings.record_creation.companies.label'));
 });
 

--- a/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
@@ -178,7 +178,7 @@ it('shows record creation mode descriptions and the recommended badge', function
         ->call('setTab', 'record_creation')
         ->assertSee(__('filament/pages/email-privacy-settings.tabs.record_creation'))
         ->assertSee(__('filament/pages/email-privacy-settings.record_creation.modes.all.description'))
-        ->assertSee(__('filament/pages/email-privacy-settings.record_creation.modes.bidirectional.description'))
+        ->assertSee(__('filament/pages/email-privacy-settings.record_creation.modes.selective.description'))
         ->assertSee(__('filament/pages/email-privacy-settings.record_creation.modes.none.description'))
         ->assertSee(__('filament/pages/email-privacy-settings.record_creation.recommended'))
         ->assertSee(__('filament/pages/email-privacy-settings.record_creation.companies.label'));
@@ -229,5 +229,5 @@ it('forbids a non-admin member from changing record creation settings', function
         false,
     ))->toThrow(HttpException::class);
 
-    expect($this->team->fresh()->contact_creation_mode)->toBe(ContactCreationMode::Bidirectional);
+    expect($this->team->fresh()->contact_creation_mode)->toBe(ContactCreationMode::Selective);
 });

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -520,25 +520,23 @@ it('does not duplicate a person when the same address appears on multiple partic
     expect(People::where('team_id', $this->team->id)->where('name', 'Dup Person')->count())->toBe(1);
 });
 
-it('does not auto-create a person when Bidirectional and only one direction exists', function (): void {
-    $this->team->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
+it('does not auto-create a person when Selective and the address has only inbound mail', function (): void {
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::Selective]);
 
-    // Only inbound email — no outbound yet
     $inboundEmail = makeLinkEmail(['direction' => EmailDirection::INBOUND]);
 
     EmailParticipant::factory()->from()->create([
         'email_id' => $inboundEmail->getKey(),
-        'email_address' => 'bidirectional@partner.com',
+        'email_address' => 'inbound-only@partner.com',
     ]);
 
     $countBefore = People::where('team_id', $this->team->id)->count();
 
-    // Store first (no existing bidirectional history), then link the new email
     $newEmail = makeLinkEmail(['direction' => EmailDirection::INBOUND]);
 
     EmailParticipant::factory()->from()->create([
         'email_id' => $newEmail->getKey(),
-        'email_address' => 'bidirectional@partner.com',
+        'email_address' => 'inbound-only@partner.com',
     ]);
 
     app(LinkEmailAction::class)->execute($newEmail);
@@ -546,27 +544,60 @@ it('does not auto-create a person when Bidirectional and only one direction exis
     expect(People::where('team_id', $this->team->id)->count())->toBe($countBefore);
 });
 
-it('auto-creates a person when Bidirectional and both directions exist', function (): void {
-    $this->team->update(['contact_creation_mode' => ContactCreationMode::Bidirectional]);
+it('auto-creates a person and company on the first outbound email in Selective mode', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::Selective,
+        'auto_create_companies' => true,
+    ]);
 
-    $address = 'bidirectional@bidirectional.com';
+    $email = makeLinkEmail(['direction' => EmailDirection::OUTBOUND]);
 
-    // Seed one inbound and one outbound email already in the system for this address
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'jane@acme.com',
+        'name' => 'Jane Prospect',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(People::where('team_id', $this->team->id)->where('name', 'Jane Prospect')->exists())->toBeTrue()
+        ->and(Company::where('team_id', $this->team->id)->where('name', 'Acme')->exists())->toBeTrue();
+});
+
+it('creates a person in Selective mode when a teammate already sent to the address', function (): void {
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::Selective]);
+
+    $teammate = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($teammate, ['role' => 'editor']);
+
+    $teammateAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+    ]));
+
+    $address = 'shared@partner.com';
+
+    $teammateOutbound = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'connected_account_id' => $teammateAccount->getKey(),
+        'direction' => EmailDirection::OUTBOUND,
+    ]);
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $teammateOutbound->getKey(),
+        'email_address' => $address,
+    ]);
+
     $inbound = makeLinkEmail(['direction' => EmailDirection::INBOUND]);
-    EmailParticipant::factory()->from()->create(['email_id' => $inbound->getKey(), 'email_address' => $address]);
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $inbound->getKey(),
+        'email_address' => $address,
+        'name' => 'Shared Contact',
+    ]);
 
-    $outbound = makeLinkEmail(['direction' => EmailDirection::OUTBOUND]);
-    EmailParticipant::factory()->to()->create(['email_id' => $outbound->getKey(), 'email_address' => $address]);
+    app(LinkEmailAction::class)->execute($inbound);
 
-    // Now link a third email — should trigger person creation because both directions exist
-    $newEmail = makeLinkEmail(['direction' => EmailDirection::INBOUND]);
-    EmailParticipant::factory()->from()->create(['email_id' => $newEmail->getKey(), 'email_address' => $address, 'name' => 'Bidirectional Contact']);
-
-    $countBefore = People::where('team_id', $this->team->id)->count();
-
-    app(LinkEmailAction::class)->execute($newEmail);
-
-    expect(People::where('team_id', $this->team->id)->count())->toBe($countBefore + 1);
+    expect(People::where('team_id', $this->team->id)->where('name', 'Shared Contact')->exists())->toBeTrue();
 });
 
 it('increments person email_count when linked', function (): void {

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -52,7 +52,7 @@ it('stores an azure connected account and flips calendar capability when Graph c
 
     expect($account->hasCalendar())->toBeTrue()
         ->and($account->capabilities['email'])->toBeTrue()
-        ->and($user->currentTeam->fresh()->contact_creation_mode)->toBe(ContactCreationMode::Bidirectional);
+        ->and($user->currentTeam->fresh()->contact_creation_mode)->toBe(ContactCreationMode::Selective);
 
     Bus::assertDispatched(InitialCalendarSyncJob::class, fn (InitialCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
 });

--- a/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Filament\Resources\CompanyResource;
 use App\Filament\Resources\CompanyResource\Pages\ListCompanies;
 use App\Filament\Resources\CompanyResource\Pages\ViewCompany;
+use App\Filament\Resources\CompanyResource\RelationManagers\MeetingsRelationManager;
 use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\User;
@@ -32,6 +33,16 @@ it('can render the view page', function (): void {
 
     livewire(ViewCompany::class, ['record' => $record->getKey()])
         ->assertOk();
+});
+
+it('registers the meetings relation manager on the company view page', function (): void {
+    $record = Company::factory()->recycle([$this->user, $this->team])->create();
+
+    $managers = livewire(ViewCompany::class, ['record' => $record->getKey()])
+        ->instance()
+        ->getRelationManagers();
+
+    expect($managers)->toContain(MeetingsRelationManager::class);
 });
 
 // Column metadata is checked against a single mounted table rather than one

--- a/tests/Feature/Filament/App/Resources/OpportunityResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/OpportunityResourceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Filament\Resources\OpportunityResource;
 use App\Filament\Resources\OpportunityResource\Pages\ListOpportunities;
 use App\Filament\Resources\OpportunityResource\Pages\ViewOpportunity;
+use App\Filament\Resources\OpportunityResource\RelationManagers\MeetingsRelationManager;
 use App\Models\Opportunity;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
@@ -31,6 +32,16 @@ it('can render the view page', function (): void {
 
     livewire(ViewOpportunity::class, ['record' => $record->getKey()])
         ->assertOk();
+});
+
+it('registers the meetings relation manager on the opportunity view page', function (): void {
+    $record = Opportunity::factory()->recycle([$this->user, $this->team])->create();
+
+    $managers = livewire(ViewOpportunity::class, ['record' => $record->getKey()])
+        ->instance()
+        ->getRelationManagers();
+
+    expect($managers)->toContain(MeetingsRelationManager::class);
 });
 
 // Column metadata is checked against a single mounted table rather than one

--- a/tests/Feature/Filament/App/Resources/PeopleResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/PeopleResourceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Filament\Resources\PeopleResource;
 use App\Filament\Resources\PeopleResource\Pages\ListPeople;
 use App\Filament\Resources\PeopleResource\Pages\ViewPeople;
+use App\Filament\Resources\PeopleResource\RelationManagers\MeetingsRelationManager;
 use App\Models\People;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
@@ -30,6 +31,16 @@ it('can render the view page', function (): void {
 
     livewire(ViewPeople::class, ['record' => $record->getKey()])
         ->assertOk();
+});
+
+it('registers the meetings relation manager on the person view page', function (): void {
+    $record = People::factory()->recycle([$this->user, $this->team])->create();
+
+    $managers = livewire(ViewPeople::class, ['record' => $record->getKey()])
+        ->instance()
+        ->getRelationManagers();
+
+    expect($managers)->toContain(MeetingsRelationManager::class);
 });
 
 // Column metadata is checked against a single mounted table rather than one

--- a/tests/Feature/Filament/RecordHeaderActionsTest.php
+++ b/tests/Feature/Filament/RecordHeaderActionsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Features\EmailIntegration;
 use App\Filament\Resources\CompanyResource\Pages\ViewCompany;
 use App\Filament\Resources\OpportunityResource\Pages\ViewOpportunity;
 use App\Filament\Resources\PeopleResource\Pages\ViewPeople;
@@ -10,6 +11,7 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Laravel\Pennant\Feature;
 
 mutates(ViewCompany::class, ViewPeople::class, ViewOpportunity::class);
 
@@ -46,3 +48,45 @@ it('no longer exposes the AI summary or ask-about-this actions on an opportunity
         ->assertActionDoesNotExist('askAboutThis')
         ->assertActionExists('edit');
 });
+
+it('hides the emails action on company, person, and opportunity views when email integration is off', function (string $page, Closure $record): void {
+    Feature::deactivate(EmailIntegration::class);
+
+    $owner = $record($this->user, $this->team);
+
+    livewire($page, ['record' => $owner->getKey()])
+        ->assertActionHidden('viewEmails');
+})->with([
+    'company' => [
+        ViewCompany::class,
+        fn (User $user, $team): Company => Company::factory()->recycle([$user, $team])->create(),
+    ],
+    'person' => [
+        ViewPeople::class,
+        fn (User $user, $team): People => People::factory()->recycle([$user, $team])->create(),
+    ],
+    'opportunity' => [
+        ViewOpportunity::class,
+        fn (User $user, $team): Opportunity => Opportunity::factory()->recycle([$user, $team])->create(),
+    ],
+]);
+
+it('shows the emails action on company, person, and opportunity views when email integration is on', function (string $page, Closure $record): void {
+    $owner = $record($this->user, $this->team);
+
+    livewire($page, ['record' => $owner->getKey()])
+        ->assertActionVisible('viewEmails');
+})->with([
+    'company' => [
+        ViewCompany::class,
+        fn (User $user, $team): Company => Company::factory()->recycle([$user, $team])->create(),
+    ],
+    'person' => [
+        ViewPeople::class,
+        fn (User $user, $team): People => People::factory()->recycle([$user, $team])->create(),
+    ],
+    'opportunity' => [
+        ViewOpportunity::class,
+        fn (User $user, $team): Opportunity => Opportunity::factory()->recycle([$user, $team])->create(),
+    ],
+]);

--- a/tests/Feature/Jobs/SendEmailJobTest.php
+++ b/tests/Feature/Jobs/SendEmailJobTest.php
@@ -45,6 +45,26 @@ it('records exception class and message on the email when the job fails', functi
         ->last_error->toBe('RuntimeException: boom');
 });
 
+it('does not mark a delivered email as failed when a later job step throws', function (): void {
+    $email = Email::create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Outbound',
+        'direction' => EmailDirection::OUTBOUND,
+        'status' => EmailStatus::SENT,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'last_error' => null,
+    ]);
+
+    (new SendEmailJob($email->getKey()))->failed(new RuntimeException('link failed'));
+
+    expect($email->fresh())
+        ->status->toBe(EmailStatus::SENT)
+        ->last_error->toBeNull();
+});
+
 it('logs the full exception when the job fails', function (): void {
     $email = Email::create([
         'team_id' => $this->team->id,


### PR DESCRIPTION
## Summary
- Rename workspace `Bidirectional` contact creation to Attio-style **Selective** (`selective`), with a data migration for existing teams.
- Create a Person when any team mailbox has sent to an address (the first outbound is enough; inbound-only still skipped).
- Create a Person on the first calendar meeting with an attendee, instead of requiring a prior meeting.

## Review fixes
| # | Feedback | Fix |
|---|----------|-----|
| 1 | Don't schedule `email:dispatch-outbox` when the email feature is off | Guard in `bootstrap/app.php` |
| 2 | Don't schedule incremental email/calendar sync when the flag is off | Same feature-flag guard |
| 3 | Don't mark a delivered (`SENT`) email as failed | `SendEmailJob::failed()` skips `SENT` |
| 4 | Meeting activity labels use the wrong translation key | `MeetingEventPalette` looks up the flat lang key |
| 5 | Company meetings tab never shown | `ViewCompany` registers `MeetingsRelationManager` |
| 6 | "Emails" header action visible while the feature is off | Hidden on company, people, and opportunity views |

## Test plan
- [ ] Send one email to a new work address (Selective, default). After sync, Person + Company exist with no reply.
- [ ] Receive inbound-only mail from a new address. No Person is created.
- [ ] Teammate sends to an address; your inbound from them creates the Person.
- [ ] One meeting with a new attendee creates that Person.
- [ ] Record creation UI still shows All / Selective / None with the Recommended badge on Selective.