### PR TITLE
Import full mailbox and calendar history on first connect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,10 @@ ANTHROPIC_API_KEY=
 EMAIL_SUMMARY_PROVIDER=openai
 EMAIL_SUMMARY_MODEL=gpt-4o-mini
 
+# Cap the first mailbox import to N days of history. Unset (default) imports
+# the whole mailbox. Self-hosters can set this to keep the first sync small.
+# EMAIL_SYNC_INITIAL_DAYS=90
+
 # Self-hosted AI via Ollama. Set OLLAMA_MODEL to a tool-calling-capable model
 # tag (e.g. qwen3:14b) to add it to the chat model picker.
 # OLLAMA_BASE_URL=http://localhost:11434

--- a/app/Jobs/SendEmailJob.php
+++ b/app/Jobs/SendEmailJob.php
@@ -55,17 +55,17 @@ final class SendEmailJob implements ShouldQueue
         });
 
         if ($email === null) {
+            $existing = Email::query()->find($this->emailId);
+            $this->syncBatchCounters($existing?->batch_id);
+
             return;
         }
 
         $sent = $sendingService->send($email);
 
-        $linkEmailAction->execute($sent);
+        $this->syncBatchCounters($sent->batch_id);
 
-        if ($sent->batch_id !== null) {
-            EmailBatch::query()->where('id', $sent->batch_id)->increment('sent_count');
-            $this->updateBatchStatus((string) $sent->batch_id);
-        }
+        $linkEmailAction->execute($sent);
     }
 
     public function failed(Throwable $exception): void
@@ -78,37 +78,61 @@ final class SendEmailJob implements ShouldQueue
         /** @var Email|null $email */
         $email = Email::query()->find($this->emailId);
 
-        if ($email === null || $email->status === EmailStatus::SENT) {
+        if ($email === null) {
             return;
         }
 
-        $email->update([
-            'status' => EmailStatus::FAILED,
-            'last_error' => $exception::class.': '.$exception->getMessage(),
-        ]);
-
-        if ($email->batch_id !== null) {
-            EmailBatch::query()->where('id', $email->batch_id)->increment('failed_count');
-            $this->updateBatchStatus((string) $email->batch_id);
+        if ($email->status !== EmailStatus::SENT) {
+            $email->update([
+                'status' => EmailStatus::FAILED,
+                'last_error' => $exception::class.': '.$exception->getMessage(),
+            ]);
         }
+
+        $this->syncBatchCounters($email->batch_id);
     }
 
-    private function updateBatchStatus(string $batchId): void
+    /**
+     * Recount sent/failed from email statuses so a crash after delivery cannot
+     * leave the batch hanging, and a retry cannot double-count.
+     */
+    private function syncBatchCounters(?string $batchId): void
     {
-        $batch = EmailBatch::query()->find($batchId);
-
-        if ($batch === null) {
+        if ($batchId === null) {
             return;
         }
 
-        $processed = $batch->sent_count + $batch->failed_count;
+        DB::transaction(function () use ($batchId): void {
+            $batch = EmailBatch::query()->lockForUpdate()->find($batchId);
 
-        if ($processed >= $batch->total_recipients) {
-            $status = $batch->failed_count > 0
-                ? EmailBatchStatus::PartialFailure
-                : EmailBatchStatus::Completed;
+            if ($batch === null) {
+                return;
+            }
 
-            $batch->update(['status' => $status]);
-        }
+            $sentCount = Email::query()
+                ->where('batch_id', $batchId)
+                ->where('status', EmailStatus::SENT)
+                ->count();
+
+            $failedCount = Email::query()
+                ->where('batch_id', $batchId)
+                ->where('status', EmailStatus::FAILED)
+                ->count();
+
+            $processed = $sentCount + $failedCount;
+            $status = $batch->status;
+
+            if ($processed >= $batch->total_recipients) {
+                $status = $failedCount > 0
+                    ? EmailBatchStatus::PartialFailure
+                    : EmailBatchStatus::Completed;
+            }
+
+            $batch->update([
+                'sent_count' => $sentCount,
+                'failed_count' => $failedCount,
+                'status' => $status,
+            ]);
+        });
     }
 }

--- a/app/Models/Concerns/HasActivityTimeline.php
+++ b/app/Models/Concerns/HasActivityTimeline.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Relaticle\ActivityLog\Concerns\InteractsWithTimeline;
 use Relaticle\ActivityLog\Timeline\Sources\RelatedModelSource;
 use Relaticle\ActivityLog\Timeline\TimelineBuilder;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 
 trait HasActivityTimeline
@@ -24,12 +26,25 @@ trait HasActivityTimeline
             ->fromActivityLog(mergedRenderer: 'merged-activity')
             ->fromRelation('emails', function (RelatedModelSource $source) use ($viewer): void {
                 $source
-                    ->event('sent_at', 'email_sent')
-                    ->event('created_at', 'email_received', when: fn ($email): bool => $email->sent_at === null)
+                    ->event(
+                        'sent_at',
+                        'email_sent',
+                        when: fn (Email $email): bool => $email->direction === EmailDirection::OUTBOUND,
+                    )
+                    ->event(
+                        'sent_at',
+                        'email_received',
+                        when: fn (Email $email): bool => $email->direction === EmailDirection::INBOUND,
+                    )
+                    ->event(
+                        'created_at',
+                        'email_received',
+                        when: fn (Email $email): bool => $email->direction === EmailDirection::INBOUND && $email->sent_at === null,
+                    )
                     ->with(['from', 'labels', 'participants'])
-                    ->title(fn ($email): string => $email->subject ?? 'Email')
-                    ->description(fn ($email): ?string => $email->from->first()?->email_address)
-                    ->causer(fn ($email) => $email->from->first());
+                    ->title(fn (Email $email): string => $email->subject ?? 'Email')
+                    ->description(fn (Email $email): ?string => $email->from->first()?->email_address)
+                    ->causer(fn (Email $email) => $email->from->first());
 
                 if ($viewer instanceof User) {
                     $source->using(fn (Builder|Relation $query) => $query->withGlobalScope(

--- a/config/email-integration.php
+++ b/config/email-integration.php
@@ -63,7 +63,11 @@ return [
      * Sync settings — override via .env
      */
     'sync' => [
-        'initial_days' => (int) env('EMAIL_SYNC_INITIAL_DAYS', 90),
+        // Unset by default so the first import covers the whole mailbox. Set
+        // EMAIL_SYNC_INITIAL_DAYS to cap history for self-hosted deployments.
+        'initial_days' => ($days = env('EMAIL_SYNC_INITIAL_DAYS')) === null || $days === ''
+            ? null
+            : (int) $days,
         'batch_size' => (int) env('EMAIL_SYNC_BATCH_SIZE', 50),
     ],
 

--- a/database/migrations/2026_08_29_121901_add_initial_sync_progress_to_connected_accounts_table.php
+++ b/database/migrations/2026_08_29_121901_add_initial_sync_progress_to_connected_accounts_table.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->unsignedInteger('initial_sync_imported')->default(0)->after('last_synced_at');
+            $table->unsignedInteger('initial_sync_estimated')->nullable()->after('initial_sync_imported');
+        });
+    }
+};

--- a/lang/en/filament/notifications/mailbox-import-complete.php
+++ b/lang/en/filament/notifications/mailbox-import-complete.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Mailbox import complete',
+    'body' => ':count emails imported from :email.',
+    'actions' => [
+        'view' => 'View accounts',
+    ],
+    'mail' => [
+        'subject' => 'Your mailbox import is complete',
+        'greeting' => 'Hello :name,',
+        'line' => 'We finished importing :count emails from :email. New mail will keep syncing automatically.',
+        'action' => 'View accounts',
+    ],
+];

--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -70,8 +70,9 @@ return [
     ],
     'synced_at' => 'Synced :time',
     'in_sync' => 'In Sync',
-    'importing_count' => 'Importing :count emails',
-    'importing_progress' => 'Importing :imported of :estimated emails',
+    'importing' => 'Importing',
+    'importing_count' => ':count emails',
+    'importing_progress' => ':imported of :estimated emails',
     'capabilities' => [
         'email' => 'Email',
         'calendar' => 'Calendar',

--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -70,6 +70,8 @@ return [
     ],
     'synced_at' => 'Synced :time',
     'in_sync' => 'In Sync',
+    'importing_count' => 'Importing :count emails',
+    'importing_progress' => 'Importing :imported of :estimated emails',
     'capabilities' => [
         'email' => 'Email',
         'calendar' => 'Calendar',

--- a/packages/EmailIntegration/resources/views/components/cluster-header.blade.php
+++ b/packages/EmailIntegration/resources/views/components/cluster-header.blade.php
@@ -1,9 +1,9 @@
-{{-- Breadcrumbs and heading are spaced like the accounts page: the page content gap
-     separates them, pulled in slightly so the pair reads as one block. --}}
-<x-filament::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
+@if ($this->shouldRenderClusterBreadcrumbs())
+    <x-filament::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
+@endif
 
 <x-filament-panels::header
-    class="-mt-2"
+    @class(['-mt-2' => $this->shouldRenderClusterBreadcrumbs()])
     :actions="$this->clusterHeaderActions()"
     :heading="$this->getTitle()"
 />

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -14,7 +14,12 @@
         :heading="__('filament/pages/email-accounts.sections.connected.heading')"
         :description="new \Illuminate\Support\HtmlString(__('filament/pages/email-accounts.sections.connected.description', ['url' => route('policy.show')]))"
     >
-        <div class="space-y-3">
+        <div
+            class="space-y-3"
+            @if ($this->connectedAccounts->contains(fn ($account): bool => $account->isImportingHistory()))
+                wire:poll.5s="refreshAccounts"
+            @endif
+        >
             @foreach ($this->connectedAccounts as $account)
                 @php
                     $capabilities = collect([
@@ -44,11 +49,22 @@
 
                     <div class="flex shrink-0 items-center gap-2">
                         <x-filament::badge
-                            :color="$account->status->getColor()"
-                            :icon="$account->isActive() ? 'heroicon-m-bolt' : 'heroicon-m-exclamation-triangle'"
+                            :color="$account->isImportingHistory() ? 'warning' : $account->status->getColor()"
+                            :icon="$account->isImportingHistory() ? 'heroicon-m-arrow-path' : ($account->isActive() ? 'heroicon-m-bolt' : 'heroicon-m-exclamation-triangle')"
                             :title="$account->last_synced_at ? __('filament/pages/email-accounts.synced_at', ['time' => $account->last_synced_at->diffForHumans()]) : null"
                         >
-                            {{ $account->isActive() ? __('filament/pages/email-accounts.in_sync') : $account->status->getLabel() }}
+                            @if ($account->isImportingHistory())
+                                @if ($account->initial_sync_estimated)
+                                    {{ __('filament/pages/email-accounts.importing_progress', [
+                                        'imported' => number_format($account->initial_sync_imported),
+                                        'estimated' => number_format($account->initial_sync_estimated),
+                                    ]) }}
+                                @else
+                                    {{ __('filament/pages/email-accounts.importing_count', ['count' => number_format($account->initial_sync_imported)]) }}
+                                @endif
+                            @else
+                                {{ $account->isActive() ? __('filament/pages/email-accounts.in_sync') : $account->status->getLabel() }}
+                            @endif
                         </x-filament::badge>
 
                         {{ $this->accountActions($account->getKey(), $account->status, [$this->editSettingsAction()]) }}

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -1,7 +1,5 @@
 <x-filament-panels::page>
-    <x-filament::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
-
-    <div class="-mt-2">
+    <div>
         <h2 class="text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
             {{ __('filament/pages/email-accounts.title') }}
         </h2>

--- a/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
-use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Data\NormalizedMeetingPayload;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
@@ -102,11 +101,8 @@ final readonly class StoreMeetingAction
         if ($payload->status === CalendarEventStatus::CANCELLED) {
             return true;
         }
-        if ($payload->selfResponseStatus === AttendeeResponseStatus::DECLINED) {
-            return true;
-        }
 
-        return $payload->startsAt->lt(Date::now()->subDays(90));
+        return $payload->selfResponseStatus === AttendeeResponseStatus::DECLINED;
     }
 
     private function softDeleteExisting(ConnectedAccount $account, string $providerEventId): void

--- a/packages/EmailIntegration/src/Data/CalendarSyncResult.php
+++ b/packages/EmailIntegration/src/Data/CalendarSyncResult.php
@@ -8,9 +8,11 @@ final readonly class CalendarSyncResult
 {
     /**
      * @param  array<int, CalendarEventData>  $events
+     * @param  string|null  $nextPageToken  Provider page token / nextLink when more of the initial window remains
      */
     public function __construct(
         public array $events,
         public ?string $nextSyncToken,
+        public ?string $nextPageToken = null,
     ) {}
 }

--- a/packages/EmailIntegration/src/Data/MailBackfillPage.php
+++ b/packages/EmailIntegration/src/Data/MailBackfillPage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Data;
+
+use Illuminate\Support\Collection;
+
+final readonly class MailBackfillPage
+{
+    /**
+     * @param  Collection<int, string>  $messageIds
+     * @param  string|null  $nextPageToken  Gmail page token or Graph @odata.nextLink; null when this is the last page
+     * @param  string|null  $cursor  Gmail historyId (first page) or Graph deltaLink (last page)
+     */
+    public function __construct(
+        public Collection $messageIds,
+        public ?string $nextPageToken,
+        public ?string $cursor,
+        public ?int $estimatedTotal = null,
+    ) {}
+}

--- a/packages/EmailIntegration/src/Filament/Concerns/HasClusterBreadcrumbs.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasClusterBreadcrumbs.php
@@ -7,12 +7,12 @@ namespace Relaticle\EmailIntegration\Filament\Concerns;
 use Filament\Actions\Action;
 
 /**
- * Email settings cluster pages render their own header (breadcrumbs, heading, actions)
+ * Email settings cluster pages render their own header (heading, actions)
  * from `<x-email-integration::cluster-header />` at the top of the page view, so it
- * starts at the content column like the accounts page rather than spanning the cluster
- * navigation. Each page blanks `$heading` so the stock full-width header is not
- * rendered at all — it would drop the breadcrumbs anyway, since the app panel disables
- * them globally (AppPanelProvider::breadcrumbs(false)).
+ * sits with the page content under the cluster tabs. Each page blanks `$heading` so the
+ * stock full-width header is not rendered. The app panel disables breadcrumbs globally
+ * (AppPanelProvider::breadcrumbs(false)); pages that still need a trail opt in via
+ * shouldRenderClusterBreadcrumbs().
  */
 trait HasClusterBreadcrumbs
 {
@@ -35,5 +35,10 @@ trait HasClusterBreadcrumbs
     public function getBreadcrumbs(): array
     {
         return [...parent::getBreadcrumbs(), static::getNavigationLabel()];
+    }
+
+    public function shouldRenderClusterBreadcrumbs(): bool
+    {
+        return true;
     }
 }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -36,8 +36,8 @@ final class EmailAccountsPage extends Page
 
     /**
      * Heading and subheading are rendered inside the content column (see the page
-     * view) so they align with the accounts panel rather than spanning the cluster
-     * navigation — the page header itself stays empty.
+     * view) so they sit with the accounts panel under the cluster tabs — the page
+     * header itself stays empty.
      */
     public function getHeading(): string
     {
@@ -47,17 +47,6 @@ final class EmailAccountsPage extends Page
     public function getSubheading(): ?string
     {
         return null;
-    }
-
-    /**
-     * @return array<int|string, string>
-     */
-    public function getBreadcrumbs(): array
-    {
-        return [
-            EmailSettings::getUrl() => (string) __('filament/clusters/email-settings.breadcrumb'),
-            (string) __('filament/pages/email-accounts.navigation_label'),
-        ];
     }
 
     public static function getNavigationLabel(): string

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -133,9 +133,14 @@ final class EmailAccountsPage extends Page
             ]));
     }
 
-    protected function afterAccountChanged(): void
+    public function refreshAccounts(): void
     {
         $this->connectedAccounts = $this->getAccounts();
+    }
+
+    protected function afterAccountChanged(): void
+    {
+        $this->refreshAccounts();
     }
 
     public function sendSuccessNotification(): void

--- a/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource/Pages/ManageEmailTemplates.php
+++ b/packages/EmailIntegration/src/Filament/Resources/EmailTemplateResource/Pages/ManageEmailTemplates.php
@@ -8,7 +8,6 @@ use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ManageRecords;
 use Filament\Support\Enums\Size;
-use Override;
 use Relaticle\EmailIntegration\Filament\Concerns\HasClusterBreadcrumbs;
 use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource;
 
@@ -27,18 +26,9 @@ final class ManageEmailTemplates extends ManageRecords
      */
     protected ?string $heading = '';
 
-    /**
-     * The resource's own crumb is empty on the index page — name it after the cluster item.
-     *
-     * @return array<string, string>
-     */
-    #[Override]
-    public function getBreadcrumbs(): array
+    public function shouldRenderClusterBreadcrumbs(): bool
     {
-        return [
-            ...array_filter(parent::getBreadcrumbs()),
-            self::getResource()::getNavigationLabel(),
-        ];
+        return false;
     }
 
     /**

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -11,6 +11,8 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Bus;
+use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -29,6 +31,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
+        public readonly ?string $pageToken = null,
     ) {
         $this->onQueue('emails-sync');
     }
@@ -42,25 +45,37 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         }
 
         $service = $serviceFactory->make($account);
-        $result = $service->initialSync();
+        $result = $service->initialSync($this->pageToken);
 
-        foreach ($result->events as $event) {
-            dispatch(new StoreMeetingJob($account, $event));
+        if ($result->events === []) {
+            self::continueOrFinish($account, $result->nextPageToken, $result->nextSyncToken);
+
+            return;
         }
 
-        $update = [
-            'last_calendar_synced_at' => now(),
-            'status' => EmailAccountStatus::ACTIVE,
-            'last_error' => null,
-        ];
+        $accountId = (int) $account->getKey();
+        $nextPageToken = $result->nextPageToken;
+        $nextSyncToken = $result->nextSyncToken;
 
-        // Never overwrite a good cursor with null: a missing sync token (partial/empty
-        // page) would otherwise force a full re-sync of the whole window on every run.
-        if ($result->nextSyncToken !== null) {
-            $update['calendar_sync_cursor'] = $result->nextSyncToken;
-        }
+        $jobs = array_map(
+            fn (CalendarEventData $event): StoreMeetingJob => new StoreMeetingJob($account, $event),
+            $result->events,
+        );
 
-        $account->update($update);
+        Bus::batch($jobs)
+            ->name("Initial calendar sync: {$account->email_address}")
+            ->onQueue('emails-sync')
+            ->allowFailures()
+            ->then(function () use ($accountId, $nextPageToken, $nextSyncToken): void {
+                $account = ConnectedAccount::query()->whereKey($accountId)->first();
+
+                if (! $account instanceof ConnectedAccount) {
+                    return;
+                }
+
+                self::continueOrFinish($account, $nextPageToken, $nextSyncToken);
+            })
+            ->dispatch();
     }
 
     public function failed(Throwable $exception): void
@@ -73,6 +88,30 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function uniqueId(): string
     {
-        return "initial-calendar-sync-{$this->connectedAccount->getKey()}";
+        return 'initial-calendar-sync-'.$this->connectedAccount->getKey().'-'.hash('xxh3', $this->pageToken ?? 'start');
+    }
+
+    private static function continueOrFinish(
+        ConnectedAccount $account,
+        ?string $nextPageToken,
+        ?string $nextSyncToken,
+    ): void {
+        if ($nextPageToken !== null && $nextPageToken !== '') {
+            dispatch(new self($account, $nextPageToken));
+
+            return;
+        }
+
+        $update = [
+            'last_calendar_synced_at' => now(),
+            'status' => EmailAccountStatus::ACTIVE,
+            'last_error' => null,
+        ];
+
+        if ($nextSyncToken !== null && $nextSyncToken !== '') {
+            $update['calendar_sync_cursor'] = $nextSyncToken;
+        }
+
+        $account->update($update);
     }
 }

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -48,7 +48,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         $result = $service->initialSync($this->pageToken);
 
         if ($result->events === []) {
-            self::continueOrFinish($account, $result->nextPageToken, $result->nextSyncToken);
+            $this->continueOrFinish($account, $result->nextPageToken, $result->nextSyncToken);
 
             return;
         }
@@ -73,7 +73,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
                     return;
                 }
 
-                self::continueOrFinish($account, $nextPageToken, $nextSyncToken);
+                $this->continueOrFinish($account, $nextPageToken, $nextSyncToken);
             })
             ->dispatch();
     }
@@ -91,7 +91,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         return 'initial-calendar-sync-'.$this->connectedAccount->getKey().'-'.hash('xxh3', $this->pageToken ?? 'start');
     }
 
-    private static function continueOrFinish(
+    private function continueOrFinish(
         ConnectedAccount $account,
         ?string $nextPageToken,
         ?string $nextSyncToken,

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -68,7 +68,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
         $newIds = array_values(array_diff($allIds, $storedIds));
 
         if ($newIds === []) {
-            self::continueOrFinish($account, $historyCursor, $page->nextPageToken, $page->cursor);
+            $this->continueOrFinish($account, $historyCursor, $page->nextPageToken, $page->cursor);
 
             return;
         }
@@ -93,7 +93,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
                     return;
                 }
 
-                self::continueOrFinish($account, $historyCursor, $nextPageToken, $pageCursor);
+                $this->continueOrFinish($account, $historyCursor, $nextPageToken, $pageCursor);
             })
             ->dispatch();
     }
@@ -122,7 +122,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
         return (int) $days;
     }
 
-    private static function continueOrFinish(
+    private function continueOrFinish(
         ConnectedAccount $account,
         ?string $historyCursor,
         ?string $nextPageToken,

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -14,39 +14,51 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Notifications\MailboxHistoryImportCompletedNotification;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Throwable;
 
 #[DeleteWhenMissingModels]
 final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use DetectsAuthErrors, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $timeout = 300;
 
+    public int $tries = 3;
+
+    /** @var array<int, int> Spaced retry delays so transient 429/5xx don't hammer the provider. */
+    public array $backoff = [60, 300, 900];
+
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
+        public readonly ?string $pageToken = null,
+        public readonly ?string $historyCursor = null,
     ) {
         $this->onQueue('emails-sync');
     }
 
     /**
-     * @throws \Throwable
+     * @throws Throwable
      */
     public function handle(MailServiceFactoryInterface $mailFactory): void
     {
         $account = $this->connectedAccount;
-
-        $daysBack = Config::integer('email-integration.sync.initial_days', 90);
-
         $service = $mailFactory->make($account);
+        $page = $service->initialBackfill($this->initialDaysCap(), $this->pageToken);
 
-        $data = $service->initialBackfill($daysBack);
+        $historyCursor = $this->historyCursor ?? $page->cursor;
 
-        $allIds = $data['message_ids']->all();
+        if ($this->pageToken === null && $page->estimatedTotal !== null) {
+            $account->update(['initial_sync_estimated' => $page->estimatedTotal]);
+        }
 
-        // Bulk dedup: exclude IDs that are already stored for this account
+        $allIds = $page->messageIds->all();
+
         $storedIds = Email::query()
             ->where('connected_account_id', $account->getKey())
             ->whereIn('provider_message_id', $allIds)
@@ -55,17 +67,15 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
 
         $newIds = array_values(array_diff($allIds, $storedIds));
 
-        // Persist the cursor only after the backfill batch has fully stored. Setting it
-        // up front means a StoreEmailJob that exhausts its retries is skipped forever:
-        // incremental sync starts from a cursor already past the unstored message.
         if ($newIds === []) {
-            $account->update(['sync_cursor' => $data['cursor']]);
+            self::continueOrFinish($account, $historyCursor, $page->nextPageToken, $page->cursor);
 
             return;
         }
 
         $accountId = (int) $account->getKey();
-        $cursor = $data['cursor'];
+        $nextPageToken = $page->nextPageToken;
+        $pageCursor = $page->cursor;
 
         $jobs = collect($newIds)
             ->chunk(Config::integer('email-integration.sync.batch_size', 50))
@@ -76,18 +86,70 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
             ->name("Initial sync: {$account->email_address}")
             ->onQueue('emails-sync')
             ->allowFailures()
-            // then() runs only when every job succeeded; with a failure the batch still
-            // completes (allowFailures) but the cursor stays null, so the backfill is
-            // re-attempted next sync (dedup makes the re-fetch cheap) instead of dropping
-            // the unstored message.
-            ->then(function () use ($accountId, $cursor): void {
-                ConnectedAccount::query()->whereKey($accountId)->first()?->update(['sync_cursor' => $cursor]);
+            ->then(function () use ($accountId, $historyCursor, $nextPageToken, $pageCursor): void {
+                $account = ConnectedAccount::query()->whereKey($accountId)->first();
+
+                if (! $account instanceof ConnectedAccount) {
+                    return;
+                }
+
+                self::continueOrFinish($account, $historyCursor, $nextPageToken, $pageCursor);
             })
             ->dispatch();
     }
 
+    public function failed(Throwable $exception): void
+    {
+        $this->connectedAccount->update([
+            'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
+            'last_error' => $exception->getMessage(),
+        ]);
+    }
+
     public function uniqueId(): string
     {
-        return "initial-sync-{$this->connectedAccount->getKey()}";
+        return 'initial-sync-'.$this->connectedAccount->getKey().'-'.hash('xxh3', $this->pageToken ?? 'start');
+    }
+
+    private function initialDaysCap(): ?int
+    {
+        $days = Config::get('email-integration.sync.initial_days');
+
+        if (! is_numeric($days) || (int) $days <= 0) {
+            return null;
+        }
+
+        return (int) $days;
+    }
+
+    private static function continueOrFinish(
+        ConnectedAccount $account,
+        ?string $historyCursor,
+        ?string $nextPageToken,
+        ?string $pageCursor,
+    ): void {
+        $imported = Email::query()
+            ->where('connected_account_id', $account->getKey())
+            ->count();
+
+        $account->update(['initial_sync_imported' => $imported]);
+
+        if ($nextPageToken !== null && $nextPageToken !== '') {
+            dispatch(new self($account, $nextPageToken, $historyCursor));
+
+            return;
+        }
+
+        $cursor = $historyCursor ?? $pageCursor;
+
+        $account->update([
+            'sync_cursor' => $cursor,
+            'last_synced_at' => now(),
+            'initial_sync_imported' => $imported,
+            'status' => EmailAccountStatus::ACTIVE,
+            'last_error' => null,
+        ]);
+
+        $account->user?->notify(new MailboxHistoryImportCompletedNotification($account->fresh() ?? $account));
     }
 }

--- a/packages/EmailIntegration/src/Jobs/StoreMeetingJob.php
+++ b/packages/EmailIntegration/src/Jobs/StoreMeetingJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Jobs;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -18,7 +19,7 @@ use Relaticle\EmailIntegration\Services\Factories\NormalizedMeetingPayloadFactor
 #[DeleteWhenMissingModels]
 final class StoreMeetingJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 3;
 
@@ -33,6 +34,10 @@ final class StoreMeetingJob implements ShouldQueue
         StoreMeetingAction $store,
         NormalizedMeetingPayloadFactory $factory,
     ): void {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
         $payload = $factory->fromCalendarEvent($this->event, $this->connectedAccount->email_address);
 
         $store->execute($payload, $this->connectedAccount);

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -40,6 +40,12 @@ use Relaticle\EmailIntegration\Observers\ConnectedAccountObserver;
  * @property Carbon|null $token_expires_at
  * @property int|null $hourly_send_limit
  * @property int|null $daily_send_limit
+ * @property string|null $sync_cursor
+ * @property Carbon|null $last_synced_at
+ * @property int $initial_sync_imported
+ * @property int|null $initial_sync_estimated
+ * @property string|null $calendar_sync_cursor
+ * @property Carbon|null $last_calendar_synced_at
  */
 #[ObservedBy(ConnectedAccountObserver::class)]
 final class ConnectedAccount extends Model
@@ -68,6 +74,8 @@ final class ConnectedAccount extends Model
         'capabilities',
         'sync_cursor',
         'last_synced_at',
+        'initial_sync_imported',
+        'initial_sync_estimated',
         'calendar_sync_cursor',
         'last_calendar_synced_at',
         'status',
@@ -84,6 +92,8 @@ final class ConnectedAccount extends Model
         'token_expires_at' => 'datetime',
         'last_synced_at' => 'datetime',
         'last_calendar_synced_at' => 'datetime',
+        'initial_sync_imported' => 'integer',
+        'initial_sync_estimated' => 'integer',
         'is_default' => 'boolean',
         'sync_inbox' => 'boolean',
         'sync_sent' => 'boolean',
@@ -210,6 +220,22 @@ final class ConnectedAccount extends Model
     public function isActive(): bool
     {
         return $this->status === EmailAccountStatus::ACTIVE;
+    }
+
+    /**
+     * True while the first mailbox or calendar backfill has not yet written a cursor.
+     */
+    public function isImportingHistory(): bool
+    {
+        if ($this->status !== EmailAccountStatus::ACTIVE) {
+            return false;
+        }
+
+        if ($this->hasEmail() && $this->sync_cursor === null) {
+            return true;
+        }
+
+        return $this->hasCalendar() && $this->calendar_sync_cursor === null;
     }
 
     /**

--- a/packages/EmailIntegration/src/Models/EmailBatch.php
+++ b/packages/EmailIntegration/src/Models/EmailBatch.php
@@ -16,10 +16,17 @@ use Relaticle\EmailIntegration\Enums\EmailBatchStatus;
 
 final class EmailBatch extends Model
 {
-    /** @use HasFactory<EmailBatchFactory> */
+    /**
+     * @use HasFactory<EmailBatchFactory>
+     */
     use HasFactory;
 
     use HasTeam, HasUlids;
+
+    protected static function newFactory(): EmailBatchFactory
+    {
+        return EmailBatchFactory::new();
+    }
 
     protected $fillable = [
         'team_id',

--- a/packages/EmailIntegration/src/Notifications/MailboxHistoryImportCompletedNotification.php
+++ b/packages/EmailIntegration/src/Notifications/MailboxHistoryImportCompletedNotification.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Notifications;
+
+use App\Models\Team;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+final class MailboxHistoryImportCompletedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public readonly ConnectedAccount $account) {}
+
+    /**
+     * @return list<string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $imported = $this->account->initial_sync_imported;
+        $message = (new MailMessage)
+            ->subject(__('filament/notifications/mailbox-import-complete.mail.subject'))
+            ->greeting(__('filament/notifications/mailbox-import-complete.mail.greeting', [
+                'name' => $notifiable instanceof User ? $notifiable->name : '',
+            ]))
+            ->line(__('filament/notifications/mailbox-import-complete.mail.line', [
+                'email' => $this->account->email_address,
+                'count' => $imported,
+            ]));
+
+        $team = Team::query()->find($this->account->team_id);
+
+        if ($team instanceof Team) {
+            $message->action(
+                __('filament/notifications/mailbox-import-complete.mail.action'),
+                EmailAccountsPage::getUrl(tenant: $team),
+            );
+        }
+
+        return $message;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toDatabase(User $notifiable): array
+    {
+        $notification = FilamentNotification::make()
+            ->title(__('filament/notifications/mailbox-import-complete.title'))
+            ->body(__('filament/notifications/mailbox-import-complete.body', [
+                'email' => $this->account->email_address,
+                'count' => $this->account->initial_sync_imported,
+            ]))
+            ->success()
+            ->icon('heroicon-o-check-circle');
+
+        $team = Team::query()->find($this->account->team_id);
+
+        if ($team instanceof Team) {
+            $notification->actions([
+                Action::make('view')
+                    ->label(__('filament/notifications/mailbox-import-complete.actions.view'))
+                    ->url(EmailAccountsPage::getUrl(tenant: $team))
+                    ->button(),
+            ]);
+        }
+
+        return $notification->getDatabaseMessage();
+    }
+}

--- a/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
@@ -9,7 +9,7 @@ use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
 
 interface CalendarServiceInterface
 {
-    public function initialSync(): CalendarSyncResult;
+    public function initialSync(?string $pageToken = null): CalendarSyncResult;
 
     /**
      * @throws CalendarSyncTokenExpired when Google invalidates the syncToken (HTTP 410)

--- a/packages/EmailIntegration/src/Services/Contracts/MailServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/MailServiceInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services\Contracts;
 
-use Illuminate\Support\Collection;
 use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Data\MailBackfillPage;
 use Relaticle\EmailIntegration\Data\MailDeltaResult;
 
 interface MailServiceInterface
@@ -15,11 +15,11 @@ interface MailServiceInterface
     public function fetchMessage(string $providerMessageId): FetchedEmailData;
 
     /**
-     * Run the first-time backfill and return the cursor to store on the account.
-     *
-     * @return array{message_ids: Collection<int, string>, cursor: string}
+     * Fetch one page of the first-time backfill. Pass $pageToken from the previous
+     * page's nextPageToken to continue; omit it to start. The history cursor is
+     * captured on the first page (Gmail) or the last page (Graph deltaLink).
      */
-    public function initialBackfill(int $daysBack): array;
+    public function initialBackfill(?int $daysBack = null, ?string $pageToken = null): MailBackfillPage;
 
     /**
      * @param array{

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -10,6 +10,7 @@ use Google\Service\Gmail\MessagePart;
 use Google\Service\Gmail\MessagePartHeader;
 use Illuminate\Support\Collection;
 use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Data\MailBackfillPage;
 use Relaticle\EmailIntegration\Data\MailDeltaResult;
 use Relaticle\EmailIntegration\Enums\EmailCategory;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -133,43 +134,41 @@ final readonly class GmailService implements MailServiceInterface
     }
 
     /**
-     * Get initial cursor and list of message IDs for backfill.
-     *
-     * @return array{message_ids: Collection<int, string>, cursor: string}
+     * Fetch one page of message IDs for the initial backfill.
      */
-    public function initialBackfill(int $daysBack): array
+    public function initialBackfill(?int $daysBack = null, ?string $pageToken = null): MailBackfillPage
     {
-        $after = now()->subDays($daysBack)->timestamp;
+        $cursor = null;
 
-        // Capture the cursor before listing so no message that arrives mid-pagination is missed.
-        $profile = $this->gmail->users->getProfile('me');
+        if ($pageToken === null) {
+            // Capture the cursor before listing so mail that arrives mid-backfill is not missed.
+            $profile = $this->gmail->users->getProfile('me');
+            $cursor = (string) $profile->getHistoryId();
+        }
 
-        $messageIds = collect();
-        $pageToken = null;
-
-        do {
-            $params = [
-                'q' => "after:$after",
-                'maxResults' => 500,
-            ];
-
-            if ($pageToken !== null) {
-                $params['pageToken'] = $pageToken;
-            }
-
-            $response = $this->gmail->users_messages->listUsersMessages('me', $params);
-
-            $messageIds = $messageIds->merge($this->pluckMessageIds($response->getMessages()));
-
-            $pageToken = $response->getNextPageToken();
-        } while ($pageToken !== null && $pageToken !== '');
-
-        $messageIds = $messageIds->unique()->values();
-
-        return [
-            'message_ids' => $messageIds,
-            'cursor' => (string) $profile->getHistoryId(),
+        $params = [
+            'maxResults' => 500,
         ];
+
+        if ($daysBack !== null && $daysBack > 0) {
+            $params['q'] = 'after:'.now()->subDays($daysBack)->timestamp;
+        }
+
+        if ($pageToken !== null && $pageToken !== '') {
+            $params['pageToken'] = $pageToken;
+        }
+
+        $response = $this->gmail->users_messages->listUsersMessages('me', $params);
+        $nextPageToken = $response->getNextPageToken();
+
+        $estimate = $pageToken === null ? $response->getResultSizeEstimate() : null;
+
+        return new MailBackfillPage(
+            messageIds: $this->pluckMessageIds($response->getMessages())->unique()->values(),
+            nextPageToken: ($nextPageToken !== null && $nextPageToken !== '') ? $nextPageToken : null,
+            cursor: $cursor,
+            estimatedTotal: is_numeric($estimate) ? (int) $estimate : null,
+        );
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -64,7 +64,7 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
 
         return new Data\CalendarSyncResult(
             events: $events,
-            nextSyncToken: is_string($nextSyncToken) && $nextSyncToken !== '' ? $nextSyncToken : null,
+            nextSyncToken: $nextSyncToken,
             nextPageToken: ($nextPageToken !== null && $nextPageToken !== '') ? $nextPageToken : null,
         );
     }

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -39,36 +39,34 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
         return $this->client;
     }
 
-    public function initialSync(): Data\CalendarSyncResult
+    public function initialSync(?string $pageToken = null): Data\CalendarSyncResult
     {
+        $params = [
+            'singleEvents' => true,
+            'showDeleted' => false,
+            'maxResults' => 250,
+        ];
+
+        if ($pageToken !== null && $pageToken !== '') {
+            $params['pageToken'] = $pageToken;
+        }
+
+        $response = $this->client->events->listEvents('primary', $params);
+
         $events = [];
-        $pageToken = null;
-        $nextSyncToken = null;
 
-        do {
-            $params = [
-                'timeMin' => now()->subDays(90)->toRfc3339String(),
-                'singleEvents' => true,
-                'showDeleted' => false,
-                'orderBy' => 'startTime',
-                'maxResults' => 250,
-            ];
+        foreach ($response->getItems() as $event) {
+            $events[] = $this->normalizeGoogleEvent($event);
+        }
 
-            if ($pageToken !== null) {
-                $params['pageToken'] = $pageToken;
-            }
+        $nextPageToken = $response->getNextPageToken();
+        $nextSyncToken = $response->getNextSyncToken() ?: null;
 
-            $response = $this->client->events->listEvents('primary', $params);
-
-            foreach ($response->getItems() as $event) {
-                $events[] = $this->normalizeGoogleEvent($event);
-            }
-
-            $pageToken = $response->getNextPageToken();
-            $nextSyncToken = $response->getNextSyncToken() ?: $nextSyncToken;
-        } while ($pageToken !== null);
-
-        return new Data\CalendarSyncResult(events: $events, nextSyncToken: $nextSyncToken);
+        return new Data\CalendarSyncResult(
+            events: $events,
+            nextSyncToken: is_string($nextSyncToken) && $nextSyncToken !== '' ? $nextSyncToken : null,
+            nextPageToken: ($nextPageToken !== null && $nextPageToken !== '') ? $nextPageToken : null,
+        );
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Services;
 
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
@@ -15,57 +16,157 @@ use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
 
 final readonly class MicrosoftCalendarService implements CalendarServiceInterface
 {
+    private const string CALENDAR_DELTA = '/me/calendarView/delta';
+
+    private const int WINDOW_YEARS = 5;
+
     public function __construct(
         private ConnectedAccount $account,
         private MicrosoftGraphClientFactory $clientFactory,
     ) {}
 
-    public function initialSync(): CalendarSyncResult
+    public function initialSync(?string $pageToken = null): CalendarSyncResult
     {
-        $start = now()->subDays(90)->toIso8601String();
-        $end = now()->addDays(180)->toIso8601String();
+        $url = $pageToken ?? $this->calendarWindowUrl($this->historyStart());
 
-        $url = '/me/calendarView/delta?startDateTime='.rawurlencode($start).'&endDateTime='.rawurlencode($end);
-
-        return $this->drain($url);
+        return $this->drainOnePage($url, isInitial: true);
     }
 
     public function fetchDelta(string $syncToken): CalendarSyncResult
     {
-        return $this->drain($syncToken);
+        return $this->drainOnePage($syncToken, isInitial: false);
     }
 
-    private function drain(string $url): CalendarSyncResult
+    /**
+     * @param  bool  $isInitial  When true, stop after one HTTP page and chain remaining windows via nextPageToken
+     */
+    private function drainOnePage(string $url, bool $isInitial): CalendarSyncResult
     {
         $http = $this->clientFactory->make($this->account);
 
-        $events = [];
-        $deltaLink = null;
+        try {
+            $response = $http->get($url)->throw()->json();
+        } catch (RequestException $e) {
+            if ($e->response->status() === 410) {
+                throw CalendarSyncTokenExpired::forAccount($this->account->getKey());
+            }
 
-        do {
-            try {
-                $response = $http->get($url)->throw()->json();
-            } catch (RequestException $e) {
-                if ($e->response->status() === 410) {
-                    throw CalendarSyncTokenExpired::forAccount($this->account->getKey());
+            throw $e;
+        }
+
+        $events = [];
+
+        foreach ($response['value'] ?? [] as $event) {
+            $events[] = isset($event['@removed'])
+                ? $this->tombstone((string) ($event['id'] ?? ''))
+                : $this->normalize($event);
+        }
+
+        $nextLink = $response['@odata.nextLink'] ?? null;
+        $deltaLink = $response['@odata.deltaLink'] ?? null;
+
+        if (! $isInitial) {
+            $follow = $nextLink;
+
+            while (is_string($follow) && $follow !== '') {
+                try {
+                    $response = $http->get($follow)->throw()->json();
+                } catch (RequestException $e) {
+                    if ($e->response->status() === 410) {
+                        throw CalendarSyncTokenExpired::forAccount($this->account->getKey());
+                    }
+
+                    throw $e;
                 }
 
-                throw $e;
+                foreach ($response['value'] ?? [] as $event) {
+                    $events[] = isset($event['@removed'])
+                        ? $this->tombstone((string) ($event['id'] ?? ''))
+                        : $this->normalize($event);
+                }
+
+                $follow = $response['@odata.nextLink'] ?? null;
+                $deltaLink = $response['@odata.deltaLink'] ?? $deltaLink;
             }
 
-            foreach ($response['value'] ?? [] as $event) {
-                // Graph delta emits tombstones for deleted events; they have no payload to
-                // normalize, so surface them as cancelled to soft-delete the stored meeting.
-                $events[] = isset($event['@removed'])
-                    ? $this->tombstone((string) ($event['id'] ?? ''))
-                    : $this->normalize($event);
-            }
+            return new CalendarSyncResult(
+                events: $events,
+                nextSyncToken: is_string($deltaLink) && $deltaLink !== '' ? $deltaLink : null,
+            );
+        }
 
-            $url = $response['@odata.nextLink'] ?? null;
-            $deltaLink = $response['@odata.deltaLink'] ?? $deltaLink;
-        } while ($url !== null);
+        if (is_string($nextLink) && $nextLink !== '') {
+            return new CalendarSyncResult(events: $events, nextSyncToken: null, nextPageToken: $nextLink);
+        }
 
-        return new CalendarSyncResult(events: $events, nextSyncToken: $deltaLink);
+        $nextWindow = $this->nextWindowUrl($url);
+
+        if ($nextWindow !== null) {
+            return new CalendarSyncResult(events: $events, nextSyncToken: null, nextPageToken: $nextWindow);
+        }
+
+        return new CalendarSyncResult(
+            events: $events,
+            nextSyncToken: is_string($deltaLink) && $deltaLink !== '' ? $deltaLink : null,
+        );
+    }
+
+    private function historyStart(): Carbon
+    {
+        return Date::parse('1990-01-01T00:00:00Z');
+    }
+
+    private function horizon(): Carbon
+    {
+        return Date::now()->addYears(self::WINDOW_YEARS);
+    }
+
+    private function calendarWindowUrl(Carbon $start): string
+    {
+        $end = $start->copy()->addYears(self::WINDOW_YEARS);
+        $horizon = $this->horizon();
+
+        if ($end->gt($horizon)) {
+            $end = $horizon;
+        }
+
+        return self::CALENDAR_DELTA
+            .'?startDateTime='.rawurlencode($start->toIso8601String())
+            .'&endDateTime='.rawurlencode($end->toIso8601String());
+    }
+
+    private function nextWindowUrl(string $currentUrl): ?string
+    {
+        $end = $this->endDateTimeFromUrl($currentUrl);
+
+        if (! $end instanceof Carbon) {
+            return null;
+        }
+
+        if ($end->gte($this->horizon())) {
+            return null;
+        }
+
+        return $this->calendarWindowUrl($end);
+    }
+
+    private function endDateTimeFromUrl(string $url): ?Carbon
+    {
+        $query = parse_url($url, PHP_URL_QUERY);
+
+        if (! is_string($query) || $query === '') {
+            return null;
+        }
+
+        parse_str($query, $params);
+
+        $end = $params['endDateTime'] ?? null;
+
+        if (! is_string($end) || $end === '') {
+            return null;
+        }
+
+        return Date::parse($end);
     }
 
     private function tombstone(string $eventId): CalendarEventData

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -7,6 +7,7 @@ namespace Relaticle\EmailIntegration\Services;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Data\MailBackfillPage;
 use Relaticle\EmailIntegration\Data\MailDeltaResult;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
@@ -150,31 +151,43 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         ], $attachments);
     }
 
-    public function initialBackfill(int $daysBack): array
+    public function initialBackfill(?int $daysBack = null, ?string $pageToken = null): MailBackfillPage
     {
         $http = $this->clientFactory->make($this->account);
 
-        $afterIso = now()->subDays($daysBack)->toIso8601String();
+        $nextUrl = $pageToken ?? $this->initialDeltaUrl($daysBack);
+
+        $response = $http->get($nextUrl)->throw()->json();
 
         $messageIds = [];
-        $deltaLink = '';
-        $nextUrl = self::MESSAGES_DELTA.'?$filter='.rawurlencode("receivedDateTime ge {$afterIso}");
 
-        do {
-            $response = $http->get($nextUrl)->throw()->json();
-
-            foreach ($response['value'] ?? [] as $message) {
-                $messageIds[] = (string) $message['id'];
+        foreach ($response['value'] ?? [] as $message) {
+            if (isset($message['@removed'])) {
+                continue;
             }
 
-            $nextUrl = $response['@odata.nextLink'] ?? null;
-            $deltaLink = (string) ($response['@odata.deltaLink'] ?? $deltaLink);
-        } while ($nextUrl !== null);
+            $messageIds[] = (string) $message['id'];
+        }
 
-        return [
-            'message_ids' => collect($messageIds)->unique()->values(),
-            'cursor' => $deltaLink,
-        ];
+        $nextLink = $response['@odata.nextLink'] ?? null;
+        $deltaLink = $response['@odata.deltaLink'] ?? null;
+
+        return new MailBackfillPage(
+            messageIds: collect($messageIds)->unique()->values(),
+            nextPageToken: is_string($nextLink) && $nextLink !== '' ? $nextLink : null,
+            cursor: is_string($deltaLink) && $deltaLink !== '' ? $deltaLink : null,
+        );
+    }
+
+    private function initialDeltaUrl(?int $daysBack): string
+    {
+        if ($daysBack === null || $daysBack <= 0) {
+            return self::MESSAGES_DELTA;
+        }
+
+        $afterIso = now()->subDays($daysBack)->toIso8601String();
+
+        return self::MESSAGES_DELTA.'?$filter='.rawurlencode("receivedDateTime ge {$afterIso}");
     }
 
     public function sendMessage(array $data): array

--- a/tests/Feature/ActivityLog/PeopleTimelineActivityTest.php
+++ b/tests/Feature/ActivityLog/PeopleTimelineActivityTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Concerns\HasActivityTimeline;
 use App\Models\People;
 use App\Models\User;
 use App\Support\ActivityLog\RequestActivityBatch;
@@ -11,9 +12,14 @@ use Relaticle\ActivityLog\Filament\Livewire\ActivityLogLivewire;
 use Relaticle\ActivityLog\Support\ActivityLogSummary;
 use Relaticle\ActivityLog\Timeline\TimelineBuilder;
 use Relaticle\ActivityLog\Timeline\TimelineEntry;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
 
 mutates(ActivityLogLivewire::class);
 mutates(ActivityLogSummary::class);
+mutates(HasActivityTimeline::class);
 mutates(People::class);
 
 beforeEach(function (): void {
@@ -142,6 +148,51 @@ it('does not render a chevron for created entries', function (): void {
 
     $tail = substr($html, (int) $createdBlockStart, 2000);
     expect($tail)->not->toContain('remix-arrow-down-s-line');
+});
+
+it('labels inbound mailbox mail as received and outbound mail as sent', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+    ]));
+
+    $person = People::factory()->create([
+        'name' => 'Jordan Hale',
+        'team_id' => $this->team->getKey(),
+        'creator_id' => $this->user->getKey(),
+    ]);
+
+    $inbound = Email::factory()->inbound()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'connected_account_id' => $account->getKey(),
+        'subject' => 'Re: Pricing for Q3',
+        'sent_at' => now()->subHour(),
+        'direction' => EmailDirection::INBOUND,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    $outbound = Email::factory()->outbound()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'connected_account_id' => $account->getKey(),
+        'subject' => 'Pricing for Q3',
+        'sent_at' => now()->subMinutes(30),
+        'direction' => EmailDirection::OUTBOUND,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    $person->emails()->attach([$inbound->getKey(), $outbound->getKey()]);
+
+    $emailEvents = $person->timeline()
+        ->get()
+        ->where('type', 'related_model')
+        ->filter(fn (TimelineEntry $entry): bool => in_array($entry->event, ['email_sent', 'email_received'], true))
+        ->keyBy(fn (TimelineEntry $entry): string => (string) $entry->relatedModel?->getKey());
+
+    expect($emailEvents)->toHaveCount(2)
+        ->and($emailEvents[$inbound->getKey()]->event)->toBe('email_received')
+        ->and($emailEvents[$outbound->getKey()]->event)->toBe('email_sent');
 });
 
 describe('ActivityLogSummary::from()', function (): void {

--- a/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
@@ -14,8 +15,8 @@ use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 
 mutates(InitialCalendarSyncJob::class);
 
-it('dispatches a StoreMeetingJob per event and stores the sync token', function (): void {
-    Bus::fake([StoreMeetingJob::class]);
+it('batches a StoreMeetingJob per event and does not advance the cursor until the page stores', function (): void {
+    Bus::fake();
 
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'capabilities' => ['email' => true, 'calendar' => true],
@@ -41,6 +42,7 @@ it('dispatches a StoreMeetingJob per event and stores the sync token', function 
 
     $service = Mockery::mock(CalendarServiceInterface::class);
     $service->shouldReceive('initialSync')->once()
+        ->with(null)
         ->andReturn(new CalendarSyncResult(events: [$event], nextSyncToken: 'token-xyz'));
 
     $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
@@ -48,8 +50,54 @@ it('dispatches a StoreMeetingJob per event and stores the sync token', function 
 
     (new InitialCalendarSyncJob($account))->handle($factory);
 
-    Bus::assertDispatched(StoreMeetingJob::class, 1);
+    Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->queue() === 'emails-sync'
+        && $batch->jobs->count() === 1
+        && $batch->jobs->first() instanceof StoreMeetingJob
+    );
+    expect($account->fresh()?->calendar_sync_cursor)->toBeNull();
+});
+
+it('stores the sync token immediately when the last page has no events', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: 'token-xyz'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new InitialCalendarSyncJob($account))->handle($factory);
+
+    Bus::assertNothingBatched();
     expect($account->fresh()?->calendar_sync_cursor)->toBe('token-xyz');
+});
+
+it('chains the next calendar page instead of advancing the cursor', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: null, nextPageToken: 'page-2'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new InitialCalendarSyncJob($account))->handle($factory);
+
+    Bus::assertDispatched(
+        InitialCalendarSyncJob::class,
+        fn (InitialCalendarSyncJob $job): bool => $job->pageToken === 'page-2',
+    );
+    expect($account->fresh()?->calendar_sync_cursor)->toBeNull();
 });
 
 it('skips accounts without calendar capability', function (): void {

--- a/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
+++ b/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
@@ -56,14 +56,14 @@ it('skips events declined by self', function (): void {
     expect(Meeting::query()->count())->toBe(0);
 });
 
-it('skips events older than 90 days', function (): void {
+it('stores events older than 90 days', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
     (app(StoreMeetingAction::class))->execute(payload([
         'startsAt' => Carbon::now()->subDays(100),
         'endsAt' => Carbon::now()->subDays(100)->addHour(),
     ]), $account);
 
-    expect(Meeting::query()->count())->toBe(0);
+    expect(Meeting::query()->count())->toBe(1);
 });
 
 it('soft-deletes existing meeting when it becomes private', function (): void {

--- a/tests/Feature/EmailIntegration/EmailSettingsBreadcrumbsTest.php
+++ b/tests/Feature/EmailIntegration/EmailSettingsBreadcrumbsTest.php
@@ -6,11 +6,12 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Filament\Concerns\HasClusterBreadcrumbs;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccessRequestsPage;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Filament\Pages\EmailSignaturesPage;
 use Relaticle\EmailIntegration\Filament\Pages\UserEmailPrivacyPage;
 use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
 
-mutates(HasClusterBreadcrumbs::class);
+mutates(HasClusterBreadcrumbs::class, EmailAccountsPage::class, ManageEmailTemplates::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -19,16 +20,22 @@ beforeEach(function (): void {
 });
 
 /**
- * The app panel disables breadcrumbs globally, so cluster pages render their own header;
- * every page in the cluster must still show the trail back to Email settings.
+ * The app panel disables breadcrumbs globally, so remaining cluster pages render their
+ * own header trail. Accounts and Templates sit under top tabs and do not repeat it.
  */
-it('renders the cluster breadcrumb trail on every email settings page', function (string $page, string $crumb): void {
+it('renders the cluster breadcrumb trail on signature, privacy, and access-request pages', function (string $page, string $crumb): void {
     livewire($page)
         ->assertSee(__('filament/clusters/email-settings.breadcrumb'))
         ->assertSee($crumb);
 })->with([
     [EmailSignaturesPage::class, 'Signatures'],
-    [ManageEmailTemplates::class, 'Templates'],
     [UserEmailPrivacyPage::class, 'My Email Privacy'],
     [EmailAccessRequestsPage::class, 'Access Requests'],
+]);
+
+it('does not render breadcrumbs on the accounts and templates pages', function (string $page): void {
+    livewire($page)->assertDontSeeHtml('fi-breadcrumbs');
+})->with([
+    [EmailAccountsPage::class],
+    [ManageEmailTemplates::class],
 ]);

--- a/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
+++ b/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Notification;
+use Relaticle\EmailIntegration\Data\MailBackfillPage;
+use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
+use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Notifications\MailboxHistoryImportCompletedNotification;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
+
+mutates(InitialEmailSyncJob::class);
+
+it('does not cap the first import when EMAIL_SYNC_INITIAL_DAYS is unset', function (): void {
+    Bus::fake();
+    Notification::fake();
+    config()->set('email-integration.sync.initial_days', null);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')
+        ->once()
+        ->with(null, null)
+        ->andReturn(new MailBackfillPage(
+            messageIds: collect(),
+            nextPageToken: null,
+            cursor: 'history-1',
+        ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    expect($account->fresh()?->sync_cursor)->toBe('history-1');
+});
+
+it('passes the optional day cap through to the mail service', function (): void {
+    Bus::fake();
+    Notification::fake();
+    config()->set('email-integration.sync.initial_days', 90);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')
+        ->once()
+        ->with(90, null)
+        ->andReturn(new MailBackfillPage(
+            messageIds: collect(),
+            nextPageToken: null,
+            cursor: 'history-1',
+        ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+});
+
+it('batches one page of messages and leaves the cursor unset until the page stores', function (): void {
+    Bus::fake();
+    Notification::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(['M1', 'M2']),
+        nextPageToken: 'page-2',
+        cursor: 'history-1',
+        estimatedTotal: 80,
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->queue() === 'emails-sync'
+        && $batch->jobs->count() === 2
+        && $batch->jobs->every(fn ($job): bool => $job instanceof StoreEmailJob)
+    );
+    expect($account->fresh()?->sync_cursor)->toBeNull()
+        ->and($account->fresh()?->initial_sync_estimated)->toBe(80);
+
+    Notification::assertNothingSent();
+});
+
+it('chains the next page when the current page has no new ids', function (): void {
+    Bus::fake();
+    Notification::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(),
+        nextPageToken: 'page-2',
+        cursor: 'history-1',
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    Bus::assertDispatched(
+        InitialEmailSyncJob::class,
+        fn (InitialEmailSyncJob $job): bool => $job->pageToken === 'page-2'
+            && $job->historyCursor === 'history-1',
+    );
+    expect($account->fresh()?->sync_cursor)->toBeNull();
+    Notification::assertNothingSent();
+});
+
+it('sets the cursor and notifies the owner when the last page is stored', function (): void {
+    Bus::fake();
+    Notification::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(),
+        nextPageToken: null,
+        cursor: 'history-1',
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    expect($account->fresh()?->sync_cursor)->toBe('history-1')
+        ->and($account->fresh()?->last_synced_at)->not->toBeNull();
+
+    Notification::assertSentTo(
+        $account->user,
+        MailboxHistoryImportCompletedNotification::class,
+    );
+});

--- a/tests/Feature/EmailIntegration/MailboxImportProgressTest.php
+++ b/tests/Feature/EmailIntegration/MailboxImportProgressTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+mutates(EmailAccountsPage::class);
+
+it('shows import progress while the mailbox cursor has not been written', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    Filament::setTenant($user->currentTeam);
+
+    ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $user->currentTeam->getKey(),
+        'user_id' => $user->getKey(),
+        'sync_cursor' => null,
+        'initial_sync_imported' => 12,
+        'initial_sync_estimated' => 40,
+    ]));
+
+    livewire(EmailAccountsPage::class)
+        ->assertSee(__('filament/pages/email-accounts.importing_progress', [
+            'imported' => number_format(12),
+            'estimated' => number_format(40),
+        ]));
+});
+
+it('shows in sync after the mailbox cursor is written', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    Filament::setTenant($user->currentTeam);
+
+    ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $user->currentTeam->getKey(),
+        'user_id' => $user->getKey(),
+        'sync_cursor' => 'history-1',
+        'last_synced_at' => now(),
+    ]));
+
+    livewire(EmailAccountsPage::class)
+        ->assertSee(__('filament/pages/email-accounts.in_sync'))
+        ->assertDontSee(__('filament/pages/email-accounts.importing_count', ['count' => '0']));
+});

--- a/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
@@ -126,6 +127,59 @@ it('maps Graph "personal" sensitivity to private so the event is treated as priv
         ->fetchDelta('https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=OLD');
 
     expect($result->events[0]->visibility)->toBe('private');
+});
+
+it('starts the initial calendar delta at 1990 rather than 90 days ago', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/calendarView/delta*' => Http::response([
+            'value' => [],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=NEW',
+        ]),
+    ]);
+
+    new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class))
+        ->initialSync();
+
+    Http::assertSent(function (Request $request): bool {
+        $url = urldecode((string) $request->url());
+
+        return str_contains($url, '/me/calendarView/delta')
+            && str_contains($url, 'startDateTime=1990-01-01')
+            && ! str_contains($url, now()->subDays(90)->toIso8601String());
+    });
+});
+
+it('returns one initial calendar page and does not follow nextLink', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/calendarView/delta*' => Http::sequence()
+            ->push([
+                'value' => [
+                    [
+                        'id' => 'evt-1',
+                        'subject' => 'One',
+                        'start' => ['dateTime' => '2026-06-01T09:00:00', 'timeZone' => 'UTC'],
+                        'end' => ['dateTime' => '2026-06-01T09:30:00', 'timeZone' => 'UTC'],
+                        'isCancelled' => false,
+                        'organizer' => ['emailAddress' => ['address' => 'org@example.com']],
+                        'attendees' => [],
+                    ],
+                ],
+                '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=NEXT',
+            ])
+            ->push([
+                'value' => [],
+                '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=NEW',
+            ]),
+    ]);
+
+    $result = new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class))
+        ->initialSync();
+
+    expect($result->events)->toHaveCount(1)
+        ->and($result->nextPageToken)->toContain('$skiptoken=NEXT')
+        ->and($result->nextSyncToken)->toBeNull();
+
+    Http::assertSentCount(1);
 });
 
 it('throws CalendarSyncTokenExpired on Graph 410', function (): void {

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -53,14 +53,54 @@ it('backfills from the all-folder /me/messages/delta stream and returns the Grap
 
     $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
 
-    $result = $service->initialBackfill(90);
+    $result = $service->initialBackfill();
 
-    expect($result['cursor'])->toContain('$deltatoken=TKN')
-        ->and($result['message_ids']->all())->toEqual(['AAA1', 'AAA2']);
+    expect($result->cursor)->toContain('$deltatoken=TKN')
+        ->and($result->messageIds->all())->toEqual(['AAA1', 'AAA2'])
+        ->and($result->nextPageToken)->toBeNull();
 
     // Must hit the all-folder endpoint, not the Inbox-only one, so Sent mail syncs.
     Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/messages/delta')
-        && ! str_contains((string) $r->url(), 'mailFolders'));
+        && ! str_contains((string) $r->url(), 'mailFolders')
+        && ! str_contains((string) $r->url(), 'receivedDateTime'));
+});
+
+it('returns one backfill page and does not follow @odata.nextLink', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/messages/delta' => Http::response([
+            'value' => [
+                ['id' => 'AAA1'],
+            ],
+            '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/messages/delta?$skiptoken=NEXT',
+        ]),
+        'https://graph.microsoft.com/v1.0/me/messages/delta?$skiptoken=NEXT' => Http::response([
+            'value' => [
+                ['id' => 'AAA2'],
+            ],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/messages/delta?$deltatoken=TKN',
+        ]),
+    ]);
+
+    $result = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->initialBackfill();
+
+    expect($result->messageIds->all())->toEqual(['AAA1'])
+        ->and($result->nextPageToken)->toContain('$skiptoken=NEXT')
+        ->and($result->cursor)->toBeNull();
+
+    Http::assertSentCount(1);
+});
+
+it('applies the optional initial_days cap as a receivedDateTime filter', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/messages/delta*' => Http::response([
+            'value' => [],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/messages/delta?$deltatoken=TKN',
+        ]),
+    ]);
+
+    resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->initialBackfill(90);
+
+    Http::assertSent(fn (Request $r): bool => str_contains(urldecode((string) $r->url()), 'receivedDateTime ge'));
 });
 
 it('paginates delta with @odata.nextLink and surfaces new + read ids + new cursor', function (): void {

--- a/tests/Feature/EmailIntegration/SendEmailIdempotencyTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailIdempotencyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Data\MailBackfillPage;
 use Relaticle\EmailIntegration\Data\MailDeltaResult;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -39,7 +40,7 @@ final class FakeMailService implements MailServiceInterface
         throw new LogicException('unused');
     }
 
-    public function initialBackfill(int $daysBack): array
+    public function initialBackfill(?int $daysBack = null, ?string $pageToken = null): MailBackfillPage
     {
         throw new LogicException('unused');
     }

--- a/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
+++ b/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
+use Relaticle\EmailIntegration\Data\MailBackfillPage;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
@@ -60,10 +61,11 @@ it('dispatches the initial-sync StoreEmailJob batch onto the emails-sync queue',
     $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
 
     $service = Mockery::mock(MailServiceInterface::class);
-    $service->shouldReceive('initialBackfill')->andReturn([
-        'cursor' => 'cursor-1',
-        'message_ids' => collect(['M1', 'M2']),
-    ]);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(['M1', 'M2']),
+        nextPageToken: null,
+        cursor: 'cursor-1',
+    ));
 
     $factory = Mockery::mock(MailServiceFactoryInterface::class);
     $factory->shouldReceive('make')->andReturn($service);

--- a/tests/Feature/Jobs/SendEmailJobTest.php
+++ b/tests/Feature/Jobs/SendEmailJobTest.php
@@ -5,12 +5,22 @@ declare(strict_types=1);
 use App\Jobs\SendEmailJob;
 use App\Models\User;
 use Illuminate\Support\Facades\Log;
+use Relaticle\EmailIntegration\Actions\LinkEmailAction;
+use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Data\MailBackfillPage;
+use Relaticle\EmailIntegration\Data\MailDeltaResult;
+use Relaticle\EmailIntegration\Enums\EmailBatchStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailBatch;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
+use Relaticle\EmailIntegration\Services\EmailSendingService;
 
 mutates(SendEmailJob::class);
 
@@ -88,4 +98,124 @@ it('logs the full exception when the job fails', function (): void {
         });
 
     (new SendEmailJob($email->getKey()))->failed($exception);
+});
+
+it('completes the batch when a later step fails after the provider already accepted the message', function (): void {
+    $batch = EmailBatch::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'total_recipients' => 1,
+        'sent_count' => 0,
+        'failed_count' => 0,
+        'status' => EmailBatchStatus::Sending,
+    ]);
+
+    $email = Email::factory()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'batch_id' => $batch->getKey(),
+        'status' => EmailStatus::SENDING,
+        'sent_at' => null,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'rfc_message_id' => '<send-job-batch@example.com>',
+        'provider_message_id' => null,
+        'thread_id' => null,
+        'attempts' => 0,
+    ]);
+
+    $email->body()->create(['body_text' => 'hi', 'body_html' => '<p>hi</p>']);
+
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'recipient@partner.com',
+    ]);
+
+    $mail = new class implements MailServiceInterface
+    {
+        public function fetchDelta(string $cursor): MailDeltaResult
+        {
+            throw new LogicException('unused');
+        }
+
+        public function fetchMessage(string $providerMessageId): FetchedEmailData
+        {
+            throw new LogicException('unused');
+        }
+
+        public function initialBackfill(?int $daysBack = null, ?string $pageToken = null): MailBackfillPage
+        {
+            throw new LogicException('unused');
+        }
+
+        public function sendMessage(array $data): array
+        {
+            return [
+                'provider_message_id' => 'sent-123',
+                'thread_id' => 'thread-123',
+                'rfc_message_id' => $data['rfc_message_id'] ?? '<derived@example.com>',
+            ];
+        }
+
+        public function findSentMessage(string $rfcMessageId): ?array
+        {
+            return null;
+        }
+
+        public function downloadAttachment(string $providerMessageId, string $providerAttachmentId): string
+        {
+            return '';
+        }
+    };
+
+    app()->bind(MailServiceFactoryInterface::class, fn (): MailServiceFactoryInterface => new class($mail) implements MailServiceFactoryInterface
+    {
+        public function __construct(private readonly MailServiceInterface $service) {}
+
+        public function make(ConnectedAccount $account): MailServiceInterface
+        {
+            return $this->service;
+        }
+    });
+
+    $crashAfterDelivery = true;
+    Email::updated(function (Email $updated) use (&$crashAfterDelivery): void {
+        if ($crashAfterDelivery && $updated->status === EmailStatus::SENT) {
+            $crashAfterDelivery = false;
+            throw new RuntimeException('link failed');
+        }
+    });
+
+    $job = new SendEmailJob($email->getKey());
+    $sendingService = app(EmailSendingService::class);
+    $linkEmailAction = app(LinkEmailAction::class);
+
+    expect(fn () => $job->handle($sendingService, $linkEmailAction))
+        ->toThrow(RuntimeException::class);
+
+    expect($email->fresh()->status)->toBe(EmailStatus::SENT)
+        ->and($batch->fresh())
+        ->sent_count->toBe(0)
+        ->failed_count->toBe(0)
+        ->status->toBe(EmailBatchStatus::Sending);
+
+    $job->handle($sendingService, $linkEmailAction);
+
+    expect($email->fresh()->status)->toBe(EmailStatus::SENT)
+        ->and($batch->fresh())
+        ->sent_count->toBe(1)
+        ->failed_count->toBe(0)
+        ->status->toBe(EmailBatchStatus::Completed);
+
+    $job->handle($sendingService, $linkEmailAction);
+
+    $job->failed(new RuntimeException('link failed'));
+
+    expect($email->fresh()->status)->toBe(EmailStatus::SENT)
+        ->and($batch->fresh())
+        ->sent_count->toBe(1)
+        ->failed_count->toBe(0)
+        ->status->toBe(EmailBatchStatus::Completed);
 });


### PR DESCRIPTION
## Summary
- First mailbox import no longer stops at 90 days: Gmail and Microsoft backfill page through the whole mailbox, and the history cursor only advances after each page of `StoreEmailJob`s stores. `EMAIL_SYNC_INITIAL_DAYS` remains an optional self-host cap (unset by default).
- Calendar initial sync matches that: Google drops the `timeMin` window; Microsoft walks 5-year `calendarView/delta` windows from 1990. Meetings older than 90 days are stored.
- The accounts page shows import progress while the cursor is empty, then notifies the owner by email and in-app when mail import finishes.

## Review fixes

| Severity | Bug | Fix |
| --- | --- | --- |
| High | `SendEmailJob` batch counters can get stuck. After `send()` marks the email SENT, a throw (linking, process kill, retry) never increments `sent_count`. A retry sees SENT and no-ops; `failed()` also returns early on SENT. The batch stays non-terminal even though every message was delivered. | Recount `sent_count` / `failed_count` from email statuses under a batch lock. Reconcile after send, on a retry that cannot re-claim the row, and from `failed()` even when status is already SENT. Retries cannot double-count. |
| Medium | Inbound emails render as "Email sent" on Company/Person/Opportunity timelines. The emails source mapped any non-null `sent_at` to `email_sent`; synced inbound mail also has `sent_at`. | Key the event off `EmailDirection`. Outbound → `email_sent`. Inbound → `email_received`, using `sent_at` for ordering when present. |

## Test plan
- [x] Connect a mailbox with years of history and confirm every non-deleted message is imported (or set `EMAIL_SYNC_INITIAL_DAYS` and confirm the cap).
- [x] Confirm the accounts page shows import progress, then In Sync, and the owner gets a completion notice.
- [x] Confirm a meeting older than 90 days is stored after calendar initial sync.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php tests/Feature/EmailIntegration/MailboxImportProgressTest.php tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php`
- [x] Post-send crash still completes the batch with `sent_count` 1 and no double-count on retry (`SendEmailJobTest`).
- [x] Inbound + outbound on the same person timeline emit `email_received` and `email_sent` (`PeopleTimelineActivityTest`).
