### PR TITLE
fix(blog): render post covers uncropped with an app-owned card

### DIFF
--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -79,7 +79,7 @@
             @else
                 <div class="divide-y divide-gray-200/60 dark:divide-white/[0.04]">
                     @foreach($posts as $post)
-                        <x-ink::post-card :post="$post" />
+                        <x-blog.post-card :post="$post" />
                     @endforeach
                 </div>
 

--- a/resources/views/blog/preview.blade.php
+++ b/resources/views/blog/preview.blade.php
@@ -9,7 +9,7 @@
         <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 min-w-0 break-words blog-prose">
             <x-ink::post-header :post="$post" />
             <x-ink::post-body :post="$post" />
-            <x-ink::related-posts :posts="$relatedPosts" />
+            <x-blog.related-posts :posts="$relatedPosts" />
         </div>
     </div>
 </x-guest-layout>

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -66,7 +66,7 @@
                         </div>
                     @endif
 
-                    <x-ink::related-posts :posts="$relatedPosts" />
+                    <x-blog.related-posts :posts="$relatedPosts" />
                 </article>
 
                 <!-- Right Sidebar: Table of Contents -->

--- a/resources/views/components/blog/post-card.blade.php
+++ b/resources/views/components/blog/post-card.blade.php
@@ -1,0 +1,37 @@
+@props(['post'])
+
+<a href="{{ $post->getUrl() }}" wire:navigate class="group block py-6 -mx-4 px-4 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-900/50 transition-colors duration-200">
+    <div class="flex items-start justify-between gap-6">
+        <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-3 mb-2">
+                @if($post->category)
+                    <x-ink::category-badge :category="$post->category" :linked="false" />
+                @endif
+                @if($post->published_at)
+                    <time datetime="{{ $post->published_at->toIso8601String() }}" class="text-xs text-gray-400 dark:text-gray-500">
+                        {{ $post->published_at->format('M j, Y') }}
+                    </time>
+                @endif
+            </div>
+
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors duration-200 mb-1 break-words">
+                {{ $post->title }}
+            </h2>
+
+            @if($post->excerpt)
+                <p class="text-sm text-gray-500 dark:text-gray-400 line-clamp-2">{{ $post->excerpt }}</p>
+            @endif
+        </div>
+
+        @if($post->featured_image)
+            {{-- Covers are 1200x630; aspect-video keeps them uncropped enough that
+                 the title baked into the image survives (a square chops 48% off). --}}
+            <img
+                src="{{ asset('storage/'.$post->featured_image) }}"
+                alt="{{ $post->title }}"
+                loading="lazy"
+                class="w-28 sm:w-40 aspect-video object-cover rounded-lg shrink-0"
+            >
+        @endif
+    </div>
+</a>

--- a/resources/views/components/blog/related-posts.blade.php
+++ b/resources/views/components/blog/related-posts.blade.php
@@ -1,0 +1,12 @@
+@props(['posts'])
+
+@if($posts->isNotEmpty())
+    <section class="mt-10 pt-10 border-t border-gray-200/60 dark:border-white/[0.04]">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Related posts</h2>
+        <div class="divide-y divide-gray-200/60 dark:divide-white/[0.04]">
+            @foreach($posts as $relatedPost)
+                <x-blog.post-card :post="$relatedPost" />
+            @endforeach
+        </div>
+    </section>
+@endif

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -450,6 +450,24 @@ describe('Blog pages', function () {
             ->assertSee($post->title);
     });
 
+    it('renders the post cover uncropped on the index', function () {
+        Post::factory()->published()->create(['featured_image' => 'ink/cover.png']);
+
+        $this->get('/blog')
+            ->assertStatus(200)
+            ->assertSee('storage/ink/cover.png')
+            ->assertSee('aspect-video');
+    });
+
+    it('renders related posts through the shared card on a post page', function () {
+        $category = Category::factory()->create();
+        [$post, $related] = Post::factory()->published()->count(2)->create(['category_id' => $category->id]);
+
+        $this->get("/blog/{$post->slug}")
+            ->assertStatus(200)
+            ->assertSee($related->title);
+    });
+
     it('canonicalises a paginated listing to its own page', function () {
         Post::factory()->published()->count(config('ink.per_page') + 1)->create();
 


### PR DESCRIPTION
## Problem

Blog covers are 1200x630, but the listing thumbnail rendered them in ink's 96x96 `object-cover` square, cropping 48% of every image and slicing the title baked into the cover on both sides. On the live blog, "How to Connect Claude to Your CRM with MCP" reads "to Your CRM with MC".

## Fix

Own the card in the app instead of overriding ink views, following the pattern the blog TOC already set:

- `x-blog.post-card` renders the cover in an `aspect-video` box: 112px on mobile, 160px from `sm` up. `aspect-video` matches the post-page hero and trims only the cover's outer padding (6.7%), never the title.
- `x-blog.related-posts` reuses the card on post and preview pages, uses the app's divider tokens, and skips the section entirely when nothing is related.
- The blog page shells keep composing ink's other components (`post-header`, `post-body`, `structured-data`, ...) unchanged.

relaticle/ink#23 fixes the same crop upstream for ink's own default pages; it can merge on its own schedule since the app no longer renders that card.

## Verification

- Rendered locally with the three live covers seeded: desktop 160x90, mobile 112x63, light + dark, index + post page (related posts inherit the fix).
- New tests: cover renders uncropped on the index (asserts `aspect-video`, which appears nowhere else on the page), related posts render through the shared card.
- `PublicPagesTest` full file: 79 passed. Pint, PHPStan, rector, type coverage 100% all green.
