### PR TITLE
feat(docs): help centre ux, seo, and responsive layout rework

### DIFF
--- a/packages/Documentation/resources/css/documentation.css
+++ b/packages/Documentation/resources/css/documentation.css
@@ -149,8 +149,10 @@ html {
     @apply my-10 border-gray-200 dark:border-white/10;
 }
 
+/* Screenshots are captured in light mode only; dimming them keeps a dark
+   page from getting a full-brightness white block per image. */
 .prose-docs img {
-    @apply my-5 rounded-lg border border-gray-200 dark:border-white/10;
+    @apply my-5 rounded-lg border border-gray-200 dark:border-white/10 dark:brightness-90;
 }
 
 .prose-docs table {

--- a/packages/Documentation/resources/views/components/article.blade.php
+++ b/packages/Documentation/resources/views/components/article.blade.php
@@ -181,6 +181,11 @@
                 <x-ri-discord-fill class="h-4 w-4" />
                 {{ __('Ask a question in Discord') }}
             </a>
+            <a href="{{ route('contact') }}"
+               class="inline-flex items-center gap-2 text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
+                <x-ri-mail-line class="h-4 w-4" />
+                {{ __('Contact support') }}
+            </a>
         </div>
     </div>
 

--- a/packages/Documentation/resources/views/components/article.blade.php
+++ b/packages/Documentation/resources/views/components/article.blade.php
@@ -16,7 +16,14 @@
 @endphp
 
 <div class="flex gap-12">
-    <div class="min-w-0 max-w-[45rem] flex-1">
+    <div class="min-w-0 flex-1">
+    <div class="mx-auto w-full max-w-[45rem]">
+        @isset($breadcrumbs)
+            <nav aria-label="{{ __('Breadcrumb') }}" class="mb-7 text-[13px] text-gray-500 dark:text-gray-400">
+                {{ $breadcrumbs }}
+            </nav>
+        @endisset
+
         <div class="flex items-start justify-between gap-6">
             <div class="min-w-0">
                 @if($eyebrow)
@@ -188,9 +195,12 @@
             </a>
         </div>
     </div>
+    </div>
 
-    @if($hasToc)
-        <aside class="hidden w-56 shrink-0 xl:block">
+    {{-- Rendered even without headings so the content column sits at the same
+         x-position on every page. --}}
+    <aside class="hidden w-56 shrink-0 xl:block">
+        @if($hasToc)
             <nav aria-label="{{ __('On this page') }}" class="sticky top-[4.5rem] text-[13px]">
                 <h2 class="text-pico font-semibold tracking-[0.08em] text-gray-400 uppercase dark:text-gray-500">{{ __('On this page') }}</h2>
                 <ul id="docs-toc" class="mt-3 space-y-0.5 border-l border-gray-200 dark:border-white/10">
@@ -203,6 +213,6 @@
                     @endforeach
                 </ul>
             </nav>
-        </aside>
-    @endif
+        @endif
+    </aside>
 </div>

--- a/packages/Documentation/resources/views/components/shell.blade.php
+++ b/packages/Documentation/resources/views/components/shell.blade.php
@@ -180,7 +180,7 @@
         </nav>
     </div>
 
-    <div class="mx-auto flex w-full max-w-[100rem]">
+    <div class="mx-auto flex w-full max-w-[90rem]">
         <aside class="sticky top-14 hidden h-[calc(100vh-3.5rem)] w-64 shrink-0 border-r border-gray-200/70 lg:block dark:border-white/[0.06]">
             <nav aria-label="{{ __('Documentation navigation') }}" class="docs-scroll h-full overflow-y-auto px-6 py-9">
                 <x-documentation::sidebar-nav :nav="$nav" :current-path="$currentPath" />
@@ -189,12 +189,6 @@
 
         <div class="min-w-0 flex-1">
             <main id="docs-content" tabindex="-1" class="px-5 py-9 sm:px-8 lg:px-12 lg:py-12">
-                @isset($breadcrumbs)
-                    <nav aria-label="{{ __('Breadcrumb') }}" {{ $breadcrumbs->attributes->class('mb-7 text-[13px] text-gray-500 dark:text-gray-400') }}>
-                        {{ $breadcrumbs }}
-                    </nav>
-                @endisset
-
                 {{ $slot }}
             </main>
 

--- a/packages/Documentation/resources/views/components/shell.blade.php
+++ b/packages/Documentation/resources/views/components/shell.blade.php
@@ -3,6 +3,7 @@
     'description',
     'ogTitle' => null,
     'ogDescription' => null,
+    'ogType' => 'website',
     'nav' => [],
     'currentPath' => null,
 ])
@@ -14,7 +15,8 @@
         :title="$title"
         :description="$description"
         :og-title="$ogTitle ?? $title"
-        :og-description="$ogDescription ?? $description" />
+        :og-description="$ogDescription ?? $description"
+        :og-type="$ogType" />
 
     {{-- documentation.js before app.js on purpose: app.js calls Alpine.start()
          as it executes, and the shell's x-data reaches for window.RelaticleDocs
@@ -188,7 +190,7 @@
         <div class="min-w-0 flex-1">
             <main id="docs-content" tabindex="-1" class="px-5 py-9 sm:px-8 lg:px-12 lg:py-12">
                 @isset($breadcrumbs)
-                    <nav aria-label="{{ __('Breadcrumb') }}" class="mb-7 text-[13px] text-gray-500 dark:text-gray-400">
+                    <nav aria-label="{{ __('Breadcrumb') }}" {{ $breadcrumbs->attributes->class('mb-7 text-[13px] text-gray-500 dark:text-gray-400') }}>
                         {{ $breadcrumbs }}
                     </nav>
                 @endisset

--- a/packages/Documentation/resources/views/components/shell.blade.php
+++ b/packages/Documentation/resources/views/components/shell.blade.php
@@ -105,7 +105,7 @@
     </nav>
 
     <header class="sticky top-0 z-40 border-b border-gray-200/70 bg-white/85 backdrop-blur-md dark:border-white/[0.06] dark:bg-gray-950/85">
-        <div class="flex h-14 items-center gap-3 px-4 sm:px-6">
+        <div class="mx-auto flex h-14 w-full max-w-[90rem] items-center gap-3 px-4 sm:px-6">
             <button type="button"
                     x-on:click="sidebarOpen = true"
                     class="-ml-1.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 lg:hidden dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"

--- a/packages/Documentation/resources/views/docs/article.blade.php
+++ b/packages/Documentation/resources/views/docs/article.blade.php
@@ -4,14 +4,6 @@
     og-type="article"
     :nav="$nav"
     :current-path="$currentPath">
-    <x-slot:breadcrumbs>
-        <ol class="flex flex-wrap items-center gap-2">
-            <li><a href="{{ route('documentation.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Developers') }}</a></li>
-            <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
-            <li aria-current="page" class="text-gray-900 dark:text-white">{{ $page->title }}</li>
-        </ol>
-    </x-slot:breadcrumbs>
-
     <x-documentation::article
         :page="$page"
         :body="$body"
@@ -19,7 +11,15 @@
         :previous="$previous"
         :next="$next"
         :eyebrow="__('Developer guides')"
-        :eyebrow-url="route('documentation.index')" />
+        :eyebrow-url="route('documentation.index')">
+        <x-slot:breadcrumbs>
+            <ol class="flex flex-wrap items-center gap-2">
+                <li><a href="{{ route('documentation.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Developers') }}</a></li>
+                <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
+                <li aria-current="page" class="text-gray-900 dark:text-white">{{ $page->title }}</li>
+            </ol>
+        </x-slot:breadcrumbs>
+    </x-documentation::article>
 
     @php
         $jsonLd = (new \Relaticle\Documentation\Support\DocsJsonLd)->article(

--- a/packages/Documentation/resources/views/docs/article.blade.php
+++ b/packages/Documentation/resources/views/docs/article.blade.php
@@ -1,12 +1,11 @@
 <x-documentation::shell
     :title="$page->title . ' - ' . config('app.name')"
     :description="$page->description"
+    og-type="article"
     :nav="$nav"
     :current-path="$currentPath">
     <x-slot:breadcrumbs>
         <ol class="flex flex-wrap items-center gap-2">
-            <li><a href="{{ route('help.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Docs') }}</a></li>
-            <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
             <li><a href="{{ route('documentation.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Developers') }}</a></li>
             <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
             <li aria-current="page" class="text-gray-900 dark:text-white">{{ $page->title }}</li>
@@ -27,7 +26,7 @@
             $page,
             route('documentation.show', ['type' => $page->slug]),
             [
-                ['name' => __('Developer Documentation'), 'url' => route('documentation.index')],
+                ['name' => __('Developers'), 'url' => route('documentation.index')],
                 ['name' => $page->title, 'url' => route('documentation.show', ['type' => $page->slug])],
             ],
         );

--- a/packages/Documentation/resources/views/docs/hub.blade.php
+++ b/packages/Documentation/resources/views/docs/hub.blade.php
@@ -9,7 +9,7 @@
     :title="$baseTitle . ' - ' . config('app.name')"
     :description="$pageDescription"
     :nav="$nav">
-    <div class="mx-auto max-w-3xl">
+    <div class="mx-auto max-w-5xl">
         <p class="text-pico font-semibold tracking-[0.08em] text-primary-600 uppercase dark:text-primary-400">
             {{ __('Build on Relaticle') }}
         </p>

--- a/packages/Documentation/resources/views/help/article.blade.php
+++ b/packages/Documentation/resources/views/help/article.blade.php
@@ -1,6 +1,7 @@
 <x-documentation::shell
-    :title="$page->title . ' - ' . config('app.name')"
+    :title="__(':title - :brand Help Centre', ['title' => $page->title, 'brand' => config('app.name')])"
     :description="$page->description"
+    og-type="article"
     :nav="$nav"
     :current-path="$currentPath">
     <x-slot:breadcrumbs>

--- a/packages/Documentation/resources/views/help/article.blade.php
+++ b/packages/Documentation/resources/views/help/article.blade.php
@@ -4,25 +4,25 @@
     og-type="article"
     :nav="$nav"
     :current-path="$currentPath">
-    <x-slot:breadcrumbs>
-        <ol class="flex flex-wrap items-center gap-2">
-            <li><a href="{{ route('help.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Help Centre') }}</a></li>
-            @if($category)
-                <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
-                <li><a href="{{ route('help.category', ['category' => $page->category]) }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ $category->title }}</a></li>
-            @endif
-            <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
-            <li aria-current="page" class="text-gray-900 dark:text-white">{{ $page->title }}</li>
-        </ol>
-    </x-slot:breadcrumbs>
-
     <x-documentation::article
         :page="$page"
         :body="$body"
         :headings="$headings"
         :related="$related"
         :eyebrow="$category?->title"
-        :eyebrow-url="$category ? route('help.category', ['category' => $page->category]) : null" />
+        :eyebrow-url="$category ? route('help.category', ['category' => $page->category]) : null">
+        <x-slot:breadcrumbs>
+            <ol class="flex flex-wrap items-center gap-2">
+                <li><a href="{{ route('help.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Help Centre') }}</a></li>
+                @if($category)
+                    <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
+                    <li><a href="{{ route('help.category', ['category' => $page->category]) }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ $category->title }}</a></li>
+                @endif
+                <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
+                <li aria-current="page" class="text-gray-900 dark:text-white">{{ $page->title }}</li>
+            </ol>
+        </x-slot:breadcrumbs>
+    </x-documentation::article>
 
     @php
         $breadcrumbTrail = [

--- a/packages/Documentation/resources/views/help/category.blade.php
+++ b/packages/Documentation/resources/views/help/category.blade.php
@@ -1,9 +1,9 @@
 <x-documentation::shell
-    :title="$category->title . ' - ' . config('app.name')"
+    :title="__(':title - :brand Help Centre', ['title' => $category->title, 'brand' => config('app.name')])"
     :description="$category->description"
     :nav="$nav"
     :current-path="$currentPath">
-    <x-slot:breadcrumbs>
+    <x-slot:breadcrumbs class="mx-auto max-w-[45rem]">
         <ol class="flex flex-wrap items-center gap-2">
             <li><a href="{{ route('help.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Help Centre') }}</a></li>
             <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
@@ -11,7 +11,7 @@
         </ol>
     </x-slot:breadcrumbs>
 
-    <div class="max-w-[45rem]">
+    <div class="mx-auto max-w-[45rem]">
         <div class="flex items-start gap-4">
             <span class="hidden h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary-50 text-primary-600 sm:inline-flex dark:bg-primary-500/10 dark:text-primary-400">
                 <x-documentation::doc-icon :topic="$category->path" class="h-5 w-5" />

--- a/packages/Documentation/resources/views/help/category.blade.php
+++ b/packages/Documentation/resources/views/help/category.blade.php
@@ -3,15 +3,16 @@
     :description="$category->description"
     :nav="$nav"
     :current-path="$currentPath">
-    <x-slot:breadcrumbs class="mx-auto max-w-[45rem]">
-        <ol class="flex flex-wrap items-center gap-2">
-            <li><a href="{{ route('help.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Help Centre') }}</a></li>
-            <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
-            <li aria-current="page" class="text-gray-900 dark:text-white">{{ $category->title }}</li>
-        </ol>
-    </x-slot:breadcrumbs>
-
-    <div class="mx-auto max-w-[45rem]">
+    <div class="flex gap-12">
+    <div class="min-w-0 flex-1">
+    <div class="mx-auto w-full max-w-[45rem]">
+        <nav aria-label="{{ __('Breadcrumb') }}" class="mb-7 text-[13px] text-gray-500 dark:text-gray-400">
+            <ol class="flex flex-wrap items-center gap-2">
+                <li><a href="{{ route('help.index') }}" class="transition-colors hover:text-gray-900 dark:hover:text-white">{{ __('Help Centre') }}</a></li>
+                <li aria-hidden="true" class="text-gray-300 dark:text-gray-600">/</li>
+                <li aria-current="page" class="text-gray-900 dark:text-white">{{ $category->title }}</li>
+            </ol>
+        </nav>
         <div class="flex items-start gap-4">
             <span class="hidden h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary-50 text-primary-600 sm:inline-flex dark:bg-primary-500/10 dark:text-primary-400">
                 <x-documentation::doc-icon :topic="$category->path" class="h-5 w-5" />
@@ -45,6 +46,11 @@
                 </li>
             @endforeach
         </ul>
+    </div>
+    </div>
+
+    {{-- Reserved so the content column sits at the same x-position as articles. --}}
+    <aside class="hidden w-56 shrink-0 xl:block" aria-hidden="true"></aside>
     </div>
 
     @php

--- a/packages/Documentation/resources/views/help/hub.blade.php
+++ b/packages/Documentation/resources/views/help/hub.blade.php
@@ -76,10 +76,13 @@
             <div>
                 <h2 class="font-display text-base font-semibold tracking-tight text-gray-950 dark:text-white">{{ __('Still stuck?') }}</h2>
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {{ __('Ask the team and other Relaticle users in Discord, or open an issue on GitHub.') }}
+                    {{ __('Message the team directly, ask other Relaticle users in Discord, or open an issue on GitHub.') }}
                 </p>
             </div>
             <div class="mt-4 flex shrink-0 flex-wrap gap-2 sm:mt-0">
+                <x-marketing.button variant="secondary" size="sm" href="{{ route('contact') }}" icon="ri-mail-line">
+                    {{ __('Contact us') }}
+                </x-marketing.button>
                 <x-marketing.button variant="secondary" size="sm" href="{{ route('discord') }}" icon="ri-discord-fill" :external="true">
                     {{ __('Join Discord') }}
                 </x-marketing.button>

--- a/packages/Documentation/resources/views/help/hub.blade.php
+++ b/packages/Documentation/resources/views/help/hub.blade.php
@@ -7,7 +7,7 @@
     :title="$baseTitle . ' - ' . config('app.name')"
     :description="$pageDescription"
     :nav="$nav">
-    <div class="mx-auto max-w-3xl">
+    <div class="mx-auto max-w-5xl">
         <p class="text-pico font-semibold tracking-[0.08em] text-primary-600 uppercase dark:text-primary-400">
             {{ __('Relaticle docs') }}
         </p>
@@ -22,7 +22,7 @@
                 x-on:click="openSearch()"
                 x-on:mouseenter="warm()"
                 x-on:focus="warm()"
-                class="mt-8 flex w-full cursor-pointer items-center gap-3 rounded-xl border border-[var(--surface-input-border)] bg-[var(--surface-input-bg)] px-4 py-3.5 text-left text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-white/15 dark:hover:text-gray-200">
+                class="mt-8 flex w-full max-w-3xl cursor-pointer items-center gap-3 rounded-xl border border-[var(--surface-input-border)] bg-[var(--surface-input-bg)] px-4 py-3.5 text-left text-gray-500 transition-colors hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-white/15 dark:hover:text-gray-200">
             <x-ri-search-line class="h-5 w-5 shrink-0 text-gray-400" />
             <span class="flex-1 text-sm sm:text-base">{{ __('Search help articles and guides') }}</span>
             <kbd class="hidden rounded border border-gray-200 bg-white px-2 py-1 font-sans text-xs font-medium text-gray-500 sm:block dark:border-white/10 dark:bg-white/5 dark:text-gray-400">⌘K</kbd>

--- a/packages/Documentation/src/Support/DocUrl.php
+++ b/packages/Documentation/src/Support/DocUrl.php
@@ -50,6 +50,6 @@ final readonly class DocUrl
 
     public static function areaTitle(string $area): string
     {
-        return $area === self::HELP ? __('Help centre') : __('Developers');
+        return $area === self::HELP ? __('Help Centre') : __('Developers');
     }
 }

--- a/packages/Documentation/src/Support/DocsJsonLd.php
+++ b/packages/Documentation/src/Support/DocsJsonLd.php
@@ -39,11 +39,18 @@ final readonly class DocsJsonLd
 
     private function articleNode(DocPage $page, string $url): Article
     {
+        $publisher = Schema::organization()
+            ->name((string) config('app.name'))
+            ->url(url('/'))
+            ->logo(asset('web-app-manifest-512x512.png'));
+
         $article = Schema::article()
             ->headline($page->title)
             ->description($page->description)
             ->mainEntityOfPage($url)
-            ->url($url);
+            ->url($url)
+            ->author($publisher)
+            ->publisher($publisher);
 
         return $page->updated instanceof CarbonImmutable
             ? $article->dateModified($page->updated)

--- a/tests/Feature/Documentation/HelpRoutesTest.php
+++ b/tests/Feature/Documentation/HelpRoutesTest.php
@@ -31,6 +31,17 @@ it('renders an article with its rendered body', function (): void {
         ->assertSee('Create your first company', false);
 });
 
+it('offers a direct contact path from the hub and the article footer', function (): void {
+    $this->get('/help')
+        ->assertOk()
+        ->assertSee(route('contact'), false);
+
+    $this->get('/help/getting-started/create-your-first-company')
+        ->assertOk()
+        ->assertSee(route('contact'), false)
+        ->assertSee('Contact support', false);
+});
+
 it('404s an unknown category and an unknown article', function (): void {
     $this->get('/help/no-such-category')->assertNotFound();
     $this->get('/help/getting-started/no-such-article')->assertNotFound();

--- a/tests/Feature/Documentation/HelpSeoTest.php
+++ b/tests/Feature/Documentation/HelpSeoTest.php
@@ -43,6 +43,7 @@ it('emits article and breadcrumb json-ld on a help article', function (): void {
         ->and($html)->toContain('"headline":"Create your first company"')
         ->and($html)->toContain('"description":"Add a company record and fill in the fields your team actually uses."')
         ->and($html)->toContain('"mainEntityOfPage":"'.$url.'"')
+        ->and($html)->toContain('"publisher":{"@type":"Organization","name":"'.config('app.name').'"')
         ->and($html)->toContain('"position":1')
         ->and($html)->toContain('"position":2')
         ->and($html)->toContain('"position":3');
@@ -110,7 +111,9 @@ it('titles every content page base-title-dash-brand, exactly once', function ():
 
         preg_match('/<title>(.*?)<\/title>/', $html, $match);
 
-        $expected = "{$page->title} - {$brand}";
+        $expected = $page->area === DocUrl::HELP
+            ? "{$page->title} - {$brand} Help Centre"
+            : "{$page->title} - {$brand}";
 
         if (($match[1] ?? null) !== $expected || substr_count($match[1] ?? '', " - {$brand}") !== 1) {
             $offenders[] = "{$page->path} -> ".($match[1] ?? '(no title)');
@@ -118,6 +121,16 @@ it('titles every content page base-title-dash-brand, exactly once', function ():
     }
 
     expect($offenders)->toBe([]);
+});
+
+it('marks content pages as articles and the hubs as websites in open graph', function (): void {
+    $article = $this->get('/help/getting-started/create-your-first-company')->assertOk()->getContent();
+    $guide = $this->get('/developers/mcp')->assertOk()->getContent();
+    $hub = $this->get('/help')->assertOk()->getContent();
+
+    expect($article)->toContain('<meta property="og:type" content="article" />')
+        ->and($guide)->toContain('<meta property="og:type" content="article" />')
+        ->and($hub)->toContain('<meta property="og:type" content="website" />');
 });
 
 it('lazy-loads article images', function (): void {


### PR DESCRIPTION
Adds a direct contact path to the help centre (hub card and every article footer) and completes the SEO/GEO layer: `og:type article` on content pages, the Organization as author/publisher in article JSON-LD, help titles suffixed with "Relaticle Help Centre", and single-root "Developers" breadcrumbs on the dev guides.

Rebuilds the docs shell on the grid model Laravel Cloud's docs use: a 90rem centred shell (header row included), a fluid content column capped at 45rem, and a reserved TOC rail so help articles, dev guides, and category pages share one column position, with breadcrumbs inside the column and both hub heroes aligned with their card grids. This removes the dead right-hand zone at 768px to 1280px widths, and light-mode screenshots are now dimmed inside dark pages.

Verified in the browser at 390px to 1920px viewport widths in light and dark; documentation tests (86), pint, rector, phpstan, and type coverage are all green.
