### PR TITLE
Finish send-job linking on retry and pin email schedules to one server

### DIFF
--- a/app/Jobs/SendEmailJob.php
+++ b/app/Jobs/SendEmailJob.php
@@ -39,6 +39,10 @@ final class SendEmailJob implements ShouldQueue
                 return null;
             }
 
+            if ($lockedEmail->status === EmailStatus::SENT) {
+                return $lockedEmail;
+            }
+
             // Accept any non-terminal state. The dispatcher claims QUEUED → SENDING
             // before enqueuing, so first attempts arrive here as SENDING; Laravel
             // retries of the same job also arrive as SENDING.
@@ -61,11 +65,14 @@ final class SendEmailJob implements ShouldQueue
             return;
         }
 
-        $sent = $sendingService->send($email);
+        if ($email->status !== EmailStatus::SENT) {
+            $email = $sendingService->send($email);
+            $this->syncBatchCounters($email->batch_id);
+        }
 
-        $this->syncBatchCounters($sent->batch_id);
+        $linkEmailAction->execute($email);
 
-        $linkEmailAction->execute($sent);
+        $this->syncBatchCounters($email->batch_id);
     }
 
     public function failed(Throwable $exception): void

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -163,13 +163,24 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
     }
 
     /**
+     * Members of a workspace: the `team_user` pivot plus the owner, who has no
+     * pivot row — the same two sources App\Support\TenantFkValidator checks.
+     *
+     * Deliberately not `current_team_id`: that column is only a user's *active*
+     * workspace, so a member who is currently working in another one would drop
+     * out of member pickers and be rejected as a share target.
+     *
      * @param  Builder<User>  $query
      * @return Builder<User>
      */
     #[Scope]
     protected function inTeam(Builder $query, string $teamId): Builder
     {
-        return $query->where('current_team_id', $teamId);
+        return $query->where(function (Builder $members) use ($teamId): void {
+            $members
+                ->whereHas('teams', fn (Builder $teams): Builder => $teams->whereKey($teamId))
+                ->orWhereHas('ownedTeams', fn (Builder $ownedTeams): Builder => $ownedTeams->whereKey($teamId));
+        });
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,7 +14,6 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
@@ -23,10 +22,6 @@ use Illuminate\Support\Facades\Route;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Pennant\Feature;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
-use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
-use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
-use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
-use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Sentry\Laravel\Integration;
 use Spatie\Health\Commands\DispatchQueueCheckJobsCommand;
 use Spatie\Health\Commands\RunHealthChecksCommand;
@@ -185,29 +180,23 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('notifications:send-setup-nudge')->hourly()->withoutOverlapping()->onOneServer();
 
         if (Feature::active(EmailIntegration::class)) {
-            // TODO::Separate it in different command class
-            $schedule->call(function (): void {
-                ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
-                    ->whereNotNull('sync_cursor')
-                    ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalEmailSyncJob($account)));
-            })
+            $schedule->command('email:incremental-sync')
                 ->everyFiveMinutes()
                 ->name('email:incremental-sync')
-                ->withoutOverlapping();
+                ->withoutOverlapping()
+                ->onOneServer();
 
-            $schedule->call(function (): void {
-                ConnectedAccount::query()->where('status', EmailAccountStatus::ACTIVE)
-                    ->whereJsonContains('capabilities->calendar', true)
-                    ->each(fn (ConnectedAccount $account): PendingDispatch => dispatch(new IncrementalCalendarSyncJob($account)));
-            })
+            $schedule->command('calendar:incremental-sync')
                 ->everyFiveMinutes()
                 ->name('calendar:incremental-sync')
-                ->withoutOverlapping();
+                ->withoutOverlapping()
+                ->onOneServer();
 
             $schedule->command('email:dispatch-outbox')
                 ->everyMinute()
                 ->name('email:dispatch-outbox')
-                ->withoutOverlapping();
+                ->withoutOverlapping()
+                ->onOneServer();
         }
 
         if (config('app.health_checks_enabled')) {

--- a/database/migrations/2026_08_30_154755_add_linked_at_to_emails_table.php
+++ b/database/migrations/2026_08_30_154755_add_linked_at_to_emails_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('emails', function (Blueprint $table): void {
+            // Set once CRM linking has completed for this email. LinkEmailAction's
+            // counter increments are not idempotent, so a retried job must be able
+            // to tell "delivered but never linked" from "already linked".
+            $table->timestamp('linked_at')->nullable()->after('attempts');
+        });
+    }
+};

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -28,7 +28,37 @@ final readonly class LinkEmailAction
         private AutomatedSenderMatcher $automatedSender,
     ) {}
 
+    /**
+     * Link an email to its CRM records exactly once.
+     *
+     * incrementEmailMetrics() is not idempotent, so a second pass over an email
+     * would inflate email_count on every record it touches. The `linked_at` claim
+     * and the linking itself share one transaction, taken under a row lock on the
+     * email: a crash mid-link rolls the claim back so a retry re-links from
+     * scratch, and a retry after a completed link is a no-op. Concurrent workers
+     * on the same email serialise on the lock, and the second one finds the claim.
+     */
     public function execute(Email $email): void
+    {
+        DB::transaction(function () use ($email): void {
+            /** @var Email|null $locked */
+            $locked = Email::query()
+                ->withoutGlobalScopes()
+                ->whereKey($email->getKey())
+                ->lockForUpdate()
+                ->first();
+
+            if ($locked === null || $locked->linked_at !== null) {
+                return;
+            }
+
+            $this->link($email);
+
+            $locked->updateQuietly(['linked_at' => now()]);
+        });
+    }
+
+    private function link(Email $email): void
     {
         $participants = $email->participants()->with('contact', 'company')->get();
         $teamId = $email->team_id;

--- a/packages/EmailIntegration/src/Console/Commands/IncrementalCalendarSyncCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/IncrementalCalendarSyncCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+#[Description('Dispatch incremental calendar sync jobs for accounts with calendar enabled.')]
+#[Signature('calendar:incremental-sync')]
+final class IncrementalCalendarSyncCommand extends Command
+{
+    public function handle(): int
+    {
+        ConnectedAccount::query()
+            ->where('status', EmailAccountStatus::ACTIVE)
+            ->whereJsonContains('capabilities->calendar', true)
+            ->each(function (ConnectedAccount $account): void {
+                dispatch(new IncrementalCalendarSyncJob($account));
+            });
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/EmailIntegration/src/Console/Commands/IncrementalEmailSyncCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/IncrementalEmailSyncCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+#[Description('Dispatch incremental mailbox sync jobs for active accounts.')]
+#[Signature('email:incremental-sync')]
+final class IncrementalEmailSyncCommand extends Command
+{
+    public function handle(): int
+    {
+        ConnectedAccount::query()
+            ->where('status', EmailAccountStatus::ACTIVE)
+            ->whereNotNull('sync_cursor')
+            ->each(function (ConnectedAccount $account): void {
+                dispatch(new IncrementalEmailSyncJob($account));
+            });
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
+++ b/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
@@ -19,6 +19,8 @@ use Laravel\Socialite\Two\GoogleProvider;
 use Livewire\Livewire;
 use Relaticle\EmailIntegration\Console\Commands\BackfillEmailThreadsCommand;
 use Relaticle\EmailIntegration\Console\Commands\DispatchOutboxCommand;
+use Relaticle\EmailIntegration\Console\Commands\IncrementalCalendarSyncCommand;
+use Relaticle\EmailIntegration\Console\Commands\IncrementalEmailSyncCommand;
 use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
 use Relaticle\EmailIntegration\Livewire\AccessRequestsTable;
 use Relaticle\EmailIntegration\Livewire\DraftsTable;
@@ -103,6 +105,8 @@ final class EmailIntegrationServiceProvider extends ServiceProvider
             $this->commands([
                 BackfillEmailThreadsCommand::class,
                 DispatchOutboxCommand::class,
+                IncrementalCalendarSyncCommand::class,
+                IncrementalEmailSyncCommand::class,
             ]);
         }
     }

--- a/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Filament\Actions;
 
 use App\Enums\CustomFields\PeopleField;
+use App\Features\EmailIntegration;
 use App\Models\CustomField;
 use App\Models\People;
 use App\Models\Team;
@@ -18,6 +19,7 @@ use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Actions\SendEmailBatchAction;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
@@ -40,7 +42,9 @@ final class MassSendBulkAction extends BulkAction
                 /** @var Team|null $team */
                 $team = filament()->getTenant();
 
-                return $user instanceof User && ConnectedAccount::hasActiveFor($user, $team);
+                return Feature::active(EmailIntegration::class)
+                    && $user instanceof User
+                    && ConnectedAccount::hasActiveFor($user, $team);
             })
             ->schema([
                 Select::make('connected_account_id')

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -459,8 +459,8 @@ abstract class BaseRecordEmailsPage extends Page
         $user = $this->authUser();
 
         return User::query()
-            ->where('current_team_id', $user->current_team_id)
-            ->where('id', '!=', $user->getKey())
+            ->inTeam($user->current_team_id)
+            ->whereKeyNot($user->getKey())
             ->orderBy('name')
             ->pluck('name', 'id')
             ->all();

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -795,8 +795,8 @@ final class EmailInboxPage extends Page
         $user = $this->authUser();
 
         return User::query()
-            ->where('current_team_id', $user->current_team_id)
-            ->where('id', '!=', $user->getKey())
+            ->inTeam($user->current_team_id)
+            ->whereKeyNot($user->getKey())
             ->orderBy('name')
             ->pluck('name', 'id')
             ->all();

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -98,8 +98,8 @@ abstract class BaseEmailsRelationManager extends RelationManager
                                         $user = $this->authUser();
 
                                         return User::query()
-                                            ->where('current_team_id', $user->current_team_id)
-                                            ->where('id', '!=', $user->getKey())
+                                            ->inTeam($user->current_team_id)
+                                            ->whereKeyNot($user->getKey())
                                             ->pluck('name', 'id')
                                             ->all();
                                     })
@@ -248,8 +248,8 @@ abstract class BaseEmailsRelationManager extends RelationManager
                                             $user = $this->authUser();
 
                                             return User::query()
-                                                ->where('current_team_id', $user->current_team_id)
-                                                ->where('id', '!=', $user->getKey())
+                                                ->inTeam($user->current_team_id)
+                                                ->whereKeyNot($user->getKey())
                                                 ->pluck('name', 'id')
                                                 ->all();
                                         })

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -58,6 +58,7 @@ use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
  * @property Carbon|null $scheduled_for
  * @property string|null $last_error
  * @property int $attempts
+ * @property Carbon|null $linked_at
  * @property EmailPriority $priority
  */
 #[ObservedBy(EmailObserver::class)]
@@ -96,6 +97,7 @@ final class Email extends Model
         'scheduled_for',
         'last_error',
         'attempts',
+        'linked_at',
         'priority',
     ];
 
@@ -118,6 +120,7 @@ final class Email extends Model
         'is_internal' => 'boolean',
         'scheduled_for' => 'datetime',
         'attempts' => 'integer',
+        'linked_at' => 'datetime',
         'priority' => EmailPriority::class,
     ];
 

--- a/tests/Feature/ActivityLog/PeopleTimelineActivityTest.php
+++ b/tests/Feature/ActivityLog/PeopleTimelineActivityTest.php
@@ -182,7 +182,17 @@ it('labels inbound mailbox mail as received and outbound mail as sent', function
         'privacy_tier' => EmailPrivacyTier::FULL,
     ]);
 
-    $person->emails()->attach([$inbound->getKey(), $outbound->getKey()]);
+    $unsentOutbound = Email::factory()->outbound()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'connected_account_id' => $account->getKey(),
+        'subject' => 'Draft pricing follow-up',
+        'sent_at' => null,
+        'direction' => EmailDirection::OUTBOUND,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    $person->emails()->attach([$inbound->getKey(), $outbound->getKey(), $unsentOutbound->getKey()]);
 
     $emailEvents = $person->timeline()
         ->get()
@@ -192,7 +202,8 @@ it('labels inbound mailbox mail as received and outbound mail as sent', function
 
     expect($emailEvents)->toHaveCount(2)
         ->and($emailEvents[$inbound->getKey()]->event)->toBe('email_received')
-        ->and($emailEvents[$outbound->getKey()]->event)->toBe('email_sent');
+        ->and($emailEvents[$outbound->getKey()]->event)->toBe('email_sent')
+        ->and($emailEvents->has($unsentOutbound->getKey()))->toBeFalse();
 });
 
 describe('ActivityLogSummary::from()', function (): void {

--- a/tests/Feature/Commands/EmailIntegrationScheduleTest.php
+++ b/tests/Feature/Commands/EmailIntegrationScheduleTest.php
@@ -3,8 +3,19 @@
 declare(strict_types=1);
 
 use App\Features\EmailIntegration;
+use App\Models\User;
+use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Bus;
 use Laravel\Pennant\Feature;
+use Relaticle\EmailIntegration\Console\Commands\IncrementalCalendarSyncCommand;
+use Relaticle\EmailIntegration\Console\Commands\IncrementalEmailSyncCommand;
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
+use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+mutates(IncrementalEmailSyncCommand::class);
+mutates(IncrementalCalendarSyncCommand::class);
 
 it('registers outbox and sync schedules when email integration is active', function (): void {
     Feature::activate(EmailIntegration::class);
@@ -15,6 +26,25 @@ it('registers outbox and sync schedules when email integration is active', funct
         ->expectsOutputToContain('email:incremental-sync')
         ->expectsOutputToContain('calendar:incremental-sync')
         ->assertSuccessful();
+});
+
+it('runs email sync and outbox schedules on a single server without overlapping', function (): void {
+    Feature::activate(EmailIntegration::class);
+    $this->app->forgetInstance(Schedule::class);
+
+    $this->artisan('schedule:list')->assertSuccessful();
+
+    $events = collect(app(Schedule::class)->events())
+        ->filter(function (Event $event): bool {
+            $haystack = $event->getSummaryForDisplay().' '.($event->command ?? '');
+
+            return str_contains($haystack, 'email:incremental-sync')
+                || str_contains($haystack, 'calendar:incremental-sync')
+                || str_contains($haystack, 'email:dispatch-outbox');
+        });
+
+    expect($events)->toHaveCount(3)
+        ->and($events->every(fn (Event $event): bool => $event->onOneServer && $event->withoutOverlapping))->toBeTrue();
 });
 
 it('does not register outbox or sync schedules when email integration is inactive', function (): void {
@@ -28,4 +58,46 @@ it('does not register outbox or sync schedules when email integration is inactiv
         ->doesntExpectOutputToContain('email:incremental-sync')
         ->doesntExpectOutputToContain('calendar:incremental-sync')
         ->assertSuccessful();
+});
+
+it('dispatches incremental email sync jobs only for active accounts with a cursor', function (): void {
+    Bus::fake([IncrementalEmailSyncJob::class]);
+
+    $user = User::factory()->withTeam()->create();
+    $withCursor = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'user_id' => $user->id,
+        'sync_cursor' => 'cursor-1',
+    ]));
+    $withoutCursor = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'user_id' => $user->id,
+        'sync_cursor' => null,
+    ]));
+
+    $this->artisan('email:incremental-sync')->assertSuccessful();
+
+    Bus::assertDispatched(fn (IncrementalEmailSyncJob $job): bool => $job->connectedAccount->is($withCursor));
+    Bus::assertNotDispatched(fn (IncrementalEmailSyncJob $job): bool => $job->connectedAccount->is($withoutCursor));
+});
+
+it('dispatches incremental calendar sync jobs only for accounts with calendar enabled', function (): void {
+    Bus::fake([IncrementalCalendarSyncJob::class]);
+
+    $user = User::factory()->withTeam()->create();
+    $withCalendar = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'user_id' => $user->id,
+        'capabilities' => ['calendar' => true],
+    ]));
+    $withoutCalendar = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'user_id' => $user->id,
+        'capabilities' => ['calendar' => false],
+    ]));
+
+    $this->artisan('calendar:incremental-sync')->assertSuccessful();
+
+    Bus::assertDispatched(fn (IncrementalCalendarSyncJob $job): bool => $job->connectedAccount->is($withCalendar));
+    Bus::assertNotDispatched(fn (IncrementalCalendarSyncJob $job): bool => $job->connectedAccount->is($withoutCalendar));
 });

--- a/tests/Feature/EmailIntegration/EmailSharingServiceTest.php
+++ b/tests/Feature/EmailIntegration/EmailSharingServiceTest.php
@@ -7,12 +7,14 @@ use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\DB;
+use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Services\EmailSharingService;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 mutates(EmailSharingService::class);
 
@@ -189,4 +191,41 @@ it('returns 0 when no emails are linked to the record', function (): void {
     $updated = $this->service->setTierForAllOnRecord($person, $this->owner, EmailPrivacyTier::FULL);
 
     expect($updated)->toBe(0);
+});
+
+it('shares with a workspace member who is currently working in another workspace', function (): void {
+    $member = User::factory()->withTeam()->create();
+    $this->team->users()->attach($member, ['role' => 'editor']);
+
+    $email = makeSharingEmail();
+
+    app(UpdateEmailSharingAction::class)->execute(
+        $email,
+        $this->owner,
+        EmailPrivacyTier::METADATA_ONLY,
+        [['shared_with' => $member->getKey(), 'tier' => EmailPrivacyTier::FULL->value]],
+    );
+
+    $this->assertDatabaseHas('email_shares', [
+        'email_id' => $email->getKey(),
+        'shared_with' => $member->getKey(),
+        'tier' => EmailPrivacyTier::FULL->value,
+    ]);
+});
+
+it('rejects a share target who is not a member of the workspace', function (): void {
+    $outsider = User::factory()->withTeam()->create();
+    $email = makeSharingEmail();
+
+    expect(fn () => app(UpdateEmailSharingAction::class)->execute(
+        $email,
+        $this->owner,
+        EmailPrivacyTier::METADATA_ONLY,
+        [['shared_with' => $outsider->getKey(), 'tier' => EmailPrivacyTier::FULL->value]],
+    ))->toThrow(HttpException::class);
+
+    $this->assertDatabaseMissing('email_shares', [
+        'email_id' => $email->getKey(),
+        'shared_with' => $outsider->getKey(),
+    ]);
 });

--- a/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
+++ b/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
@@ -20,8 +20,10 @@ mutates(BaseEmailsRelationManager::class);
 
 beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
-    $this->viewer = User::factory()->create(['current_team_id' => $this->owner->currentTeam->id]);
     $this->team = $this->owner->currentTeam;
+
+    $this->viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($this->viewer, ['role' => 'editor']);
 
     $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $this->team->id,
@@ -209,6 +211,7 @@ describe('manageSharing table action', function (): void {
 
     it('creates EmailShare rows for multiple teammates selected in one tier row', function (): void {
         $secondViewer = User::factory()->create(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($secondViewer, ['role' => 'editor']);
 
         $email = Email::factory()->create([
             'team_id' => $this->team->id,

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -3,11 +3,13 @@
 declare(strict_types=1);
 
 use App\Enums\CustomFields\PeopleField;
+use App\Features\EmailIntegration;
 use App\Filament\Resources\PeopleResource\Pages\ListPeople;
 use App\Models\CustomField;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Actions\SendEmailBatchAction;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Filament\Actions\MassSendBulkAction;
@@ -49,6 +51,18 @@ function setPersonEmail(People $person, string $emailAddress): void
 
     $person->saveCustomFieldValue($emailsField, [$emailAddress], $person->team);
 }
+
+it('hides mass send when email integration is disabled', function (): void {
+    Feature::deactivate(EmailIntegration::class);
+
+    livewire(ListPeople::class)
+        ->assertTableBulkActionHidden('massSend');
+});
+
+it('shows mass send when email integration is enabled and an account is connected', function (): void {
+    livewire(ListPeople::class)
+        ->assertTableBulkActionVisible('massSend');
+});
 
 it('creates an EmailBatch and persists one Email row per recipient', function (): void {
     $people = collect(range(1, 3))->map(fn (int $i): People => People::create([

--- a/tests/Feature/Jobs/SendEmailJobTest.php
+++ b/tests/Feature/Jobs/SendEmailJobTest.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use App\Enums\CustomFields\PeopleField;
 use App\Jobs\SendEmailJob;
+use App\Models\CustomField;
+use App\Models\People;
 use App\Models\User;
 use Illuminate\Support\Facades\Log;
 use Relaticle\EmailIntegration\Actions\LinkEmailAction;
@@ -218,4 +221,158 @@ it('completes the batch when a later step fails after the provider already accep
         ->sent_count->toBe(1)
         ->failed_count->toBe(0)
         ->status->toBe(EmailBatchStatus::Completed);
+});
+
+it('retries linking after a post-send crash without double-counting the batch or CRM metrics', function (): void {
+    $emailsField = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'people')
+        ->where('code', PeopleField::EMAILS->value)
+        ->first();
+
+    if (! $emailsField) {
+        $this->markTestSkipped('No emails custom field seeded for this team.');
+    }
+
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Retry Link Person',
+        'creator_id' => $this->user->id,
+        'email_count' => 0,
+        'outbound_email_count' => 0,
+    ]);
+    $person->saveCustomFieldValue($emailsField, ['recipient@partner.com'], $this->team);
+
+    $batch = EmailBatch::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'total_recipients' => 1,
+        'sent_count' => 0,
+        'failed_count' => 0,
+        'status' => EmailBatchStatus::Sending,
+    ]);
+
+    $email = Email::factory()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'batch_id' => $batch->getKey(),
+        'status' => EmailStatus::SENDING,
+        'sent_at' => null,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'rfc_message_id' => '<send-job-link@example.com>',
+        'provider_message_id' => null,
+        'thread_id' => null,
+        'attempts' => 0,
+    ]);
+
+    $email->body()->create(['body_text' => 'hi', 'body_html' => '<p>hi</p>']);
+
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'recipient@partner.com',
+    ]);
+
+    $mail = new class implements MailServiceInterface
+    {
+        public int $sendCount = 0;
+
+        public function fetchDelta(string $cursor): MailDeltaResult
+        {
+            throw new LogicException('unused');
+        }
+
+        public function fetchMessage(string $providerMessageId): FetchedEmailData
+        {
+            throw new LogicException('unused');
+        }
+
+        public function initialBackfill(?int $daysBack = null, ?string $pageToken = null): MailBackfillPage
+        {
+            throw new LogicException('unused');
+        }
+
+        public function sendMessage(array $data): array
+        {
+            $this->sendCount++;
+
+            return [
+                'provider_message_id' => 'sent-link-123',
+                'thread_id' => 'thread-link-123',
+                'rfc_message_id' => $data['rfc_message_id'] ?? '<derived-link@example.com>',
+            ];
+        }
+
+        public function findSentMessage(string $rfcMessageId): ?array
+        {
+            return null;
+        }
+
+        public function downloadAttachment(string $providerMessageId, string $providerAttachmentId): string
+        {
+            return '';
+        }
+    };
+
+    app()->bind(MailServiceFactoryInterface::class, fn (): MailServiceFactoryInterface => new class($mail) implements MailServiceFactoryInterface
+    {
+        public function __construct(private readonly MailServiceInterface $service) {}
+
+        public function make(ConnectedAccount $account): MailServiceInterface
+        {
+            return $this->service;
+        }
+    });
+
+    $throwOnLink = false;
+    Email::updated(function (Email $updated) use (&$throwOnLink): void {
+        if ($updated->status === EmailStatus::SENT) {
+            $throwOnLink = true;
+        }
+    });
+    EmailParticipant::retrieved(function () use (&$throwOnLink): void {
+        if (! $throwOnLink) {
+            return;
+        }
+
+        $throwOnLink = false;
+
+        throw new RuntimeException('link failed');
+    });
+
+    $job = new SendEmailJob($email->getKey());
+    $sendingService = app(EmailSendingService::class);
+    $linkEmailAction = app(LinkEmailAction::class);
+
+    expect(fn () => $job->handle($sendingService, $linkEmailAction))
+        ->toThrow(RuntimeException::class);
+
+    expect($email->fresh()->status)->toBe(EmailStatus::SENT)
+        ->and($email->people()->whereKey($person->getKey())->exists())->toBeFalse()
+        ->and($mail->sendCount)->toBe(1);
+
+    $job->handle($sendingService, $linkEmailAction);
+
+    expect($email->fresh()->status)->toBe(EmailStatus::SENT)
+        ->and($email->people()->whereKey($person->getKey())->exists())->toBeTrue()
+        ->and($person->fresh()->email_count)->toBe(1)
+        ->and($person->fresh()->outbound_email_count)->toBe(1)
+        ->and($mail->sendCount)->toBe(1)
+        ->and($batch->fresh())
+        ->sent_count->toBe(1)
+        ->failed_count->toBe(0)
+        ->status->toBe(EmailBatchStatus::Completed);
+
+    $job->handle($sendingService, $linkEmailAction);
+    $job->failed(new RuntimeException('link failed'));
+
+    expect($person->fresh()->email_count)->toBe(1)
+        ->and($batch->fresh())
+        ->sent_count->toBe(1)
+        ->failed_count->toBe(0)
+        ->status->toBe(EmailBatchStatus::Completed)
+        ->and($mail->sendCount)->toBe(1);
 });


### PR DESCRIPTION
## Summary
- After Gmail/Microsoft accepts a message, a `SendEmailJob` retry of an already-`SENT` row still runs `LinkEmailAction` and recounts the batch, without sending twice or double-counting metrics.
- Incremental email/calendar sync and the outbox dispatcher are real artisan commands scheduled with `withoutOverlapping()` + `onOneServer()`.
- Mass send is hidden unless the email integration feature flag is on (and an account is connected). Timeline coverage asserts queued outbound mail stays off the timeline until `sent_at` is set.

## Test plan
- [ ] Crash after send (linking throws): retry links the person, `sent_count` is 1, provider is not called again.
- [ ] Person timeline: inbound → received, sent outbound → sent, queued outbound with null `sent_at` → absent.
- [ ] `schedule:list` with the flag on: three email tasks, each `onOneServer`; `email:incremental-sync` / `calendar:incremental-sync` only dispatch the matching accounts.
- [ ] People list: mass send hidden with the flag off, visible with the flag on and a connected account.