### PR TITLE
feat(email): monitored reply-to, security.txt, and privacy contact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,9 @@ MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
+# Monitored Reply-To stamped on all outgoing mail. Set this when the from
+# address has no inbox (e.g. a send-only subdomain), or replies will bounce.
+# MAIL_REPLY_TO_ADDRESS="support@example.com"
 
 CONTACT_EMAIL="hello@relaticle.com"
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Email [security@relaticle.com](mailto:security@relaticle.com). Do not open a public issue for security reports.
+
+Include what you found, where, and steps to reproduce. We aim to acknowledge reports within 48 hours and will keep you informed while we work on a fix.
+
+## Supported Versions
+
+Security fixes land on the latest release and the hosted service at [relaticle.com](https://relaticle.com). Older self-hosted versions should upgrade to receive fixes.
+
+## Scope
+
+The `relaticle/relaticle` codebase and the relaticle.com hosted service. Findings that require a compromised admin account or physical access are out of scope.

--- a/app/Support/Markdown/UnwrapEmailAutolinksPostprocessor.php
+++ b/app/Support/Markdown/UnwrapEmailAutolinksPostprocessor.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Markdown;
+
+use Spatie\MarkdownResponse\Postprocessors\Postprocessor;
+
+/**
+ * league/html-to-markdown renders a mailto link whose text equals its address
+ * as the markdown autolink form "<user@example.com>". That looks like an HTML
+ * tag to RemoveHtmlTagsPostprocessor's strip_tags(), which deletes it, so every
+ * email address vanishes from the markdown variant of a page. Unwrapping the
+ * autolink to a bare address before the tag stripper runs keeps it on the wire.
+ */
+final readonly class UnwrapEmailAutolinksPostprocessor implements Postprocessor
+{
+    public function __invoke(string $markdown): string
+    {
+        return preg_replace('/<([^\s<>@]+@[^\s<>@]+\.[^\s<>@]+)>/', '$1', $markdown) ?? $markdown;
+    }
+}

--- a/config/mail.php
+++ b/config/mail.php
@@ -120,4 +120,21 @@ return [
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Global "Reply-To" Address
+    |--------------------------------------------------------------------------
+    |
+    | The transactional "from" address lives on a sending subdomain with no
+    | inbox, so replies to it bounce. Stamping a monitored Reply-To on all
+    | outgoing mail gives recipients a working reply path. Left unset, no
+    | Reply-To header is added.
+    |
+    */
+
+    'reply_to' => [
+        'address' => env('MAIL_REPLY_TO_ADDRESS'),
+        'name' => env('MAIL_REPLY_TO_NAME'),
+    ],
+
 ];

--- a/config/markdown-response.php
+++ b/config/markdown-response.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Support\DetectsPublicMarkdownRequest;
 use App\Support\Markdown\DecodeHtmlEntitiesPostprocessor;
+use App\Support\Markdown\UnwrapEmailAutolinksPostprocessor;
 use Spatie\MarkdownResponse\Actions\GeneratesCacheKey;
 use Spatie\MarkdownResponse\Postprocessors\CollapseBlankLinesPostprocessor;
 use Spatie\MarkdownResponse\Postprocessors\RemoveHtmlTagsPostprocessor;
@@ -80,6 +81,7 @@ return [
      * Each class must implement the Postprocessor interface.
      */
     'postprocessors' => [
+        UnwrapEmailAutolinksPostprocessor::class,
         RemoveHtmlTagsPostprocessor::class,
         DecodeHtmlEntitiesPostprocessor::class,
         CollapseBlankLinesPostprocessor::class,

--- a/resources/markdown/policy.md
+++ b/resources/markdown/policy.md
@@ -79,7 +79,7 @@ You have the right to:
 - **Delete** your account and associated data
 - **Object** to data processing for specific purposes
 
-To exercise these rights, contact us at [Contact Us](/contact). We will respond within 15 business days.
+To exercise these rights, email privacy@relaticle.com or use [Contact Us](/contact). We will respond within 15 business days.
 
 ## 7. Cookies
 
@@ -141,4 +141,4 @@ We may update this Privacy Policy from time to time. We will notify registered u
 
 ## 11. Contact
 
-Questions about this Privacy Policy? Reach us at [Contact Us](/contact).
+Questions about this Privacy Policy? Email privacy@relaticle.com or reach us at [Contact Us](/contact).

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\PrivacyPolicyController;
 use App\Http\Controllers\TermsOfServiceController;
 use App\Http\Middleware\AddVaryAcceptHeader;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Response;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Support\Facades\Route;
 use Laravel\Pennant\Feature;
@@ -50,6 +51,20 @@ Route::middleware('guest')->group(function () {
 
     Route::get('/forgot-password', fn () => redirect()->to(url()->getAppUrl('forgot-password')))->name('password.request');
 });
+
+Route::get('/.well-known/security.txt', function (): Response {
+    $lines = [
+        'Contact: mailto:security@relaticle.com',
+        'Expires: '.now()->addMonths(6)->toIso8601ZuluString(),
+        'Preferred-Languages: en',
+        'Canonical: '.url('/.well-known/security.txt'),
+    ];
+
+    return response(implode("\n", $lines)."\n", Response::HTTP_OK, [
+        'Content-Type' => 'text/plain; charset=UTF-8',
+        'Cache-Control' => 'public, max-age=86400',
+    ]);
+})->name('securityTxt');
 
 Route::middleware([ProvideMarkdownResponse::class, AddVaryAcceptHeader::class])->group(function (): void {
     Route::get('/', HomeController::class);

--- a/tests/Feature/Email/GlobalReplyToTest.php
+++ b/tests/Feature/Email/GlobalReplyToTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mail\NewContactSubmissionMail;
+use App\Mail\TaskAssignedMail;
+use Illuminate\Mail\Transport\ArrayTransport;
+use Illuminate\Support\Facades\Mail;
+use Symfony\Component\Mime\Email;
+
+function sentReplyToAddresses(): array
+{
+    $transport = Mail::getSymfonyTransport();
+    assert($transport instanceof ArrayTransport);
+
+    $original = $transport->messages()->sole()->getOriginalMessage();
+    assert($original instanceof Email);
+
+    return collect($original->getReplyTo())->map->getAddress()->all();
+}
+
+it('stamps the configured global reply-to on outbound mail', function (): void {
+    config()->set('mail.reply_to', ['address' => 'support@relaticle.com', 'name' => 'Relaticle']);
+
+    Mail::to('assignee@example.com')->sendNow(new TaskAssignedMail('Follow up', 'https://relaticle.com'));
+
+    expect(sentReplyToAddresses())->toBe(['support@relaticle.com']);
+});
+
+it('keeps the submitter reply-to alongside the global one on contact mail', function (): void {
+    config()->set('mail.reply_to', ['address' => 'support@relaticle.com', 'name' => 'Relaticle']);
+
+    Mail::to('hello@relaticle.com')->sendNow(new NewContactSubmissionMail([
+        'name' => 'Jane Doe',
+        'email' => 'jane@gmail.com',
+        'company' => null,
+        'message' => 'I would like to learn more.',
+    ]));
+
+    expect(sentReplyToAddresses())->toContain('support@relaticle.com', 'jane@gmail.com');
+});
+
+it('sends without a reply-to when none is configured', function (): void {
+    Mail::to('assignee@example.com')->sendNow(new TaskAssignedMail('Follow up', 'https://relaticle.com'));
+
+    expect(sentReplyToAddresses())->toBe([]);
+});

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -97,6 +97,7 @@ describe('Legal pages', function () {
 
         $response->assertSee('Privacy Policy');
         $response->assertSee('Relaticle');
+        $response->assertSee('privacy@relaticle.com');
         $response->assertSee('August 26, 2026');
         $response->assertSee('Data from a self-hosted installation stays on your servers unless you configure an external integration.');
         $response->assertSee('That integration may send authorized data to its provider.');
@@ -922,5 +923,19 @@ describe('Hero AI tab — entry phase', function () {
         expect($body)->toContain('transitionToConversation');
         expect($body)->toContain('entryHoldMs');
         expect($body)->toContain('entryTransitionMs');
+    });
+});
+
+describe('security.txt', function () {
+    it('serves the security contact with a future expiry', function () {
+        $response = $this->get('/.well-known/security.txt');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+        $response->assertSee('Contact: mailto:security@relaticle.com', false);
+        $response->assertSee('Canonical:', false);
+
+        preg_match('/Expires: (.+)/', (string) $response->getContent(), $matches);
+        expect(Carbon\Carbon::parse($matches[1])->isFuture())->toBeTrue();
     });
 });


### PR DESCRIPTION
## Why

Transactional mail sends from `noreply@notifications.relaticle.com`, a subdomain with no MX record. Anyone replying to a task assignment, digest, or invite gets a bounce. With the new monitored Gmail aliases live on the apex, outbound mail can now carry a working reply path, and the security/privacy contacts can be published.

## What

- **Global Reply-To**: `mail.reply_to` config block, applied by Laravel's MailManager to every outgoing message. Inert until `MAIL_REPLY_TO_ADDRESS` is set, so nothing changes for self-hosters or tests. Contact-form mail keeps the submitter as an additional reply-to.
- **security.txt**: dynamic `/.well-known/security.txt` (RFC 9116) with a rolling 6-month expiry, plus `.github/SECURITY.md` so the repo stops showing the missing-security-policy prompt.
- **Privacy contact**: `privacy@relaticle.com` named in the privacy policy DSAR and contact sections, alongside the existing form.
- **Markdown pipeline fix**: any email address on a markdown-response page was silently deleted in the `text/markdown` variant. html-to-markdown renders mailto links whose text equals the address as `<user@host>` autolinks, and `RemoveHtmlTagsPostprocessor`'s `strip_tags()` treats that as an HTML tag. A new `UnwrapEmailAutolinksPostprocessor` unwraps them to bare addresses first.

## Deploy note

Set `MAIL_REPLY_TO_ADDRESS=support@relaticle.com` in the production environment; the reply-to fix does nothing until then.

## Verification

- New `GlobalReplyToTest` covers reply-to stamping through the array transport (set, unset, and contact-mail interplay).
- `PublicPagesTest` covers security.txt and asserts the privacy address in both HTML and markdown variants (the markdown one fails without the postprocessor fix).
- Verified on the running site: security.txt serves, privacy page shows the address in both content types.
- pint, rector, phpstan (0 errors), type coverage 100%, `tests/Feature/Public` + `tests/Feature/Email` green (220 passed).