### PR TITLE
Unify billing status across the sysadmin panel and add a billing filter

### DIFF
--- a/app/Actions/Billing/NotifyWorkspaceOfPaymentFailure.php
+++ b/app/Actions/Billing/NotifyWorkspaceOfPaymentFailure.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Billing;
+
+use App\Filament\Pages\Billing;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+
+/**
+ * Tell the workspace owner that a renewal charge failed.
+ *
+ * The owner alone, because the billing page's portal button is owner-only:
+ * anyone else would get an alarm about something they cannot act on.
+ */
+final readonly class NotifyWorkspaceOfPaymentFailure
+{
+    public function execute(Team $team): void
+    {
+        $owner = $team->owner()->first();
+
+        if (! $owner instanceof User) {
+            return;
+        }
+
+        Notification::make()
+            ->title(__('billing.payment_failed.notification_title', ['workspace' => $team->name]))
+            ->body(__('billing.payment_failed.notification_body'))
+            ->icon(Heroicon::OutlinedExclamationTriangle)
+            ->iconColor('danger')
+            ->actions([
+                Action::make('billing')
+                    ->button()
+                    ->label(__('billing.payment_failed.notification_action'))
+                    // A webhook binds no Filament tenant, so the panel and tenant
+                    // have to be named or getUrl() resolves against neither.
+                    ->url(Billing::getUrl(panel: 'app', tenant: $team))
+                    ->markAsRead(),
+            ])
+            ->sendToDatabase($owner);
+    }
+}

--- a/app/Console/Commands/LocalSeedCommand.php
+++ b/app/Console/Commands/LocalSeedCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Database\Seeders\LocalSeeder;
+use Database\Seeders\Personas\PersonaCatalog;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Database\Seeder;
+
+/**
+ * The entry point for local development data.
+ *
+ * It exists because `db:seed` refuses unknown options, and this seeder needs
+ * one: which personas to build. Seeding all of them bills two workspaces
+ * against the Stripe sandbox, which takes about a minute.
+ */
+#[Description('Seed local development logins, one per state worth reproducing by hand')]
+#[Signature('local:seed
+        {--only= : Comma-separated persona slugs to seed, e.g. owner,paused}')]
+final class LocalSeedCommand extends Command
+{
+    public function handle(): int
+    {
+        if (! app()->isLocal()) {
+            $this->components->error('local:seed only runs in the local environment.');
+
+            return self::FAILURE;
+        }
+
+        $unknown = array_diff($this->slugs(), PersonaCatalog::slugs());
+
+        if ($unknown !== []) {
+            $this->components->error('Unknown persona(s): '.implode(', ', $unknown));
+            $this->components->info('Available: '.implode(', ', PersonaCatalog::slugs()));
+
+            return self::FAILURE;
+        }
+
+        $this->callSeeder();
+
+        return self::SUCCESS;
+    }
+
+    private function callSeeder(): void
+    {
+        $seeder = $this->laravel->make(LocalSeeder::class);
+
+        /** @var Seeder $seeder */
+        $seeder->setContainer($this->laravel)->setCommand($this)->__invoke();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function slugs(): array
+    {
+        return array_values(array_filter(array_map(
+            trim(...),
+            explode(',', (string) $this->option('only')),
+        )));
+    }
+}

--- a/app/Enums/BillingStatus.php
+++ b/app/Enums/BillingStatus.php
@@ -8,6 +8,8 @@ use App\Models\Team;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
+use Illuminate\Database\Eloquent\Builder;
+use Laravel\Cashier\Subscription;
 
 /**
  * Why a workspace has the plan it has.
@@ -73,6 +75,32 @@ enum BillingStatus: string implements HasColor, HasDescription, HasLabel
         return self::Free;
     }
 
+    /**
+     * The query counterpart of fromTeam(), so a table can be filtered by the
+     * badge it renders.
+     *
+     * fromTeam() returns on the first predicate that holds, which a filter has
+     * to reproduce: matching Subscribed on its own would also return every
+     * past-due workspace. Case declaration order is the precedence order, so
+     * every status that outranks this one is excluded before its own predicate
+     * applies.
+     *
+     * @param  Builder<Team>  $query
+     * @return Builder<Team>
+     */
+    public function applyToQuery(Builder $query): Builder
+    {
+        foreach (self::cases() as $case) {
+            if ($case === $this) {
+                break;
+            }
+
+            $query->whereNot(fn (Builder $outranking): Builder => $case->constrain($outranking));
+        }
+
+        return $this->constrain($query);
+    }
+
     public function getLabel(): string
     {
         return match ($this) {
@@ -114,5 +142,51 @@ enum BillingStatus: string implements HasColor, HasDescription, HasLabel
             self::Grandfathered, self::Free => 'gray',
             self::Granted => 'warning',
         };
+    }
+
+    /**
+     * This status's own predicate, blind to the statuses that outrank it.
+     * Only applyToQuery() may call it.
+     *
+     * @param  Builder<Team>  $query
+     * @return Builder<Team>
+     */
+    private function constrain(Builder $query): Builder
+    {
+        return match ($this) {
+            self::PastDue => $query->whereHas('latestDefaultSubscription', self::pastDue(...)),
+            self::Subscribed => $query->whereHas('latestDefaultSubscription', self::valid(...)),
+            self::Enterprise => $query->where('plan', Plan::Enterprise),
+            self::Trialing => $query->onGenericTrial(),
+            self::Grandfathered => $query->whereNotNull('hosted_free_grandfathered_at'),
+            self::Granted => $query->whereNot('plan', Plan::Free),
+            self::Free => $query->where('plan', Plan::Free),
+        };
+    }
+
+    /**
+     * @param  Builder<Subscription>  $query
+     * @return Builder<Subscription>
+     */
+    private static function pastDue(Builder $query): Builder
+    {
+        return $query->pastDue();
+    }
+
+    /**
+     * Cashier's `Subscription::valid()` as a query. Cashier ships no
+     * `scopeValid`, so the three scopes behind it are OR'd here rather than a
+     * stripe_status list being hardcoded and drifting from the predicate the
+     * badge uses.
+     *
+     * @param  Builder<Subscription>  $query
+     * @return Builder<Subscription>
+     */
+    private static function valid(Builder $query): Builder
+    {
+        return $query->where(fn (Builder $subscription): Builder => $subscription
+            ->where(fn (Builder $active): Builder => $active->active())
+            ->orWhere(fn (Builder $onTrial): Builder => $onTrial->onTrial())
+            ->orWhere(fn (Builder $onGracePeriod): Builder => $onGracePeriod->onGracePeriod()));
     }
 }

--- a/app/Enums/Plan.php
+++ b/app/Enums/Plan.php
@@ -24,6 +24,50 @@ enum Plan: string implements HasColor, HasLabel
      */
     public static function fromStripePrice(?string $priceId): ?self
     {
+        $key = self::stripePriceKey($priceId);
+
+        return $key === null ? null : self::tryFrom(explode('_', $key)[0]);
+    }
+
+    /**
+     * The human label for a Stripe price id, `Pro · monthly`. Falls back to the
+     * id itself when it is not in the price map, so an unmapped price is still
+     * identifiable on screen.
+     */
+    public static function stripePriceLabel(?string $priceId): string
+    {
+        $plan = self::fromStripePrice($priceId);
+
+        if (! $plan instanceof self) {
+            return $priceId ?? '—';
+        }
+
+        $interval = self::intervalFromStripePrice($priceId);
+
+        return $interval === null ? $plan->getLabel() : "{$plan->getLabel()} · {$interval}";
+    }
+
+    /**
+     * The billing interval a Stripe price id sells the plan at (`monthly`,
+     * `yearly`), read from the same map. Null when the id is not in it.
+     */
+    private static function intervalFromStripePrice(?string $priceId): ?string
+    {
+        $key = self::stripePriceKey($priceId);
+
+        return $key === null ? null : explode('_', $key, 2)[1] ?? null;
+    }
+
+    /**
+     * The `<plan>_<interval>` key a Stripe price id sits under in
+     * `config('services.stripe.prices')`.
+     *
+     * The single place the map is walked: a display helper that re-listed
+     * `pro_monthly` and `pro_yearly` by hand went stale the moment a price was
+     * added, and showed the raw `price_...` id instead.
+     */
+    private static function stripePriceKey(?string $priceId): ?string
+    {
         if ($priceId === null) {
             return null;
         }
@@ -33,7 +77,7 @@ enum Plan: string implements HasColor, HasLabel
 
         foreach ($prices as $key => $mappedPriceId) {
             if ($mappedPriceId !== null && $mappedPriceId === $priceId) {
-                return self::tryFrom(explode('_', $key)[0]);
+                return $key;
             }
         }
 

--- a/app/Enums/StripeSubscriptionStatus.php
+++ b/app/Enums/StripeSubscriptionStatus.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * The `subscriptions.stripe_status` values Stripe writes, for display.
+ *
+ * It sits beside `BillingStatus` so the two speak one badge vocabulary and stay
+ * under static analysis: colours here must keep agreeing with
+ * `BillingStatus::getColor()`, and `packages/SystemAdmin` is excluded from
+ * PHPStan, so an exhaustive `match` living there would be unchecked.
+ *
+ * This is a Stripe status, not a Relaticle billing status. It says what the
+ * subscription row holds; `BillingStatus` says what the workspace is entitled
+ * to and why. A workspace can read `Pro` while its subscription reads
+ * `past_due`, because this app calls `Cashier::keepPastDueSubscriptionsActive()`.
+ */
+enum StripeSubscriptionStatus: string implements HasColor, HasDescription, HasLabel
+{
+    case Active = 'active';
+
+    case Trialing = 'trialing';
+
+    case PastDue = 'past_due';
+
+    case Unpaid = 'unpaid';
+
+    case Canceled = 'canceled';
+
+    case Incomplete = 'incomplete';
+
+    case IncompleteExpired = 'incomplete_expired';
+
+    case Paused = 'paused';
+
+    /**
+     * The badge state for a raw `stripe_status`. A value Stripe adds later
+     * falls through as its own string rather than throwing, so the panel keeps
+     * rendering what the database holds.
+     */
+    public static function forDisplay(string $status): self|string
+    {
+        return self::tryFrom($status) ?? $status;
+    }
+
+    /**
+     * The tooltip for whatever forDisplay() returned. An unrecognised status
+     * has nothing to explain.
+     */
+    public static function tooltipFor(self|string $state): ?string
+    {
+        return $state instanceof self ? $state->getDescription() : null;
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Active => 'Active',
+            self::Trialing => 'Trialing',
+            self::PastDue => 'Past due',
+            self::Unpaid => 'Unpaid',
+            self::Canceled => 'Canceled',
+            self::Incomplete => 'Incomplete',
+            self::IncompleteExpired => 'Incomplete expired',
+            self::Paused => 'Paused',
+        };
+    }
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Active => 'Paid and current. The latest invoice was charged successfully.',
+            self::Trialing => 'Inside a Stripe trial. Nothing has been charged yet.',
+            self::PastDue => 'The latest invoice failed. Stripe is retrying, and access stays open until it gives up.',
+            self::Unpaid => 'Stripe exhausted its retries and stopped trying. Access is gone.',
+            self::Canceled => 'Ended. No further invoices will be raised.',
+            self::Incomplete => 'The first payment never completed, so the subscription never started.',
+            self::IncompleteExpired => 'The first payment was abandoned and Stripe expired the attempt.',
+            self::Paused => 'Paused at the end of a trial that collected no payment method.',
+        };
+    }
+
+    /**
+     * Kept in step with `BillingStatus::getColor()`: past due is danger on both
+     * sides, an unstarted or ended subscription is grey rather than alarming.
+     */
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Active => 'success',
+            self::Trialing => 'info',
+            self::PastDue, self::Unpaid => 'danger',
+            self::Paused => 'warning',
+            self::Canceled, self::Incomplete, self::IncompleteExpired => 'gray',
+        };
+    }
+}

--- a/app/Filament/Pages/Billing.php
+++ b/app/Filament/Pages/Billing.php
@@ -22,6 +22,7 @@ use Laravel\Pennant\Feature;
 use Livewire\Attributes\Url;
 use Override;
 use Relaticle\Chat\Models\AiCreditBalance;
+use Relaticle\Chat\Services\CreditService;
 use Throwable;
 
 final class Billing extends Page
@@ -149,6 +150,9 @@ final class Billing extends Page
 
         return [
             'team' => $team,
+            // Not $team->plan->credits(): a past-due workspace refills at the Free
+            // allowance, so the plan's figure would name credits it never gets.
+            'allowance' => resolve(CreditService::class)->allowanceFor($team),
             'isOwner' => $this->user()->ownsTeam($team),
             'subscription' => $subscription,
             'pastDue' => $subscription?->pastDue() ?? false,

--- a/app/Http/Controllers/Billing/StripeWebhookController.php
+++ b/app/Http/Controllers/Billing/StripeWebhookController.php
@@ -22,6 +22,16 @@ final class StripeWebhookController extends CashierWebhookController
      */
     private const array NON_GRANTING_STATUSES = ['incomplete', 'incomplete_expired'];
 
+    /**
+     * Why an invoice was raised, for the failures worth alarming a workspace
+     * about: a renewal, and a plan change billed immediately. Both belong to a
+     * subscription the workspace already has, which is what the notification's
+     * wording assumes.
+     *
+     * @var list<string>
+     */
+    private const array ALARMING_BILLING_REASONS = ['subscription_cycle', 'subscription_update'];
+
     public function __construct(
         private readonly RestoreWorkspaceTrial $restoreTrial,
         private readonly GrantPurchasedCredits $grantCredits,
@@ -68,10 +78,16 @@ final class StripeWebhookController extends CashierWebhookController
      * key would match nothing and silently notify no one. A credit-pack invoice
      * has no such parent and must not raise a subscription alarm.
      *
-     * Stripe repeats this event for every retry of the same invoice — eight
-     * over two weeks under the default Smart Retries policy — so only the first
+     * Stripe repeats this event for every retry of the same invoice, eight over
+     * two weeks under the default Smart Retries policy, so only the first
      * attempt is news. A missing count is read as the first, because failing
      * toward one extra alarm beats failing toward silence.
+     *
+     * The notification tells the owner to update their card "to keep Pro", so
+     * it only fits a subscription that is already running. A failed first
+     * charge is `subscription_create`, where nothing was ever kept and Stripe
+     * expires the attempt instead of retrying it; the checkout flow reports
+     * that one synchronously.
      *
      * @param  array<string, mixed>  $payload
      */
@@ -82,6 +98,10 @@ final class StripeWebhookController extends CashierWebhookController
         $customer = $object['customer'] ?? null;
 
         if (($object['parent']['type'] ?? null) !== 'subscription_details' || ! is_string($customer)) {
+            return $this->successMethod();
+        }
+
+        if (! in_array($object['billing_reason'] ?? null, self::ALARMING_BILLING_REASONS, true)) {
             return $this->successMethod();
         }
 

--- a/app/Http/Controllers/Billing/StripeWebhookController.php
+++ b/app/Http/Controllers/Billing/StripeWebhookController.php
@@ -68,6 +68,11 @@ final class StripeWebhookController extends CashierWebhookController
      * key would match nothing and silently notify no one. A credit-pack invoice
      * has no such parent and must not raise a subscription alarm.
      *
+     * Stripe repeats this event for every retry of the same invoice — eight
+     * over two weeks under the default Smart Retries policy — so only the first
+     * attempt is news. A missing count is read as the first, because failing
+     * toward one extra alarm beats failing toward silence.
+     *
      * @param  array<string, mixed>  $payload
      */
     protected function handleInvoicePaymentFailed(array $payload): Response
@@ -77,6 +82,10 @@ final class StripeWebhookController extends CashierWebhookController
         $customer = $object['customer'] ?? null;
 
         if (($object['parent']['type'] ?? null) !== 'subscription_details' || ! is_string($customer)) {
+            return $this->successMethod();
+        }
+
+        if (($object['attempt_count'] ?? 1) !== 1) {
             return $this->successMethod();
         }
 

--- a/app/Http/Controllers/Billing/StripeWebhookController.php
+++ b/app/Http/Controllers/Billing/StripeWebhookController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Billing;
 
 use App\Actions\Billing\GrantPurchasedCredits;
+use App\Actions\Billing\NotifyWorkspaceOfPaymentFailure;
 use App\Actions\Billing\RestoreWorkspaceTrial;
 use App\Models\Team;
 use Illuminate\Support\Facades\Log;
@@ -21,8 +22,11 @@ final class StripeWebhookController extends CashierWebhookController
      */
     private const array NON_GRANTING_STATUSES = ['incomplete', 'incomplete_expired'];
 
-    public function __construct(private readonly RestoreWorkspaceTrial $restoreTrial, private readonly GrantPurchasedCredits $grantCredits)
-    {
+    public function __construct(
+        private readonly RestoreWorkspaceTrial $restoreTrial,
+        private readonly GrantPurchasedCredits $grantCredits,
+        private readonly NotifyWorkspaceOfPaymentFailure $notifyPaymentFailure,
+    ) {
         parent::__construct();
     }
 
@@ -53,6 +57,36 @@ final class StripeWebhookController extends CashierWebhookController
         }
 
         return $response;
+    }
+
+    /**
+     * Cashier ships no handler for this event, so WebhookHandled never fires for
+     * it and a listener on that event could never see it.
+     *
+     * The subscription lives at parent.subscription_details on the current API
+     * version, which dropped the top-level `subscription` key. Reading the old
+     * key would match nothing and silently notify no one. A credit-pack invoice
+     * has no such parent and must not raise a subscription alarm.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    protected function handleInvoicePaymentFailed(array $payload): Response
+    {
+        /** @var array<string, mixed> $object */
+        $object = $payload['data']['object'] ?? [];
+        $customer = $object['customer'] ?? null;
+
+        if (($object['parent']['type'] ?? null) !== 'subscription_details' || ! is_string($customer)) {
+            return $this->successMethod();
+        }
+
+        $team = Team::query()->where('stripe_id', $customer)->first();
+
+        if ($team instanceof Team) {
+            $this->notifyPaymentFailure->execute($team);
+        }
+
+        return $this->successMethod();
     }
 
     /**

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Laravel\Cashier\Billable;
+use Laravel\Cashier\Subscription;
 use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamDeleted;
 use Laravel\Jetstream\Events\TeamUpdated;
@@ -263,6 +264,28 @@ final class Team extends JetstreamTeam implements HasAvatar, Onboardable
     public function billingStatus(): BillingStatus
     {
         return BillingStatus::fromTeam($this);
+    }
+
+    /**
+     * The single row `Cashier::subscription()` resolves: the newest `default`
+     * subscription. It exists so a query can ask what `billingStatus()` asks:
+     * `whereHas('subscriptions', ...)` would match a superseded row and label a
+     * workspace by a subscription it no longer bills on.
+     *
+     * The type filter lives in the aggregate closure because the `ofMany`
+     * sub-query is built from a fresh query and does not inherit outer
+     * constraints. Filtering only on the outside would take MAX(created_at)
+     * across every type and then discard it.
+     *
+     * @return HasOne<Subscription, $this>
+     */
+    public function latestDefaultSubscription(): HasOne
+    {
+        return $this->hasOne(Subscription::class, $this->getForeignKey())
+            ->ofMany(
+                ['created_at' => 'MAX', 'id' => 'MAX'],
+                fn (Builder $query): Builder => $query->where('type', 'default'),
+            );
     }
 
     /**

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -313,7 +313,7 @@ final class AppPanelProvider extends PanelProvider
                 ResizedColumnPlugin::make(),
             ])
             ->renderHook(
-                PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE,
+                PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
                 fn (): View|Factory => view('filament.auth.developer_login'),
             )
             ->renderHook(

--- a/app/Services/Billing/SidebarBillingState.php
+++ b/app/Services/Billing/SidebarBillingState.php
@@ -14,7 +14,7 @@ use Laravel\Pennant\Feature;
  * The sidebar's one-line billing prompt. Derives from the same state the
  * Billing page shows, so the two cannot tell a workspace different stories.
  *
- * Returns null for every workspace with nothing to ask for: subscribers,
+ * Returns null for every workspace with nothing to ask for: paying subscribers,
  * Enterprise, grandfathered free, and any install with billing switched off.
  */
 final readonly class SidebarBillingState
@@ -22,12 +22,28 @@ final readonly class SidebarBillingState
     public function __construct(private HostedWorkspaceAccess $access) {}
 
     /**
-     * @return array{label: string, action: string}|null
+     * `urgent` separates a failure from an offer: past due is the only state
+     * here reporting something already broken, and the row renders it in danger
+     * colours rather than the same neutral pill as an upgrade prompt.
+     *
+     * @return array{label: string, action: string, urgent: bool}|null
      */
     public function for(Team $team): ?array
     {
         if (! Feature::active(Billing::class)) {
             return null;
+        }
+
+        // Ranked above the valid() check for the same reason BillingStatus ranks
+        // PastDue above Subscribed: keepPastDueSubscriptionsActive() leaves
+        // valid() true throughout dunning, so asking it first returns null and
+        // leaves the one state that ends in losing the workspace unmentioned.
+        if ($team->subscription()?->pastDue() === true) {
+            return [
+                'label' => __('billing.sidebar.past_due'),
+                'action' => __('billing.sidebar.fix'),
+                'urgent' => true,
+            ];
         }
 
         if ($team->subscription()?->valid() === true || $team->plan === Plan::Enterprise) {
@@ -40,6 +56,7 @@ final readonly class SidebarBillingState
                     'days' => $this->daysLeft($team),
                 ]),
                 'action' => __('billing.sidebar.keep_pro'),
+                'urgent' => false,
             ];
         }
 
@@ -53,6 +70,7 @@ final readonly class SidebarBillingState
         return [
             'label' => __('billing.sidebar.paused'),
             'action' => __('billing.sidebar.subscribe'),
+            'urgent' => false,
         ];
     }
 

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -58,6 +58,9 @@ return [
             // settle later via this event — without it StripeWebhookController's
             // async handler never fires and the pack is never fulfilled.
             'checkout.session.async_payment_succeeded',
+            // Cashier's defaults stop at payment_succeeded; without this the
+            // owner is never told a renewal failed.
+            'invoice.payment_failed',
         ],
     ],
 

--- a/database/seeders/LocalSeeder.php
+++ b/database/seeders/LocalSeeder.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
+use App\Enums\BillingStatus;
 use App\Enums\CreationSource;
+use App\Enums\Plan;
 use App\Models\ActivityLog\Activity;
 use App\Models\ActivityLog\Scopes\TeamScope;
 use App\Models\Company;
@@ -13,6 +15,7 @@ use App\Models\Note;
 use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\Task;
+use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\Factories\Sequence;
@@ -20,6 +23,7 @@ use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use Laravel\Cashier\Subscription;
 use Relaticle\Chat\Enums\AiCreditType;
 use Relaticle\Chat\Models\AiCreditBalance;
 use Relaticle\Chat\Models\AiCreditTransaction;
@@ -65,6 +69,7 @@ final class LocalSeeder extends Seeder
                 ]);
             });
 
+        $this->seedBillingStatusFixture();
         $this->topUpAiCreditsForLocalTeams();
         $this->seedViewerTimezoneBoundaryFixture();
         //
@@ -102,6 +107,127 @@ final class LocalSeeder extends Seeder
         //                $opportunity->saveCustomFieldValue($customFields->get('stage'), $customFields->get('stage')->options->random()->id);
         //            })
         //            ->create();
+    }
+
+    /**
+     * One workspace per BillingStatus plus a subscription per Stripe status, so
+     * every badge, tooltip and filter option in the sysadmin billing surfaces
+     * has a row behind it without hunting for production-shaped data.
+     *
+     * The subscription rows are local only. Cashier reads them without calling
+     * Stripe, and `past_due` and `unpaid` cannot be reached through the Stripe
+     * test API at all without a test clock, so seeding them here is the only
+     * way to see those badges. "Open in Stripe" will not resolve on these rows.
+     */
+    private function seedBillingStatusFixture(): void
+    {
+        if (Team::query()->where('slug', 'billing-free')->exists()) {
+            $this->command?->info('Billing fixture already seeded.');
+
+            return;
+        }
+
+        $monthly = (string) config('services.stripe.prices.pro_monthly', 'price_local_pro_monthly');
+        $yearly = (string) config('services.stripe.prices.pro_yearly', 'price_local_pro_yearly');
+
+        $subscribed = $this->billingWorkspace('Subscribed', ['plan' => Plan::Pro, 'stripe_id' => 'cus_local_subscribed']);
+        Subscription::factory()->active()->withPrice($monthly)->create(['team_id' => $subscribed->getKey()]);
+
+        $pastDue = $this->billingWorkspace('Past due', ['plan' => Plan::Pro, 'stripe_id' => 'cus_local_past_due']);
+        Subscription::factory()->pastDue()->withPrice($yearly)->create(['team_id' => $pastDue->getKey()]);
+
+        $this->billingWorkspace('Trialing', [
+            'plan' => Plan::Pro,
+            'trial_ends_at' => now()->addDays(9),
+            'pro_trial_used_at' => now()->subDays(5),
+        ]);
+
+        $this->billingWorkspace('Enterprise', ['plan' => Plan::Enterprise]);
+
+        $this->billingWorkspace('Granted', ['plan' => Plan::Pro]);
+
+        $this->billingWorkspace('Grandfathered', ['hosted_free_grandfathered_at' => now()->subYear()]);
+
+        $this->billingWorkspace('Free');
+
+        $this->seedSupersededSubscriptionWorkspace($monthly);
+        $this->seedSubscriptionHistoryWorkspace($monthly);
+
+        $seeded = collect(BillingStatus::cases())
+            ->map(fn (BillingStatus $status): string => $status->getLabel())
+            ->join(', ', ' and ');
+
+        $this->command?->info("Seeded a billing workspace for each of: {$seeded}.");
+    }
+
+    /**
+     * The case `Team::latestDefaultSubscription()` exists for: a lapsed
+     * subscription still on file under a live one. It must read Pro, not Past
+     * due, on every surface and in the Billing filter.
+     */
+    private function seedSupersededSubscriptionWorkspace(string $price): void
+    {
+        $team = $this->billingWorkspace('Resubscribed', ['plan' => Plan::Pro, 'stripe_id' => 'cus_local_resubscribed']);
+
+        Subscription::factory()->pastDue()->withPrice($price)->create([
+            'team_id' => $team->getKey(),
+            'created_at' => now()->subMonths(4),
+            'updated_at' => now()->subMonths(4),
+            'ends_at' => now()->subMonths(3),
+        ]);
+
+        Subscription::factory()->active()->withPrice($price)->create([
+            'team_id' => $team->getKey(),
+            'created_at' => now()->subMonth(),
+            'updated_at' => now()->subMonth(),
+        ]);
+    }
+
+    /**
+     * The statuses no other fixture workspace produces, as one workspace's
+     * billing history, so the Subscriptions table has a row for every option in
+     * its status filter.
+     */
+    private function seedSubscriptionHistoryWorkspace(string $price): void
+    {
+        $team = $this->billingWorkspace('History', ['stripe_id' => 'cus_local_history']);
+
+        $history = [
+            10 => Subscription::factory()->incompleteAndExpired(),
+            9 => Subscription::factory()->incomplete(),
+            8 => Subscription::factory()->trialing(now()->subMonths(8)->addDays(14)),
+            // Cashier ships no `paused` state; Stripe writes it when a trial ends
+            // with no payment method on file.
+            7 => Subscription::factory()->state(['stripe_status' => 'paused']),
+            6 => Subscription::factory()->unpaid(),
+            5 => Subscription::factory()->canceled()->state(['ends_at' => now()->subMonths(4)]),
+        ];
+
+        foreach ($history as $monthsAgo => $factory) {
+            $factory->withPrice($price)->create([
+                'team_id' => $team->getKey(),
+                'created_at' => now()->subMonths($monthsAgo),
+                'updated_at' => now()->subMonths($monthsAgo),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function billingWorkspace(string $label, array $attributes = []): Team
+    {
+        $slug = 'billing-'.Str::slug($label);
+
+        $owner = User::factory()->withTeam()->create([
+            'name' => "{$label} Owner",
+            'email' => "{$slug}@example.test",
+        ]);
+
+        $team = $owner->currentTeam;
+        $team->forceFill(['name' => "Billing · {$label}", 'slug' => $slug, ...$attributes])->save();
+
+        return $team;
     }
 
     /**

--- a/database/seeders/LocalSeeder.php
+++ b/database/seeders/LocalSeeder.php
@@ -14,8 +14,9 @@ use Illuminate\Support\Collection;
 /**
  * Local development data: one login per state worth reproducing by hand.
  *
- * Everything this seeder creates is declared in PersonaCatalog. Adding a login
- * means adding a row there, not code here.
+ * Every login it creates is declared in PersonaCatalog. Adding one means adding
+ * a row there, not code here. The two fixtures it calls first are not logins:
+ * the sysadmin accounts, and the viewer-timezone boundary rows.
  *
  * Run it as often as you like. Every write is an upsert keyed on the persona's
  * email, so a second run converges instead of duplicating or aborting.
@@ -35,6 +36,7 @@ final class LocalSeeder extends Seeder
         }
 
         $this->call(SystemAdministratorSeeder::class);
+        $this->call(ViewerTimezoneBoundarySeeder::class);
 
         $this->seedPersonas(PersonaCatalog::only($this->slugs()));
     }
@@ -73,11 +75,15 @@ final class LocalSeeder extends Seeder
                 $persona->label(),
                 $persona->workspace,
                 $this->billingCell($persona, $result['billing']),
+                $result['note'],
             ];
         }
 
         $this->command?->newLine();
-        $this->command?->table(['Login (password: '.PersonaCatalog::PASSWORD.')', 'Workspace', 'Billing'], $rows);
+        $this->command?->table(
+            ['Login (password: '.PersonaCatalog::PASSWORD.')', 'Workspace', 'Billing', 'Note'],
+            $rows,
+        );
     }
 
     /**

--- a/database/seeders/LocalSeeder.php
+++ b/database/seeders/LocalSeeder.php
@@ -42,33 +42,7 @@ final class LocalSeeder extends Seeder
 
         $this->call(SystemAdministratorSeeder::class);
 
-        $user = User::factory()
-            ->withPersonalTeam()
-            ->create([
-                'name' => 'Manuk Minasyan',
-                'email' => 'manuk.minasyan1@gmail.com',
-            ]);
-
-        $teamId = $user->personalTeam()->id;
-        //
-        //        User::factory()
-        //            ->withPersonalTeam()
-        //            ->create([
-        //                'name' => 'Test User',
-        //                'email' => 'test@example.com',
-        //            ]);
-        //
-        //        // Create 10 Test Users
-        User::factory()
-            ->count(10)
-            ->create()
-            ->after(function (User $user) use ($teamId): void {
-                // Assign the user to the personal team.
-                $user->teams()->attach($teamId, [
-                    'role' => 'member',
-                ]);
-            });
-
+        $this->seedDeveloperWorkspace();
         $this->seedBillingStatusFixture();
         $this->topUpAiCreditsForLocalTeams();
         $this->seedViewerTimezoneBoundaryFixture();
@@ -107,6 +81,36 @@ final class LocalSeeder extends Seeder
         //                $opportunity->saveCustomFieldValue($customFields->get('stage'), $customFields->get('stage')->options->random()->id);
         //            })
         //            ->create();
+    }
+
+    /**
+     * The developer's own workspace and ten members to populate it.
+     *
+     * Guarded as a whole rather than per row: re-running this on a seeded
+     * database used to abort the entire seeder on the owner's unique email,
+     * which left every fixture below it unreachable. Making only the owner
+     * idempotent would trade that for ten more members on every run.
+     */
+    private function seedDeveloperWorkspace(): void
+    {
+        $email = 'manuk.minasyan1@gmail.com';
+
+        if (User::query()->where('email', $email)->exists()) {
+            $this->command?->info('Developer workspace already seeded.');
+
+            return;
+        }
+
+        $teamId = User::factory()
+            ->withPersonalTeam()
+            ->create(['name' => 'Manuk Minasyan', 'email' => $email])
+            ->personalTeam()
+            ->id;
+
+        User::factory()
+            ->count(10)
+            ->create()
+            ->each(fn (User $member) => $member->teams()->attach($teamId, ['role' => 'member']));
     }
 
     /**
@@ -262,6 +266,12 @@ final class LocalSeeder extends Seeder
             'email_verified_at' => now(),
             'timezone' => null,
         ]);
+
+        if (Team::query()->where('name', 'Boundary Evening Team')->exists()) {
+            $this->command?->info('Viewer-timezone boundary fixture already seeded.');
+
+            return;
+        }
 
         foreach (['Evening' => $evening, 'AfterMidnight' => $afterMidnight] as $label => $instant) {
             $owner = User::factory()->withTeam()->create([

--- a/database/seeders/LocalSeeder.php
+++ b/database/seeders/LocalSeeder.php
@@ -4,352 +4,101 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
-use App\Enums\BillingStatus;
-use App\Enums\CreationSource;
-use App\Enums\Plan;
-use App\Models\ActivityLog\Activity;
-use App\Models\ActivityLog\Scopes\TeamScope;
-use App\Models\Company;
-use App\Models\CustomField;
-use App\Models\Note;
-use App\Models\Opportunity;
-use App\Models\People;
-use App\Models\Task;
-use App\Models\Team;
-use App\Models\User;
-use Filament\Facades\Filament;
-use Illuminate\Database\Eloquent\Factories\Sequence;
+use Database\Seeders\Personas\Persona;
+use Database\Seeders\Personas\PersonaCatalog;
+use Database\Seeders\Personas\PersonaSeeder;
+use Database\Seeders\Personas\StripeSandbox;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Date;
-use Illuminate\Support\Str;
-use Laravel\Cashier\Subscription;
-use Relaticle\Chat\Enums\AiCreditType;
-use Relaticle\Chat\Models\AiCreditBalance;
-use Relaticle\Chat\Models\AiCreditTransaction;
-use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
-use Relaticle\SystemAdmin\Models\SystemAdministrator;
+use Illuminate\Support\Collection;
 
+/**
+ * Local development data: one login per state worth reproducing by hand.
+ *
+ * Everything this seeder creates is declared in PersonaCatalog. Adding a login
+ * means adding a row there, not code here.
+ *
+ * Run it as often as you like. Every write is an upsert keyed on the persona's
+ * email, so a second run converges instead of duplicating or aborting.
+ *
+ * The paid personas bill against the Stripe test sandbox for real, so a
+ * workspace never claims to bill against a customer that does not exist. That
+ * costs network on every run, and the past-due persona costs a test clock.
+ */
 final class LocalSeeder extends Seeder
 {
     public function run(): void
     {
         if (! app()->isLocal()) {
-            $this->command->info('Skipping local seeding as the environment is not local.');
+            $this->command?->info('Skipping local seeding as the environment is not local.');
 
             return;
         }
 
         $this->call(SystemAdministratorSeeder::class);
 
-        $this->seedDeveloperWorkspace();
-        $this->seedBillingStatusFixture();
-        $this->topUpAiCreditsForLocalTeams();
-        $this->seedViewerTimezoneBoundaryFixture();
-        //
-        //        // Set the current user and tenant.
-        //        Auth::setUser($user);
-        //        Filament::setTenant($user->personalTeam());
-        //
-        //        $customFields = CustomField::query()
-        //            ->whereIn('code', ['icp', 'stage', 'domain_name'])
-        //            ->get()
-        //            ->keyBy('code');
-        //
-        //        Company::factory()
-        //            ->for($user->personalTeam(), 'team')
-        //            ->count(50)
-        //            ->afterCreating(function (Company $company) use ($customFields): void {
-        //                $company->saveCustomFieldValue($customFields->get('domain_name'), 'https://'.fake()->domainName());
-        //                $company->saveCustomFieldValue($customFields->get('icp'), fake()->boolean(70));
-        //            })
-        //            ->create();
-        //
-        //        // Create people.
-        //        People::factory()
-        //            ->for($user->personalTeam(), 'team')
-        //            ->for($user->currentTeam->companies->random(), 'company')
-        //            ->state(new Sequence(
-        //                fn (Sequence $sequence): array => ['company_id' => $user->personalTeam()->companies->random()->id]
-        //            ))
-        //            ->count(500)->create();
-        //
-        //        // Create opportunities.
-        //        Opportunity::factory()->for($user->personalTeam(), 'team')
-        //            ->count(150)
-        //            ->afterCreating(function (Opportunity $opportunity) use ($customFields): void {
-        //                $opportunity->saveCustomFieldValue($customFields->get('stage'), $customFields->get('stage')->options->random()->id);
-        //            })
-        //            ->create();
+        $this->seedPersonas(PersonaCatalog::only($this->slugs()));
     }
 
     /**
-     * The developer's own workspace and ten members to populate it.
-     *
-     * Guarded as a whole rather than per row: re-running this on a seeded
-     * database used to abort the entire seeder on the owner's unique email,
-     * which left every fixture below it unreachable. Making only the owner
-     * idempotent would trade that for ten more members on every run.
+     * `local:seed` defines `--only`; plain `db:seed` does not, and asking it for
+     * an option it never defined throws. Both entry points have to keep working,
+     * so an absent option is simply its default.
      */
-    private function seedDeveloperWorkspace(): void
+    private function option(string $name, mixed $default = null): mixed
     {
-        $email = 'manuk.minasyan1@gmail.com';
+        $definition = $this->command?->getDefinition();
 
-        if (User::query()->where('email', $email)->exists()) {
-            $this->command?->info('Developer workspace already seeded.');
-
-            return;
+        if ($definition === null || ! $definition->hasOption($name)) {
+            return $default;
         }
 
-        $teamId = User::factory()
-            ->withPersonalTeam()
-            ->create(['name' => 'Manuk Minasyan', 'email' => $email])
-            ->personalTeam()
-            ->id;
-
-        User::factory()
-            ->count(10)
-            ->create()
-            ->each(fn (User $member) => $member->teams()->attach($teamId, ['role' => 'member']));
+        return $this->command?->option($name) ?? $default;
     }
 
     /**
-     * One workspace per BillingStatus plus a subscription per Stripe status, so
-     * every badge, tooltip and filter option in the sysadmin billing surfaces
-     * has a row behind it without hunting for production-shaped data.
-     *
-     * The subscription rows are local only. Cashier reads them without calling
-     * Stripe, and `past_due` and `unpaid` cannot be reached through the Stripe
-     * test API at all without a test clock, so seeding them here is the only
-     * way to see those badges. "Open in Stripe" will not resolve on these rows.
+     * @param  Collection<int, Persona>  $personas
      */
-    private function seedBillingStatusFixture(): void
+    private function seedPersonas(iterable $personas): void
     {
-        if (Team::query()->where('slug', 'billing-free')->exists()) {
-            $this->command?->info('Billing fixture already seeded.');
+        $seeder = new PersonaSeeder(new StripeSandbox($this->command));
 
-            return;
+        $rows = [];
+
+        foreach ($personas as $persona) {
+            $this->command?->info("Seeding {$persona->slug}...");
+
+            $result = $seeder->seed($persona);
+
+            $rows[] = [
+                $persona->label(),
+                $persona->workspace,
+                $this->billingCell($persona, $result['billing']),
+            ];
         }
 
-        $monthly = (string) config('services.stripe.prices.pro_monthly', 'price_local_pro_monthly');
-        $yearly = (string) config('services.stripe.prices.pro_yearly', 'price_local_pro_yearly');
-
-        $subscribed = $this->billingWorkspace('Subscribed', ['plan' => Plan::Pro, 'stripe_id' => 'cus_local_subscribed']);
-        Subscription::factory()->active()->withPrice($monthly)->create(['team_id' => $subscribed->getKey()]);
-
-        $pastDue = $this->billingWorkspace('Past due', ['plan' => Plan::Pro, 'stripe_id' => 'cus_local_past_due']);
-        Subscription::factory()->pastDue()->withPrice($yearly)->create(['team_id' => $pastDue->getKey()]);
-
-        $this->billingWorkspace('Trialing', [
-            'plan' => Plan::Pro,
-            'trial_ends_at' => now()->addDays(9),
-            'pro_trial_used_at' => now()->subDays(5),
-        ]);
-
-        $this->billingWorkspace('Enterprise', ['plan' => Plan::Enterprise]);
-
-        $this->billingWorkspace('Granted', ['plan' => Plan::Pro]);
-
-        $this->billingWorkspace('Grandfathered', ['hosted_free_grandfathered_at' => now()->subYear()]);
-
-        $this->billingWorkspace('Free');
-
-        $this->seedSupersededSubscriptionWorkspace($monthly);
-        $this->seedSubscriptionHistoryWorkspace($monthly);
-
-        $seeded = collect(BillingStatus::cases())
-            ->map(fn (BillingStatus $status): string => $status->getLabel())
-            ->join(', ', ' and ');
-
-        $this->command?->info("Seeded a billing workspace for each of: {$seeded}.");
+        $this->command?->newLine();
+        $this->command?->table(['Login (password: '.PersonaCatalog::PASSWORD.')', 'Workspace', 'Billing'], $rows);
     }
 
     /**
-     * The case `Team::latestDefaultSubscription()` exists for: a lapsed
-     * subscription still on file under a live one. It must read Pro, not Past
-     * due, on every surface and in the Billing filter.
+     * The seeder asserts the state it set out to produce rather than reporting
+     * whatever it happened to create: a persona that silently drifts to a
+     * different badge is the bug this fixture exists to prevent.
      */
-    private function seedSupersededSubscriptionWorkspace(string $price): void
+    private function billingCell(Persona $persona, string $actual): string
     {
-        $team = $this->billingWorkspace('Resubscribed', ['plan' => Plan::Pro, 'stripe_id' => 'cus_local_resubscribed']);
-
-        Subscription::factory()->pastDue()->withPrice($price)->create([
-            'team_id' => $team->getKey(),
-            'created_at' => now()->subMonths(4),
-            'updated_at' => now()->subMonths(4),
-            'ends_at' => now()->subMonths(3),
-        ]);
-
-        Subscription::factory()->active()->withPrice($price)->create([
-            'team_id' => $team->getKey(),
-            'created_at' => now()->subMonth(),
-            'updated_at' => now()->subMonth(),
-        ]);
+        return $actual === $persona->expect->value
+            ? $actual
+            : "{$actual} (EXPECTED {$persona->expect->value})";
     }
 
     /**
-     * The statuses no other fixture workspace produces, as one workspace's
-     * billing history, so the Subscriptions table has a row for every option in
-     * its status filter.
+     * @return array<int, string>
      */
-    private function seedSubscriptionHistoryWorkspace(string $price): void
+    private function slugs(): array
     {
-        $team = $this->billingWorkspace('History', ['stripe_id' => 'cus_local_history']);
+        $only = (string) $this->option('only', '');
 
-        $history = [
-            10 => Subscription::factory()->incompleteAndExpired(),
-            9 => Subscription::factory()->incomplete(),
-            8 => Subscription::factory()->trialing(now()->subMonths(8)->addDays(14)),
-            // Cashier ships no `paused` state; Stripe writes it when a trial ends
-            // with no payment method on file.
-            7 => Subscription::factory()->state(['stripe_status' => 'paused']),
-            6 => Subscription::factory()->unpaid(),
-            5 => Subscription::factory()->canceled()->state(['ends_at' => now()->subMonths(4)]),
-        ];
-
-        foreach ($history as $monthsAgo => $factory) {
-            $factory->withPrice($price)->create([
-                'team_id' => $team->getKey(),
-                'created_at' => now()->subMonths($monthsAgo),
-                'updated_at' => now()->subMonths($monthsAgo),
-            ]);
-        }
-    }
-
-    /**
-     * @param  array<string, mixed>  $attributes
-     */
-    private function billingWorkspace(string $label, array $attributes = []): Team
-    {
-        $slug = 'billing-'.Str::slug($label);
-
-        $owner = User::factory()->withTeam()->create([
-            'name' => "{$label} Owner",
-            'email' => "{$slug}@example.test",
-        ]);
-
-        $team = $owner->currentTeam;
-        $team->forceFill(['name' => "Billing · {$label}", 'slug' => $slug, ...$attributes])->save();
-
-        return $team;
-    }
-
-    /**
-     * Fixture for walking the sysadmin panel's timezone behaviour by hand.
-     *
-     * Every row lands on one of two instants on the same UTC day: 19:00 UTC is
-     * 23:00 that evening in Asia/Yerevan, and 21:00 UTC is 01:00 the NEXT
-     * morning there. So an administrator on Yerevan must see the pair split
-     * across two calendar days while one on UTC sees them on the same day, and
-     * the 21:00 row must appear in the Yerevan administrator's "today".
-     *
-     * Paired with two administrators, one zoned and one not, this is what makes
-     * a wrong answer visible rather than merely plausible.
-     */
-    private function seedViewerTimezoneBoundaryFixture(): void
-    {
-        $evening = Date::now('UTC')->subDay()->setTime(19, 0);
-        $afterMidnight = Date::now('UTC')->subDay()->setTime(21, 0);
-
-        SystemAdministrator::query()->firstOrCreate(['email' => 'yerevan@relaticle.com'], [
-            'name' => 'Yerevan Administrator',
-            'password' => bcrypt('password'),
-            'role' => SystemAdministratorRole::SuperAdministrator,
-            'email_verified_at' => now(),
-            'timezone' => 'Asia/Yerevan',
-        ]);
-
-        SystemAdministrator::query()->firstOrCreate(['email' => 'utc@relaticle.com'], [
-            'name' => 'UTC Administrator',
-            'password' => bcrypt('password'),
-            'role' => SystemAdministratorRole::SuperAdministrator,
-            'email_verified_at' => now(),
-            'timezone' => null,
-        ]);
-
-        if (Team::query()->where('name', 'Boundary Evening Team')->exists()) {
-            $this->command?->info('Viewer-timezone boundary fixture already seeded.');
-
-            return;
-        }
-
-        foreach (['Evening' => $evening, 'AfterMidnight' => $afterMidnight] as $label => $instant) {
-            $owner = User::factory()->withTeam()->create([
-                'name' => "Boundary {$label}",
-                'email' => 'boundary-'.mb_strtolower($label).'-'.Str::lower(Str::ulid()).'@example.test',
-                'created_at' => $instant,
-                'updated_at' => $instant,
-            ]);
-
-            $team = $owner->currentTeam;
-            $team->forceFill([
-                'name' => "Boundary {$label} Team",
-                'personal_team' => false,
-                'created_at' => $instant,
-                'updated_at' => $instant,
-            ])->save();
-
-            foreach ([Company::class, People::class, Task::class, Note::class, Opportunity::class] as $model) {
-                $model::withoutEvents(fn () => $model::factory()->for($team)->create([
-                    'creator_id' => $owner->id,
-                    'creation_source' => CreationSource::WEB,
-                    'created_at' => $instant,
-                    'updated_at' => $instant,
-                ]));
-            }
-
-            Activity::query()->withoutGlobalScope(TeamScope::class)->create([
-                'log_name' => 'crm',
-                'description' => "boundary {$label}",
-                'event' => 'updated',
-                'subject_type' => 'company',
-                'subject_id' => (string) Str::ulid(),
-                'causer_type' => 'user',
-                'causer_id' => $owner->id,
-                'team_id' => $team->id,
-                'properties' => [],
-                'created_at' => $instant,
-            ]);
-        }
-
-        $this->command?->info('Seeded viewer-timezone boundary fixture at 19:00 and 21:00 UTC yesterday.');
-    }
-
-    /**
-     * Bump every existing AI credit balance to a developer-friendly ceiling so
-     * local chat sessions don't hit the free plan's 100-credit allowance while
-     * exercising features. Production runs this seeder behind the isLocal()
-     * gate at the top of run(), so this only ever fires in dev.
-     */
-    private function topUpAiCreditsForLocalTeams(): void
-    {
-        $target = 1_000_000;
-
-        AiCreditBalance::query()
-            ->where('credits_remaining', '<', $target)
-            ->cursor()
-            ->each(function (AiCreditBalance $balance) use ($target): void {
-                $delta = $target - $balance->credits_remaining;
-
-                $balance->update(['credits_remaining' => $target]);
-
-                AiCreditTransaction::query()->create([
-                    'team_id' => $balance->team_id,
-                    'user_id' => null,
-                    'conversation_id' => null,
-                    'idempotency_key' => 'local-dev-grant-'.Str::ulid(),
-                    'type' => AiCreditType::Adjustment,
-                    'model' => 'system',
-                    'input_tokens' => 0,
-                    'output_tokens' => 0,
-                    'credits_charged' => 0,
-                    'metadata' => [
-                        'action' => 'local_dev_grant',
-                        'delta' => $delta,
-                        'target' => $target,
-                    ],
-                    'created_at' => now(),
-                ]);
-            });
+        return array_values(array_filter(array_map(trim(...), explode(',', $only))));
     }
 }

--- a/database/seeders/Personas/Persona.php
+++ b/database/seeders/Personas/Persona.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\Personas;
+
+use App\Enums\BillingStatus;
+use App\Enums\OnboardingUseCase;
+
+/**
+ * One local login and the workspace state it exists to reproduce.
+ *
+ * Every persona is addressable by slug (`local:seed --only=paused`) and carries
+ * the billing status it must render, so the seeder asserts what it produced
+ * instead of hoping.
+ */
+final readonly class Persona
+{
+    /**
+     * @param  string  $purpose  What this login is for, shown in the local persona switcher.
+     * @param  array<string, mixed>  $team  Attributes force-filled onto the workspace.
+     * @param  ?OnboardingUseCase  $useCase  Drives which fixture set onboarding seeds; null leaves the workspace empty.
+     * @param  ?string  $stripe  A Stripe test payment method, when this persona bills for real.
+     * @param  array<int, array{email: string, role: string}>  $members
+     */
+    public function __construct(
+        public string $slug,
+        public string $email,
+        public string $name,
+        public string $workspace,
+        public string $purpose,
+        public BillingStatus $expect,
+        public array $team = [],
+        public ?OnboardingUseCase $useCase = null,
+        public ?string $stripe = null,
+        public bool $pastDue = false,
+        public array $members = [],
+    ) {}
+
+    /**
+     * Whether this workspace should come with CRM records. The app seeds those
+     * from the onboarding use case, so a persona without one stays empty.
+     */
+    public function wantsRecords(): bool
+    {
+        return $this->useCase instanceof OnboardingUseCase;
+    }
+
+    /**
+     * Whether this persona bills against the Stripe sandbox rather than getting
+     * its state force-filled onto the workspace.
+     */
+    public function needsStripe(): bool
+    {
+        return $this->stripe !== null;
+    }
+
+    public function label(): string
+    {
+        return "{$this->name} <{$this->email}>";
+    }
+}

--- a/database/seeders/Personas/PersonaCatalog.php
+++ b/database/seeders/Personas/PersonaCatalog.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\Personas;
+
+use App\Enums\BillingStatus;
+use App\Enums\OnboardingUseCase;
+use App\Enums\Plan;
+use App\Enums\TeamRole;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Every local login, in one table.
+ *
+ * This is the file to edit when a new state becomes worth reproducing by hand.
+ * The seeder reads it and does nothing else, so a persona cannot exist in the
+ * database without a row here explaining why.
+ *
+ * Passwords are always `password`. These accounts only ever exist behind the
+ * `isLocal()` gate in LocalSeeder.
+ */
+final class PersonaCatalog
+{
+    public const string PASSWORD = 'password';
+
+    public const string DOMAIN = 'relaticle.test';
+
+    /**
+     * @return Collection<int, Persona>
+     */
+    public static function all(): Collection
+    {
+        return collect([
+            new Persona(
+                slug: 'owner',
+                email: 'owner@'.self::DOMAIN,
+                name: 'Olivia Owner',
+                workspace: 'Acme Sales',
+                purpose: 'Full CRM data, admin and editor teammates. The daily driver.',
+                // Grandfathered rather than trialing: a trial lapses and then
+                // every local login lands on /billing until someone re-seeds.
+                expect: BillingStatus::Grandfathered,
+                team: ['hosted_free_grandfathered_at' => '-1 year'],
+                useCase: OnboardingUseCase::Sales,
+                members: [
+                    ['email' => 'admin@'.self::DOMAIN, 'role' => TeamRole::Admin->value],
+                    ['email' => 'editor@'.self::DOMAIN, 'role' => TeamRole::Editor->value],
+                ],
+            ),
+
+            new Persona(
+                slug: 'empty',
+                email: 'empty@'.self::DOMAIN,
+                name: 'Evan Empty',
+                workspace: 'Empty Workspace',
+                purpose: 'No records at all, for walking every empty state.',
+                // The only way to see every empty state without deleting rows
+                // out of a populated workspace by hand.
+                expect: BillingStatus::Grandfathered,
+                team: ['hosted_free_grandfathered_at' => '-1 year'],
+            ),
+
+            new Persona(
+                slug: 'paused',
+                email: 'paused@'.self::DOMAIN,
+                name: 'Pia Paused',
+                workspace: 'Paused Workspace',
+                purpose: 'Free plan with billing on, so every page hits the paywall.',
+                // Free with billing on, so EnsureHostedWorkspaceAccess pins
+                // every page to /billing. The paywall, walkable.
+                expect: BillingStatus::Free,
+            ),
+
+            new Persona(
+                slug: 'trial',
+                email: 'trial@'.self::DOMAIN,
+                name: 'Tara Trial',
+                workspace: 'Trialing Workspace',
+                purpose: 'Nine days left on a Pro trial, with recruiting data.',
+                expect: BillingStatus::Trialing,
+                team: [
+                    'plan' => Plan::Pro,
+                    'trial_ends_at' => '+9 days',
+                    'pro_trial_used_at' => '-5 days',
+                ],
+                useCase: OnboardingUseCase::Recruiting,
+            ),
+
+            new Persona(
+                slug: 'pro',
+                email: 'pro@'.self::DOMAIN,
+                name: 'Pedro Pro',
+                workspace: 'Paying Workspace',
+                purpose: 'A real Stripe subscription: invoices and portal resolve.',
+                // A real Stripe subscription: the badge, the invoice list and
+                // "Open in Stripe" all resolve against the sandbox.
+                expect: BillingStatus::Subscribed,
+                team: ['plan' => Plan::Pro],
+                useCase: OnboardingUseCase::Marketing,
+                stripe: 'pm_card_visa',
+            ),
+
+            new Persona(
+                slug: 'past-due',
+                email: 'past-due@'.self::DOMAIN,
+                name: 'Dana Pastdue',
+                workspace: 'Lapsed Workspace',
+                purpose: 'A real renewal that Stripe declined, so it reads past due.',
+                // Reached by advancing a Stripe test clock past a renewal that
+                // the card declines. There is no other way to see this state.
+                expect: BillingStatus::PastDue,
+                team: ['plan' => Plan::Pro],
+                stripe: 'pm_card_visa',
+                pastDue: true,
+            ),
+        ]);
+    }
+
+    /**
+     * The personas that have actually been seeded. login-link creates a missing
+     * user on the fly, so offering a login for an unseeded persona would
+     * silently make a bare account with none of the state its row names.
+     *
+     * @return Collection<int, Persona>
+     */
+    public static function seeded(): Collection
+    {
+        $emails = User::query()->whereIn('email', self::all()->pluck('email'))->pluck('email');
+
+        return self::all()->filter(fn (Persona $persona): bool => $emails->contains($persona->email))->values();
+    }
+
+    /**
+     * @param  array<int, string>  $slugs
+     * @return Collection<int, Persona>
+     */
+    public static function only(array $slugs): Collection
+    {
+        return $slugs === []
+            ? self::all()
+            : self::all()->filter(fn (Persona $persona): bool => in_array($persona->slug, $slugs, true))->values();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function slugs(): array
+    {
+        return self::all()->pluck('slug')->all();
+    }
+}

--- a/database/seeders/Personas/PersonaSeeder.php
+++ b/database/seeders/Personas/PersonaSeeder.php
@@ -9,6 +9,8 @@ use App\Models\User;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Laravel\Pennant\Feature;
+use Relaticle\Chat\Services\CreditService;
+use Throwable;
 
 /**
  * Turns a Persona into a workspace you can log into.
@@ -25,7 +27,7 @@ final readonly class PersonaSeeder
     ) {}
 
     /**
-     * @return array{persona: Persona, team: Team, billing: string}
+     * @return array{persona: Persona, team: Team, billing: string, note: string}
      */
     public function seed(Persona $persona): array
     {
@@ -34,15 +36,55 @@ final readonly class PersonaSeeder
 
         $this->members($team, $persona);
 
-        if ($persona->needsStripe()) {
-            $this->stripe->subscribe($team, $persona);
-        }
+        // Billing first: the allowance depends on the subscription Stripe just
+        // wrote, and a past-due workspace refills at the Free tier.
+        $note = $persona->needsStripe() ? $this->bill($team, $persona) : '';
+
+        $this->allowance($team);
 
         return [
             'persona' => $persona,
             'team' => $team,
+            'note' => $note,
             'billing' => Team::query()->with('subscriptions')->findOrFail($team->getKey())->billingStatus()->value,
         ];
+    }
+
+    /**
+     * Bill the sandbox, reporting rather than throwing.
+     *
+     * Only the Stripe leg is caught: it is the one step that depends on a
+     * credential and a network this checkout may not have, and a local seed must
+     * still produce the four workspaces that need neither. A failure anywhere
+     * else is a real defect and is left to surface.
+     */
+    private function bill(Team $team, Persona $persona): string
+    {
+        if (! $this->stripe->available()) {
+            return 'no test-mode STRIPE_SECRET, billed nothing';
+        }
+
+        try {
+            $this->stripe->subscribe($team, $persona);
+
+            return '';
+        } catch (Throwable $e) {
+            return 'Stripe failed: '.Str::limit($e->getMessage(), 70);
+        }
+    }
+
+    /**
+     * Give the workspace the credit allowance its plan actually grants.
+     *
+     * The balance is created when the team is, before the persona's plan is
+     * force-filled, so it holds the Free allowance no matter which plan the
+     * persona claims. Left alone, a Pro persona shows a Pro allowance on the
+     * billing page while holding a Free one, which is the exact divergence
+     * these fixtures exist to make visible rather than reproduce.
+     */
+    private function allowance(Team $team): void
+    {
+        resolve(CreditService::class)->resetPeriod($team->refresh()->load('subscriptions'));
     }
 
     /**

--- a/database/seeders/Personas/PersonaSeeder.php
+++ b/database/seeders/Personas/PersonaSeeder.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\Personas;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
+use Laravel\Pennant\Feature;
+
+/**
+ * Turns a Persona into a workspace you can log into.
+ *
+ * Idempotent by construction: every write is an upsert keyed on the persona's
+ * email or slug, so running it twice converges instead of duplicating. That is
+ * the property the old seeder lacked, which is why a re-run used to abort on a
+ * unique email and strand every fixture behind it.
+ */
+final readonly class PersonaSeeder
+{
+    public function __construct(
+        private StripeSandbox $stripe,
+    ) {}
+
+    /**
+     * @return array{persona: Persona, team: Team, billing: string}
+     */
+    public function seed(Persona $persona): array
+    {
+        $user = $this->account($persona->email, $persona->name);
+        $team = $this->workspace($user, $persona);
+
+        $this->members($team, $persona);
+
+        if ($persona->needsStripe()) {
+            $this->stripe->subscribe($team, $persona);
+        }
+
+        return [
+            'persona' => $persona,
+            'team' => $team,
+            'billing' => Team::query()->with('subscriptions')->findOrFail($team->getKey())->billingStatus()->value,
+        ];
+    }
+
+    /**
+     * The login itself. `password` everywhere, verified, so no persona is ever
+     * one confirmation email away from being unusable.
+     */
+    private function account(string $email, string $name): User
+    {
+        $user = User::query()->firstOrNew(['email' => $email]);
+
+        if (! $user->exists) {
+            $user->forceFill(User::factory()->raw(['email' => $email]))->save();
+        }
+
+        $user->forceFill([
+            'name' => $name,
+            'password' => bcrypt(PersonaCatalog::PASSWORD),
+            'email_verified_at' => now(),
+        ])->save();
+
+        return $user;
+    }
+
+    /**
+     * The persona's personal workspace, force-filled with the billing state the
+     * persona exists to demonstrate. Relative dates in the catalog (`-1 year`)
+     * are resolved here so the table stays declarative.
+     */
+    private function workspace(User $user, Persona $persona): Team
+    {
+        $team = $user->ownedTeams()->where('personal_team', true)->first()
+            ?? $this->createWorkspace($user, $persona);
+
+        $team->forceFill([
+            'name' => $persona->workspace,
+            'slug' => Str::slug($persona->workspace),
+            ...$this->resolveDates($persona->team),
+        ])->save();
+
+        $user->forceFill(['current_team_id' => $team->getKey()])->save();
+
+        return $team;
+    }
+
+    /**
+     * Teammates, so role-scoped behaviour has somebody to be scoped to.
+     * `syncWithoutDetaching` keeps this idempotent without wiping a membership
+     * someone added by hand while testing.
+     */
+    private function members(Team $team, Persona $persona): void
+    {
+        foreach ($persona->members as $member) {
+            $user = $this->account($member['email'], Str::headline(Str::before($member['email'], '@')));
+
+            $team->users()->syncWithoutDetaching([$user->getKey() => ['role' => $member['role']]]);
+        }
+    }
+
+    /**
+     * Creating a personal team fires TeamCreated, and the app's own listener
+     * seeds custom fields plus the CRM fixture set for the workspace's
+     * onboarding use case. So the use case is set at creation time and the app
+     * populates the workspace exactly as it would for a real signup.
+     *
+     * A persona with no use case wants an empty workspace, which means
+     * suppressing that listener rather than deleting rows after the fact.
+     */
+    private function createWorkspace(User $user, Persona $persona): Team
+    {
+        $attributes = [
+            'user_id' => $user->getKey(),
+            'personal_team' => true,
+            'name' => $persona->workspace,
+            'onboarding_use_case' => $persona->useCase,
+        ];
+
+        if ($persona->wantsRecords()) {
+            return Team::factory()->create($attributes);
+        }
+
+        return $this->withoutOnboardSeed(fn (): Team => Team::factory()->create($attributes));
+    }
+
+    /**
+     * The OnboardSeed feature reads config, but Pennant memoises the resolved
+     * value for the request, so the cache has to be flushed on both sides of the
+     * change or the flip is silently ignored.
+     *
+     * @param  callable(): Team  $callback
+     */
+    private function withoutOnboardSeed(callable $callback): Team
+    {
+        $key = 'relaticle.features.onboard_seed';
+        $previous = config($key);
+
+        config([$key => false]);
+        Feature::flushCache();
+
+        try {
+            return $callback();
+        } finally {
+            config([$key => $previous]);
+            Feature::flushCache();
+        }
+    }
+
+    /**
+     * The catalog states dates as relative strings (`-1 year`) so it stays a
+     * readable table. They are resolved against the clock here, by column name
+     * rather than by sniffing the value, so a future string attribute cannot be
+     * mistaken for a date.
+     *
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    private function resolveDates(array $attributes): array
+    {
+        $dates = ['hosted_free_grandfathered_at', 'trial_ends_at', 'pro_trial_used_at'];
+
+        return collect($attributes)
+            ->map(fn (mixed $value, string $column): mixed => in_array($column, $dates, true) && is_string($value)
+                ? Date::parse($value)
+                : $value)
+            ->all();
+    }
+}

--- a/database/seeders/Personas/StripeSandbox.php
+++ b/database/seeders/Personas/StripeSandbox.php
@@ -149,12 +149,23 @@ final readonly class StripeSandbox
     }
 
     /**
+     * Whether this checkout can bill the sandbox at all. A clone with no Stripe
+     * keys is the normal case, not an error: the seeder skips these personas
+     * rather than aborting the whole local seed over a credential it does not
+     * need for the other four.
+     */
+    public function available(): bool
+    {
+        return str_contains((string) config('cashier.secret'), '_test_');
+    }
+
+    /**
      * A live key here would create real customers and real charges.
      */
     private function assertTestMode(): void
     {
         throw_unless(
-            str_contains((string) config('cashier.secret'), '_test_'),
+            $this->available(),
             RuntimeException::class,
             'Refusing to seed: STRIPE_SECRET is not a test-mode key.',
         );

--- a/database/seeders/Personas/StripeSandbox.php
+++ b/database/seeders/Personas/StripeSandbox.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\Personas;
+
+use App\Models\Team;
+use Illuminate\Console\Command;
+use Illuminate\Support\Sleep;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Subscription;
+use RuntimeException;
+use Stripe\Exception\InvalidRequestException;
+
+/**
+ * Real subscriptions in the Stripe test sandbox, not hand-written rows.
+ *
+ * A locally invented `subscriptions` row renders the right badge and then lies
+ * about everything else: "Open in Stripe" 404s, the invoice list is empty, and
+ * the billing portal has nothing to show. Going through Cashier means the
+ * workspace bills against a real customer, so a browser walk exercises the same
+ * path production does.
+ *
+ * This costs network on every seed: roughly 7s per subscription, and the
+ * past-due persona needs a test clock advanced past a renewal, which takes
+ * about a minute.
+ */
+final readonly class StripeSandbox
+{
+    /**
+     * Stripe's own test payment method: succeeds on the first charge, then
+     * declines every renewal. That decline is what produces `past_due`.
+     */
+    private const string DECLINING_CARD = 'pm_card_chargeCustomerFail';
+
+    private const int CLOCK_TIMEOUT_SECONDS = 180;
+
+    public function __construct(private ?Command $command = null) {}
+
+    /**
+     * Give the workspace a live subscription, replacing whatever it had.
+     */
+    public function subscribe(Team $team, Persona $persona): void
+    {
+        $this->assertTestMode();
+        $this->reset($team);
+
+        $price = (string) config('services.stripe.prices.pro_monthly');
+
+        if ($persona->pastDue) {
+            $this->subscribeThenFailRenewal($team, $price, $persona);
+
+            return;
+        }
+
+        $team->newSubscription('default', $price)->create(
+            $persona->stripe,
+            $this->customerOptions($persona),
+        );
+    }
+
+    /**
+     * A Team carries no email, so Cashier would create a nameless customer that
+     * is impossible to identify in the Stripe dashboard. Naming it after the
+     * persona is what makes a sandbox customer recognisable at a glance.
+     *
+     * @return array<string, string>
+     */
+    private function customerOptions(Persona $persona): array
+    {
+        return [
+            'email' => $persona->email,
+            'name' => $persona->workspace,
+            'description' => "Local persona: {$persona->slug}",
+        ];
+    }
+
+    /**
+     * Subscribe on a test clock, swap in a card that declines, then advance past
+     * the renewal so Stripe itself moves the subscription to `past_due`.
+     */
+    private function subscribeThenFailRenewal(Team $team, string $price, Persona $persona): void
+    {
+        $stripe = Cashier::stripe();
+
+        $clock = $stripe->testHelpers->testClocks->create([
+            'frozen_time' => now()->timestamp,
+            'name' => "local-{$team->slug}",
+        ]);
+
+        $team->createAsStripeCustomer([...$this->customerOptions($persona), 'test_clock' => $clock->id]);
+        $subscription = $team->newSubscription('default', $price)->create('pm_card_visa');
+
+        $team->updateDefaultPaymentMethod(self::DECLINING_CARD);
+
+        $renewal = $stripe->subscriptions->retrieve($subscription->stripe_id);
+        $periodEnd = $renewal->items->data[0]->current_period_end ?? null;
+
+        throw_unless(is_int($periodEnd), RuntimeException::class, 'Stripe returned no current_period_end to advance past.');
+
+        $this->command?->info('  Advancing the Stripe test clock past renewal (up to 3 minutes)...');
+
+        $stripe->testHelpers->testClocks->advance($clock->id, ['frozen_time' => $periodEnd + 3600]);
+
+        $this->awaitClock($clock->id);
+
+        $subscription->syncStripeStatus();
+    }
+
+    /**
+     * Stripe advances a clock asynchronously and bills while it does, so the
+     * subscription's new status is only trustworthy once the clock is `ready`.
+     */
+    private function awaitClock(string $clockId): void
+    {
+        $stripe = Cashier::stripe();
+        $deadline = now()->addSeconds(self::CLOCK_TIMEOUT_SECONDS);
+
+        do {
+            Sleep::sleep(5);
+            $status = $stripe->testHelpers->testClocks->retrieve($clockId)->status;
+
+            if ($status === 'ready') {
+                return;
+            }
+        } while (now()->lessThan($deadline));
+
+        throw new RuntimeException("Stripe test clock {$clockId} did not settle within ".self::CLOCK_TIMEOUT_SECONDS.'s (status: '.$status.').');
+    }
+
+    /**
+     * Detach the workspace from any sandbox customer a previous run left behind,
+     * so re-seeding does not strand billable objects in Stripe.
+     */
+    private function reset(Team $team): void
+    {
+        if (! $team->hasStripeId()) {
+            return;
+        }
+
+        try {
+            Cashier::stripe()->customers->delete($team->stripe_id);
+        } catch (InvalidRequestException) {
+            // Already gone from Stripe; the local row below is the only cleanup left.
+        }
+
+        Subscription::query()->where('team_id', $team->getKey())->delete();
+        $team->forceFill(['stripe_id' => null, 'pm_type' => null, 'pm_last_four' => null])->save();
+    }
+
+    /**
+     * A live key here would create real customers and real charges.
+     */
+    private function assertTestMode(): void
+    {
+        throw_unless(
+            str_contains((string) config('cashier.secret'), '_test_'),
+            RuntimeException::class,
+            'Refusing to seed: STRIPE_SECRET is not a test-mode key.',
+        );
+    }
+}

--- a/database/seeders/ViewerTimezoneBoundarySeeder.php
+++ b/database/seeders/ViewerTimezoneBoundarySeeder.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Enums\CreationSource;
+use App\Models\ActivityLog\Activity;
+use App\Models\ActivityLog\Scopes\TeamScope;
+use App\Models\Company;
+use App\Models\Note;
+use App\Models\Opportunity;
+use App\Models\People;
+use App\Models\Task;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
+use Relaticle\SystemAdmin\Enums\SystemAdministratorRole;
+use Relaticle\SystemAdmin\Models\SystemAdministrator;
+
+/**
+ * Fixture for walking the sysadmin panel's timezone behaviour by hand.
+ *
+ * Every row lands on one of two instants on the same UTC day: 19:00 UTC is
+ * 23:00 that evening in Asia/Yerevan, and 21:00 UTC is 01:00 the NEXT morning
+ * there. So an administrator on Yerevan must see the pair split across two
+ * calendar days while one on UTC sees them on the same day, and the 21:00 row
+ * must appear in the Yerevan administrator's "today".
+ *
+ * Paired with two administrators, one zoned and one not, this is what makes a
+ * wrong answer visible rather than merely plausible.
+ *
+ * Re-runnable like the rest of local seeding: the workspaces are keyed by name
+ * and their rows are rebuilt against today's clock, so the two instants stay
+ * "yesterday" however long ago you first seeded.
+ */
+final class ViewerTimezoneBoundarySeeder extends Seeder
+{
+    private const string PASSWORD = 'password';
+
+    public function run(): void
+    {
+        if (! app()->isLocal()) {
+            return;
+        }
+
+        $this->administrator('yerevan@relaticle.com', 'Yerevan Administrator', 'Asia/Yerevan');
+        $this->administrator('utc@relaticle.com', 'UTC Administrator', null);
+
+        $instants = [
+            'Evening' => Date::now('UTC')->subDay()->setTime(19, 0),
+            'AfterMidnight' => Date::now('UTC')->subDay()->setTime(21, 0),
+        ];
+
+        foreach ($instants as $label => $instant) {
+            $this->boundaryWorkspace($label, $instant);
+        }
+
+        $this->command?->info('Seeded viewer-timezone boundary fixture at 19:00 and 21:00 UTC yesterday.');
+    }
+
+    private function administrator(string $email, string $name, ?string $timezone): void
+    {
+        SystemAdministrator::query()->updateOrCreate(['email' => $email], [
+            'name' => $name,
+            'password' => bcrypt(self::PASSWORD),
+            'role' => SystemAdministratorRole::SuperAdministrator,
+            'email_verified_at' => now(),
+            'timezone' => $timezone,
+        ]);
+    }
+
+    /**
+     * One workspace per instant, rebuilt from scratch each run so the rows stay
+     * pinned to yesterday rather than drifting into the past.
+     */
+    private function boundaryWorkspace(string $label, Carbon $instant): void
+    {
+        $email = 'boundary-'.mb_strtolower($label).'@example.test';
+
+        $owner = User::query()->firstOrNew(['email' => $email]);
+
+        if (! $owner->exists) {
+            $owner->forceFill(User::factory()->raw(['email' => $email]))->save();
+        }
+
+        $owner->forceFill([
+            'name' => "Boundary {$label}",
+            'created_at' => $instant,
+            'updated_at' => $instant,
+        ])->save();
+
+        $team = $owner->ownedTeams()->where('name', "Boundary {$label} Team")->first()
+            ?? Team::factory()->create(['user_id' => $owner->getKey(), 'name' => "Boundary {$label} Team"]);
+
+        $team->forceFill([
+            'personal_team' => false,
+            'created_at' => $instant,
+            'updated_at' => $instant,
+        ])->save();
+
+        $owner->forceFill(['current_team_id' => $team->getKey()])->save();
+
+        foreach ([Company::class, People::class, Task::class, Note::class, Opportunity::class] as $model) {
+            $model::query()->where('team_id', $team->getKey())->delete();
+
+            $model::withoutEvents(fn () => $model::factory()->for($team)->create([
+                'creator_id' => $owner->getKey(),
+                'creation_source' => CreationSource::WEB,
+                'created_at' => $instant,
+                'updated_at' => $instant,
+            ]));
+        }
+
+        Activity::query()->withoutGlobalScope(TeamScope::class)->where('team_id', $team->getKey())->delete();
+
+        Activity::query()->withoutGlobalScope(TeamScope::class)->create([
+            'log_name' => 'crm',
+            'description' => "boundary {$label}",
+            'event' => 'updated',
+            'subject_type' => 'company',
+            'subject_id' => (string) Str::ulid(),
+            'causer_type' => 'user',
+            'causer_id' => $owner->getKey(),
+            'team_id' => $team->getKey(),
+            'properties' => [],
+            'created_at' => $instant,
+        ]);
+    }
+}

--- a/lang/en/billing.php
+++ b/lang/en/billing.php
@@ -35,6 +35,8 @@ return [
         'keep_pro' => 'Keep Pro',
         'paused' => 'Your workspace is paused',
         'subscribe' => 'Subscribe',
+        'past_due' => 'Payment failed',
+        'fix' => 'Fix',
     ],
 
     'trial' => [
@@ -92,11 +94,17 @@ return [
         'body' => 'Update your payment method, download invoices, or change your plan in the billing portal.',
         'button' => 'Manage subscription',
         'auto_renews' => 'Renews automatically',
+        'past_due_tagline' => 'Renewal failed. Stripe is retrying.',
         'cancel_scheduled_title' => 'Cancellation scheduled',
         'cancel_scheduled_body' => 'Cloud Pro stays active until :date. After that, workspace access pauses.',
         'cancel_scheduled_legacy_body' => 'Cloud Pro stays active until :date. Then this workspace returns to its grandfathered Free plan.',
         'past_due_title' => 'Payment issue',
         'past_due_body' => 'Your last payment failed. Update your payment method to keep Pro.',
+    ],
+    'payment_failed' => [
+        'notification_title' => 'Payment failed for :workspace',
+        'notification_body' => 'Update your payment method to keep Pro. Stripe will retry the charge.',
+        'notification_action' => 'Fix payment',
     ],
     'enterprise' => [
         'title' => 'Enterprise plan',

--- a/packages/Chat/src/Http/Controllers/ChatController.php
+++ b/packages/Chat/src/Http/Controllers/ChatController.php
@@ -148,12 +148,15 @@ final readonly class ChatController
 
             $isFree = $team->plan === Plan::Free;
             $canTopUp = ! $isFree && resolve(CreditPackCatalog::class)->hasPurchasable();
+            // Not $team->plan->credits(): a past-due workspace refills at the
+            // Free allowance, so the plan's figure would name credits it never got.
+            $allowance = $this->creditService->allowanceFor($team);
 
             return response()->json([
                 'error' => 'credits_exhausted',
-                'message' => "You have used all {$team->plan->credits()} credits for this {$team->plan->getLabel()} plan period.",
+                'message' => "You have used all {$allowance} credits for this {$team->plan->getLabel()} plan period.",
                 'plan' => $team->plan->value,
-                'allowance' => $team->plan->credits(),
+                'allowance' => $allowance,
                 'reset_at' => $balance?->period_ends_at?->toIso8601String(),
                 'upgrade_available' => $isFree,
                 'upgrade_url' => $isFree ? $this->billingUrl($team) : null,

--- a/packages/Chat/src/Services/CreditService.php
+++ b/packages/Chat/src/Services/CreditService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\Chat\Services;
 
 use App\Actions\Chat\SeedTeamCreditBalance;
+use App\Enums\Plan;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -418,11 +419,35 @@ final readonly class CreditService
         });
     }
 
+    /**
+     * The allowance a workspace is refilled with when its period rolls over.
+     *
+     * A past-due workspace refills at the Free allowance rather than the one it
+     * has stopped paying for. keepPastDueSubscriptionsActive() leaves valid()
+     * true throughout dunning, so the plan column still reads Pro and this is
+     * the only place that can tell the difference — without it, a workspace
+     * that has stopped paying is granted a fresh paid-tier allowance every
+     * period, for as long as Stripe leaves the subscription past due.
+     *
+     * Purchased packs are untouched by this and by resetPeriod: that money
+     * already changed hands.
+     */
+    public function allowanceFor(Team $team): int
+    {
+        $team->loadMissing('subscriptions');
+
+        if ($team->subscription()?->pastDue() === true) {
+            return Plan::Free->credits();
+        }
+
+        return $team->plan->credits();
+    }
+
     public function resetPeriod(Team $team, ?string $sysadminId = null): void
     {
         DB::transaction(function () use ($team, $sysadminId): void {
             $plan = $team->plan;
-            $allowance = $plan->credits();
+            $allowance = $this->allowanceFor($team);
 
             $previous = AiCreditBalance::query()
                 ->where('team_id', $team->getKey())

--- a/packages/Chat/src/Services/CreditService.php
+++ b/packages/Chat/src/Services/CreditService.php
@@ -425,9 +425,9 @@ final readonly class CreditService
      * A past-due workspace refills at the Free allowance rather than the one it
      * has stopped paying for. keepPastDueSubscriptionsActive() leaves valid()
      * true throughout dunning, so the plan column still reads Pro and this is
-     * the only place that can tell the difference — without it, a workspace
-     * that has stopped paying is granted a fresh paid-tier allowance every
-     * period, for as long as Stripe leaves the subscription past due.
+     * the only place that can tell the difference. Without it, a workspace that
+     * has stopped paying is granted a fresh paid-tier allowance every period,
+     * for as long as Stripe leaves the subscription past due.
      *
      * Purchased packs are untouched by this and by resetPeriod: that money
      * already changed hands.

--- a/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/AiCreditBalanceResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources;
 
+use App\Enums\BillingStatus;
 use App\Enums\Plan;
 use Filament\Actions\Action;
 use Filament\Actions\BulkAction;
@@ -109,25 +110,11 @@ final class AiCreditBalanceResource extends Resource
                     ->sortable()
                     ->color('primary')
                     ->url(RecordLink::to(TeamResource::class, 'team')),
-                TextColumn::make('origin')
-                    ->label('Origin')
-                    ->state(function (AiCreditBalance $record): string {
-                        $team = $record->team;
-
-                        return match (true) {
-                            $team->subscription()?->valid() ?? false => 'subscription',
-                            $team->trial_ends_at?->isFuture() ?? false => 'trial',
-                            $team->plan !== Plan::default() => 'manual',
-                            default => '—',
-                        };
-                    })
-                    ->badge()
-                    ->color(fn (string $state): string => match ($state) {
-                        'subscription' => 'success',
-                        'trial' => 'info',
-                        'manual' => 'warning',
-                        default => 'gray',
-                    }),
+                TextColumn::make('billing_status')
+                    ->label('Billing')
+                    ->state(fn (AiCreditBalance $record): BillingStatus => $record->team->billingStatus())
+                    ->tooltip(fn (BillingStatus $state): string => $state->getDescription())
+                    ->badge(),
                 TextColumn::make('credits_remaining')
                     ->numeric()
                     ->sortable()

--- a/packages/SystemAdmin/src/Filament/Resources/SubscriptionResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/SubscriptionResource.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Relaticle\SystemAdmin\Filament\Resources;
 
+use App\Enums\Plan;
+use App\Enums\StripeSubscriptionStatus;
 use App\Models\Team;
 use BackedEnum;
 use Filament\Actions\Action;
@@ -56,22 +58,27 @@ final class SubscriptionResource extends Resource
         return parent::getEloquentQuery()->with('owner');
     }
 
+    /**
+     * Filament injects closure arguments by parameter name, so the callable it
+     * is handed must take `$state`. That is the only reason this sits between
+     * the column and `Plan::stripePriceLabel()`.
+     */
     public static function planLabel(?string $state): string
     {
-        return match (true) {
-            $state === config('services.stripe.prices.pro_monthly') => 'Pro · monthly',
-            $state === config('services.stripe.prices.pro_yearly') => 'Pro · yearly',
-            default => $state ?? '—',
-        };
+        return Plan::stripePriceLabel($state);
     }
 
-    public static function statusColor(string $state): string
+    /**
+     * Shared with SubscriptionsRelationManager so the two tables cannot drift
+     * apart again the way their colour maps did.
+     */
+    public static function statusColumn(): TextColumn
     {
-        return match ($state) {
-            'active', 'trialing' => 'success',
-            'past_due' => 'warning',
-            default => 'gray',
-        };
+        return TextColumn::make('stripe_status')
+            ->label('Status')
+            ->state(fn (Subscription $record): StripeSubscriptionStatus|string => StripeSubscriptionStatus::forDisplay($record->stripe_status))
+            ->tooltip(StripeSubscriptionStatus::tooltipFor(...))
+            ->badge();
     }
 
     #[Override]
@@ -92,8 +99,9 @@ final class SubscriptionResource extends Resource
                         ->formatStateUsing(self::planLabel(...)),
                     TextEntry::make('stripe_status')
                         ->label('Status')
-                        ->badge()
-                        ->color(self::statusColor(...)),
+                        ->state(fn (Subscription $record): StripeSubscriptionStatus|string => StripeSubscriptionStatus::forDisplay($record->stripe_status))
+                        ->tooltip(StripeSubscriptionStatus::tooltipFor(...))
+                        ->badge(),
                     TextEntry::make('quantity')
                         ->numeric()
                         ->placeholder('—'),
@@ -129,10 +137,7 @@ final class SubscriptionResource extends Resource
                 TextColumn::make('stripe_price')
                     ->label('Plan')
                     ->formatStateUsing(self::planLabel(...)),
-                TextColumn::make('stripe_status')
-                    ->label('Status')
-                    ->badge()
-                    ->color(self::statusColor(...)),
+                self::statusColumn(),
                 TextColumn::make('ends_at')
                     ->label('Ends')
                     ->dateTime()
@@ -145,13 +150,8 @@ final class SubscriptionResource extends Resource
             ->filters([
                 SelectFilter::make('stripe_status')
                     ->label('Status')
-                    ->options([
-                        'active' => 'Active',
-                        'trialing' => 'Trialing',
-                        'past_due' => 'Past due',
-                        'canceled' => 'Canceled',
-                        'incomplete' => 'Incomplete',
-                    ]),
+                    ->options(StripeSubscriptionStatus::class)
+                    ->multiple(),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource.php
@@ -61,6 +61,13 @@ final class TeamResource extends Resource
     protected static ?string $slug = 'teams';
 
     /**
+     * `teams.plan` is capability, `BillingStatus` is provenance, and the two
+     * badges sit side by side. Without this the pair reads as a contradiction:
+     * a trialling workspace shows a green Pro next to an amber Trial.
+     */
+    private const string PLAN_TOOLTIP = 'What the workspace may use: its AI credit allowance and rate limit. A trial writes Pro here, so it cannot say whether anyone is paying. Billing answers that.';
+
+    /**
      * @return Builder<Team>
      */
     #[Override]
@@ -118,9 +125,11 @@ final class TeamResource extends Resource
                     TextEntry::make('billing_status')
                         ->label('Billing')
                         ->state(fn (Team $record): BillingStatus => $record->billingStatus())
+                        ->tooltip(fn (BillingStatus $state): string => $state->getDescription())
                         ->badge(),
                     TextEntry::make('plan')
                         ->label('Plan')
+                        ->tooltip(self::PLAN_TOOLTIP)
                         ->badge(),
                     TextEntry::make('trial_ends_at')
                         ->label('Trial Ends')
@@ -175,6 +184,7 @@ final class TeamResource extends Resource
                     ->badge(),
                 TextColumn::make('plan')
                     ->label('Plan')
+                    ->tooltip(self::PLAN_TOOLTIP)
                     ->badge()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
@@ -198,6 +208,11 @@ final class TeamResource extends Resource
                     ->sortable(),
             ])
             ->filters([
+                SelectFilter::make('billing_status')
+                    ->label('Billing')
+                    ->options(BillingStatus::class)
+                    ->multiple()
+                    ->query(self::filterByBillingStatus(...)),
                 TernaryFilter::make('personal_team')
                     ->label('Personal Team'),
                 SelectFilter::make('onboarding_use_case')
@@ -218,6 +233,32 @@ final class TeamResource extends Resource
                     }),
                 ]),
             ]);
+    }
+
+    /**
+     * Rows whose derived billing badge is one of the selected statuses.
+     *
+     * The badge is computed per row in PHP, so the filter cannot read a column.
+     * BillingStatus::applyToQuery() owns the translation, including the
+     * precedence between statuses, and each selection is OR'd here.
+     *
+     * @param  Builder<Team>  $query
+     * @param  array{values?: array<int, string>}  $data
+     * @return Builder<Team>
+     */
+    private static function filterByBillingStatus(Builder $query, array $data): Builder
+    {
+        $statuses = array_filter(array_map(BillingStatus::tryFrom(...), $data['values'] ?? []));
+
+        if ($statuses === []) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $anyStatus) use ($statuses): void {
+            foreach ($statuses as $status) {
+                $anyStatus->orWhere(fn (Builder $matching): Builder => $status->applyToQuery($matching));
+            }
+        });
     }
 
     #[Override]

--- a/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/SubscriptionsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/TeamResource/RelationManagers/SubscriptionsRelationManager.php
@@ -33,10 +33,7 @@ final class SubscriptionsRelationManager extends RelationManager
                     ->formatStateUsing(SubscriptionResource::planLabel(...))
                     ->color('primary')
                     ->url(fn (Subscription $record): string => SubscriptionResource::getUrl('view', ['record' => $record])),
-                TextColumn::make('stripe_status')
-                    ->label('Status')
-                    ->badge()
-                    ->color(SubscriptionResource::statusColor(...)),
+                SubscriptionResource::statusColumn(),
                 TextColumn::make('ends_at')
                     ->label('Ends')
                     ->dateTime()

--- a/resources/views/filament/app/sidebar-footer.blade.php
+++ b/resources/views/filament/app/sidebar-footer.blade.php
@@ -20,6 +20,11 @@
     // Mirrors a nav item's geometry so the footer reads as part of the same
     // list rather than a stack bolted underneath it.
     $rowClasses = 'mx-4 flex items-center gap-3 rounded-lg px-2 py-1.5 text-sm text-gray-700 transition hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-white/5';
+
+    // A failure gets a solid button; an offer keeps the quieter outlined pill.
+    $actionClasses = $billing !== null && $billing['urgent']
+        ? 'border-transparent bg-danger-600 px-2 py-1 text-white group-hover:bg-danger-500'
+        : 'border-gray-200 px-1.5 py-0.5 text-gray-600 group-hover:border-gray-300 group-hover:text-gray-900 dark:border-white/10 dark:text-gray-300 dark:group-hover:text-white';
 @endphp
 
 @if($canManage)
@@ -52,7 +57,7 @@
 
                     <span class="flex-1 truncate">{{ $billing['label'] }}</span>
 
-                    <span class="flex-shrink-0 rounded-md border border-gray-200 px-1.5 py-0.5 text-xs font-medium text-gray-600 transition group-hover:border-gray-300 group-hover:text-gray-900 dark:border-white/10 dark:text-gray-300 dark:group-hover:text-white">
+                    <span class="flex-shrink-0 rounded-md border text-xs font-medium transition {{ $actionClasses }}">
                         {{ $billing['action'] }}
                     </span>
                 </a>

--- a/resources/views/filament/auth/developer_login.blade.php
+++ b/resources/views/filament/auth/developer_login.blade.php
@@ -1,9 +1,33 @@
+@use(Database\Seeders\Personas\PersonaCatalog)
+
 @env('local')
-    <div class="fixed bottom-4 end-4 z-10">
-        <x-login-link
-            email="manuk.minasyan1@gmail.com"
-            :redirect-url="url()->getAppUrl()"
-            class="text-xs text-gray-400 underline-offset-2 hover:text-gray-600 hover:underline dark:text-gray-600 dark:hover:text-gray-400"
-        />
-    </div>
+    @php($personas = PersonaCatalog::seeded())
+
+    @if ($personas->isNotEmpty())
+        <div class="mt-6">
+            <p class="mb-2 text-center text-xs text-gray-400 dark:text-gray-500">
+                {{ __('Local test accounts. Password: :password', ['password' => PersonaCatalog::PASSWORD]) }}
+            </p>
+
+            <div class="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-white/10 dark:border-white/10">
+                @foreach ($personas as $persona)
+                    <div
+                        class="flex items-center justify-between gap-3 px-3 py-2"
+                        title="{{ $persona->purpose }}"
+                    >
+                        <x-login-link
+                            :email="$persona->email"
+                            :label="$persona->email"
+                            :redirect-url="url()->getAppUrl()"
+                            class="font-mono text-xs text-gray-600 hover:underline dark:text-gray-300"
+                        />
+
+                        <x-filament::badge :color="$persona->expect->getColor()">
+                            {{ $persona->expect->getLabel() }}
+                        </x-filament::badge>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
 @endenv

--- a/resources/views/filament/pages/billing.blade.php
+++ b/resources/views/filament/pages/billing.blade.php
@@ -101,6 +101,8 @@
                                     {{ $isGrandfathered
                                         ? __('billing.manage.cancel_scheduled_legacy_body', ['date' => $subscription?->ends_at?->toFormattedDateString()])
                                         : __('billing.manage.cancel_scheduled_body', ['date' => $subscription?->ends_at?->toFormattedDateString()]) }}
+                                @elseif($pastDue)
+                                    {{ __('billing.manage.past_due_tagline') }}
                                 @elseif($isSubscribed)
                                     {{ __('billing.manage.auto_renews') }}
                                 @elseif($isPaused)
@@ -208,6 +210,10 @@
                 <h3 class="font-display text-lg font-semibold text-gray-900 dark:text-white">{{ __('billing.enterprise.title') }}</h3>
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('billing.enterprise.body') }}</p>
             </div>
+        @elseif($pastDue)
+            {{-- The past-due panel above already states the problem and carries
+                 the portal button. Claiming "You're on Pro" underneath it, in a
+                 success card, contradicts the panel it sits below. --}}
         @elseif($canManageSubscription)
             <div class="{{ $card }} p-6">
                 <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/resources/views/filament/pages/billing.blade.php
+++ b/resources/views/filament/pages/billing.blade.php
@@ -1,7 +1,6 @@
 <x-filament-panels::page>
     @php
         $purchased = (int) ($balance?->purchased_credits ?? 0);
-        $allowance = $team->plan->credits();
         $used = (int) ($balance?->credits_used ?? 0);
         $usedPercent = $allowance > 0 ? min(100, (int) round($used / $allowance * 100)) : 0;
 

--- a/tests/Feature/Billing/BillingPageTest.php
+++ b/tests/Feature/Billing/BillingPageTest.php
@@ -193,6 +193,28 @@ it('shows past-due warning', function (): void {
         ->assertDontSee(__('billing.manage.title'));
 });
 
+it('meters a past-due workspace against the allowance it will be refilled with', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['plan' => Plan::Pro])->save();
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_due_allowance',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    AiCreditBalance::query()->where('team_id', $team->getKey())->update([
+        'credits_remaining' => 0,
+        'credits_used' => Plan::Free->credits(),
+    ]);
+
+    livewire(Billing::class)
+        ->assertSee('/ '.number_format(Plan::Free->credits()))
+        ->assertDontSee('/ '.number_format(Plan::Pro->credits()))
+        ->assertSee('100%');
+});
+
 it('shows enterprise manual state without upgrade actions', function (): void {
     [, $team] = billingPageOwner();
     $team->forceFill(['plan' => Plan::Enterprise])->save();

--- a/tests/Feature/Billing/BillingPageTest.php
+++ b/tests/Feature/Billing/BillingPageTest.php
@@ -186,7 +186,11 @@ it('shows past-due warning', function (): void {
         'quantity' => 1,
     ]);
 
-    livewire(Billing::class)->assertSee(__('billing.manage.past_due_title'));
+    livewire(Billing::class)
+        ->assertSee(__('billing.manage.past_due_title'))
+        ->assertSee(__('billing.manage.past_due_tagline'))
+        ->assertDontSee(__('billing.manage.auto_renews'))
+        ->assertDontSee(__('billing.manage.title'));
 });
 
 it('shows enterprise manual state without upgrade actions', function (): void {

--- a/tests/Feature/Billing/SidebarBillingStateTest.php
+++ b/tests/Feature/Billing/SidebarBillingStateTest.php
@@ -25,7 +25,8 @@ it('counts the days left on an active trial', function (): void {
 
     expect($state)->not->toBeNull()
         ->and($state['label'])->toBe('10 days left on trial!')
-        ->and($state['action'])->toBe(__('billing.sidebar.keep_pro'));
+        ->and($state['action'])->toBe(__('billing.sidebar.keep_pro'))
+        ->and($state['urgent'])->toBeFalse();
 });
 
 it('says one day, singular, on the final day', function (): void {
@@ -46,6 +47,37 @@ it('asks a paused workspace to subscribe', function (): void {
     expect($state)->not->toBeNull()
         ->and($state['label'])->toBe(__('billing.sidebar.paused'))
         ->and($state['action'])->toBe(__('billing.sidebar.subscribe'));
+});
+
+it('flags a past-due workspace even though its subscription still reads valid', function (): void {
+    $this->team->forceFill(['plan' => Plan::Pro])->save();
+    $this->team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_sidebar_past_due',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    $state = resolve(SidebarBillingState::class)->for($this->team->fresh());
+
+    expect($state)->not->toBeNull()
+        ->and($state['label'])->toBe(__('billing.sidebar.past_due'))
+        ->and($state['action'])->toBe(__('billing.sidebar.fix'))
+        ->and($state['urgent'])->toBeTrue();
+});
+
+it('asks nothing of a paying subscriber', function (): void {
+    $this->team->forceFill(['plan' => Plan::Pro])->save();
+    $this->team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_sidebar_active',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    expect(resolve(SidebarBillingState::class)->for($this->team->fresh()))->toBeNull();
 });
 
 it('asks nothing of a grandfathered free workspace', function (): void {

--- a/tests/Feature/Billing/StripeWebhookTest.php
+++ b/tests/Feature/Billing/StripeWebhookTest.php
@@ -438,6 +438,19 @@ it('notifies the workspace owner when a renewal charge fails', function (): void
         ->and($notification->data['body'])->toBe(__('billing.payment_failed.notification_body'));
 });
 
+it('notifies once per invoice, not once per Stripe retry attempt', function (): void {
+    $team = stripeBillingTeam();
+
+    foreach ([1, 2, 3] as $attempt) {
+        sendStripeWebhook(invoicePaymentFailedEvent($team, [
+            'id' => 'in_test_retried',
+            'attempt_count' => $attempt,
+        ]))->assertOk();
+    }
+
+    expect($team->owner->notifications()->count())->toBe(1);
+});
+
 it('raises no subscription alarm for a one-off invoice', function (): void {
     $team = stripeBillingTeam();
 

--- a/tests/Feature/Billing/StripeWebhookTest.php
+++ b/tests/Feature/Billing/StripeWebhookTest.php
@@ -451,6 +451,26 @@ it('notifies once per invoice, not once per Stripe retry attempt', function (): 
     expect($team->owner->notifications()->count())->toBe(1);
 });
 
+it('alarms on a plan change that failed to bill', function (): void {
+    $team = stripeBillingTeam();
+
+    sendStripeWebhook(invoicePaymentFailedEvent($team, [
+        'billing_reason' => 'subscription_update',
+    ]))->assertOk();
+
+    expect($team->owner->notifications()->count())->toBe(1);
+});
+
+it('stays quiet when the very first subscription charge fails', function (): void {
+    $team = stripeBillingTeam();
+
+    sendStripeWebhook(invoicePaymentFailedEvent($team, [
+        'billing_reason' => 'subscription_create',
+    ]))->assertOk();
+
+    expect($team->owner->notifications()->count())->toBe(0);
+});
+
 it('raises no subscription alarm for a one-off invoice', function (): void {
     $team = stripeBillingTeam();
 

--- a/tests/Feature/Billing/StripeWebhookTest.php
+++ b/tests/Feature/Billing/StripeWebhookTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Billing\GrantPurchasedCredits;
+use App\Actions\Billing\NotifyWorkspaceOfPaymentFailure;
 use App\Actions\Billing\StartProTrial;
 use App\Actions\Billing\SyncTeamPlanFromSubscription;
 use App\Enums\Plan;
@@ -23,6 +24,7 @@ use Relaticle\SystemAdmin\Models\SystemAdministrator;
 mutates(SyncTeamPlanFromSubscription::class);
 mutates(SyncPlanOnStripeSubscriptionChange::class);
 mutates(GrantPurchasedCredits::class);
+mutates(NotifyWorkspaceOfPaymentFailure::class);
 
 beforeEach(function (): void {
     config()->set('cashier.webhook.secret', 'whsec_test_secret');
@@ -395,6 +397,68 @@ it('logs and grants nothing when a payment-mode session is missing pack metadata
             && in_array('metadata.team_id', $context['missing_fields'], true)
             && ! in_array('metadata.credit_pack_price', $context['missing_fields'], true)
         );
+});
+
+/**
+ * Shaped after a real event off the sandbox (API 2026-05-27.dahlia): that
+ * version carries the subscription at parent.subscription_details and has no
+ * top-level `subscription` key at all.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function invoicePaymentFailedEvent(Team $team, array $overrides = []): array
+{
+    return [
+        'type' => 'invoice.payment_failed',
+        'data' => [
+            'object' => array_merge([
+                'id' => 'in_'.Str::ulid(),
+                'object' => 'invoice',
+                'customer' => $team->stripe_id,
+                'billing_reason' => 'subscription_cycle',
+                'attempt_count' => 1,
+                'parent' => [
+                    'type' => 'subscription_details',
+                    'subscription_details' => ['subscription' => 'sub_test_1'],
+                ],
+            ], $overrides),
+        ],
+    ];
+}
+
+it('notifies the workspace owner when a renewal charge fails', function (): void {
+    $team = stripeBillingTeam();
+
+    sendStripeWebhook(invoicePaymentFailedEvent($team))->assertOk();
+
+    $notification = $team->owner->notifications()->sole();
+
+    expect($notification->data['title'])->toContain($team->name)
+        ->and($notification->data['body'])->toBe(__('billing.payment_failed.notification_body'));
+});
+
+it('raises no subscription alarm for a one-off invoice', function (): void {
+    $team = stripeBillingTeam();
+
+    sendStripeWebhook(invoicePaymentFailedEvent($team, [
+        'billing_reason' => 'manual',
+        'parent' => null,
+    ]))->assertOk();
+
+    expect($team->owner->notifications()->count())->toBe(0);
+});
+
+it('notifies nobody for a customer that belongs to no workspace', function (): void {
+    $team = stripeBillingTeam();
+
+    sendStripeWebhook(invoicePaymentFailedEvent($team, ['customer' => 'cus_unknown']))->assertOk();
+
+    expect($team->owner->notifications()->count())->toBe(0);
+});
+
+it('subscribes the Stripe endpoint to the failed-payment event', function (): void {
+    expect(config('cashier.webhook.events'))->toContain('invoice.payment_failed');
 });
 
 it('subscribes the Stripe endpoint to every checkout event the controller handles', function (): void {

--- a/tests/Feature/Chat/OutOfCreditsResponseTest.php
+++ b/tests/Feature/Chat/OutOfCreditsResponseTest.php
@@ -306,3 +306,48 @@ it('withholds the top-up url when no credit pack has a configured price', functi
     expect($response->json('top_up_available'))->toBeFalse();
     expect($response->json('top_up_url'))->toBeNull();
 });
+
+it('names the Free allowance, not the Pro one, when a past-due workspace runs out', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $team = $user->currentTeam;
+    $team->plan = Plan::Pro;
+    $team->save();
+
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_test_past_due_exhausted',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    AiCreditBalance::query()->updateOrCreate(['team_id' => $team->getKey()], [
+        'team_id' => $team->getKey(),
+        'credits_remaining' => 0,
+        'credits_used' => Plan::Free->credits(),
+        'period_starts_at' => now()->startOfMonth(),
+        'period_ends_at' => now()->endOfMonth(),
+    ]);
+
+    $conversationId = (string) Str::uuid7();
+    DB::table('agent_conversations')->insert([
+        'id' => $conversationId,
+        'participant_type' => 'user',
+        'participant_id' => (string) $user->getKey(),
+        'team_id' => $team->getKey(),
+        'title' => 'test',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $response = $this->actingAs($user)->postJson("/chat/{$conversationId}", [
+        'document' => ['type' => 'doc', 'content' => [
+            ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'hi']]],
+        ]],
+    ]);
+
+    $response->assertStatus(402);
+    expect($response->json('allowance'))->toBe(Plan::Free->credits())
+        ->and($response->json('allowance'))->not->toBe(Plan::Pro->credits())
+        ->and($response->json('message'))->toContain((string) Plan::Free->credits());
+});

--- a/tests/Feature/Chat/PlanAwareResetTest.php
+++ b/tests/Feature/Chat/PlanAwareResetTest.php
@@ -70,6 +70,90 @@ it('resets an Enterprise team to 10000 credits when the scheduled reset runs', f
     expect($team->fresh()->aiCreditBalance->credits_remaining)->toBe(Plan::Enterprise->credits());
 });
 
+it('refills a past-due Pro team at the Free allowance, not the one it stopped paying for', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $team = $user->currentTeam;
+    $team->forceFill(['plan' => Plan::Pro->value])->save();
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_reset_past_due',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    AiCreditBalance::query()
+        ->where('team_id', $team->getKey())
+        ->update([
+            'credits_remaining' => 0,
+            'credits_used' => 2_000,
+            'period_starts_at' => now()->subMonth(),
+            'period_ends_at' => now()->subDay(),
+        ]);
+
+    Artisan::call('chat:reset-credits');
+
+    expect($team->fresh()->aiCreditBalance->credits_remaining)->toBe(Plan::Free->credits());
+});
+
+it('leaves purchased packs intact when a past-due team refills', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $team = $user->currentTeam;
+    $team->forceFill(['plan' => Plan::Pro->value])->save();
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_reset_past_due_packs',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    AiCreditBalance::query()
+        ->where('team_id', $team->getKey())
+        ->update([
+            'credits_remaining' => 500,
+            'credits_used' => 2_000,
+            'purchased_credits' => 500,
+            'period_starts_at' => now()->subMonth(),
+            'period_ends_at' => now()->subDay(),
+        ]);
+
+    Artisan::call('chat:reset-credits');
+
+    $balance = $team->fresh()->aiCreditBalance;
+
+    expect($balance->purchased_credits)->toBe(500)
+        ->and($balance->credits_remaining)->toBe(Plan::Free->credits() + 500);
+});
+
+it('restores the Pro allowance once the past-due charge clears', function (): void {
+    $user = User::factory()->withPersonalTeam()->create();
+    $team = $user->currentTeam;
+    $team->forceFill(['plan' => Plan::Pro->value])->save();
+    $subscription = $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_reset_recovered',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    $subscription->forceFill(['stripe_status' => 'active'])->save();
+
+    AiCreditBalance::query()
+        ->where('team_id', $team->getKey())
+        ->update([
+            'credits_remaining' => 0,
+            'credits_used' => 300,
+            'period_starts_at' => now()->subMonth(),
+            'period_ends_at' => now()->subDay(),
+        ]);
+
+    Artisan::call('chat:reset-credits');
+
+    expect($team->fresh()->aiCreditBalance->credits_remaining)->toBe(Plan::Pro->credits());
+});
+
 it('skips teams whose period has not yet expired', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
     $team = $user->currentTeam;

--- a/tests/Feature/SystemAdmin/AiCreditBalanceResourceTest.php
+++ b/tests/Feature/SystemAdmin/AiCreditBalanceResourceTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Enums\BillingStatus;
+use App\Enums\Plan;
 use App\Models\Team;
 use Filament\Facades\Filament;
 use Relaticle\Chat\Models\AiCreditBalance;
@@ -104,4 +106,18 @@ it('renders the period dates on the administrator calendar day, not the server o
 
     livewire(ListAiCreditBalances::class)
         ->assertTableColumnFormattedStateSet('period_starts_at', 'Jun 10, 2026', $balance);
+});
+
+it('explains an allowance with the workspace billing badge, not a vocabulary of its own', function (): void {
+    $team = Team::factory()->create();
+    $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save();
+
+    AiCreditBalance::query()->where('team_id', $team->getKey())->delete();
+    $balance = AiCreditBalance::factory()->create(['team_id' => $team->getKey()]);
+
+    livewire(ListAiCreditBalances::class)
+        ->assertCanSeeTableRecords([$balance])
+        ->assertCanRenderTableColumn('billing_status')
+        ->assertSee(BillingStatus::Trialing->getLabel())
+        ->assertSeeHtml(BillingStatus::Trialing->getDescription());
 });

--- a/tests/Feature/SystemAdmin/SubscriptionResourceTest.php
+++ b/tests/Feature/SystemAdmin/SubscriptionResourceTest.php
@@ -2,14 +2,17 @@
 
 declare(strict_types=1);
 
+use App\Enums\BillingStatus;
+use App\Enums\StripeSubscriptionStatus;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Laravel\Cashier\Subscription;
 use Relaticle\SystemAdmin\Filament\Resources\SubscriptionResource;
 use Relaticle\SystemAdmin\Filament\Resources\SubscriptionResource\Pages\ListSubscriptions;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
-mutates(SubscriptionResource::class);
+mutates(SubscriptionResource::class, StripeSubscriptionStatus::class);
 
 beforeEach(function (): void {
     $this->actingAs(SystemAdministrator::factory()->create(), 'sysadmin');
@@ -20,13 +23,8 @@ beforeEach(function (): void {
 it('lists subscriptions with team and status for sysadmins', function (): void {
     /** @var Team $team */
     $team = User::factory()->withPersonalTeam()->create()->currentTeam;
-    $subscription = $team->subscriptions()->create([
-        'type' => 'default',
-        'stripe_id' => 'sub_list',
-        'stripe_status' => 'active',
-        'stripe_price' => 'price_pro_monthly_test',
-        'quantity' => 1,
-    ]);
+    $subscription = Subscription::factory()->active()->withPrice('price_pro_monthly_test')
+        ->create(['team_id' => $team->getKey()]);
 
     livewire(ListSubscriptions::class)
         ->assertCanSeeTableRecords([$subscription])
@@ -41,17 +39,63 @@ it('filters subscriptions by status', function (): void {
     /** @var Team $teamB */
     $teamB = User::factory()->withPersonalTeam()->create()->currentTeam;
 
-    $active = $teamA->subscriptions()->create([
-        'type' => 'default', 'stripe_id' => 'sub_a', 'stripe_status' => 'active',
-        'stripe_price' => 'price_pro_monthly_test', 'quantity' => 1,
-    ]);
-    $canceled = $teamB->subscriptions()->create([
-        'type' => 'default', 'stripe_id' => 'sub_b', 'stripe_status' => 'canceled',
-        'stripe_price' => 'price_pro_monthly_test', 'quantity' => 1, 'ends_at' => now()->subDay(),
-    ]);
+    $active = Subscription::factory()->active()->withPrice('price_pro_monthly_test')
+        ->create(['team_id' => $teamA->getKey()]);
+    $canceled = Subscription::factory()->canceled()->withPrice('price_pro_monthly_test')
+        ->create(['team_id' => $teamB->getKey(), 'ends_at' => now()->subDay()]);
 
     livewire(ListSubscriptions::class)
         ->filterTable('stripe_status', 'active')
         ->assertCanSeeTableRecords([$active])
         ->assertCanNotSeeTableRecords([$canceled]);
+});
+
+it('spells a stripe status the way the workspace billing badge spells it', function (): void {
+    /** @var Team $team */
+    $team = User::factory()->withPersonalTeam()->create()->currentTeam;
+    $subscription = Subscription::factory()->pastDue()->withPrice('price_pro_monthly_test')
+        ->create(['team_id' => $team->getKey()]);
+
+    livewire(ListSubscriptions::class)
+        ->assertCanSeeTableRecords([$subscription])
+        ->assertSee(StripeSubscriptionStatus::PastDue->getLabel())
+        ->assertSeeHtml(StripeSubscriptionStatus::PastDue->getDescription());
+
+    expect(StripeSubscriptionStatus::PastDue->getLabel())->toBe(BillingStatus::PastDue->getLabel())
+        ->and(StripeSubscriptionStatus::PastDue->getColor())->toBe(BillingStatus::PastDue->getColor());
+});
+
+it('renders a status Stripe adds later as its raw value instead of failing', function (): void {
+    /** @var Team $team */
+    $team = User::factory()->withPersonalTeam()->create()->currentTeam;
+    $subscription = Subscription::factory()->withPrice('price_pro_monthly_test')
+        ->create(['team_id' => $team->getKey(), 'stripe_status' => 'some_future_status']);
+
+    livewire(ListSubscriptions::class)
+        ->assertCanSeeTableRecords([$subscription])
+        ->assertSee('some_future_status');
+});
+
+it('labels a subscription by the plan and interval its price maps to', function (): void {
+    config()->set('services.stripe.prices.pro_yearly', 'price_pro_yearly_test');
+
+    /** @var Team $team */
+    $team = User::factory()->withPersonalTeam()->create()->currentTeam;
+    $subscription = Subscription::factory()->active()->withPrice('price_pro_yearly_test')
+        ->create(['team_id' => $team->getKey()]);
+
+    livewire(ListSubscriptions::class)
+        ->assertCanSeeTableRecords([$subscription])
+        ->assertSee('Pro · yearly');
+});
+
+it('falls back to the raw price id when it is not in the configured price map', function (): void {
+    /** @var Team $team */
+    $team = User::factory()->withPersonalTeam()->create()->currentTeam;
+    $subscription = Subscription::factory()->active()->withPrice('price_not_in_the_map')
+        ->create(['team_id' => $team->getKey()]);
+
+    livewire(ListSubscriptions::class)
+        ->assertCanSeeTableRecords([$subscription])
+        ->assertSee('price_not_in_the_map');
 });

--- a/tests/Feature/SystemAdmin/TeamResourceTest.php
+++ b/tests/Feature/SystemAdmin/TeamResourceTest.php
@@ -8,6 +8,7 @@ use App\Models\Company;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Laravel\Cashier\Subscription;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\EditTeam;
 use Relaticle\SystemAdmin\Filament\Resources\TeamResource\Pages\ListTeams;
@@ -93,6 +94,49 @@ function billingStatusTeam(): Team
     return User::factory()->withPersonalTeam()->create()->ownedTeams()->firstOrFail();
 }
 
+/**
+ * @return array<string, array{0: callable(Team): void, 1: BillingStatus}>
+ */
+function billingStatusArrangements(): array
+{
+    return [
+        'a trial reads Trial, never Pro' => [
+            fn (Team $team) => $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save(),
+            BillingStatus::Trialing,
+        ],
+        'a paid subscription reads Pro' => [
+            function (Team $team): void {
+                $team->forceFill(['plan' => Plan::Pro])->save();
+                Subscription::factory()->active()->create(['team_id' => $team->getKey()]);
+            },
+            BillingStatus::Subscribed,
+        ],
+        'a lapsed subscription reads Past due, not Pro' => [
+            function (Team $team): void {
+                $team->forceFill(['plan' => Plan::Pro])->save();
+                Subscription::factory()->pastDue()->create(['team_id' => $team->getKey()]);
+            },
+            BillingStatus::PastDue,
+        ],
+        'a hand-assigned plan reads Granted, not Pro' => [
+            fn (Team $team) => $team->forceFill(['plan' => Plan::Pro])->save(),
+            BillingStatus::Granted,
+        ],
+        'an enterprise workspace reads Enterprise' => [
+            fn (Team $team) => $team->forceFill(['plan' => Plan::Enterprise])->save(),
+            BillingStatus::Enterprise,
+        ],
+        'a pre-billing workspace reads Free (legacy)' => [
+            fn (Team $team) => $team->forceFill(['hosted_free_grandfathered_at' => now()])->save(),
+            BillingStatus::Grandfathered,
+        ],
+        'a workspace with nothing bought reads Free' => [
+            fn (Team $team): null => null,
+            BillingStatus::Free,
+        ],
+    ];
+}
+
 it('labels a workspace by why it has its plan, not by the plan alone', function (callable $arrange, BillingStatus $expected): void {
     $team = billingStatusTeam();
     $arrange($team);
@@ -103,65 +147,58 @@ it('labels a workspace by why it has its plan, not by the plan alone', function 
         ->assertCanSeeTableRecords([$team])
         ->assertSee($expected->getLabel())
         ->assertSeeHtml($expected->getDescription());
-})->with([
-    'a trial reads Trial, never Pro' => [
-        fn (Team $team) => $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save(),
-        BillingStatus::Trialing,
-    ],
-    'a paid subscription reads Pro' => [
-        function (Team $team): void {
-            $team->forceFill(['plan' => Plan::Pro])->save();
-            $team->subscriptions()->create([
-                'type' => 'default',
-                'stripe_id' => 'sub_active',
-                'stripe_status' => 'active',
-                'stripe_price' => 'price_pro_monthly_test',
-                'quantity' => 1,
-            ]);
-        },
-        BillingStatus::Subscribed,
-    ],
-    'a lapsed subscription reads Past due, not Pro' => [
-        function (Team $team): void {
-            $team->forceFill(['plan' => Plan::Pro])->save();
-            $team->subscriptions()->create([
-                'type' => 'default',
-                'stripe_id' => 'sub_due',
-                'stripe_status' => 'past_due',
-                'stripe_price' => 'price_pro_monthly_test',
-                'quantity' => 1,
-            ]);
-        },
-        BillingStatus::PastDue,
-    ],
-    'a hand-assigned plan reads Granted, not Pro' => [
-        fn (Team $team) => $team->forceFill(['plan' => Plan::Pro])->save(),
-        BillingStatus::Granted,
-    ],
-    'an enterprise workspace reads Enterprise' => [
-        fn (Team $team) => $team->forceFill(['plan' => Plan::Enterprise])->save(),
-        BillingStatus::Enterprise,
-    ],
-    'a pre-billing workspace reads Free (legacy)' => [
-        fn (Team $team) => $team->forceFill(['hosted_free_grandfathered_at' => now()])->save(),
-        BillingStatus::Grandfathered,
-    ],
-]);
+})->with(billingStatusArrangements());
+
+it('filters workspaces by the badge they show, and by no other', function (): void {
+    $teams = [];
+
+    foreach (billingStatusArrangements() as [$arrange, $status]) {
+        $team = billingStatusTeam();
+        $arrange($team);
+        $teams[$status->value] = $team->fresh();
+    }
+
+    expect(array_keys($teams))
+        ->toEqualCanonicalizing(array_column(BillingStatus::cases(), 'value'));
+
+    expect(collect($teams)->map(fn (Team $team): string => $team->billingStatus()->value)->all())
+        ->toBe(array_combine(array_keys($teams), array_keys($teams)));
+
+    foreach ($teams as $value => $team) {
+        livewire(ListTeams::class)
+            ->filterTable('billing_status', [$value])
+            ->assertCanSeeTableRecords([$team])
+            ->assertCanNotSeeTableRecords(collect($teams)->except($value)->values()->all());
+    }
+});
+
+it('filters on the subscription a workspace bills on now, not a superseded one', function (): void {
+    $team = billingStatusTeam();
+    $team->forceFill(['plan' => Plan::Pro])->save();
+
+    Subscription::factory()->pastDue()->create([
+        'team_id' => $team->getKey(),
+        'created_at' => now()->subMonths(2),
+        'updated_at' => now()->subMonths(2),
+    ]);
+
+    Subscription::factory()->active()->create(['team_id' => $team->getKey()]);
+
+    expect($team->fresh()?->billingStatus())->toBe(BillingStatus::Subscribed);
+
+    livewire(ListTeams::class)
+        ->filterTable('billing_status', [BillingStatus::Subscribed])
+        ->assertCanSeeTableRecords([$team]);
+
+    livewire(ListTeams::class)
+        ->filterTable('billing_status', [BillingStatus::PastDue])
+        ->assertCanNotSeeTableRecords([$team]);
+});
 
 it('prefers a live subscription over a trial that has not run out yet', function (): void {
     $team = billingStatusTeam();
     $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save();
-    $team->subscriptions()->create([
-        'type' => 'default',
-        'stripe_id' => 'sub_converted',
-        'stripe_status' => 'active',
-        'stripe_price' => 'price_pro_monthly_test',
-        'quantity' => 1,
-    ]);
+    Subscription::factory()->active()->create(['team_id' => $team->getKey()]);
 
     expect($team->fresh()?->billingStatus())->toBe(BillingStatus::Subscribed);
-});
-
-it('reads a workspace with nothing bought and no trial as Free', function (): void {
-    expect(billingStatusTeam()->billingStatus())->toBe(BillingStatus::Free);
 });

--- a/tests/Feature/SystemAdmin/TeamResourceTest.php
+++ b/tests/Feature/SystemAdmin/TeamResourceTest.php
@@ -195,6 +195,52 @@ it('filters on the subscription a workspace bills on now, not a superseded one',
         ->assertCanNotSeeTableRecords([$team]);
 });
 
+it('filters a workspace still inside its grace period as Pro, the way the badge reads it', function (): void {
+    $team = billingStatusTeam();
+    $team->forceFill(['plan' => Plan::Pro])->save();
+
+    Subscription::factory()->unpaid()->create([
+        'team_id' => $team->getKey(),
+        'ends_at' => now()->addDays(5),
+    ]);
+
+    expect($team->fresh()?->billingStatus())->toBe(BillingStatus::Subscribed);
+
+    livewire(ListTeams::class)
+        ->filterTable('billing_status', [BillingStatus::Subscribed])
+        ->assertCanSeeTableRecords([$team]);
+
+    livewire(ListTeams::class)
+        ->filterTable('billing_status', [BillingStatus::PastDue])
+        ->assertCanNotSeeTableRecords([$team]);
+});
+
+it('filters on the default subscription, ignoring a newer one of another type', function (): void {
+    $team = billingStatusTeam();
+    $team->forceFill(['plan' => Plan::Pro])->save();
+
+    Subscription::factory()->active()->create([
+        'team_id' => $team->getKey(),
+        'created_at' => now()->subMonths(2),
+        'updated_at' => now()->subMonths(2),
+    ]);
+
+    Subscription::factory()->pastDue()->create([
+        'team_id' => $team->getKey(),
+        'type' => 'addon',
+    ]);
+
+    expect($team->fresh()?->billingStatus())->toBe(BillingStatus::Subscribed);
+
+    livewire(ListTeams::class)
+        ->filterTable('billing_status', [BillingStatus::Subscribed])
+        ->assertCanSeeTableRecords([$team]);
+
+    livewire(ListTeams::class)
+        ->filterTable('billing_status', [BillingStatus::PastDue])
+        ->assertCanNotSeeTableRecords([$team]);
+});
+
 it('prefers a live subscription over a trial that has not run out yet', function (): void {
     $team = billingStatusTeam();
     $team->forceFill(['plan' => Plan::Pro, 'trial_ends_at' => now()->addDays(5)])->save();


### PR DESCRIPTION
The Team view page showed a green `Pro` plan badge beside an amber `Trial` billing badge with nothing explaining the pair: `teams.plan` records capability (a trial writes `Plan::Pro` for credits and rate limits) while `BillingStatus` records provenance, and only the table column carried the tooltip. Three surfaces also spoke three vocabularies for the same facts, with the credit balance table reimplementing `BillingStatus` as a local match that had no answer for past due, Enterprise or grandfathered, and the subscription tables rendering raw snake_case under a colour map where `past_due` was a warning in one place and a danger in the other. This adds tooltips to both badges, points the credit balance column at the real `BillingStatus`, introduces `StripeSubscriptionStatus` (label, colour, description) beside `BillingStatus` in `app/Enums` where PHPStan can check its match arms, shares one status column between the subscription table and its relation manager, and moves the price label onto `Plan::stripePriceLabel()` so it reads the configured price map instead of naming two price ids by hand. Workspaces can now be filtered by the badge they show: it is derived per row, so `BillingStatus::applyToQuery()` reproduces `fromTeam()`'s precedence and `Team::latestDefaultSubscription()` mirrors the row Cashier resolves, which stops a superseded subscription mislabelling a workspace. `LocalSeeder` gains a workspace per billing status and a subscription per Stripe status, seeded as local rows because `past_due` and `unpaid` are unreachable through the Stripe test API without a test clock, so "Open in Stripe" will not resolve on them.

## Verification

- Every `BillingStatus` case cross-checked query against derived badge across 61 local workspaces: all agree, including the superseded-subscription case.
- Walked in the browser, light and dark: Team view tooltips, Teams list filter and its indicator, Subscriptions list (all 8 status badges), the Subscriptions relation tab, and Credit Balances.
- `pint --test --parallel`, `phpstan` (0 errors), `rector --dry-run` (clean), type coverage 100%, full suite 3998 tests / 3996 passed / 2 skipped.
- A new test asserts the filter arrangements cover every `BillingStatus` case, so a case added without one fails rather than going unfiltered.