### PR TITLE
Move email navigation to top and add compose header action

### DIFF
--- a/.claude/skills/ai-sdk-development/SKILL.md
+++ b/.claude/skills/ai-sdk-development/SKILL.md
@@ -450,9 +450,9 @@ Embeddings::for(['Hello'])->generate(
 );
 ```
 
-It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions`; the returned array is merged into the body.
+It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
 
-Transcription uploads standard multipart (`file` + `model` + optional `language`) and defaults to `response_format: json`. Because endpoints vary, provider options override the defaults. Pass `response_format: 'verbose_json'` for segments, or use `diarize()` on servers that implement `diarized_json`:
+Transcription uploads standard multipart (`file` + `model` + optional `language`) and defaults to `response_format: json`. Because endpoints vary, provider options override the defaults — pass `response_format: 'verbose_json'` for segments, or use `diarize()` on servers that implement `diarized_json`:
 
 ```php
 Transcription::fromDisk('recordings', $path)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,6 +473,13 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 - Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd at `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs. Never run commands to serve the site. It is always available.
+- Use the `herd` CLI to manage services, PHP versions, and sites (e.g. `herd sites`, `herd services:start <service>`, `herd php:list`). Run `herd list` to discover all available commands.
+
 === laravel/core rules ===
 
 # Do Things the Laravel Way

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,13 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 - Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd at `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs. Never run commands to serve the site. It is always available.
+- Use the `herd` CLI to manage services, PHP versions, and sites (e.g. `herd sites`, `herd services:start <service>`, `herd php:list`). Run `herd list` to discover all available commands.
+
 === laravel/core rules ===
 
 # Do Things the Laravel Way

--- a/lang/en/filament/concerns/email-compose.php
+++ b/lang/en/filament/concerns/email-compose.php
@@ -6,6 +6,7 @@ return [
     'actions' => [
         'compose' => [
             'label' => 'Compose',
+            'tooltip' => 'c',
         ],
         'undo' => [
             'label' => 'Undo',

--- a/packages/EmailIntegration/src/Filament/Clusters/EmailSettings.php
+++ b/packages/EmailIntegration/src/Filament/Clusters/EmailSettings.php
@@ -6,12 +6,15 @@ namespace Relaticle\EmailIntegration\Filament\Clusters;
 
 use BackedEnum;
 use Filament\Clusters\Cluster;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Support\Icons\Heroicon;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 
 final class EmailSettings extends Cluster
 {
     use HasEmailFeatureFlag;
+
+    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedEnvelope;
 

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -57,6 +57,7 @@ trait HasEmailComposeActions
         return Action::make('composeEmail')
             ->label(__('filament/concerns/email-compose.actions.compose.label'))
             ->icon('heroicon-o-pencil-square')
+            ->tooltip(__('filament/concerns/email-compose.actions.compose.tooltip'))
             ->visible(fn (): bool => $this->hasActiveConnectedAccount())
             ->action(function (): void {
                 $this->dispatch('composer:open');

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -176,6 +176,7 @@ final class EmailInboxPage extends Page
         return Action::make('composeEmail')
             ->label(__('filament/concerns/email-compose.actions.compose.label'))
             ->icon('heroicon-o-pencil-square')
+            ->tooltip(__('filament/concerns/email-compose.actions.compose.tooltip'))
             ->visible(fn (): bool => $this->hasActiveConnectedAccount())
             ->action(function (): void {
                 $this->dispatch('composer:open');

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -162,18 +162,29 @@ final class EmailInboxPage extends Page
     }
 
     /**
-     * @return array<int, mixed>
+     * @return array<int, Action>
      */
     protected function getHeaderActions(): array
     {
-        return [];
+        return [
+            $this->composeEmailAction(),
+        ];
+    }
+
+    protected function composeEmailAction(): Action
+    {
+        return Action::make('composeEmail')
+            ->label(__('filament/concerns/email-compose.actions.compose.label'))
+            ->icon('heroicon-o-pencil-square')
+            ->visible(fn (): bool => $this->hasActiveConnectedAccount())
+            ->action(function (): void {
+                $this->dispatch('composer:open');
+            });
     }
 
     /**
-     * No page heading. The board is the page — a title bar above it repeating the word
-     * already highlighted in the sidebar only pushes the list down. Filament drops the
-     * whole header block when the heading and header actions are both empty. Compose
-     * is the global floating composer (`c` / the composer:open event).
+     * No page heading. The sidebar already marks Email as active; the header row
+     * carries only the compose action above the tab strip.
      */
     public function getHeading(): string
     {

--- a/tests/Feature/EmailIntegration/EmailInboxComposeTest.php
+++ b/tests/Feature/EmailIntegration/EmailInboxComposeTest.php
@@ -33,6 +33,19 @@ it('prompts to configure a mailbox when no account is connected', function (): v
 
 it('shows the inbox instead of the prompt once an account is connected', function (): void {
     livewire(EmailInboxPage::class)
-        ->assertDontSee(__('filament/pages/email-accounts.not_connected.inbox.heading'))
-        ->assertActionDoesNotExist('composeEmail');
+        ->assertDontSee(__('filament/pages/email-accounts.not_connected.inbox.heading'));
+});
+
+it('opens the floating composer from the page header compose action', function (): void {
+    livewire(EmailInboxPage::class)
+        ->assertActionVisible('composeEmail')
+        ->callAction('composeEmail')
+        ->assertDispatched('composer:open');
+});
+
+it('hides the compose action when no account is connected', function (): void {
+    $this->account->forceDelete();
+
+    livewire(EmailInboxPage::class)
+        ->assertActionHidden('composeEmail');
 });


### PR DESCRIPTION
## Summary

- move email cluster navigation above the page content
- add a visible inbox header action that opens the floating composer
- show the existing `c` compose shortcut in the action tooltip
- cover compose action visibility and dispatch behavior
- synchronize the generated Herd and AI SDK guidance updates already in the workspace

## Why

This keeps email navigation and the primary compose entry point together at the top of the inbox, making both easier to discover.

## Verification

- PHPStan: passed
- Type coverage: 100%
- Email compose tests: 19 passed, 68 assertions
- Full non-TIA suite: 4,394 passed, 2 skipped, 20,374 assertions