### PR TITLE
Improve email access request controls

### DIFF
--- a/.claude/skills/ai-sdk-development/SKILL.md
+++ b/.claude/skills/ai-sdk-development/SKILL.md
@@ -450,9 +450,9 @@ Embeddings::for(['Hello'])->generate(
 );
 ```
 
-It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions`; the returned array is merged into the body.
+It uses OpenAI-standard shapes and supports text, streaming, tools, structured output, image attachments, text embeddings, and audio transcription. Embedding dimensions are optional; omit them to use the model's native dimensions. For extra request-body fields, implement `HasProviderOptions` — the returned array is merged into the body.
 
-Transcription uploads standard multipart (`file` + `model` + optional `language`) and defaults to `response_format: json`. Because endpoints vary, provider options override the defaults. Pass `response_format: 'verbose_json'` for segments, or use `diarize()` on servers that implement `diarized_json`:
+Transcription uploads standard multipart (`file` + `model` + optional `language`) and defaults to `response_format: json`. Because endpoints vary, provider options override the defaults — pass `response_format: 'verbose_json'` for segments, or use `diarize()` on servers that implement `diarized_json`:
 
 ```php
 Transcription::fromDisk('recordings', $path)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,6 +473,13 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 - Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd at `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs. Never run commands to serve the site. It is always available.
+- Use the `herd` CLI to manage services, PHP versions, and sites (e.g. `herd sites`, `herd services:start <service>`, `herd php:list`). Run `herd list` to discover all available commands.
+
 === laravel/core rules ===
 
 # Do Things the Laravel Way

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,13 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 - Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
 
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd at `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs. Never run commands to serve the site. It is always available.
+- Use the `herd` CLI to manage services, PHP versions, and sites (e.g. `herd sites`, `herd services:start <service>`, `herd php:list`). Run `herd list` to discover all available commands.
+
 === laravel/core rules ===
 
 # Do Things the Laravel Way

--- a/packages/EmailIntegration/resources/views/forms/sharing-tier-cards.blade.php
+++ b/packages/EmailIntegration/resources/views/forms/sharing-tier-cards.blade.php
@@ -8,7 +8,7 @@
         'icon' => $tier->getIcon(),
         'label' => $tier->getLabel(),
         'description' => $tier->getDescription(),
-    ], EmailPrivacyTier::cases());
+    ], $tiers ?? EmailPrivacyTier::cases());
 
     /**
      * The settings page leads with a "whatever the workspace has set" card; a single
@@ -42,6 +42,7 @@
                 <input
                     type="radio"
                     value="{{ $option['value'] }}"
+                    @disabled($isDisabled())
                     {{ $applyStateBindingModifiers('wire:model') }}="{{ $statePath }}"
                     class="fi-radio-input mt-1 shrink-0"
                 />

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailReaderActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailReaderActions.php
@@ -20,6 +20,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
+use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
@@ -204,14 +205,36 @@ trait HasEmailReaderActions
                     && $this->readerUser()->can('requestAccess', $record);
             })
             ->schema([
-                Select::make('tier_requested')
+                Radio::make('tier_requested')
                     ->label(__('filament/pages/record-emails.fields.tier_requested.label'))
                     ->options([
                         EmailPrivacyTier::SUBJECT->value => EmailPrivacyTier::SUBJECT->getLabel(),
                         EmailPrivacyTier::FULL->value => EmailPrivacyTier::FULL->getLabel(),
                     ])
+                    ->view('email-integration::forms.sharing-tier-cards')
+                    ->viewData([
+                        'ariaLabel' => __('filament/pages/record-emails.fields.tier_requested.label'),
+                        'tiers' => [EmailPrivacyTier::SUBJECT, EmailPrivacyTier::FULL],
+                    ])
                     ->required(),
             ])
+            ->mountUsing(function (Action $action, Schema $schema, array $arguments, mixed $record = null): void {
+                $email = $this->emailForReaderAction($record instanceof Email ? $record : null, $arguments, 'requestAccess');
+                $pendingRequest = $email instanceof Email
+                    ? EmailAccessRequest::query()
+                        ->where('email_id', $email->getKey())
+                        ->where('requester_id', $this->readerUser()->getKey())
+                        ->where('status', EmailAccessRequestStatus::PENDING)
+                        ->first()
+                    : null;
+
+                $schema->fill(['tier_requested' => $pendingRequest?->tier_requested]);
+
+                if ($pendingRequest instanceof EmailAccessRequest) {
+                    $schema->disabled();
+                    $action->modalSubmitAction(false);
+                }
+            })
             ->action(function (array $data, array $arguments, mixed $record = null): void {
                 $email = $this->emailForReaderAction($record instanceof Email ? $record : null, $arguments, 'requestAccess');
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -356,9 +356,10 @@ final class EmailInboxPage extends Page
                     ->orWhere('created_by', $user->getKey()))
                 ->count(),
             EmailPageTab::REQUESTS->value => EmailAccessRequest::query()
-                ->where('owner_id', $user->getKey())
+                ->where(fn (Builder $query): Builder => $query
+                    ->where('owner_id', $user->getKey())
+                    ->orWhere('requester_id', $user->getKey()))
                 ->whereHas('email', fn (Builder $query): Builder => $query->where('team_id', $teamId))
-                ->where('status', EmailAccessRequestStatus::PENDING)
                 ->count(),
         ];
     }

--- a/tests/Feature/EmailIntegration/EmailPageTabsTest.php
+++ b/tests/Feature/EmailIntegration/EmailPageTabsTest.php
@@ -125,16 +125,30 @@ it('counts drafts, pending outbox mail and available templates for the tab badge
     ]);
 });
 
-it('shows received access requests in the emails tab bar', function (): void {
-    $requester = User::factory()->create(['current_team_id' => $this->team->id]);
+it('shows the total incoming and sent access requests in the emails tab bar', function (): void {
+    $teammate = User::factory()->create(['current_team_id' => $this->team->id]);
+    $teammateAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'status' => 'active',
+    ]));
 
     EmailAccessRequest::factory()->pending()->create([
         'owner_id' => $this->user->id,
-        'requester_id' => $requester->id,
+        'requester_id' => $teammate->id,
         'email_id' => Email::factory()->private()->create([
             'team_id' => $this->team->id,
             'user_id' => $this->user->id,
             'connected_account_id' => $this->account->id,
+        ])->id,
+    ]);
+    EmailAccessRequest::factory()->approved()->create([
+        'owner_id' => $teammate->id,
+        'requester_id' => $this->user->id,
+        'email_id' => Email::factory()->private()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $teammate->id,
+            'connected_account_id' => $teammateAccount->id,
         ])->id,
     ]);
 
@@ -142,7 +156,7 @@ it('shows received access requests in the emails tab bar', function (): void {
         ->assertSee('Requests');
 
     expect($page->instance()->tabCounts())
-        ->toMatchArray(['requests' => 1]);
+        ->toMatchArray(['requests' => 2]);
 });
 
 it('refreshes the tab badges when the composer saves a draft', function (): void {

--- a/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
+++ b/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
@@ -6,9 +6,11 @@ use App\Filament\Resources\PeopleResource\Pages\ViewPeople;
 use App\Filament\Resources\PeopleResource\RelationManagers\EmailsRelationManager;
 use App\Models\People;
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Notification;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailReaderActions;
 use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -16,7 +18,7 @@ use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Notifications\EmailAccessRequestedNotification;
 
-mutates(BaseEmailsRelationManager::class);
+mutates(BaseEmailsRelationManager::class, HasEmailReaderActions::class);
 
 beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
@@ -40,6 +42,65 @@ beforeEach(function (): void {
 });
 
 describe('requestAccess table action', function (): void {
+    it('renders the available access levels as radio cards', function (): void {
+        $this->actingAs($this->viewer);
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->owner->id,
+            'connected_account_id' => $this->account->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        ]);
+
+        $this->person->emails()->attach($email->getKey());
+
+        livewire(EmailsRelationManager::class, [
+            'ownerRecord' => $this->person,
+            'pageClass' => ViewPeople::class,
+        ])
+            ->mountAction(TestAction::make('requestAccess')->table($email))
+            ->assertMountedActionModalSeeHtml('role="radiogroup"')
+            ->assertMountedActionModalSeeHtml('value="subject"')
+            ->assertMountedActionModalSeeHtml('value="full"')
+            ->assertMountedActionModalSee(EmailPrivacyTier::SUBJECT->getDescription())
+            ->assertMountedActionModalSee(EmailPrivacyTier::FULL->getDescription())
+            ->assertMountedActionModalDontSee(EmailPrivacyTier::METADATA_ONLY->getLabel())
+            ->assertMountedActionModalDontSee(EmailPrivacyTier::PRIVATE->getLabel());
+    });
+
+    it('shows an existing pending request as a read-only selected card', function (): void {
+        $this->actingAs($this->viewer);
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->owner->id,
+            'connected_account_id' => $this->account->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        ]);
+
+        $this->person->emails()->attach($email->getKey());
+
+        EmailAccessRequest::factory()->pending()->forTier(EmailPrivacyTier::SUBJECT)->create([
+            'email_id' => $email->getKey(),
+            'requester_id' => $this->viewer->id,
+            'owner_id' => $this->owner->id,
+        ]);
+
+        $component = livewire(EmailsRelationManager::class, [
+            'ownerRecord' => $this->person,
+            'pageClass' => ViewPeople::class,
+        ])
+            ->mountAction(TestAction::make('requestAccess')->table($email))
+            ->assertSchemaStateSet([
+                'tier_requested' => EmailPrivacyTier::SUBJECT->value,
+            ])
+            ->assertFormFieldDisabled('tier_requested')
+            ->assertMountedActionModalDontSee('Submit');
+
+        expect(preg_match_all('/<input(?=[^>]*type="radio")(?=[^>]*disabled)[^>]*>/', $component->getMountedActionModalHtml()))
+            ->toBe(2);
+    });
+
     it('creates an EmailAccessRequest and notifies the owner', function (): void {
         $this->actingAs($this->viewer);
 


### PR DESCRIPTION
## Summary

- replace the email access-level dropdown with radio cards
- show an existing pending request as selected and read-only
- display the combined incoming and sent request total on the Emails Requests tab
- include regression coverage and refresh the bundled guidance updates already present in the workspace

## Why

Make access requests easier to understand, prevent editing a pending request, and keep the total request workload visible from the Emails page.

## Verification

- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/rector --dry-run`
- `vendor/bin/phpstan analyse`
- type coverage: 100%
- `EmailPageTabsTest`: 13 passed
- access-request relation-manager tests: 16 passed
- browser verified in light, dark, and mobile layouts

The complete parallel suite was attempted, but an unrelated `ProductPagesTest` worker exceeded the existing 120-second limit while scanning the Blade icons manifest.