### PR TITLE
ci: warm the composer cache on main so release runs stop starting cold

### DIFF
--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -1,0 +1,45 @@
+name: Warm Caches
+
+# Tag-triggered release runs can only restore caches created on the default branch,
+# and only pull_request workflows saved composer caches, so every release ran cold.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - composer.lock
+      - .github/workflows/warm-caches.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  composer:
+    runs-on: ubuntu-latest
+    name: Warm Composer Cache
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.5-composer-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.5
+          extensions: json, dom, curl, libxml, mbstring, zip, intl
+          tools: composer:v2
+          coverage: none
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --no-progress --ansi --prefer-dist --optimize-autoloader


### PR DESCRIPTION
## Why

The v3.5.5 release's Deploy run failed with no test ever executing: shards 3 and 4 died during `composer install` on `HTTP 429` from `codeload.github.com` (laravel/pint dist zip), which skipped **Deploy to Forge**. Production shipped anyway because Forge Quick Deploy fires on the push to main, but the release workflow is red and the failure class will recur on any release.

## Root cause, verified from the run and the cache API

1. **Every job in the run was a cache miss.** All shards logged `Cache not found for input keys: Linux-php-8.5-composer-38f2918f…` (run [33432538262](https://github.com/relaticle/relaticle/actions/runs/33432538262)), including the ones that passed. The failures were the two jobs that drew the rate limiter; the rest got lucky on the same cold start.
2. **The key exists, but only where tag runs cannot see it.** `GET /actions/caches` shows `Linux-php-8.5-composer-38f2918f…` on nine `refs/pull/*/merge` refs and **zero** times on `refs/heads/main`. GitHub scopes `pull_request` caches to their merge ref; a tag-triggered run can only restore caches created on the default branch. Main's 188 caches are all Docker buildkit blobs from the docker-publish workflow, the only workflow that runs on main pushes.
3. So every release run starts cold: 8 jobs concurrently downloading the full vendor tree. Composer is already authenticated (setup-php receives the default `github-token`), so more auth is not the fix; concurrency times cold start is.

## Fix

A `Warm Caches` workflow on pushes to main that touch `composer.lock` (plus `workflow_dispatch`): restore-or-install, then save under the **exact key and paths** the Deploy, Tests, and Security Audit workflows already use (the cache block is copied verbatim from deploy.yml). Tag runs then restore a warm cache instead of downloading ~600 packages per job.

The merge-then-tag race is covered: if a release is tagged before the warm job finishes after a `composer.lock` bump, `restore-keys` falls back to the previous lock's cache and composer downloads only the delta. This follows docker-publish's existing precedent of running on main pushes; it is a ~90s job that only fires when the lock changes.

## Verification and its limits

- Cache block diffed against deploy.yml: byte-identical paths, key, and restore-keys.
- YAML parses; job structure mirrors the existing composer jobs (same PHP version, extensions, tools, install flags).
- The full proof needs one main push and one subsequent tag, which cannot happen inside this PR. First check after merge: the `Warm Caches` run appears on main (this file's own path triggers it), then `GET /actions/caches?ref=refs/heads/main` shows the composer key.
- Not touched: the failed v3.5.5 run itself. Its passing shards saved a cache on the tag's own ref at 19:50, so re-running its failed jobs will restore that and go green.