### PR TITLE
feat: add product hunt badge to marketing footer

### DIFF
--- a/resources/views/components/layout/footer.blade.php
+++ b/resources/views/components/layout/footer.blade.php
@@ -33,6 +33,16 @@
                         <x-ri-linkedin-box-fill class="h-5 w-5" />
                     </a>
                 </div>
+
+                <a href="https://www.producthunt.com/products/relaticle?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-relaticle"
+                   target="_blank" rel="noopener noreferrer" class="inline-flex w-fit">
+                    <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1238864&amp;theme=light"
+                         alt="Relaticle - Open-source CRM with approval-gated AI writes | Product Hunt"
+                         width="250" height="54" loading="lazy" class="dark:hidden" />
+                    <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1238864&amp;theme=dark"
+                         alt="Relaticle - Open-source CRM with approval-gated AI writes | Product Hunt"
+                         width="250" height="54" loading="lazy" class="hidden dark:block" />
+                </a>
             </div>
 
             @php($columns = app(\App\Support\MarketingNavigation::class)->footer())

--- a/tests/Feature/Public/MarketingNavigationTest.php
+++ b/tests/Feature/Public/MarketingNavigationTest.php
@@ -171,3 +171,11 @@ it('renders the works-with strip on the homepage with a link to the developer do
         ->and($strip)->toContain('href="'.route('documentation.index').'"')
         ->and($strip)->toContain('21,000+');
 });
+
+it('shows one product hunt badge per theme in the footer', function (): void {
+    $html = $this->get('/')->assertOk()->getContent();
+
+    expect($html)->toContain('https://www.producthunt.com/products/relaticle?embed=true')
+        ->and($html)->toContain('featured.svg?post_id=1238864&amp;theme=light')
+        ->and($html)->toContain('featured.svg?post_id=1238864&amp;theme=dark');
+});


### PR DESCRIPTION
## What

Adds the Product Hunt "Find us on Product Hunt" badge to the marketing footer, under the social icons in the company column.

- Light and dark variants from Product Hunt's embed generator, swapped with `dark:hidden` / `hidden dark:block` so each theme shows its own badge.
- Links to the product page through Product Hunt's badge tracking parameters, `rel="noopener noreferrer"`, lazy-loaded, fixed 250x54 so it never shifts layout.
- The cache-buster `t=` parameter from the generated snippet is dropped; both SVGs return 200 without it.

## Verification

- Smoke suite: 77 passed.
- Rendered on the local marketing site in light and dark, footer screenshots checked: correct badge visible per theme, no layout shift.