### PR TITLE
feat(tables): enable reorderable columns in the app panel

### DIFF
--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -120,7 +120,9 @@ final class AppPanelProvider extends PanelProvider
         // Table and Schema configuration is global, so both callbacks have to check
         // which panel is actually serving the request before they touch the format.
         Table::configureUsing(fn (Table $table): Table => $this->isCurrentPanel()
-            ? $table->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+            ? $table
+                ->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+                ->reorderableColumns()
             : $table);
 
         Schema::configureUsing(fn (Schema $schema): Schema => $this->isCurrentPanel()


### PR DESCRIPTION
Filament's column manager supports drag-to-reorder columns via reorderableColumns(), but Relaticle never enables it, so list columns are fixed in definition order. Enable it globally for the app panel alongside the existing date-format default so users can rearrange columns on every resource table.