### PR TITLE
feat(tables): persist column manager state per user in the database

### DIFF
--- a/app/Actions/Users/UpdateTableColumnPreferences.php
+++ b/app/Actions/Users/UpdateTableColumnPreferences.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Models\User;
+
+final readonly class UpdateTableColumnPreferences
+{
+    /**
+     * Persist a user's per-table column manager state (visibility + order).
+     *
+     * Column state lives in the session by default in Filament, which resets on
+     * session expiry (and never crosses devices). Storing it per user in the DB
+     * makes a user's column choices stick across sessions and browsers.
+     *
+     * @param  array<string, array{columns: array<int, mixed>, has_reordered: bool}>  $preferences
+     */
+    public function execute(User $user, array $preferences): void
+    {
+        $user->update(['table_column_preferences' => $preferences]);
+    }
+}

--- a/app/Filament/Concerns/PersistsTableColumnState.php
+++ b/app/Filament/Concerns/PersistsTableColumnState.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Concerns;
+
+use App\Actions\Users\UpdateTableColumnPreferences;
+use App\Models\User;
+use Filament\Tables\Concerns\InteractsWithTable;
+
+/**
+ * Persist the Filament column manager state (visibility toggles + column order)
+ * per user in the database instead of the session.
+ *
+ * Filament's HasColumnManager stores column state under
+ * `tables.{md5(class)}_columns` in the session by default. Session state dies
+ * with the session (120 min TTL here) and never crosses devices, so a user who
+ * hides "Created By" finds it back after the session expires. This trait
+ * swaps the storage backend for the same state array, keyed by user + table.
+ *
+ * Add to any list page that should remember column choices:
+ *
+ *     use PersistsTableColumnState;
+ *
+ * Requires the `table_column_preferences` jsonb column on `users` and the
+ * `UpdateTableColumnPreferences` action (both shipped alongside this trait).
+ */
+trait PersistsTableColumnState
+{
+    protected function loadTableColumnsFromSession(): array
+    {
+        $user = auth()->user();
+
+        if ($user instanceof User) {
+            $key = $this->getTableColumnsSessionKey();
+            $stored = $user->table_column_preferences[$key] ?? null;
+
+            if (is_array($stored) && array_key_exists('columns', $stored)) {
+                // Re-seed the session reorder flag so applyTableColumnManager()
+                // still routes through the reorderable sync path.
+                session()->put(
+                    $this->getHasReorderedTableColumnsSessionKey(),
+                    (bool) ($stored['has_reordered'] ?? false),
+                );
+
+                return $stored['columns'];
+            }
+        }
+
+        return $this->getDefaultTableColumnState();
+    }
+
+    protected function persistTableColumns(): void
+    {
+        if (! $this->getTable()->persistsColumnsInSession()) {
+            return;
+        }
+
+        $user = auth()->user();
+
+        if (! $user instanceof User) {
+            return;
+        }
+
+        $preferences = $user->table_column_preferences ?? [];
+        $preferences[$this->getTableColumnsSessionKey()] = [
+            'columns' => $this->tableColumns,
+            'has_reordered' => (bool) session()->get($this->getHasReorderedTableColumnsSessionKey(), false),
+        ];
+
+        app(UpdateTableColumnPreferences::class)->execute($user, $preferences);
+    }
+
+    protected function persistHasReorderedTableColumns(bool $wasReordered = false): void
+    {
+        parent::persistHasReorderedTableColumns($wasReordered);
+
+        $this->persistTableColumns();
+    }
+}

--- a/app/Filament/Resources/CompanyResource/Pages/ListCompanies.php
+++ b/app/Filament/Resources/CompanyResource/Pages/ListCompanies.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\CompanyResource\Pages;
 
+use App\Filament\Concerns\PersistsTableColumnState;
 use App\Filament\Exports\CompanyExporter;
 use App\Filament\Resources\CompanyResource;
 use Asmit\ResizedColumn\HasResizableColumn;
@@ -22,6 +23,7 @@ final class ListCompanies extends ListRecords
 {
     use HasResizableColumn;
     use InteractsWithCustomFields;
+    use PersistsTableColumnState;
 
     /** @var class-string<CompanyResource> */
     protected static string $resource = CompanyResource::class;

--- a/app/Filament/Resources/NoteResource/Pages/ManageNotes.php
+++ b/app/Filament/Resources/NoteResource/Pages/ManageNotes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\NoteResource\Pages;
 
+use App\Filament\Concerns\PersistsTableColumnState;
 use App\Filament\Exports\NoteExporter;
 use App\Filament\Resources\NoteResource;
 use Asmit\ResizedColumn\HasResizableColumn;
@@ -22,6 +23,7 @@ final class ManageNotes extends ManageRecords
 {
     use HasResizableColumn;
     use InteractsWithCustomFields;
+    use PersistsTableColumnState;
 
     protected static string $resource = NoteResource::class;
 

--- a/app/Filament/Resources/OpportunityResource/Pages/ListOpportunities.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ListOpportunities.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\OpportunityResource\Pages;
 
 use App\Filament\Concerns\HasBoardViewSwitcher;
+use App\Filament\Concerns\PersistsTableColumnState;
 use App\Filament\Exports\OpportunityExporter;
 use App\Filament\Resources\OpportunityResource;
 use Asmit\ResizedColumn\HasResizableColumn;
@@ -24,6 +25,7 @@ final class ListOpportunities extends ListRecords
     use HasBoardViewSwitcher;
     use HasResizableColumn;
     use InteractsWithCustomFields;
+    use PersistsTableColumnState;
 
     protected static string $resource = OpportunityResource::class;
 

--- a/app/Filament/Resources/PeopleResource/Pages/ListPeople.php
+++ b/app/Filament/Resources/PeopleResource/Pages/ListPeople.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\PeopleResource\Pages;
 
+use App\Filament\Concerns\PersistsTableColumnState;
 use App\Filament\Exports\PeopleExporter;
 use App\Filament\Resources\PeopleResource;
 use Asmit\ResizedColumn\HasResizableColumn;
@@ -22,6 +23,7 @@ final class ListPeople extends ListRecords
 {
     use HasResizableColumn;
     use InteractsWithCustomFields;
+    use PersistsTableColumnState;
 
     protected static string $resource = PeopleResource::class;
 

--- a/app/Filament/Resources/TaskResource/Pages/ManageTasks.php
+++ b/app/Filament/Resources/TaskResource/Pages/ManageTasks.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\TaskResource\Pages;
 
 use App\Actions\Task\NotifyTaskAssignees;
 use App\Filament\Concerns\HasBoardViewSwitcher;
+use App\Filament\Concerns\PersistsTableColumnState;
 use App\Filament\Exports\TaskExporter;
 use App\Filament\Resources\TaskResource;
 use App\Models\Task;
@@ -26,6 +27,7 @@ final class ManageTasks extends ManageRecords
     use HasBoardViewSwitcher;
     use HasResizableColumn;
     use InteractsWithCustomFields;
+    use PersistsTableColumnState;
 
     protected static string $resource = TaskResource::class;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -61,6 +61,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $two_factor_secret
  * @property array<string, mixed>|null $ai_preferences
  * @property array<string, mixed>|null $notification_preferences
+ * @property array<string, mixed>|null $table_column_preferences
  * @property-read Team|null $currentTeam
  */
 #[Appends([
@@ -73,6 +74,7 @@ use Laravel\Sanctum\HasApiTokens;
     'password',
     'ai_preferences',
     'notification_preferences',
+    'table_column_preferences',
 ])]
 #[Hidden([
     'password',
@@ -111,6 +113,7 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
             'password' => 'hashed',
             'ai_preferences' => 'array',
             'notification_preferences' => 'array',
+            'table_column_preferences' => 'array',
             'scheduled_deletion_at' => 'datetime',
         ];
     }

--- a/database/migrations/2026_09_02_120000_add_table_column_preferences_to_users_table.php
+++ b/database/migrations/2026_09_02_120000_add_table_column_preferences_to_users_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->jsonb('table_column_preferences')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
Filament's HasColumnManager stores column visibility and order under tables.{md5(class)}_columns in the session, which resets on session expiry (120 min TTL here) and never crosses devices. A user who hides 'Created By' finds it back after the session dies.

Add a table_column_preferences jsonb column on users and a PersistsTableColumnState trait that swaps the storage backend for the same state array, keyed by user + table. The trait overrides loadTableColumnsFromSession() and persistTableColumns() to read/write the DB, re-seeding the session reorder flag so Filament's sync paths behave unchanged. Writes go through the UpdateTableColumnPreferences action per the app's action-class convention.

Applied to the five list pages (people, companies, opportunities, tasks, notes) that already use InteractsWithCustomFields.