### PR TITLE
feat(profile): per-user default landing page

### DIFF
--- a/app/Actions/User/UpdateLandingPage.php
+++ b/app/Actions/User/UpdateLandingPage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\User;
+
+use App\Enums\LandingPage;
+use App\Models\User;
+
+final readonly class UpdateLandingPage
+{
+    public function execute(User $user, LandingPage $landingPage): void
+    {
+        $user->update(['landing_page' => $landingPage]);
+    }
+}

--- a/app/Enums/LandingPage.php
+++ b/app/Enums/LandingPage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use App\Filament\Pages\Dashboard;
+use App\Filament\Resources\CompanyResource;
+use App\Filament\Resources\NoteResource;
+use App\Filament\Resources\OpportunityResource;
+use App\Filament\Resources\PeopleResource;
+use App\Filament\Resources\TaskResource;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * The page a user lands on after signing in.
+ *
+ * Stored as a string on `users.landing_page`. `null` means the default
+ * (Dashboard), so existing users keep their current behaviour until they opt in.
+ */
+enum LandingPage: string
+{
+    case Dashboard = 'dashboard';
+    case People = 'people';
+    case Companies = 'companies';
+    case Opportunities = 'opportunities';
+    case Tasks = 'tasks';
+    case Notes = 'notes';
+
+    public function url(Team $team): string
+    {
+        return match ($this) {
+            self::Dashboard => Dashboard::getUrl(['tenant' => $team]),
+            self::People => PeopleResource::getUrl('index', ['tenant' => $team]),
+            self::Companies => CompanyResource::getUrl('index', ['tenant' => $team]),
+            self::Opportunities => OpportunityResource::getUrl('index', ['tenant' => $team]),
+            self::Tasks => TaskResource::getUrl('index', ['tenant' => $team]),
+            self::Notes => NoteResource::getUrl('index', ['tenant' => $team]),
+        };
+    }
+
+    public function label(): string
+    {
+        return __("profile.landing_pages.{$this->value}");
+    }
+
+    public static function fromUser(User $user): self
+    {
+        return $user->landing_page ?? self::Dashboard;
+    }
+}

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -8,6 +8,7 @@ use App\Filament\Clusters\Settings;
 use App\Livewire\App\Profile\DeleteAccount;
 use App\Livewire\App\Profile\LogoutOtherBrowserSessions;
 use App\Livewire\App\Profile\ManagePasskeys;
+use App\Livewire\App\Profile\UpdateLandingPage;
 use App\Livewire\App\Profile\UpdatePassword;
 use App\Livewire\App\Profile\UpdateProfileInformation;
 use Filament\Clusters\Cluster;
@@ -37,6 +38,7 @@ final class EditProfile extends Page
     {
         return $schema->components([
             Livewire::make(UpdateProfileInformation::class),
+            Livewire::make(UpdateLandingPage::class),
             Livewire::make(UpdatePassword::class),
             Livewire::make(ManagePasskeys::class),
             Livewire::make(LogoutOtherBrowserSessions::class),

--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Responses;
 
-use App\Filament\Pages\Dashboard;
+use App\Enums\LandingPage;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
@@ -28,7 +28,7 @@ final readonly class LoginResponse implements \Filament\Auth\Http\Responses\Cont
             return redirect()->intended(Filament::getUrl());
         }
 
-        $dashboard = Dashboard::getUrl(['tenant' => $user->currentTeam]);
+        $landingPage = LandingPage::fromUser($user)->url($user->currentTeam);
 
         // Honour a pre-login deep link only when it points at a workspace the
         // user can actually access. A stale or cross-tenant `url.intended`
@@ -40,7 +40,7 @@ final readonly class LoginResponse implements \Filament\Auth\Http\Responses\Cont
             return redirect()->to($intended);
         }
 
-        return redirect()->to($dashboard);
+        return redirect()->to($landingPage);
     }
 
     private function intendedIsAccessible(string $intended, User $user): bool

--- a/app/Livewire/App/Profile/UpdateLandingPage.php
+++ b/app/Livewire/App/Profile/UpdateLandingPage.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\App\Profile;
+
+use App\Actions\User\UpdateLandingPage as UpdateLandingPageAction;
+use App\Enums\LandingPage;
+use App\Livewire\BaseLivewireComponent;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+final class UpdateLandingPage extends BaseLivewireComponent
+{
+    /** @var array<string, mixed>|null */
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'landing_page' => LandingPage::fromUser($this->authUser())->value,
+        ]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->schema([
+                Section::make(__('profile.sections.update_landing_page.title'))
+                    ->aside()
+                    ->description(__('profile.sections.update_landing_page.description'))
+                    ->schema([
+                        Select::make('landing_page')
+                            ->label(__('profile.form.landing_page.label'))
+                            ->helperText(__('profile.form.landing_page.helper_text'))
+                            ->options(collect(LandingPage::cases())->mapWithKeys(
+                                fn (LandingPage $page): array => [$page->value => $page->label()],
+                            ))
+                            ->native(false),
+                        Actions::make([
+                            Action::make('save')
+                                ->label(__('profile.actions.save'))
+                                ->submit('updateLandingPage'),
+                        ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function updateLandingPage(): void
+    {
+        try {
+            $this->rateLimit(5);
+        } catch (TooManyRequestsException $exception) {
+            $this->sendRateLimitedNotification($exception);
+
+            return;
+        }
+
+        $data = $this->form->getState();
+
+        resolve(UpdateLandingPageAction::class)->execute(
+            $this->authUser(),
+            LandingPage::from($data['landing_page']),
+        );
+
+        $this->sendNotification();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Casts\AsCanonicalEmail;
 use App\Data\NotificationPreferences;
+use App\Enums\LandingPage;
 use App\Enums\Notifications\NotificationChannel;
 use App\Enums\Notifications\NotificationType;
 use App\Enums\TeamRole;
@@ -61,6 +62,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $two_factor_secret
  * @property array<string, mixed>|null $ai_preferences
  * @property array<string, mixed>|null $notification_preferences
+ * @property string|null $landing_page
  * @property-read Team|null $currentTeam
  */
 #[Appends([
@@ -73,6 +75,7 @@ use Laravel\Sanctum\HasApiTokens;
     'password',
     'ai_preferences',
     'notification_preferences',
+    'landing_page',
 ])]
 #[Hidden([
     'password',
@@ -110,6 +113,7 @@ final class User extends Authenticatable implements FilamentUser, HasAvatar, Has
             'last_login_at' => 'datetime',
             'password' => 'hashed',
             'ai_preferences' => 'array',
+            'landing_page' => LandingPage::class,
             'notification_preferences' => 'array',
             'scheduled_deletion_at' => 'datetime',
         ];

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers\Filament;
 
+use App\Enums\LandingPage;
 use App\Enums\SupportFormType;
 use App\Features\Billing as BillingFeature;
 use App\Features\SupportMenu;
@@ -191,6 +192,19 @@ final class AppPanelProvider extends PanelProvider
     }
 
     /**
+     * The panel home URL (logo click) follows the user's landing-page
+     * preference, falling back to the Dashboard for guests and sysadmin.
+     */
+    private function homeUrlFor(?User $user): string
+    {
+        if ($user instanceof User && $user->currentTeam) {
+            return LandingPage::fromUser($user)->url($user->currentTeam);
+        }
+
+        return Dashboard::getUrl();
+    }
+
+    /**
      * Configure the Filament admin panel.
      *
      * @throws Exception
@@ -208,7 +222,9 @@ final class AppPanelProvider extends PanelProvider
         }
 
         $panel
-            ->homeUrl(fn (): string => Dashboard::getUrl())
+            ->homeUrl(fn (): string => $this->isCurrentPanel()
+                ? $this->homeUrlFor(Auth::user())
+                : Dashboard::getUrl())
             ->brandName('Relaticle')
             ->brandLogo(fn (): View|Factory => Auth::user()?->hasVerifiedEmail()
                 ? view('filament.app.logo-empty')

--- a/database/migrations/2026_09_02_130000_add_landing_page_to_users_table.php
+++ b/database/migrations/2026_09_02_130000_add_landing_page_to_users_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('landing_page')->nullable()->after('timezone');
+        });
+    }
+};

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -18,6 +18,10 @@ return [
             'helper_text' => 'Dates and times across the app are shown in this timezone.',
             'placeholder' => 'Select a timezone',
         ],
+        'landing_page' => [
+            'label' => 'Landing page',
+            'helper_text' => 'Where you land after signing in.',
+        ],
         'current_password' => [
             'label' => 'Current Password',
         ],
@@ -37,6 +41,10 @@ return [
         'update_profile_information' => [
             'title' => 'Profile Information',
             'description' => 'Update your account\'s profile information and email address.',
+        ],
+        'update_landing_page' => [
+            'title' => 'Default Landing Page',
+            'description' => 'Choose which page you see first after signing in.',
         ],
         'update_password' => [
             'title' => 'Update Password',
@@ -137,6 +145,15 @@ return [
     ],
 
     'edit_profile' => 'Edit Profile',
+
+    'landing_pages' => [
+        'dashboard' => 'Dashboard',
+        'people' => 'People',
+        'companies' => 'Companies',
+        'opportunities' => 'Opportunities',
+        'tasks' => 'Tasks',
+        'notes' => 'Notes',
+    ],
 
     'scheduled_deletion_interstitial' => [
         'heading' => 'Your account is scheduled for deletion',

--- a/resources/views/livewire/app/profile/update-landing-page.blade.php
+++ b/resources/views/livewire/app/profile/update-landing-page.blade.php
@@ -1,0 +1,7 @@
+<div>
+    <form wire:submit="updateLandingPage">
+        {{ $this->form }}
+    </form>
+
+    <x-filament-actions::modals/>
+</div>

--- a/tests/Feature/Auth/LoginResponseTest.php
+++ b/tests/Feature/Auth/LoginResponseTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Filament\Pages\Dashboard;
+use App\Filament\Resources\PeopleResource;
 use App\Http\Responses\LoginResponse;
 use App\Http\Responses\PasskeyLoginResponse;
 use App\Models\Team;
@@ -58,6 +59,27 @@ it('falls back to the dashboard when there is no intended url', function (): voi
     $target = loginResponseFor($user, null);
 
     expect($target)->toBe(Dashboard::getUrl(['tenant' => $user->currentTeam]));
+});
+
+it('lands on the user preferred landing page when there is no intended url', function (): void {
+    $user = User::factory()->withTeam()->create([
+        'landing_page' => 'people',
+    ]);
+
+    $target = loginResponseFor($user, null);
+
+    expect($target)->toBe(PeopleResource::getUrl('index', ['tenant' => $user->currentTeam]));
+});
+
+it('prefers an accessible deep link over the landing page preference', function (): void {
+    $user = User::factory()->withTeam()->create([
+        'landing_page' => 'people',
+    ]);
+    $team = $user->currentTeam;
+
+    $target = loginResponseFor($user, "/app/{$team->slug}/companies");
+
+    expect($target)->toEndWith("/app/{$team->slug}/companies");
 });
 
 it('falls back to the dashboard when the intended url has no resolvable workspace slug', function (): void {

--- a/tests/Feature/Profile/UpdateLandingPageTest.php
+++ b/tests/Feature/Profile/UpdateLandingPageTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\User\UpdateLandingPage;
+use App\Livewire\App\Profile\UpdateLandingPage as UpdateLandingPageComponent;
+use App\Models\User;
+
+mutates(UpdateLandingPage::class, UpdateLandingPageComponent::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create([
+        'email' => 'landing@example.com',
+        'email_verified_at' => now(),
+    ]);
+
+    $this->actingAs($this->user);
+});
+
+describe('landing page preference', function (): void {
+    test('component renders with the current preference selected', function (): void {
+        Livewire::test(UpdateLandingPageComponent::class)
+            ->assertSuccessful()
+            ->assertSee('Default Landing Page')
+            ->assertFormSet(['landing_page' => 'dashboard']);
+    });
+
+    test('can change the landing page to people', function (): void {
+        Livewire::test(UpdateLandingPageComponent::class)
+            ->fillForm(['landing_page' => 'people'])
+            ->call('updateLandingPage')
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        expect($this->user->fresh()->landing_page)->toBe('people');
+    });
+
+    test('persists the chosen landing page across remounts', function (): void {
+        Livewire::test(UpdateLandingPageComponent::class)
+            ->fillForm(['landing_page' => 'notes'])
+            ->call('updateLandingPage')
+            ->assertHasNoFormErrors();
+
+        Livewire::test(UpdateLandingPageComponent::class)
+            ->assertFormSet(['landing_page' => 'notes']);
+    });
+
+    test('rejects an invalid landing page value', function (): void {
+        Livewire::test(UpdateLandingPageComponent::class)
+            ->fillForm(['landing_page' => 'not-a-page'])
+            ->call('updateLandingPage')
+            ->assertHasFormErrors(['landing_page']);
+    });
+});


### PR DESCRIPTION
The post-login redirect is hardcoded to the Dashboard in LoginResponse, and the panel homeUrl (logo click) does the same, so every user lands on a page they may never use after signing in.

Add a users.landing_page preference (enum-backed, null = Dashboard) and wire it into all three landing seams:

- LoginResponse: resolve LandingPage::fromUser()->url() instead of the hardcoded dashboard, keeping the existing deep-link and cross-tenant guards in front of it
- Panel homeUrl: the logo follows the same preference (app panel only; sysadmin and guests fall back to the Dashboard)
- Profile: new 'Default Landing Page' section with a select, saving via an UpdateLandingPage action

Enum cases resolve to the resource index pages (people, companies, opportunities, tasks, notes) with the current team as the tenant.

Includes tests for the component and the login redirect.