### PR TITLE
feat(teams): per-workspace branding — logo and accent color

### DIFF
--- a/app/Actions/Team/UpdateTeamBranding.php
+++ b/app/Actions/Team/UpdateTeamBranding.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Team;
+
+use App\Enums\TeamAccent;
+use App\Models\Team;
+
+final readonly class UpdateTeamBranding
+{
+    public function execute(Team $team, ?string $logoPath, ?TeamAccent $accent): void
+    {
+        $team->update([
+            'logo_path' => $logoPath,
+            'accent_color' => $accent?->value,
+        ]);
+    }
+}

--- a/app/Enums/TeamAccent.php
+++ b/app/Enums/TeamAccent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Accent palettes a workspace can pick, mirroring the Hermes Web UI skin
+ * concept: each is a single seed color Filament expands into a full 50-950
+ * ramp via Filament\Support\Colors\Color::hex(). `null` means the brand
+ * default (BrandColors::primary()).
+ */
+enum TeamAccent: string
+{
+    case Ares = '#C0392B';
+    case Slate = '#475569';
+    case Poseidon = '#0369A1';
+    case Sisyphus = '#7C3AED';
+    case Charizard = '#EA580C';
+    case Sienna = '#D97757';
+    case Mono = '#666666';
+    case Nous = '#4682B4';
+
+    public function label(): string
+    {
+        return __("teams.accent_colors.{$this->name}");
+    }
+}

--- a/app/Filament/Pages/EditTeam.php
+++ b/app/Filament/Pages/EditTeam.php
@@ -6,6 +6,7 @@ namespace App\Filament\Pages;
 
 use App\Filament\Pages\Concerns\HasWorkspaceSettingsNavigation;
 use App\Livewire\App\Teams\DeleteTeam;
+use App\Livewire\App\Teams\UpdateTeamBranding;
 use App\Livewire\App\Teams\UpdateTeamName;
 use App\Models\Team;
 use Filament\Pages\Tenancy\EditTenantProfile;
@@ -30,6 +31,9 @@ final class EditTeam extends EditTenantProfile
         return $schema->components([
             Livewire::make(UpdateTeamName::class)
                 ->data(['team' => $tenant]),
+            Livewire::make(UpdateTeamBranding::class)
+                ->data(['team' => $tenant])
+                ->visible(fn (): bool => $tenant->isPersonalTeam() === false),
             Livewire::make(DeleteTeam::class)
                 ->visible(fn (): bool => $tenant->isPersonalTeam() === false)
                 ->data(['team' => $tenant]),

--- a/app/Livewire/App/Teams/UpdateTeamBranding.php
+++ b/app/Livewire/App/Teams/UpdateTeamBranding.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\App\Teams;
+
+use App\Actions\Team\UpdateTeamBranding as UpdateTeamBrandingAction;
+use App\Enums\TeamAccent;
+use App\Livewire\BaseLivewireComponent;
+use App\Models\Team;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Attributes\Locked;
+
+final class UpdateTeamBranding extends BaseLivewireComponent
+{
+    /** @var array<string, mixed>|null */
+    public ?array $data = [];
+
+    #[Locked]
+    public Team $team;
+
+    public function mount(Team $team): void
+    {
+        $this->team = $team;
+
+        $this->form->fill([
+            'logo_path' => $team->logo_path,
+            'accent_color' => $team->accent_color,
+        ]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->schema([
+                Section::make(__('teams.sections.update_team_branding.title'))
+                    ->aside()
+                    ->description(__('teams.sections.update_team_branding.description'))
+                    ->schema([
+                        FileUpload::make('logo_path')
+                            ->label(__('teams.form.team_logo.label'))
+                            ->helperText(__('teams.form.team_logo.helper_text'))
+                            ->image()
+                            ->imageEditor()
+                            ->disk(config('jetstream.profile_photo_disk'))
+                            ->directory('team-logos')
+                            ->visibility('public'),
+                        Select::make('accent_color')
+                            ->label(__('teams.form.accent_color.label'))
+                            ->helperText(__('teams.form.accent_color.helper_text'))
+                            ->placeholder(__('teams.form.accent_color.placeholder'))
+                            ->options(collect(TeamAccent::cases())->mapWithKeys(
+                                fn (TeamAccent $accent): array => [$accent->value => $accent->label()],
+                            ))
+                            ->native(false),
+                        Actions::make([
+                            Action::make('save')
+                                ->label(__('profile.actions.save'))
+                                ->submit('updateBranding'),
+                        ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function updateBranding(): void
+    {
+        try {
+            $this->rateLimit(5);
+        } catch (TooManyRequestsException $exception) {
+            $this->sendRateLimitedNotification($exception);
+
+            return;
+        }
+
+        $data = $this->form->getState();
+
+        $this->deleteReplacedLogo($this->team->logo_path, $data['logo_path']);
+
+        resolve(UpdateTeamBrandingAction::class)->execute(
+            $this->team,
+            $data['logo_path'],
+            $data['accent_color'] ? TeamAccent::from($data['accent_color']) : null,
+        );
+
+        $this->sendNotification();
+    }
+
+    private function deleteReplacedLogo(?string $oldPath, ?string $newPath): void
+    {
+        if ($oldPath === null || $oldPath === $newPath) {
+            return;
+        }
+
+        Storage::disk(config('jetstream.profile_photo_disk'))->delete($oldPath);
+    }
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -56,6 +56,8 @@ use Spatie\Sluggable\SlugOptions;
  * @property Carbon|null $pro_trial_used_at
  * @property Carbon|null $hosted_free_grandfathered_at
  * @property string $invite_link_default_role
+ * @property string|null $logo_path
+ * @property string|null $accent_color
  * @property-read Membership|null $membership the `team_user` row, populated only when the team was
  *     loaded through `User::teams()`; null on a team reached any other way
  */
@@ -67,6 +69,8 @@ use Spatie\Sluggable\SlugOptions;
     'onboarding_context',
     'onboarding_referral_source',
     'invite_link_default_role',
+    'logo_path',
+    'accent_color',
 ])]
 #[Hidden([
     'invite_link_token',
@@ -343,6 +347,10 @@ final class Team extends JetstreamTeam implements HasAvatar, Onboardable
 
     public function getFilamentAvatarUrl(): string
     {
+        if (filled($this->logo_path)) {
+            return asset('storage/'.$this->logo_path);
+        }
+
         return resolve(AvatarService::class)->generate(name: $this->name, bgColor: '#000000', textColor: '#ffffff');
     }
 

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -53,6 +53,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Platform;
 use Filament\Support\Enums\Size;
+use Filament\Support\Colors\Color;
 use Filament\Support\Facades\FilamentTimezone;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
@@ -191,6 +192,41 @@ final class AppPanelProvider extends PanelProvider
     }
 
     /**
+     * The panel brand logo: a workspace with a custom logo shows that instead
+     * of the stock mark, so the active workspace is identifiable at a glance.
+     */
+    private function brandLogoView(?User $user): View|Factory
+    {
+        $team = $user?->currentTeam;
+
+        if ($team instanceof Team && filled($team->logo_path)) {
+            return view('filament.app.team-logo', ['team' => $team]);
+        }
+
+        return $user?->hasVerifiedEmail()
+            ? view('filament.app.logo-empty')
+            : view('filament.app.logo');
+    }
+
+    /**
+     * The primary color ramp follows the workspace accent when one is set,
+     * falling back to the brand palette. Filament expands the hex via
+     * Color::hex() into a full 50-950 ramp, so one seed color is enough.
+     *
+     * @return array<int|string, string>
+     */
+    private function primaryColors(): array
+    {
+        $team = Filament::getTenant();
+
+        if ($team instanceof Team && filled($team->accent_color)) {
+            return Color::hex($team->accent_color);
+        }
+
+        return BrandColors::primary();
+    }
+
+    /**
      * Configure the Filament admin panel.
      *
      * @throws Exception
@@ -210,9 +246,7 @@ final class AppPanelProvider extends PanelProvider
         $panel
             ->homeUrl(fn (): string => Dashboard::getUrl())
             ->brandName('Relaticle')
-            ->brandLogo(fn (): View|Factory => Auth::user()?->hasVerifiedEmail()
-                ? view('filament.app.logo-empty')
-                : view('filament.app.logo'))
+            ->brandLogo(fn (): View|Factory => $this->brandLogoView(Auth::user()))
             ->brandLogoHeight('2.6rem')
             ->login(Login::class)
             ->authGuard('web')
@@ -235,8 +269,8 @@ final class AppPanelProvider extends PanelProvider
                 livewireComponent: AppDatabaseNotifications::class,
                 position: DatabaseNotificationsPosition::Sidebar,
             )
-            ->colors([
-                'primary' => BrandColors::primary(),
+            ->colors(fn (): array => [
+                'primary' => $this->primaryColors(),
             ])
             ->viteTheme('resources/css/filament/app/theme.css')
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\Resources')

--- a/database/migrations/2026_09_02_150000_add_branding_to_teams_table.php
+++ b/database/migrations/2026_09_02_150000_add_branding_to_teams_table.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table): void {
+            $table->string('logo_path')->nullable()->after('personal_team');
+            $table->string('accent_color')->nullable()->after('logo_path');
+        });
+    }
+};

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -19,12 +19,36 @@ return [
         'invite_as' => [
             'label' => 'Invite as',
         ],
+        'team_logo' => [
+            'label' => 'Workspace logo',
+            'helper_text' => 'Shown in the sidebar and workspace switcher so workspaces are easy to tell apart.',
+        ],
+        'accent_color' => [
+            'label' => 'Accent color',
+            'helper_text' => 'Colors the whole workspace so it is identifiable at a glance.',
+            'placeholder' => 'Brand default',
+        ],
+    ],
+
+    'accent_colors' => [
+        'Ares' => 'Ares — red',
+        'Slate' => 'Slate — blue-gray',
+        'Poseidon' => 'Poseidon — ocean blue',
+        'Sisyphus' => 'Sisyphus — purple',
+        'Charizard' => 'Charizard — orange',
+        'Sienna' => 'Sienna — clay',
+        'Mono' => 'Mono — gray',
+        'Nous' => 'Nous — steel blue',
     ],
 
     'sections' => [
         'update_team_name' => [
             'title' => 'Workspace Name',
             'description' => 'The workspace\'s name and owner information.',
+        ],
+        'update_team_branding' => [
+            'title' => 'Workspace Look',
+            'description' => 'Give this workspace its own logo and accent color so it is easy to tell apart from the others.',
         ],
         'add_team_member' => [
             'title' => 'Invite people',

--- a/resources/views/filament/app/team-logo.blade.php
+++ b/resources/views/filament/app/team-logo.blade.php
@@ -1,0 +1,8 @@
+@props(['team'])
+
+@php
+    $src = asset('storage/'.$team->logo_path);
+@endphp
+
+<span class="sr-only">{{ $team->name }}</span>
+<img src="{{ $src }}" alt="{{ $team->name }}" class="h-10 w-auto rounded" />

--- a/resources/views/livewire/app/teams/update-team-branding.blade.php
+++ b/resources/views/livewire/app/teams/update-team-branding.blade.php
@@ -1,0 +1,7 @@
+<div>
+    <form wire:submit="updateBranding">
+        {{ $this->form }}
+    </form>
+
+    <x-filament-actions::modals/>
+</div>

--- a/tests/Feature/Teams/UpdateTeamBrandingTest.php
+++ b/tests/Feature/Teams/UpdateTeamBrandingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Team\UpdateTeamBranding;
+use App\Enums\TeamAccent;
+use App\Livewire\App\Teams\UpdateTeamBranding as UpdateTeamBrandingComponent;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+mutates(UpdateTeamBranding::class, UpdateTeamBrandingComponent::class);
+
+beforeEach(function (): void {
+    Storage::fake('public');
+
+    $this->user = User::factory()->create([
+        'email' => 'branding@example.com',
+        'email_verified_at' => now(),
+    ]);
+
+    $this->team = Team::factory()->create([
+        'user_id' => $this->user->id,
+        'personal_team' => false,
+    ]);
+
+    $this->actingAs($this->user);
+    Filament::setTenant($this->team);
+});
+
+it('renders the branding section with the stored values', function (): void {
+    $this->team->forceFill(['accent_color' => TeamAccent::Poseidon->value])->save();
+
+    Livewire::test(UpdateTeamBrandingComponent::class, ['team' => $this->team])
+        ->assertSuccessful()
+        ->assertSee('Workspace Look')
+        ->assertFormSet(['accent_color' => TeamAccent::Poseidon->value]);
+});
+
+it('saves a logo and accent color', function (): void {
+    $logo = UploadedFile::fake()->image('logo.png', 200, 200);
+
+    Livewire::test(UpdateTeamBrandingComponent::class, ['team' => $this->team])
+        ->fillForm([
+            'logo_path' => $logo,
+            'accent_color' => TeamAccent::Sisyphus->value,
+        ])
+        ->call('updateBranding')
+        ->assertHasNoFormErrors()
+        ->assertNotified();
+
+    $team = $this->team->fresh();
+
+    expect($team->accent_color)->toBe(TeamAccent::Sisyphus->value)
+        ->and($team->logo_path)->not->toBeNull()
+        ->and(Storage::disk('public')->exists($team->logo_path))->toBeTrue();
+});
+
+it('clears the accent back to the brand default', function (): void {
+    $this->team->forceFill(['accent_color' => TeamAccent::Ares->value])->save();
+
+    Livewire::test(UpdateTeamBrandingComponent::class, ['team' => $this->team])
+        ->fillForm(['accent_color' => null])
+        ->call('updateBranding')
+        ->assertHasNoFormErrors();
+
+    expect($this->team->fresh()->accent_color)->toBeNull();
+});
+
+it('replaces the workspace initials avatar with the logo url', function (): void {
+    $this->team->forceFill(['logo_path' => 'team-logos/logo.png'])->save();
+
+    expect($this->team->getFilamentAvatarUrl())->toEndWith('storage/team-logos/logo.png');
+});
+
+it('falls back to the generated initials avatar without a logo', function (): void {
+    $this->team->forceFill(['logo_path' => null])->save();
+
+    expect($this->team->getFilamentAvatarUrl())->toContain('data:image/svg+xml');
+});


### PR DESCRIPTION
Multi-workspace users land in the same panel for every team, so it is easy to lose track of which workspace is active. The only differentiator today is a black-on-white initials avatar generated from the team name.

Add per-workspace branding, following the Hermes Web UI skin model: dark/light stays a per-user preference, while each workspace picks its own logo and accent seed color.

- Migration: teams.logo_path + teams.accent_color
- Team::getFilamentAvatarUrl() returns the uploaded logo when set, falling back to the generated initials avatar otherwise (workspace switcher, invitation emails, join pages)
- AppPanelProvider: brandLogo closure renders the workspace logo in the sidebar; colors() closure expands the workspace accent via Color::hex() into the full Filament primary ramp, falling back to BrandColors
- EditTeam gains a 'Workspace Look' section (UpdateTeamBranding Livewire component + action) with a logo upload and an accent select from eight curated skins (Ares, Slate, Poseidon, Sisyphus, Charizard, Sienna, Mono, Nous)

Includes tests for the component, the avatar fallback, and accent clearing.