### PR TITLE
Fix email company matching and auto-create rules

### DIFF
--- a/lang/en/filament/pages/email-privacy-settings.php
+++ b/lang/en/filament/pages/email-privacy-settings.php
@@ -134,7 +134,7 @@ return [
         ],
         'companies' => [
             'label' => 'Automatically create company records',
-            'description' => 'Company records will be automatically created based on the domain in a person\'s email address.',
+            'description' => 'When enabled, a company is created from a person\'s email domain. This follows the contact setting above. It is unavailable when record creation is None.',
         ],
     ],
     'notifications' => [

--- a/lang/en/filament/pages/email-privacy-settings.php
+++ b/lang/en/filament/pages/email-privacy-settings.php
@@ -116,7 +116,7 @@ return [
     ],
     'record_creation' => [
         'heading' => 'Automatic record creation',
-        'description' => 'Applies to every connected mailbox and calendar in the workspace. Changing this setting only affects newly synced emails and events. To apply it to mail already in Relaticle, open Email → Accounts and choose Re-import history on each mailbox.',
+        'description' => 'Applies to every connected mailbox and calendar in the workspace. Changing this setting only affects newly synced emails and events.',
         'recommended' => 'Recommended',
         'modes' => [
             'all' => [

--- a/packages/EmailIntegration/resources/views/forms/company-creation-card.blade.php
+++ b/packages/EmailIntegration/resources/views/forms/company-creation-card.blade.php
@@ -1,12 +1,18 @@
 @php
+    use Relaticle\EmailIntegration\Enums\ContactCreationMode;
+
     $statePath = $getStatePath();
     $toggleState = '$wire.$entangle(\''.$statePath.'\', true)';
+    $disabled = $getLivewire()->contact_creation_mode === ContactCreationMode::None->value;
 @endphp
 
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
-        class="ei-sharing-card"
-        x-on:click="if (! $event.target.closest('.fi-toggle')) $refs.companyToggle.click()"
+        @class([
+            'ei-sharing-card',
+            'pointer-events-none opacity-60' => $disabled,
+        ])
+        x-on:click="if (@js($disabled)) { return } if (! $event.target.closest('.fi-toggle')) $refs.companyToggle.click()"
     >
         <span class="ei-sharing-card-icon flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 transition dark:bg-white/10 dark:text-gray-400">
             <x-filament::icon icon="heroicon-o-building-office-2" class="h-5 w-5" />
@@ -24,6 +30,7 @@
         <x-filament::toggle
             x-ref="companyToggle"
             class="mt-1 shrink-0"
+            :disabled="$disabled"
             :state="$toggleState"
             :aria-label="__('filament/pages/email-privacy-settings.record_creation.companies.label')"
         />

--- a/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
+++ b/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
@@ -27,21 +27,25 @@ final readonly class AutoCreateCompanyAction
      * advisory lock so two StoreEmailJob/calendar workers processing the first
      * email from a brand-new domain in parallel can't both miss the match and
      * create duplicate companies: the first holder creates, the rest re-check
-     * inside the lock and reuse it.
+     * inside the lock and reuse it. The lock key is the full host www.
+     * stripped). Distinct hosts such as accounts.printtest.com and
+     * ideas.printtest.com do not share a lock.
      */
     public function execute(string $domain, string $teamId, Team $team): Company
     {
-        return $this->advisoryLock->transactional("auto-create-company:{$teamId}:{$domain}", function () use ($domain, $teamId, $team): Company {
+        $host = $this->domainMatcher->host($domain);
+
+        return $this->advisoryLock->transactional("auto-create-company:{$teamId}:{$host}", function () use ($host, $teamId, $team): Company {
             // Only create when the domain is not already in another company. The
             // caller's unlocked match can be stale by the time we get the lock, so
             // re-check here under mutual exclusion before creating.
-            $existing = $this->domainMatcher->firstMatching($domain, $teamId);
+            $existing = $this->domainMatcher->firstMatching($host, $teamId);
 
             if ($existing instanceof Company) {
                 return $existing;
             }
 
-            return $this->createCompany($domain, $teamId, $team);
+            return $this->createCompany($host, $teamId, $team);
         });
     }
 

--- a/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
+++ b/packages/EmailIntegration/src/Actions/AutoCreateCompanyAction.php
@@ -27,7 +27,7 @@ final readonly class AutoCreateCompanyAction
      * advisory lock so two StoreEmailJob/calendar workers processing the first
      * email from a brand-new domain in parallel can't both miss the match and
      * create duplicate companies: the first holder creates, the rest re-check
-     * inside the lock and reuse it. The lock key is the full host www.
+     * inside the lock and reuse it. The lock key is the full host (www.
      * stripped). Distinct hosts such as accounts.printtest.com and
      * ideas.printtest.com do not share a lock.
      */

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -119,8 +119,17 @@ final readonly class LinkEmailAction
             if ($domain && $skippedDomains->doesntContain($domain)) {
                 $company = $this->domainMatcher->firstMatching($domain, $teamId);
 
-                // 2. Auto-create Company when no existing record found.
-                if (! $company && ! $isAutomatedSender && ! $suppressCreate && $team?->auto_create_companies) {
+                // 2. Auto-create Company when no existing record found. Blocked
+                // addresses must not spawn a company, and creation still follows
+                // the same All / Selective / None rule as people.
+                if (
+                    ! $company
+                    && ! $isAutomatedSender
+                    && ! $suppressCreate
+                    && $connectedAccount
+                    && $team
+                    && $this->shouldCreateCompany($team, $participant->email_address, $email)
+                ) {
                     $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
                 }
 
@@ -198,6 +207,18 @@ final readonly class LinkEmailAction
                 || $this->hasTeamOutboundHistory($team, $emailAddress),
             ContactCreationMode::None => false,
         };
+    }
+
+    /**
+     * A company is created only when a person would be created for this address
+     * and the workspace company toggle is on. None never creates companies.
+     * Selective creates them only for addresses the workspace has emailed (or
+     * the outbound message being linked). All creates them for every eligible
+     * address.
+     */
+    private function shouldCreateCompany(Team $team, string $emailAddress, Email $email): bool
+    {
+        return $team->auto_create_companies && $this->shouldCreatePerson($team, $emailAddress, $email);
     }
 
     /**

--- a/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
@@ -51,7 +51,7 @@ final readonly class LinkMeetingAction
             if ($domain && $skippedDomains->doesntContain($domain)) {
                 $company = $this->domainMatcher->firstMatching($domain, $teamId);
 
-                if (! $company && ! $suppressCreate && $team?->auto_create_companies) {
+                if (! $company && ! $suppressCreate && $team && $team->auto_create_companies && $this->shouldCreatePerson($team)) {
                     $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
                 }
 

--- a/packages/EmailIntegration/src/Actions/UpdateTeamContactCreationSettingsAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateTeamContactCreationSettingsAction.php
@@ -24,7 +24,9 @@ final readonly class UpdateTeamContactCreationSettingsAction
 
         $team->update([
             'contact_creation_mode' => $contactCreationMode,
-            'auto_create_companies' => $autoCreateCompanies,
+            'auto_create_companies' => $contactCreationMode === ContactCreationMode::None
+                ? false
+                : $autoCreateCompanies,
         ]);
     }
 }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailPrivacySettingsPage.php
@@ -114,6 +114,13 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
         $this->tab = $tab;
     }
 
+    public function updatedContactCreationMode(): void
+    {
+        if ($this->contact_creation_mode === ContactCreationMode::None->value) {
+            $this->auto_create_companies = false;
+        }
+    }
+
     public function saveAction(): Action
     {
         return Action::make('save')
@@ -241,6 +248,10 @@ final class EmailPrivacySettingsPage extends Page implements HasSchemas
 
         /** @var User $user */
         $user = auth()->user();
+
+        if ($mode === ContactCreationMode::None) {
+            $this->auto_create_companies = false;
+        }
 
         resolve(UpdateTeamContactCreationSettingsAction::class)->execute(
             $user->currentTeam,

--- a/packages/EmailIntegration/src/Support/CompanyDomainMatcher.php
+++ b/packages/EmailIntegration/src/Support/CompanyDomainMatcher.php
@@ -6,38 +6,62 @@ namespace Relaticle\EmailIntegration\Support;
 
 use App\Models\Company;
 use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Support\Str;
 
 /**
  * Single source of truth for resolving an email/attendee domain to an existing
  * Company via the team's "domains" custom field. Shared by the email and meeting
  * link actions (fast path) and the system auto-create action (locked re-check),
  * so the matching semantics never drift between them.
+ *
+ * Identity is the full host: accounts.printtest.com and ideas.printtest.com
+ * are distinct companies. A www. prefix on the same host is not. Parent
+ * domains are not a match (cap.so does not own send.cap.so).
  */
 final class CompanyDomainMatcher
 {
     /**
      * Find the first Company in the team whose "domains" custom field contains
-     * the given domain as a complete host token. Returns null when no company
+     * the given host as a complete host token. Returns null when no company
      * owns the domain.
      */
     public function firstMatching(string $domain, string $teamId): ?Company
     {
+        $host = $this->host($domain);
+
         return Company::query()->where('team_id', $teamId)
             ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
                 ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('code', 'domains'))
-                ->whereRaw('json_value::text ~* ?', [$this->matchPattern($domain)])
+                ->whereRaw('json_value::text ~* ?', [$this->matchPattern($host)])
             )
             ->first();
     }
 
     /**
-     * Build a POSIX regex matching the domain as a complete host token inside the
-     * JSON-encoded domains array. Tolerates scheme/subdomain/path variants while
-     * avoiding substring collisions (e.g. "acme.co" vs "acme.com.au") and
-     * neutralising LIKE wildcards present in sender-controlled input.
+     * Lowercase host with a single leading www. stripped. The create lock and
+     * stored domain both use this so www.cap.so and cap.so collide, while
+     * send.cap.so does not.
+     */
+    public function host(string $domain): string
+    {
+        $domain = Str::lower(trim($domain, '.'));
+
+        if (Str::before($domain, '.') !== 'www') {
+            return $domain;
+        }
+
+        return Str::after($domain, '.');
+    }
+
+    /**
+     * Build a POSIX regex matching the host as a complete hostname inside the
+     * JSON-encoded domains array. Allows a www. prefix, scheme, and path.
+     * Does not treat a leading "." as a boundary, so a parent like "cap.so"
+     * cannot collide with "send.cap.so", and "acme.co" cannot collide with
+     * "acme.com.au". Sender-controlled LIKE wildcards are quoted.
      */
     public function matchPattern(string $domain): string
     {
-        return '(^|["/.])'.preg_quote($domain).'(["/:]|$)';
+        return '(^|["/])(www\.)?'.preg_quote($this->host($domain)).'(["/:]|$)';
     }
 }

--- a/packages/EmailIntegration/src/Support/PublicSuffixList.php
+++ b/packages/EmailIntegration/src/Support/PublicSuffixList.php
@@ -39,31 +39,73 @@ final class PublicSuffixList
     }
 
     /**
+     * The organisational domain (eTLD+1). Used only to pick a default company
+     * name: email.anthropic.com → Anthropic, mail.acme.co.uk → Acme. Company
+     * identity is the full host, not this value.
+     */
+    public function registrableDomain(string $host): ?string
+    {
+        $labels = $this->labels($host);
+
+        if ($labels === []) {
+            return null;
+        }
+
+        $suffixStart = $this->publicSuffixStart($labels);
+
+        if ($suffixStart < 1) {
+            return null;
+        }
+
+        return implode('.', array_slice($labels, $suffixStart - 1));
+    }
+
+    /**
      * The label immediately to the left of the public suffix, the part a company
      * registered. Null when the host is itself a public suffix or has no
      * registrable label.
      */
     public function registrableLabel(string $host): ?string
     {
-        $host = trim(mb_strtolower($host), '.');
+        $domain = $this->registrableDomain($host);
 
-        if ($host === '') {
+        if ($domain === null) {
             return null;
         }
 
-        $labels = explode('.', $host);
-        $count = count($labels);
+        return explode('.', $domain)[0];
+    }
 
-        // Exception rules win outright: the suffix is the rule minus its leftmost
-        // label, so that leftmost label IS the registrable one.
-        for ($i = 0; $i < $count; $i++) {
-            if (isset($this->exceptions[implode('.', array_slice($labels, $i))])) {
-                return $labels[$i];
-            }
+    /**
+     * @return list<string>
+     */
+    private function labels(string $host): array
+    {
+        $host = trim(mb_strtolower($host), '.');
+
+        if ($host === '') {
+            return [];
         }
 
-        // Longest matching normal/wildcard rule = smallest start index.
-        $suffixStart = null;
+        return explode('.', $host);
+    }
+
+    /**
+     * Index of the first label of the public suffix. Exception rules win: the
+     * suffix is the rule minus its leftmost label, so that leftmost label is
+     * registrable.
+     *
+     * @param  list<string>  $labels
+     */
+    private function publicSuffixStart(array $labels): int
+    {
+        $count = count($labels);
+
+        for ($i = 0; $i < $count; $i++) {
+            if (isset($this->exceptions[implode('.', array_slice($labels, $i))])) {
+                return $i + 1;
+            }
+        }
 
         for ($i = 0; $i < $count; $i++) {
             $rest = implode('.', array_slice($labels, $i + 1));
@@ -71,15 +113,11 @@ final class PublicSuffixList
             if (isset($this->rules[implode('.', array_slice($labels, $i))])
                 || ($rest !== '' && isset($this->wildcards[$rest]))
             ) {
-                $suffixStart = $i;
-                break;
+                return $i;
             }
         }
 
-        // No rule matched → implicit "*" default: the rightmost label is the suffix.
-        $suffixStart ??= $count - 1;
-
-        return $suffixStart >= 1 ? $labels[$suffixStart - 1] : null;
+        return $count - 1;
     }
 
     private function load(string $path): void

--- a/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
@@ -112,7 +112,10 @@ it('skips person creation when contact_creation_mode=None', function (): void {
         'team_id' => $team->id,
         'user_id' => $user->id,
     ]));
-    $team->update(['contact_creation_mode' => ContactCreationMode::None]);
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::None,
+        'auto_create_companies' => true,
+    ]);
 
     $meeting = Meeting::factory()->create([
         'team_id' => $account->team_id,

--- a/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\People;
 use App\Models\User;
@@ -126,6 +127,7 @@ it('skips person creation when contact_creation_mode=None', function (): void {
     (app(LinkMeetingAction::class))->execute($meeting->fresh());
 
     expect(People::query()->where('team_id', $team->id)->count())->toBe(0);
+    expect(Company::query()->where('team_id', $team->id)->count())->toBe(0);
 });
 
 it('auto-creates a person on the first meeting in Selective mode', function (): void {
@@ -271,7 +273,10 @@ it('does not auto-create a person for a workspace-blocked attendee', function ()
         'team_id' => $team->id,
         'user_id' => $user->id,
     ]));
-    $team->update(['contact_creation_mode' => ContactCreationMode::All]);
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     TeamEmailBlocklist::factory()->blocked()->email('blocked@acme.com')->create([
         'team_id' => $team->id,
@@ -291,4 +296,5 @@ it('does not auto-create a person for a workspace-blocked attendee', function ()
     (app(LinkMeetingAction::class))->execute($meeting->fresh());
 
     expect(People::query()->where('team_id', $team->id)->count())->toBe(0);
+    expect(Company::query()->where('team_id', $team->id)->count())->toBe(0);
 });

--- a/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
@@ -299,6 +299,28 @@ it('saves auto_create_companies when the record creation tab is saved', function
     expect($this->team->fresh()->auto_create_companies)->toBeFalse();
 });
 
+it('turns off company creation when record creation is saved as None', function (): void {
+    $this->team->update(['auto_create_companies' => true]);
+
+    livewire(EmailPrivacySettingsPage::class)
+        ->call('setTab', 'record_creation')
+        ->set('contact_creation_mode', ContactCreationMode::None->value)
+        ->assertSet('auto_create_companies', false)
+        ->callAction('save')
+        ->assertNotified('Privacy settings saved.');
+
+    expect($this->team->fresh()->contact_creation_mode)->toBe(ContactCreationMode::None)
+        ->and($this->team->fresh()->auto_create_companies)->toBeFalse();
+});
+
+it('disables the company creation switch when record creation is None', function (): void {
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::None]);
+
+    livewire(EmailPrivacySettingsPage::class)
+        ->call('setTab', 'record_creation')
+        ->assertSeeHtml('disabled');
+});
+
 it('does not save record creation settings when adding a visibility entry', function (): void {
     livewire(EmailPrivacySettingsPage::class)
         ->call('setTab', 'record_creation')

--- a/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailPrivacySettingsPageTest.php
@@ -313,12 +313,28 @@ it('turns off company creation when record creation is saved as None', function 
         ->and($this->team->fresh()->auto_create_companies)->toBeFalse();
 });
 
+it('turns off company creation in the action when record creation is None', function (): void {
+    $this->team->update(['auto_create_companies' => true]);
+
+    resolve(UpdateTeamContactCreationSettingsAction::class)->execute(
+        $this->team,
+        $this->user,
+        ContactCreationMode::None,
+        true,
+    );
+
+    $team = $this->team->fresh();
+
+    expect($team->contact_creation_mode)->toBe(ContactCreationMode::None);
+    expect($team->auto_create_companies)->toBeFalse();
+});
+
 it('disables the company creation switch when record creation is None', function (): void {
     $this->team->update(['contact_creation_mode' => ContactCreationMode::None]);
 
     livewire(EmailPrivacySettingsPage::class)
         ->call('setTab', 'record_creation')
-        ->assertSeeHtml('disabled');
+        ->assertSeeHtml('pointer-events-none opacity-60');
 });
 
 it('does not save record creation settings when adding a visibility entry', function (): void {

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -23,6 +23,7 @@ use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 
 mutates(LinkEmailAction::class);
 mutates(AutoCreatePersonAction::class);
+mutates(AutoCreateCompanyAction::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -240,7 +241,10 @@ it('updates participant contact_id when linked to a person', function (): void {
 });
 
 it('does not auto-create companies when auto_create_companies is false', function (): void {
-    $this->team->update(['auto_create_companies' => false]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => false,
+    ]);
 
     $email = makeLinkEmail();
 
@@ -256,8 +260,51 @@ it('does not auto-create companies when auto_create_companies is false', functio
     expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore);
 });
 
+it('does not auto-create a company when record creation is None', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::None,
+        'auto_create_companies' => true,
+    ]);
+
+    $email = makeLinkEmail(['direction' => EmailDirection::OUTBOUND]);
+
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'prospect@none-corp.com',
+    ]);
+
+    $countBefore = Company::where('team_id', $this->team->id)->count();
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore);
+});
+
+it('does not auto-create a company in Selective mode for inbound-only addresses', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::Selective,
+        'auto_create_companies' => true,
+    ]);
+
+    $email = makeLinkEmail(['direction' => EmailDirection::INBOUND]);
+
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'inbound@selective-corp.com',
+    ]);
+
+    $countBefore = Company::where('team_id', $this->team->id)->count();
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore);
+});
+
 it('auto-creates a company when auto_create_companies is true', function (): void {
-    $this->team->update(['auto_create_companies' => true]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     $email = makeLinkEmail();
 
@@ -272,7 +319,10 @@ it('auto-creates a company when auto_create_companies is true', function (): voi
 });
 
 it('derives the company name from the registrable domain, not a mail subdomain', function (): void {
-    $this->team->update(['auto_create_companies' => true]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     $email = makeLinkEmail();
 
@@ -283,12 +333,32 @@ it('derives the company name from the registrable domain, not a mail subdomain',
 
     app(LinkEmailAction::class)->execute($email);
 
-    expect(Company::where('team_id', $this->team->id)->where('name', 'Anthropic')->exists())->toBeTrue()
+    $company = Company::where('team_id', $this->team->id)
+        ->where('name', 'Anthropic')
+        ->with('customFieldValues.customField')
+        ->first();
+
+    expect($company)->not->toBeNull()
         ->and(Company::where('team_id', $this->team->id)->where('name', 'Email')->exists())->toBeFalse();
+
+    $domainsField = CustomField::query()
+        ->where('tenant_id', $this->team->id)
+        ->where('entity_type', 'company')
+        ->where('code', 'domains')
+        ->first();
+
+    if ($domainsField && $company) {
+        expect($company->getCustomFieldValue($domainsField))
+            ->toContain('www.email.anthropic.com')
+            ->not->toContain('www.anthropic.com');
+    }
 });
 
 it('derives the company name from the registrable label across TLD shapes', function (string $address, string $expected): void {
-    $this->team->update(['auto_create_companies' => true]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     $email = makeLinkEmail();
 
@@ -311,7 +381,10 @@ it('derives the company name from the registrable label across TLD shapes', func
 ]);
 
 it('does not auto-create a company for a no-reply / automated sender', function (): void {
-    $this->team->update(['auto_create_companies' => true]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     $email = makeLinkEmail();
 
@@ -346,7 +419,10 @@ it('does not auto-create a person for a no-reply / automated sender', function (
 });
 
 it('seeds an auto-created company with a protocol-less domain and ICP set to false', function (): void {
-    $this->team->update(['auto_create_companies' => true]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     $email = makeLinkEmail();
 
@@ -385,6 +461,71 @@ it('seeds an auto-created company with a protocol-less domain and ICP set to fal
     }
 });
 
+it('creates distinct companies for different subdomains of the same apex', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    foreach (['a@accounts.printtest.com', 'b@ideas.printtest.com'] as $address) {
+        $email = makeLinkEmail();
+        EmailParticipant::factory()->from()->create([
+            'email_id' => $email->getKey(),
+            'email_address' => $address,
+        ]);
+        app(LinkEmailAction::class)->execute($email);
+    }
+
+    $domainsField = CustomField::query()
+        ->where('tenant_id', $this->team->id)
+        ->where('entity_type', 'company')
+        ->where('code', 'domains')
+        ->first();
+
+    $companies = Company::where('team_id', $this->team->id)
+        ->where('creation_source', CreationSource::SYSTEM)
+        ->where('name', 'Printtest')
+        ->with('customFieldValues.customField')
+        ->get();
+
+    expect($companies)->toHaveCount(2);
+
+    if ($domainsField) {
+        $stored = $companies
+            ->map(fn (Company $company): string => json_encode($company->getCustomFieldValue($domainsField)) ?: '')
+            ->implode(' ');
+
+        expect($stored)->toContain('www.accounts.printtest.com')
+            ->and($stored)->toContain('www.ideas.printtest.com');
+    }
+});
+
+it('reuses one company when the host only differs by a www prefix', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $first = makeLinkEmail();
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $first->getKey(),
+        'email_address' => 'hello@cap.so',
+    ]);
+    app(LinkEmailAction::class)->execute($first);
+
+    $second = makeLinkEmail();
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $second->getKey(),
+        'email_address' => 'alerts@www.cap.so',
+    ]);
+    app(LinkEmailAction::class)->execute($second);
+
+    expect(Company::where('team_id', $this->team->id)
+        ->where('creation_source', CreationSource::SYSTEM)
+        ->where('name', 'Cap')
+        ->count())->toBe(1);
+});
+
 it('does not create a duplicate company when the domain is already owned', function (): void {
     $action = app(AutoCreateCompanyAction::class);
 
@@ -393,6 +534,16 @@ it('does not create a duplicate company when the domain is already owned', funct
 
     expect($second->getKey())->toBe($first->getKey());
     expect(Company::where('team_id', $this->team->id)->where('name', 'Brandnewcorp')->count())->toBe(1);
+});
+
+it('creates distinct companies for a mail subdomain and the apex domain', function (): void {
+    $action = app(AutoCreateCompanyAction::class);
+
+    $first = $action->execute('cap.so', $this->team->id, $this->team);
+    $second = $action->execute('send.cap.so', $this->team->id, $this->team);
+
+    expect($second->getKey())->not->toBe($first->getKey());
+    expect(Company::where('team_id', $this->team->id)->where('name', 'Cap')->count())->toBe(2);
 });
 
 it('reuses an existing company that already owns the domain instead of creating one', function (): void {
@@ -481,7 +632,10 @@ it('auto-creates a person when contact_creation_mode is All', function (): void 
 });
 
 it('does not auto-create a person for a workspace-blocked address', function (): void {
-    $this->team->update(['contact_creation_mode' => ContactCreationMode::All]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     TeamEmailBlocklist::factory()->blocked()->email('blocked@partner.com')->create([
         'team_id' => $this->team->id,
@@ -496,9 +650,12 @@ it('does not auto-create a person for a workspace-blocked address', function ():
         'name' => 'Blocked Contact',
     ]);
 
+    $companyCountBefore = Company::where('team_id', $this->team->id)->count();
+
     app(LinkEmailAction::class)->execute($email);
 
     expect(People::where('team_id', $this->team->id)->where('name', 'Blocked Contact')->exists())->toBeFalse();
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($companyCountBefore);
 });
 
 it('still auto-creates a person for a protected address', function (): void {
@@ -523,7 +680,10 @@ it('still auto-creates a person for a protected address', function (): void {
 });
 
 it('does not auto-create a person for a mailbox-blocklisted address', function (): void {
-    $this->team->update(['contact_creation_mode' => ContactCreationMode::All]);
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
 
     EmailBlocklist::factory()->email('spam@badactor.com')->create([
         'user_id' => $this->user->id,
@@ -539,9 +699,12 @@ it('does not auto-create a person for a mailbox-blocklisted address', function (
         'name' => 'Spam Sender',
     ]);
 
+    $companyCountBefore = Company::where('team_id', $this->team->id)->count();
+
     app(LinkEmailAction::class)->execute($email);
 
     expect(People::where('team_id', $this->team->id)->where('name', 'Spam Sender')->exists())->toBeFalse();
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($companyCountBefore);
 });
 
 it('auto-creates other participants when one address is blocked', function (): void {

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -300,6 +300,24 @@ it('does not auto-create a company in Selective mode for inbound-only addresses'
     expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore);
 });
 
+it('auto-creates a company in Selective mode for outbound addresses', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::Selective,
+        'auto_create_companies' => true,
+    ]);
+
+    $email = makeLinkEmail(['direction' => EmailDirection::OUTBOUND]);
+
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'prospect@selective-corp.com',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(Company::where('team_id', $this->team->id)->where('name', 'Selective-corp')->exists())->toBeTrue();
+});
+
 it('auto-creates a company when auto_create_companies is true', function (): void {
     $this->team->update([
         'contact_creation_mode' => ContactCreationMode::All,
@@ -347,11 +365,10 @@ it('derives the company name from the registrable domain, not a mail subdomain',
         ->where('code', 'domains')
         ->first();
 
-    if ($domainsField && $company) {
-        expect($company->getCustomFieldValue($domainsField))
-            ->toContain('www.email.anthropic.com')
-            ->not->toContain('www.anthropic.com');
-    }
+    expect($domainsField)->not->toBeNull();
+    expect($company->getCustomFieldValue($domainsField))
+        ->toContain('www.email.anthropic.com')
+        ->not->toContain('www.anthropic.com');
 });
 
 it('derives the company name from the registrable label across TLD shapes', function (string $address, string $expected): void {
@@ -489,15 +506,14 @@ it('creates distinct companies for different subdomains of the same apex', funct
         ->get();
 
     expect($companies)->toHaveCount(2);
+    expect($domainsField)->not->toBeNull();
 
-    if ($domainsField) {
-        $stored = $companies
-            ->map(fn (Company $company): string => json_encode($company->getCustomFieldValue($domainsField)) ?: '')
-            ->implode(' ');
+    $stored = $companies
+        ->map(fn (Company $company): string => json_encode($company->getCustomFieldValue($domainsField)) ?: '')
+        ->implode(' ');
 
-        expect($stored)->toContain('www.accounts.printtest.com')
-            ->and($stored)->toContain('www.ideas.printtest.com');
-    }
+    expect($stored)->toContain('www.accounts.printtest.com');
+    expect($stored)->toContain('www.ideas.printtest.com');
 });
 
 it('reuses one company when the host only differs by a www prefix', function (): void {
@@ -544,6 +560,49 @@ it('creates distinct companies for a mail subdomain and the apex domain', functi
 
     expect($second->getKey())->not->toBe($first->getKey());
     expect(Company::where('team_id', $this->team->id)->where('name', 'Cap')->count())->toBe(2);
+});
+
+it('creates distinct companies when a subdomain is stored before the apex', function (): void {
+    $action = app(AutoCreateCompanyAction::class);
+
+    $subdomain = $action->execute('send.cap.so', $this->team->id, $this->team);
+    $apex = $action->execute('cap.so', $this->team->id, $this->team);
+
+    expect($apex->getKey())->not->toBe($subdomain->getKey());
+    expect(Company::where('team_id', $this->team->id)->where('name', 'Cap')->count())->toBe(2);
+});
+
+it('does not attach a parent company to a subdomain sender when creation is off', function (): void {
+    $domainsField = CustomField::query()
+        ->where('tenant_id', $this->team->id)
+        ->where('entity_type', 'company')
+        ->where('code', 'domains')
+        ->first();
+
+    expect($domainsField)->not->toBeNull();
+
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => false,
+    ]);
+
+    $company = Company::create([
+        'team_id' => $this->team->id,
+        'name' => 'Cap',
+        'creator_id' => $this->user->id,
+    ]);
+    $company->saveCustomFieldValue($domainsField, 'www.cap.so', $this->team);
+
+    $email = makeLinkEmail();
+
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'alerts@send.cap.so',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect($email->companies()->where('companies.id', $company->getKey())->exists())->toBeFalse();
 });
 
 it('reuses an existing company that already owns the domain instead of creating one', function (): void {


### PR DESCRIPTION
## Summary
- Match and create companies from the full email host (`accounts.printtest.com` vs `ideas.printtest.com` stay two records). A leading `www.` on the same host still counts as one.
- Create a company only when a person would be created, and only if the company toggle is on. None turns that toggle off and creates neither people nor companies. Selective creates them only for addresses the workspace has emailed, or calendar guests. All creates them for every eligible address in mail and calendar.
- Keep linking to existing companies by domain even when creation is skipped.

## Test plan
- [x] Import mail with `accounts.printtest.com` and `ideas.printtest.com`: two companies.
- [x] Import `cap.so` and `www.cap.so`: one company.
- [x] Set record creation to None with companies previously on: toggle is off and disabled, no new people or companies from sync.
- [x] Selective: inbound-only address creates neither person nor company. Outbound to that address creates both (if the company toggle is on).
- [x] All with the company toggle on: inbound work addresses create people and companies. Noreply and gmail stay skipped.
- [x] All with the company toggle off: people create, companies do not.
- [x] Calendar guest in Selective still creates person and company when the toggle is on.