### PR TITLE
Hide hidden-mail addresses from compose autocomplete

### DIFF
--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -18,7 +18,6 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Support\Enums\Width;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
@@ -31,16 +30,16 @@ use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\RichContent\SignatureBlock;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
-use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
+use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 use RuntimeException;
 
 trait HasEmailComposeActions
 {
     /**
-     * Return the CRM record these emails belong to (People, Company, or Opportunity).
+     * Return the CRM record these emails belong to (People, Company, or Opportunity)
      */
     abstract protected function getCrmRecord(): Model;
 
@@ -386,19 +385,7 @@ trait HasEmailComposeActions
      */
     private function contactEmailSuggestions(): array
     {
-        $teamId = filament()->getTenant()?->getKey();
-
-        /** @var list<string> */
-        return EmailParticipant::query()
-            ->whereHas('email', fn (Builder $q): Builder => $q->where('team_id', $teamId))
-            ->whereNotNull('email_address')
-            ->select('email_address')
-            ->distinct()
-            ->orderBy('email_address')
-            ->limit(300)
-            ->pluck('email_address')
-            ->values()
-            ->all();
+        return resolve(RecipientSuggestionService::class)->addressesFor($this->getAuthenticatedUser());
     }
 
     /**

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -42,11 +42,11 @@ use Relaticle\EmailIntegration\Filament\Concerns\HasEmailReaderActions;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
-use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
+use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 
 final class EmailInboxPage extends Page
@@ -792,24 +792,7 @@ final class EmailInboxPage extends Page
      */
     private function contactEmailSuggestions(): array
     {
-        $teamId = filament()->getTenant()?->getKey();
-
-        /** @var list<string> */
-        return EmailParticipant::query()
-            // Drafts are private (never-sent, PRIVATE tier). Without this, a
-            // teammate's still-unsent draft leaks its to/cc/bcc addresses into
-            // everyone else's recipient autocomplete via this team-wide query.
-            ->whereHas('email', fn (Builder $q): Builder => $q
-                ->where('team_id', $teamId)
-                ->where('status', '!=', EmailStatus::DRAFT))
-            ->whereNotNull('email_address')
-            ->select('email_address')
-            ->distinct()
-            ->orderBy('email_address')
-            ->limit(300)
-            ->pluck('email_address')
-            ->values()
-            ->all();
+        return resolve(RecipientSuggestionService::class)->addressesFor($this->authUser());
     }
 
     /**

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -56,6 +56,7 @@ use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
+use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 
 /**
  * @property-read Action $createSignatureAction
@@ -644,23 +645,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
     #[Computed]
     public function recipientSuggestions(): array
     {
-        $teamId = $this->authUser()->current_team_id;
-
-        /** @var list<string> */
-        return EmailParticipant::query()
-            // Drafts are private (never-sent, PRIVATE tier). Without this, a
-            // teammate's still-unsent draft leaks its to/cc/bcc addresses into
-            // everyone else's recipient autocomplete via this team-wide query.
-            ->whereHas('email', fn (Builder $q): Builder => $q
-                ->where('team_id', $teamId)
-                ->where('status', '!=', EmailStatus::DRAFT))
-            ->whereNotNull('email_address')
-            ->select('email_address')
-            ->distinct()
-            ->orderBy('email_address')
-            ->limit(300)
-            ->pluck('email_address')
-            ->all();
+        return resolve(RecipientSuggestionService::class)->addressesFor($this->authUser());
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/RecipientSuggestionService.php
+++ b/packages/EmailIntegration/src/Services/RecipientSuggestionService.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
+use Relaticle\EmailIntegration\Enums\EmailStatus;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
+
+final readonly class RecipientSuggestionService
+{
+    /**
+     * Addresses the viewer may reuse in compose autocomplete.
+     *
+     * Restricted to mail VisibleEmailScope would list, excluding drafts and
+     * other people's BCC rows. Without those gates, private, protected,
+     * internal, and BCC addresses leak into teammates' To/Cc/Bcc suggestions.
+     *
+     * @return list<string>
+     */
+    public function addressesFor(User $user, int $limit = 300): array
+    {
+        /** @var list<string> */
+        return EmailParticipant::query()
+            ->whereHas('email', function (Builder $emailQuery) use ($user): void {
+                $emailQuery
+                    ->withGlobalScope('visible', new VisibleEmailScope($user))
+                    ->where('status', '!=', EmailStatus::DRAFT);
+            })
+            ->where(function (Builder $participantQuery) use ($user): void {
+                $participantQuery
+                    ->where('role', '!=', EmailParticipantRole::BCC)
+                    ->orWhereHas(
+                        'email',
+                        fn (Builder $ownedEmail): Builder => $ownedEmail->where('user_id', $user->getKey()),
+                    );
+            })
+            ->whereNotNull('email_address')
+            ->select('email_address')
+            ->distinct()
+            ->orderBy('email_address')
+            ->limit($limit)
+            ->pluck('email_address')
+            ->all();
+    }
+}

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -18,18 +18,23 @@ use Relaticle\EmailIntegration\Actions\SaveEmailDraftAction;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
 use Relaticle\EmailIntegration\Livewire\EmailComposer;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAttachment;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
+use Relaticle\EmailIntegration\Models\ProtectedRecipient;
+use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 
 use function Pest\Laravel\actingAs;
 
-mutates(EmailComposer::class, SaveEmailDraftAction::class, DeleteEmailDraftAction::class);
+mutates(EmailComposer::class, SaveEmailDraftAction::class, DeleteEmailDraftAction::class, RecipientSuggestionService::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -403,6 +408,78 @@ it('excludes a teammate\'s unsent draft recipients from recipient suggestions', 
         ->recipientSuggestions();
 
     expect($suggestions)->not->toContain('hidden-recipient@example.com');
+});
+
+it('excludes a teammate\'s private mail recipients from recipient suggestions', function (): void {
+    $address = 'private-only@example.com';
+    teammateSentEmail($this->user, EmailPrivacyTier::PRIVATE, $address, EmailParticipantRole::TO);
+
+    expect(composerRecipientSuggestions())->not->toContain($address);
+});
+
+it('excludes protected-recipient addresses from recipient suggestions', function (): void {
+    $address = 'vip@protected.example';
+
+    ProtectedRecipient::factory()->email($address)->create([
+        'team_id' => $this->user->current_team_id,
+        'created_by' => $this->user->id,
+    ]);
+
+    teammateSentEmail($this->user, EmailPrivacyTier::FULL, $address, EmailParticipantRole::TO);
+
+    expect(composerRecipientSuggestions())->not->toContain($address);
+});
+
+it('excludes a teammate\'s BCC addresses from recipient suggestions', function (): void {
+    $bcc = 'secret-bcc@example.com';
+    teammateSentEmail($this->user, EmailPrivacyTier::FULL, $bcc, EmailParticipantRole::BCC);
+
+    expect(composerRecipientSuggestions())->not->toContain($bcc);
+});
+
+it('excludes a teammate\'s internal mail recipients from recipient suggestions', function (): void {
+    $address = 'internal-only@example.com';
+    teammateSentEmail($this->user, EmailPrivacyTier::FULL, $address, EmailParticipantRole::TO, isInternal: true);
+
+    expect(composerRecipientSuggestions())->not->toContain($address);
+});
+
+it('includes recipients from a teammate\'s workspace-visible mail in recipient suggestions', function (): void {
+    $address = 'shared-to@example.com';
+    teammateSentEmail($this->user, EmailPrivacyTier::METADATA_ONLY, $address, EmailParticipantRole::TO);
+
+    expect(composerRecipientSuggestions())->toContain($address);
+});
+
+it('includes the owner\'s own private and BCC addresses in recipient suggestions', function (): void {
+    $to = 'own-private@example.com';
+    $bcc = 'own-bcc@example.com';
+
+    $email = Email::factory()->create([
+        'team_id' => $this->user->current_team_id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'status' => EmailStatus::SYNCED,
+        'privacy_tier' => EmailPrivacyTier::PRIVATE,
+        'is_internal' => false,
+    ]);
+
+    EmailParticipant::factory()->create([
+        'email_id' => $email->id,
+        'email_address' => $to,
+        'role' => EmailParticipantRole::TO,
+    ]);
+
+    EmailParticipant::factory()->create([
+        'email_id' => $email->id,
+        'email_address' => $bcc,
+        'role' => EmailParticipantRole::BCC,
+    ]);
+
+    $suggestions = composerRecipientSuggestions();
+
+    expect($suggestions)->toContain($to)
+        ->and($suggestions)->toContain($bcc);
 });
 
 it('adds every company team member primary email to recipients', function (): void {
@@ -871,3 +948,45 @@ it('drops a pending attachment when it is removed before sending', function (): 
     $email = Email::query()->where('subject', 'No attachment after all')->sole();
     expect($email->attachments()->pluck('filename')->all())->toBe(['keep.pdf']);
 });
+
+/**
+ * @return list<string>
+ */
+function composerRecipientSuggestions(): array
+{
+    return Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->instance()
+        ->recipientSuggestions();
+}
+
+function teammateSentEmail(
+    User $viewer,
+    EmailPrivacyTier $privacyTier,
+    string $address,
+    EmailParticipantRole $role,
+    bool $isInternal = false,
+): void {
+    $teammate = User::factory()->create(['current_team_id' => $viewer->current_team_id]);
+
+    $teammateAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'user_id' => $teammate->id,
+        'team_id' => $viewer->current_team_id,
+        'status' => 'active',
+    ]));
+
+    $email = Email::factory()->create([
+        'team_id' => $viewer->current_team_id,
+        'user_id' => $teammate->id,
+        'connected_account_id' => $teammateAccount->id,
+        'status' => EmailStatus::SYNCED,
+        'privacy_tier' => $privacyTier,
+        'is_internal' => $isInternal,
+    ]);
+
+    EmailParticipant::factory()->create([
+        'email_id' => $email->id,
+        'email_address' => $address,
+        'role' => $role,
+    ]);
+}


### PR DESCRIPTION
## Summary
- Compose To/Cc/Bcc suggestions were loaded from every non-draft participant in the workspace, not from mail the viewer is allowed to see.
- Suggestions now go through `VisibleEmailScope` (private, protected, and internal mail stay owner-only) and drop other people's BCC rows.
- The same query is shared by the floating composer, inbox compose, and CRM record compose.

## Test plan
- [x] As teammate B, open Compose and type part of an address that only exists on A's **private** sent mail. It must not appear.
- [x] Repeat for a **protected recipient** address on mail B cannot open.
- [x] Repeat for a **BCC** on A's shared mail. It must not appear for B. It may appear for A.
- [x] An address on A's **workspace-visible** To/Cc still appears for B.
- [x] A's unsent draft recipients still stay out of B's list.