### PR TITLE
Add Paseo workspace lifecycle support

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -3,7 +3,7 @@
 # Gitignored files each new worktree needs (.env, Passport keys) are copied via
 # .worktreeinclude at the repo root. Everything else (Herd site, .env
 # rewrites, per-workspace testing DB, dependencies, build) lives in the
-# scripts, shared with Polyscope (polyscope.json calls the same files).
+# scripts, shared with Paseo and Polyscope.
 
 [scripts]
 setup = "bash bin/setup-workspace.sh"

--- a/bin/archive-workspace.sh
+++ b/bin/archive-workspace.sh
@@ -18,18 +18,30 @@ unlink_site() {
     herd unlink "$1" >/dev/null 2>&1 || true
 }
 
-unlink_site "$FOLDER"
+site_points_here() {
+    herd links 2>/dev/null | grep -F "| $1 " | grep -qF "| $PWD "
+}
+
+SITE_NAME="$(sed -n 's/^WORKSPACE_SITE_NAME=//p' .env 2>/dev/null | head -1)"
+SITE_NAME="${SITE_NAME:-$FOLDER}"
+
+if site_points_here "$SITE_NAME"; then
+    unlink_site "$SITE_NAME"
+fi
+
+if [[ "$SITE_NAME" != "$FOLDER" ]] && site_points_here "$FOLDER"; then
+    unlink_site "$FOLDER"
+fi
 
 # An older setup may have linked the workspace name rather than the folder.
 # Only touch that site when it provably points at THIS directory. The name
 # can also belong to a different workspace's folder.
 WORKSPACE_NAME="${CONDUCTOR_WORKSPACE_NAME:-}"
-if [[ -n "$WORKSPACE_NAME" && "$WORKSPACE_NAME" != "$FOLDER" ]] &&
-    herd links 2>/dev/null | grep -F " $WORKSPACE_NAME " | grep -qF "$PWD"; then
+if [[ -n "$WORKSPACE_NAME" && "$WORKSPACE_NAME" != "$FOLDER" ]] && site_points_here "$WORKSPACE_NAME"; then
     unlink_site "$WORKSPACE_NAME"
 fi
 
-TEST_DB="relaticle_testing_$(echo "$FOLDER" | tr '-' '_')"
+TEST_DB="relaticle_testing_$(echo "$SITE_NAME" | tr '-' '_')"
 TEST_DB_USER="$(sed -n 's/^DB_USERNAME=//p' .env.testing 2>/dev/null | head -1)"
 for db in $(psql -U "${TEST_DB_USER:-postgres}" -h 127.0.0.1 -d postgres -tAc "SELECT datname FROM pg_database WHERE datname='${TEST_DB}' OR datname ~ '^${TEST_DB}_test_[0-9]+$'" 2>/dev/null); do
     echo "→ Dropping ${db}"
@@ -40,7 +52,7 @@ done
 # --scan without -n only ever looks at db 0 and would silently delete nothing.
 if command -v redis-cli >/dev/null 2>&1; then
     for db in $(sed -n 's/^REDIS_DB=//p; s/^REDIS_CACHE_DB=//p' .env 2>/dev/null | sort -u); do
-        for pattern in "${FOLDER}_database_*" "${FOLDER}_cache_*" "${FOLDER}_horizon:*"; do
+        for pattern in "${SITE_NAME}_database_*" "${SITE_NAME}_cache_*" "${SITE_NAME}_horizon:*"; do
             redis-cli -n "$db" --scan --pattern "$pattern" | xargs -n 100 redis-cli -n "$db" del >/dev/null 2>&1 || true
         done
     done

--- a/bin/setup-workspace.sh
+++ b/bin/setup-workspace.sh
@@ -97,8 +97,17 @@ fi
 composer install --no-interaction --prefer-dist
 
 echo "→ JS dependencies"
-PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@').pop()")"
-CI=true npx --yes "pnpm@${PNPM_VERSION}" install --frozen-lockfile --prefer-offline
+if [[ -f pnpm-lock.yaml ]]; then
+    PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@').pop()")"
+    CI=true npx --yes "pnpm@${PNPM_VERSION}" install --frozen-lockfile --prefer-offline
+    JS_BUILD_COMMAND=(npx --yes "pnpm@${PNPM_VERSION}" run build)
+elif [[ -f package-lock.json ]]; then
+    npm ci
+    JS_BUILD_COMMAND=(npm run build)
+else
+    echo "✗ no supported JS lockfile found" >&2
+    exit 1
+fi
 
 # Tokens must verify across every checkout because the dev database is shared:
 # copy the root's keys instead of minting fresh ones.
@@ -113,6 +122,6 @@ php artisan config:clear --no-interaction
 php artisan route:clear --no-interaction
 
 echo "→ Building frontend assets"
-npx --yes "pnpm@${PNPM_VERSION}" run build
+"${JS_BUILD_COMMAND[@]}"
 
 echo "✓ Workspace ready: https://${SITE_NAME}.test (app panel at /app, sysadmin at /sysadmin)"

--- a/bin/setup-workspace.sh
+++ b/bin/setup-workspace.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Provisions a parallel workspace (Polyscope or Conductor): Herd site, .env
+# Provisions a parallel workspace (Paseo, Polyscope, or Conductor): Herd site, .env
 # rewrites, per-workspace testing database, dependencies, and a frontend build.
 # Run from the workspace root. Idempotent: safe to re-run.
 #
-# Everything is keyed off the folder basename, never CONDUCTOR_WORKSPACE_NAME:
-# Conductor renames workspaces after setup, which would strand the Herd site
-# and .env under the old name. The folder never changes.
+# Isolation keys use the folder basename, never CONDUCTOR_WORKSPACE_NAME.
+# They add the repository name only when another project already owns that
+# workspace name.
 #
 # The dev database (relaticle_app) stays shared across workspaces. We rewrite
 # APP_URL and SESSION_DOMAIN so absolute URLs and session cookies match
@@ -31,13 +31,36 @@ if [[ ! -f .env ]]; then
     cp "$ROOT/.env" .env
 fi
 
-echo "→ Herd site"
-herd link "$FOLDER"
-herd secure "$FOLDER"
+site_is_linked() {
+    herd links 2>/dev/null | grep -Fq "| $1 "
+}
 
-echo "→ Pointing .env at ${FOLDER}.test"
-sed -i '' "s|^APP_URL=.*|APP_URL=https://${FOLDER}.test|" .env
-sed -i '' "s|^SESSION_DOMAIN=.*|SESSION_DOMAIN=.${FOLDER}.test|" .env
+site_points_here() {
+    herd links 2>/dev/null | grep -F "| $1 " | grep -qF "| $PWD "
+}
+
+SITE_NAME="${WORKSPACE_SITE_NAME:-$FOLDER}"
+if [[ "$SITE_NAME" == "$FOLDER" ]] && site_is_linked "$SITE_NAME" && ! site_points_here "$SITE_NAME"; then
+    SITE_NAME="$(basename "$ROOT")-$FOLDER"
+fi
+
+if site_is_linked "$SITE_NAME" && ! site_points_here "$SITE_NAME"; then
+    echo "✗ Herd site '${SITE_NAME}' already belongs to another directory" >&2
+    exit 1
+fi
+
+sed -i '' "/^WORKSPACE_SITE_NAME=/d" .env
+echo "WORKSPACE_SITE_NAME=${SITE_NAME}" >> .env
+
+echo "→ Herd site"
+if ! site_points_here "$SITE_NAME"; then
+    herd link "$SITE_NAME"
+fi
+herd secure "$SITE_NAME"
+
+echo "→ Pointing .env at ${SITE_NAME}.test"
+sed -i '' "s|^APP_URL=.*|APP_URL=https://${SITE_NAME}.test|" .env
+sed -i '' "s|^SESSION_DOMAIN=.*|SESSION_DOMAIN=.${SITE_NAME}.test|" .env
 sed -i '' "s|^APP_PANEL_DOMAIN=.*|APP_PANEL_DOMAIN=|" .env
 sed -i '' "s|^SYSADMIN_DOMAIN=.*|SYSADMIN_DOMAIN=|" .env
 
@@ -45,20 +68,20 @@ sed -i '' "s|^SYSADMIN_DOMAIN=.*|SYSADMIN_DOMAIN=|" .env
 # checkout resolves the same default key prefix (APP_NAME-derived), so another
 # workspace's Horizon worker consumes THIS workspace's jobs with foreign code,
 # and cache entries leak across branches.
-echo "→ Isolating Redis keys for ${FOLDER}"
+echo "→ Isolating Redis keys for ${SITE_NAME}"
 sed -i '' "/^REDIS_PREFIX=/d; /^CACHE_PREFIX=/d; /^HORIZON_PREFIX=/d" .env
 {
     echo ""
-    echo "REDIS_PREFIX=${FOLDER}_database_"
-    echo "CACHE_PREFIX=${FOLDER}_cache_"
-    echo "HORIZON_PREFIX=${FOLDER}_horizon:"
+    echo "REDIS_PREFIX=${SITE_NAME}_database_"
+    echo "CACHE_PREFIX=${SITE_NAME}_cache_"
+    echo "HORIZON_PREFIX=${SITE_NAME}_horizon:"
 } >> .env
 
 # Each workspace gets its own testing database: two suites sharing one DB
 # deadlock, and a migration on one branch breaks the other's schema mid-run.
 # phpunit.xml deliberately omits DB_DATABASE so this .env.testing value wins;
 # skip-worktree keeps the tracked file's rewrite out of every diff.
-TEST_DB="relaticle_testing_$(echo "$FOLDER" | tr '-' '_')"
+TEST_DB="relaticle_testing_$(echo "$SITE_NAME" | tr '-' '_')"
 echo "→ Testing database ${TEST_DB}"
 sed -i '' "s|^DB_DATABASE=.*|DB_DATABASE=${TEST_DB}|" .env.testing
 git update-index --skip-worktree .env.testing
@@ -74,7 +97,8 @@ fi
 composer install --no-interaction --prefer-dist
 
 echo "→ JS dependencies"
-pnpm install --prefer-offline
+PNPM_VERSION="$(node -p "require('./package.json').packageManager.split('@').pop()")"
+CI=true npx --yes "pnpm@${PNPM_VERSION}" install --frozen-lockfile --prefer-offline
 
 # Tokens must verify across every checkout because the dev database is shared:
 # copy the root's keys instead of minting fresh ones.
@@ -89,6 +113,6 @@ php artisan config:clear --no-interaction
 php artisan route:clear --no-interaction
 
 echo "→ Building frontend assets"
-pnpm run build
+npx --yes "pnpm@${PNPM_VERSION}" run build
 
-echo "✓ Workspace ready: https://${FOLDER}.test (app panel at /app, sysadmin at /sysadmin)"
+echo "✓ Workspace ready: https://${SITE_NAME}.test (app panel at /app, sysadmin at /sysadmin)"

--- a/bin/setup-workspace.sh
+++ b/bin/setup-workspace.sh
@@ -23,7 +23,7 @@ if [[ ! -f artisan ]]; then
 fi
 
 FOLDER="$(basename "$PWD")"
-ROOT="${CONDUCTOR_ROOT_PATH:-$HOME/Herd/relaticle}"
+ROOT="${PASEO_SOURCE_CHECKOUT_PATH:-$HOME/Herd/relaticle}"
 
 echo "→ Provisioning workspace '${FOLDER}' (root: ${ROOT})"
 

--- a/paseo.json
+++ b/paseo.json
@@ -1,6 +1,6 @@
 {
     "worktree": {
-        "setup": "CONDUCTOR_ROOT_PATH=\"$PASEO_SOURCE_CHECKOUT_PATH\" bash bin/setup-workspace.sh",
+        "setup": "bash bin/setup-workspace.sh",
         "teardown": "bash bin/archive-workspace.sh"
     }
 }

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,6 @@
+{
+    "worktree": {
+        "setup": "CONDUCTOR_ROOT_PATH=\"$PASEO_SOURCE_CHECKOUT_PATH\" bash bin/setup-workspace.sh",
+        "teardown": "bash bin/archive-workspace.sh"
+    }
+}


### PR DESCRIPTION
## Summary

- configure Paseo to run the shared workspace setup and archive lifecycle
- namespace Herd, PostgreSQL, and Redis resources safely when workspace names collide
- protect unrelated Herd sites during teardown and pin the repository pnpm version

## Verification

- created and archived disposable Paseo worktrees, including a real hostname collision
- verified setup reruns without tracked changes
- verified all eight migrated workspaces return HTTP 200
- passed Pint, Rector, PHPStan, 100% type coverage, whole-repository lint, and 4,194 tests