### PR TITLE
Add composer merge tags toolbar and To autofocus

### DIFF
--- a/packages/EmailIntegration/resources/css/email-integration.css
+++ b/packages/EmailIntegration/resources/css/email-integration.css
@@ -116,10 +116,23 @@
     /* The unclassed div is the editor's own Alpine root. Without it in the
        chain the height stops one level above the ProseMirror surface. */
     & .fi-input-wrp-content-ctn,
-    & .fi-input-wrp-content-ctn > div:not([class]),
-    & .fi-fo-rich-editor-main,
+    & .fi-input-wrp-content-ctn > div:not([class]) {
+        @apply flex min-h-0 flex-1 flex-col;
+    }
+
+    /* Filament's merge-tags panel sits on the right from `@2xl` (42rem) on the
+       editor container. The docked composer is 38rem, so that query never
+       fires. Match the wide layout here so the list docks on the right. */
+    & .fi-fo-rich-editor-main {
+        @apply flex min-h-0 flex-1 flex-row;
+    }
+
     & .fi-fo-rich-editor-content {
         @apply flex min-h-0 flex-1 flex-col;
+    }
+
+    & .fi-fo-rich-editor-panels {
+        @apply max-w-3xs shrink-0 self-stretch rounded-ee-lg border-s border-b-0;
     }
 
     & .ProseMirror {

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -632,6 +632,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                     [ToolbarButtonGroup::make(__('filament/emails/composer.toolbar.alignment'), ['alignStart', 'alignCenter', 'alignEnd', 'alignJustify'])],
                     ['blockquote', 'codeBlock', 'bulletList', 'orderedList'],
                     ['undo', 'redo'],
+                    ['mergeTags'],
                 ])
                 ->floatingToolbars([
                     'paragraph' => ['bold', 'italic', 'underline', 'strike', 'link', 'bulletList', 'orderedList', 'blockquote'],

--- a/resources/views/components/emails/recipient-chips.blade.php
+++ b/resources/views/components/emails/recipient-chips.blade.php
@@ -1,6 +1,7 @@
 @props([
     'options' => [],
     'suggestions' => [],
+    'autofocus' => false,
 ])
 
 @php
@@ -172,6 +173,9 @@
     x-effect="if (isOpen) updatePopover()"
     x-on:resize.window="updatePopover()"
     x-on:scroll.window="updatePopover()"
+    @if ($autofocus)
+        x-init="$nextTick(() => $refs.input.focus())"
+    @endif
     @if ($wireModel) wire:ignore @endif
     {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => 'flex min-h-[1.75rem] min-w-0 flex-wrap items-center gap-1']) }}
 >
@@ -196,6 +200,7 @@
         x-bind:aria-controls="'{{ $listboxId }}'"
         role="combobox"
         autocomplete="off"
+        @if ($autofocus) autofocus @endif
         class="min-w-[8rem] flex-1 border-0 bg-transparent p-0 text-sm focus:outline-none focus:ring-0"
     />
 

--- a/resources/views/livewire/email-composer.blade.php
+++ b/resources/views/livewire/email-composer.blade.php
@@ -154,7 +154,7 @@
 
                     <x-emails.composer-field :label="__('filament/emails/composer.fields.to')">
                         <div class="min-w-0 flex-1">
-                            <x-emails.recipient-chips wire:model="to" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" />
+                            <x-emails.recipient-chips wire:model="to" :autofocus="true" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" />
                         </div>
                         <span class="shrink-0 space-x-2 text-xs font-medium text-gray-400">
                             <button type="button" wire:click="toggleCc" @class(['transition hover:text-gray-700 dark:hover:text-gray-200', 'text-primary-600 dark:text-primary-400' => $showCc])>{{ __('filament/emails/composer.fields.cc') }}</button>

--- a/resources/views/livewire/email-composer.blade.php
+++ b/resources/views/livewire/email-composer.blade.php
@@ -8,15 +8,6 @@
     {{-- Inline: the draft is appended to the reading pane's scroll region, so it is
          simply as tall as its message; the region does the scrolling. --}}
     @class(['shrink-0' => $dock === 'inline'])
-    x-data="{
-        insertVariable(id) {
-            const editor = this.$root.querySelector('.email-composer-body [x-data^=\'richEditorFormComponent\']')
-
-            if (editor) {
-                Alpine.$data(editor).insertMergeTag(id)
-            }
-        },
-    }"
     @if ($dock === 'floating')
         x-on:keydown.window="(() => {
             if ($event.key === 'c'
@@ -243,17 +234,6 @@
                             :click="fn (?string $id): string => 'applyTemplate(\''.$id.'\')'"
                             :create-label="__('filament/emails/composer.actions.create_template')"
                             create-click="mountAction('createTemplate')"
-                        />
-
-                        {{-- Inserts a merge tag into the RichEditor via its own Alpine
-                             component (`insertMergeTag`), which is what the editor's
-                             native `{{` autocomplete calls too. --}}
-                        <x-emails.composer-picker-menu
-                            icon="heroicon-o-variable"
-                            handler="alpine"
-                            :label="__('filament/emails/composer.actions.variable')"
-                            :options="\Relaticle\EmailIntegration\Services\EmailTemplateRenderService::MERGE_TAGS"
-                            :click="fn (?string $id): string => 'insertVariable(\''.$id.'\')'"
                         />
 
                         <span wire:loading wire:target="attachments" class="pl-1 text-xs text-gray-400">{{ __('filament/emails/composer.actions.uploading') }}</span>

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -56,6 +56,19 @@ it('opens via the composer:open event with the default account preselected', fun
         ->assertSet('accountId', $this->account->id);
 });
 
+it('puts merge tags last on the message toolbar instead of the footer', function (): void {
+    $html = Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->html();
+
+    expect($html)
+        ->toContain("togglePanel('mergeTags')")
+        ->not->toContain(__('filament/emails/composer.actions.variable'));
+
+    expect(strpos($html, "togglePanel('mergeTags')"))
+        ->toBeGreaterThan(strpos($html, 'redo().run()'));
+});
+
 it('opens the composer on a grant permission empty state when the mailbox cannot send', function (): void {
     $this->account->update([
         'capabilities' => [


### PR DESCRIPTION
## Summary
- Move merge tags from the composer footer onto Filament's native rich editor toolbar, last after Undo and Redo.
- Dock the merge-tags panel on the right so it matches Filament's default editor.
- Focus the To field when Compose opens.

## Test plan
- [x] Open Compose and confirm merge tags is last on the message toolbar.
- [x] Click merge tags and insert Full name into the body.
- [x] Confirm the footer has attach, signature, template, and send only.
- [x] Confirm the To field is focused when the composer opens.