### PR TITLE
Keep restricted emails on the list and show loading while the reader opens

### DIFF
--- a/lang/en/filament/pages/email-inbox.php
+++ b/lang/en/filament/pages/email-inbox.php
@@ -73,6 +73,7 @@ return [
         'timestamp_yesterday' => 'Yesterday, :time',
         'request_access' => 'Request access from :name',
         'requested' => 'Requested',
+        'opening' => 'Opening…',
     ],
     'detail_empty' => [
         'heading' => 'Select an email to read',

--- a/packages/EmailIntegration/resources/css/email-integration.css
+++ b/packages/EmailIntegration/resources/css/email-integration.css
@@ -261,15 +261,6 @@
     @apply min-w-5 px-1.5 py-0.5;
 }
 
-/* ── Record mailbox list: opening overlay ──────────────────────────────────
-   Livewire 4 marks the clicked row button with `data-loading` for the round
-   trip that mounts the reader. Show a spinner over that row so the click is
-   not silent until the overlay arrives. */
-.ei-email-list-row[data-loading] .ei-email-list-row-opening,
-.ei-email-list-row:has([data-loading]) .ei-email-list-row-opening {
-    display: flex;
-}
-
 .ei-emails-relation-manager .fi-ta-row[data-loading] {
     cursor: wait;
     opacity: 0.6;

--- a/packages/EmailIntegration/resources/css/email-integration.css
+++ b/packages/EmailIntegration/resources/css/email-integration.css
@@ -260,3 +260,17 @@
 .fi-header-actions-ctn .fi-btn .fi-btn-badge-ctn .fi-badge {
     @apply min-w-5 px-1.5 py-0.5;
 }
+
+/* ── Record mailbox list: opening overlay ──────────────────────────────────
+   Livewire 4 marks the clicked row button with `data-loading` for the round
+   trip that mounts the reader. Show a spinner over that row so the click is
+   not silent until the overlay arrives. */
+.ei-email-list-row[data-loading] .ei-email-list-row-opening,
+.ei-email-list-row:has([data-loading]) .ei-email-list-row-opening {
+    display: flex;
+}
+
+.ei-emails-relation-manager .fi-ta-row[data-loading] {
+    cursor: wait;
+    opacity: 0.6;
+}

--- a/packages/EmailIntegration/resources/views/filament/relation-managers/emails-relation-manager.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/relation-managers/emails-relation-manager.blade.php
@@ -1,4 +1,4 @@
-<div class="fi-resource-relation-manager">
+<div class="fi-resource-relation-manager ei-emails-relation-manager">
     {{ $this->content }}
 
     <x-filament-panels::unsaved-action-changes-alert />

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailReaderActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailReaderActions.php
@@ -17,6 +17,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Relaticle\EmailIntegration\Actions\ApproveEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
+use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Actions\UpdateEmailSharingAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
@@ -30,9 +31,37 @@ use Relaticle\EmailIntegration\Services\EmailThreadSummaryService;
 /**
  * Sharing, summarize, and request-access actions for `x-emails.email-view`,
  * used by the inbox, CRM record email pages, and the emails relation manager.
+ *
+ * @property ?string $selectedEmailId
+ *
+ * @method Email|null selectedEmail()
  */
 trait HasEmailReaderActions
 {
+    /**
+     * Open the reader overlay only when the viewer has full body access.
+     * Metadata and subject-only mail stay on the list with request-access.
+     */
+    protected function openEmailReader(string $id): bool
+    {
+        $this->selectedEmailId = $id;
+        unset($this->selectedEmail);
+
+        if (! $this->selectedEmail() instanceof Email) {
+            $this->selectedEmailId = null;
+            unset($this->selectedEmail);
+
+            return false;
+        }
+
+        $this->dispatch('composer:dismiss-inline');
+        $this->dispatch('composer:resume-draft', emailId: $id);
+
+        resolve(MarkEmailAsReadAction::class)->execute($id, $this->readerUser());
+
+        return true;
+    }
+
     /**
      * @return Collection<int, EmailAccessRequest>
      */

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -19,7 +19,6 @@ use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\MarkAllEmailsAsReadAction;
-use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailComposeActions;
@@ -185,13 +184,19 @@ abstract class BaseRecordEmailsPage extends Page
         /** @var Company|Opportunity|People $record */
         $record = $this->getRecord();
 
-        /** @var Email|null */
-        return $record
+        /** @var Email|null $email */
+        $email = $record
             ->emails()
             ->with(['body', 'participants', 'labels', 'attachments', 'from'])
             ->withGlobalScope('visible', new VisibleEmailScope($this->authUser()))
             ->whereKey($this->selectedEmailId)
             ->first();
+
+        if (! $email instanceof Email || $this->authUser()->cannot('viewBody', $email)) {
+            return null;
+        }
+
+        return $email;
     }
 
     #[Computed]
@@ -213,17 +218,9 @@ abstract class BaseRecordEmailsPage extends Page
 
     public function selectEmail(string $id): void
     {
-        $this->selectedEmailId = $id;
-
-        // A reply answers the message that was open; it cannot stay docked under a
-        // different one. The composer saves whatever was typed as a draft.
-        $this->dispatch('composer:dismiss-inline');
-
-        // ...and if this message already has an unfinished reply, bring it back up.
-        $this->dispatch('composer:resume-draft', emailId: $id);
-
-        // Optimistically mark the email as read so the unread count updates immediately
-        resolve(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
+        if (! $this->openEmailReader($id)) {
+            return;
+        }
 
         unset($this->inboxUnreadCount);
     }

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -26,7 +26,6 @@ use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
 use Livewire\WithPagination;
 use Relaticle\EmailIntegration\Actions\MarkAllEmailsAsReadAction;
-use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
@@ -216,13 +215,19 @@ final class EmailInboxPage extends Page
             return null;
         }
 
-        /** @var Email|null */
-        return Email::query()
+        /** @var Email|null $email */
+        $email = Email::query()
             ->with(['body', 'participants', 'labels', 'attachments', 'from'])
             ->forTeam($this->authUser()->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($this->authUser()))
             ->whereKey($this->selectedEmailId)
             ->first();
+
+        if (! $email instanceof Email || $this->authUser()->cannot('viewBody', $email)) {
+            return null;
+        }
+
+        return $email;
     }
 
     /**
@@ -275,16 +280,9 @@ final class EmailInboxPage extends Page
 
     public function selectEmail(string $id): void
     {
-        $this->selectedEmailId = $id;
-
-        // A reply answers the message that was open; it cannot stay docked under a
-        // different one. The composer saves whatever was typed as a draft.
-        $this->dispatch('composer:dismiss-inline');
-
-        // ...and if this message already has an unfinished reply, bring it back up.
-        $this->dispatch('composer:resume-draft', emailId: $id);
-
-        resolve(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
+        if (! $this->openEmailReader($id)) {
+            return;
+        }
 
         unset($this->inboxUnreadCount);
     }

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -21,7 +21,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
-use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Actions\ConfigureMailboxAction;
@@ -274,6 +273,7 @@ abstract class BaseEmailsRelationManager extends RelationManager
             ->icon('heroicon-o-eye')
             ->modal(false)
             ->slideOver(false)
+            ->visible(fn (Email $record): bool => $this->authUser()->can('viewBody', $record))
             ->action(function (Email $record): void {
                 $this->selectEmail($record->getKey());
             });
@@ -281,12 +281,7 @@ abstract class BaseEmailsRelationManager extends RelationManager
 
     public function selectEmail(string $id): void
     {
-        $this->selectedEmailId = $id;
-
-        $this->dispatch('composer:dismiss-inline');
-        $this->dispatch('composer:resume-draft', emailId: $id);
-
-        resolve(MarkEmailAsReadAction::class)->execute($id, $this->authUser());
+        $this->openEmailReader($id);
     }
 
     public function deselectEmail(): void
@@ -304,12 +299,18 @@ abstract class BaseEmailsRelationManager extends RelationManager
             return null;
         }
 
-        /** @var Email|null */
-        return $this->getRelationship()
+        /** @var Email|null $email */
+        $email = $this->getRelationship()
             ->with(['body', 'participants', 'labels', 'attachments', 'from'])
             ->withGlobalScope('visible', new VisibleEmailScope($this->authUser()))
             ->whereKey($this->selectedEmailId)
             ->first();
+
+        if (! $email instanceof Email || $this->authUser()->cannot('viewBody', $email)) {
+            return null;
+        }
+
+        return $email;
     }
 
     /**

--- a/packages/EmailIntegration/src/Livewire/EmailAccessNotificationHandler.php
+++ b/packages/EmailIntegration/src/Livewire/EmailAccessNotificationHandler.php
@@ -15,7 +15,6 @@ use Illuminate\Support\Js;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Component;
-use Relaticle\EmailIntegration\Actions\MarkEmailAsReadAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailReaderActions;
 use Relaticle\EmailIntegration\Models\Email;
@@ -46,12 +45,7 @@ final class EmailAccessNotificationHandler extends Component implements HasActio
     {
         $this->closeNotificationsPanel();
 
-        $this->selectedEmailId = $emailId;
-
-        $this->dispatch('composer:dismiss-inline');
-        $this->dispatch('composer:resume-draft', emailId: $emailId);
-
-        resolve(MarkEmailAsReadAction::class)->execute($emailId, $this->authUser());
+        $this->openEmailReader($emailId);
     }
 
     /**
@@ -74,7 +68,7 @@ final class EmailAccessNotificationHandler extends Component implements HasActio
     #[Computed]
     public function selectedEmail(): ?Email
     {
-        $email = $this->resolveTeamEmail($this->selectedEmailId, 'view');
+        $email = $this->resolveTeamEmail($this->selectedEmailId, 'viewBody');
 
         if (! $email instanceof Email) {
             return null;

--- a/resources/views/components/emails/list-row-wide.blade.php
+++ b/resources/views/components/emails/list-row-wide.blade.php
@@ -55,9 +55,32 @@
         ? trim(preg_replace('/^\s*\S+@\S+\.\S+\s*/u', '', $decode($email->snippet)) ?? '')
         : '';
 
+    $rowTag = $canViewBody ? 'button' : 'div';
 @endphp
+<{{ $rowTag }}
+    @if ($canViewBody)
+        type="button"
+        wire:click="selectEmail('{{ $email->id }}')"
+        wire:loading.attr="disabled"
+    @endif
+    @class([
+        'ei-email-list-row group relative flex w-full items-start gap-3 bg-white px-4 py-3 text-left transition-colors hover:bg-gray-50 dark:bg-gray-950 dark:hover:!bg-gray-900 sm:px-6',
+        'cursor-pointer data-[loading]:cursor-wait data-[loading]:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:data-[loading]:bg-gray-900' => $canViewBody,
+        'cursor-default' => ! $canViewBody,
+    ])
+>
+    @if ($canViewBody)
+        <span
+            wire:loading.flex
+            wire:target="selectEmail('{{ $email->id }}')"
+            class="ei-email-list-row-opening pointer-events-none absolute inset-0 z-10 hidden items-center justify-center bg-white/70 group-data-[loading]:flex dark:bg-gray-950/70"
+            role="status"
+            aria-label="{{ __('filament/pages/email-inbox.list_row.opening') }}"
+        >
+            <x-filament::loading-indicator class="h-5 w-5 text-primary-500" />
+        </span>
+    @endif
 
-<div class="group relative flex w-full items-start gap-3 bg-white px-4 py-3 transition-colors hover:bg-gray-50 dark:bg-gray-950 dark:hover:!bg-gray-900 sm:px-6">
     <span
         @class([
             'flex h-8 w-8 shrink-0 select-none items-center justify-center rounded-full text-[11px] font-semibold ring-1 ring-inset ring-white/60 dark:bg-gray-800 dark:text-gray-200 dark:ring-white/10',
@@ -69,58 +92,55 @@
     </span>
 
     <span class="min-w-0 flex-1">
-        <button
-            wire:click="selectEmail('{{ $email->id }}')"
-            type="button"
-            class="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500"
-        >
-            <span class="flex items-center justify-between gap-3">
-                <span class="min-w-0 flex-1 truncate text-sm font-medium leading-5 text-gray-800 dark:text-gray-200">
-                    {{ $canViewSubject ? ($subject ?: '(no subject)') : '(subject hidden)' }}
-                </span>
+        <span class="flex items-center justify-between gap-3">
+            <span class="min-w-0 flex-1 truncate text-sm font-medium leading-5 text-gray-800 dark:text-gray-200">
+                {{ $canViewSubject ? ($subject ?: '(no subject)') : '(subject hidden)' }}
+            </span>
 
-                <span class="flex shrink-0 items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
-                    @if (filled($mailboxViaName))
-                        <span class="flex min-w-0 items-center gap-1 text-gray-500 dark:text-gray-400">
-                            <x-heroicon-m-envelope class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
-                            <span class="max-w-[7rem] truncate">{{ __('filament/pages/email-inbox.list_row.via', ['name' => $mailboxViaName]) }}</span>
-                        </span>
-                    @endif
-
-                    <span class="flex items-center gap-1.5 whitespace-nowrap">
-                        @if ($email->has_attachments)
-                            <x-heroicon-m-paper-clip class="h-3.5 w-3.5" aria-hidden="true" />
-                        @endif
-                        <time class="tabular-nums" title="{{ $sentAt?->format('M j, Y · g:i A') }}">{{ $timestamp }}</time>
+            <span class="flex shrink-0 items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+                @if (filled($mailboxViaName))
+                    <span class="flex min-w-0 items-center gap-1 text-gray-500 dark:text-gray-400">
+                        <x-heroicon-m-envelope class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                        <span class="max-w-[7rem] truncate">{{ __('filament/pages/email-inbox.list_row.via', ['name' => $mailboxViaName]) }}</span>
                     </span>
+                @endif
+
+                <span class="flex items-center gap-1.5 whitespace-nowrap">
+                    @if ($email->has_attachments)
+                        <x-heroicon-m-paper-clip class="h-3.5 w-3.5" aria-hidden="true" />
+                    @endif
+                    <time
+                        class="tabular-nums"
+                        title="{{ $sentAt?->format('M j, Y · g:i A') }}"
+                    >{{ $timestamp }}</time>
                 </span>
             </span>
+        </span>
 
-            <span class="mt-0.5 block truncate text-xs text-gray-500 dark:text-gray-400">
-                {{ $participantLine }}
+        <span class="mt-0.5 block truncate text-xs text-gray-500 dark:text-gray-400">
+            {{ $participantLine }}
+        </span>
+
+        @if ($canViewBody && (filled($snippet) || $categoryLabel !== null))
+            <span class="mt-0.5 flex items-center justify-between gap-3">
+                @if (filled($snippet))
+                    <span class="flex min-w-0 items-center gap-1 truncate text-xs leading-5 text-gray-500 dark:text-gray-400">
+                        @if ($isReply)
+                            <x-ri-reply-line class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                        @else
+                            <x-ri-file-text-line class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                        @endif
+                        <span class="truncate">{{ $snippet }}</span>
+                    </span>
+                @else
+                    <span class="min-w-0 flex-1"></span>
+                @endif
+
+                @if ($categoryLabel !== null)
+                    <x-emails.category-badge :label="$categoryLabel->label" class="ml-auto" />
+                @endif
             </span>
-
-            @if ($canViewBody && (filled($snippet) || $categoryLabel !== null))
-                <span class="mt-0.5 flex items-center justify-between gap-3">
-                    @if (filled($snippet))
-                        <span class="flex min-w-0 items-center gap-1 truncate text-xs leading-5 text-gray-500 dark:text-gray-400">
-                            @if ($isReply)
-                                <x-ri-reply-line class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
-                            @else
-                                <x-ri-file-text-line class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
-                            @endif
-                            <span class="truncate">{{ $snippet }}</span>
-                        </span>
-                    @else
-                        <span class="min-w-0 flex-1"></span>
-                    @endif
-
-                    @if ($categoryLabel !== null)
-                        <x-emails.category-badge :label="$categoryLabel->label" class="ml-auto" />
-                    @endif
-                </span>
-            @endif
-        </button>
+        @endif
 
         @if ($canRequestAccess)
             <x-emails.request-access-list-pill
@@ -130,4 +150,4 @@
             />
         @endif
     </span>
-</div>
+</{{ $rowTag }}>

--- a/resources/views/components/emails/list-row-wide.blade.php
+++ b/resources/views/components/emails/list-row-wide.blade.php
@@ -65,7 +65,7 @@
         wire:target="selectEmail('{{ $email->id }}')"
     @endif
     {{ $attributes->class([
-        'ei-email-list-row group relative flex w-full items-start gap-3 bg-white px-4 py-3 text-left transition-colors hover:bg-gray-50 dark:bg-gray-950 dark:hover:!bg-gray-900 sm:px-6',
+        'ei-email-list-row relative flex w-full items-start gap-3 bg-white px-4 py-3 text-left transition-colors hover:bg-gray-50 dark:bg-gray-950 dark:hover:!bg-gray-900 sm:px-6',
         'cursor-pointer data-[loading]:cursor-wait data-[loading]:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:data-[loading]:bg-gray-900' => $canViewBody,
         'cursor-default' => ! $canViewBody,
     ]) }}
@@ -74,7 +74,7 @@
         <span
             wire:loading.flex
             wire:target="selectEmail('{{ $email->id }}')"
-            class="ei-email-list-row-opening pointer-events-none absolute inset-0 z-10 hidden items-center justify-center bg-white/70 group-data-[loading]:flex dark:bg-gray-950/70"
+            class="pointer-events-none absolute inset-0 z-10 items-center justify-center bg-white/70 dark:bg-gray-950/70"
             role="status"
             aria-label="{{ __('filament/pages/email-inbox.list_row.opening') }}"
         >

--- a/resources/views/components/emails/list-row-wide.blade.php
+++ b/resources/views/components/emails/list-row-wide.blade.php
@@ -62,12 +62,13 @@
         type="button"
         wire:click="selectEmail('{{ $email->id }}')"
         wire:loading.attr="disabled"
+        wire:target="selectEmail('{{ $email->id }}')"
     @endif
-    @class([
+    {{ $attributes->class([
         'ei-email-list-row group relative flex w-full items-start gap-3 bg-white px-4 py-3 text-left transition-colors hover:bg-gray-50 dark:bg-gray-950 dark:hover:!bg-gray-900 sm:px-6',
         'cursor-pointer data-[loading]:cursor-wait data-[loading]:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 dark:data-[loading]:bg-gray-900' => $canViewBody,
         'cursor-default' => ! $canViewBody,
-    ])
+    ]) }}
 >
     @if ($canViewBody)
         <span

--- a/resources/views/filament/pages/record-emails.blade.php
+++ b/resources/views/filament/pages/record-emails.blade.php
@@ -50,7 +50,7 @@
 
         <div class="flex flex-1 flex-col divide-y divide-gray-100 overflow-y-auto bg-white dark:divide-gray-800 dark:bg-gray-950">
             @forelse ($this->emails as $email)
-                <x-emails.list-row-wide :email="$email" />
+                <x-emails.list-row-wide :email="$email" wire:key="email-list-row-{{ $email->id }}" />
             @empty
                 <x-emails.list-empty
                     class="flex-1"

--- a/tests/Feature/EmailIntegration/EmailUnreadCountPerViewerTest.php
+++ b/tests/Feature/EmailIntegration/EmailUnreadCountPerViewerTest.php
@@ -14,6 +14,7 @@ beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
     $this->viewer = User::factory()->create(['current_team_id' => $this->owner->currentTeam->id]);
     $this->team = $this->owner->currentTeam;
+    $this->team->users()->attach($this->viewer, ['role' => 'editor']);
 
     $this->account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'team_id' => $this->team->id,

--- a/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
+++ b/tests/Feature/EmailIntegration/EmailsRelationManagerReadingTest.php
@@ -374,6 +374,34 @@ describe('shareAllOnRecord header action', function (): void {
     });
 });
 
+describe('view table action', function (): void {
+    it('stays hidden when the viewer cannot read the body', function (EmailPrivacyTier $tier): void {
+        $this->actingAs($this->viewer);
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->owner->id,
+            'connected_account_id' => $this->account->getKey(),
+            'privacy_tier' => $tier,
+        ]);
+
+        $this->person->emails()->attach($email->getKey());
+
+        livewire(EmailsRelationManager::class, [
+            'ownerRecord' => $this->person,
+            'pageClass' => ViewPeople::class,
+        ])
+            ->assertTableActionHidden('view', $email)
+            ->assertTableActionVisible('requestAccess', $email)
+            ->call('selectEmail', $email->getKey())
+            ->assertSet('selectedEmailId', null)
+            ->assertDontSee('fi-email-reader-panel');
+    })->with([
+        EmailPrivacyTier::METADATA_ONLY,
+        EmailPrivacyTier::SUBJECT,
+    ]);
+});
+
 describe('access request approve and deny from the reader overlay', function (): void {
     it('approves a pending request from the relation manager overlay', function (): void {
         $email = Email::factory()->private()->create([

--- a/tests/Feature/EmailIntegration/RecordEmailsEmptyStateTest.php
+++ b/tests/Feature/EmailIntegration/RecordEmailsEmptyStateTest.php
@@ -21,6 +21,7 @@ use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Notification;
 use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailReaderActions;
 use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
 use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -30,7 +31,7 @@ use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
-mutates(BaseRecordEmailsPage::class, BaseEmailsRelationManager::class, EmailVisibilityService::class);
+mutates(BaseRecordEmailsPage::class, BaseEmailsRelationManager::class, EmailVisibilityService::class, HasEmailReaderActions::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -563,7 +564,8 @@ it('shows the imported mailbox name on record email list rows', function (): voi
     $this->person->emails()->attach($email->getKey());
 
     livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
-        ->assertSee(__('filament/pages/email-inbox.list_row.via', ['name' => 'Sales Inbox']));
+        ->assertSee(__('filament/pages/email-inbox.list_row.via', ['name' => 'Sales Inbox']))
+        ->assertSee(__('filament/pages/email-inbox.list_row.opening'));
 });
 
 it('shows a request access pill on record mailbox rows without body access', function (): void {
@@ -601,6 +603,11 @@ it('shows a request access pill on record mailbox rows without body access', fun
     livewire(PeopleEmailsPage::class, ['record' => $person->getKey()])
         ->assertSee(__('filament/pages/email-inbox.list_row.request_access', ['name' => $owner->name]))
         ->assertDontSee('Secret preview text')
+        ->assertDontSeeHtml("selectEmail('{$email->getKey()}')")
+        ->assertDontSee(__('filament/pages/email-inbox.list_row.opening'))
+        ->call('selectEmail', $email->getKey())
+        ->assertSet('selectedEmailId', null)
+        ->assertDontSee('fi-email-reader-panel')
         ->mountAction('requestAccess', arguments: ['emailId' => $email->getKey()])
         ->setActionData(['tier_requested' => EmailPrivacyTier::FULL->value])
         ->callMountedAction()


### PR DESCRIPTION
## Summary
- Open the email reader only when the viewer has full body access. Metadata and subject-only mail stay on the list with request-access.
- Show a spinner over the whole list row while the reader mounts, so a click is not silent until the overlay appears.

## Test plan
- [x] As the mailbox owner, click a record email list row. Confirm the whole row, including the avatar, shows a spinner until the reader opens.
- [x] As a teammate with metadata-only access, confirm the row is not clickable, the reader does not open, and request-access still works.
- [x] Confirm owners can still open mail from the record emails page, the emails relation manager, and an access-request notification.