### PR TITLE
fix(email): stop retrying and re-dispatching mailcoach 422 rejections

### DIFF
--- a/.ai/rules/email.md
+++ b/.ai/rules/email.md
@@ -1,0 +1,13 @@
+---
+paths:
+  - 'app/Jobs/Email/**'
+  - 'app/Support/Email/**'
+---
+
+# Email (Mailcoach subscriber sync)
+
+## Mailcoach validates email against DNS, and a 422 is permanent
+Mailcoach's hosted API rejects any subscriber `email` whose domain has no resolvable MX or A record (parked domains with null MX `0 .`, or domains whose nameservers were dropped) with HTTP 422 `InvalidData`, even when it already stores that exact address. `email` is required on `PATCH /subscribers/{uuid}` (Mailcoach API docs), so the update path cannot omit it to dodge the check. A 422 therefore never clears on retry: `SyncSubscriberJob` catches `InvalidData`, records the hash in `rejected_subscriber_profile_hash` so `subscribers:reconcile` stops re-offering the same profile every night, and fails once. Do not add retries, `retryUntil`, or throttling middleware around Mailcoach writes (PR #555 explains why), and do not branch on the `email` key: every 422 is permanent for its payload.
+
+## subscriber_profile_hash caches what Mailcoach holds; rejections live in their own column
+`subscriber_profile_hash` is only ever written together with `mailcoach_subscriber_uuid` after a successful write, so it always describes the profile Mailcoach actually stores. Never write it on a failed write. A 422 goes to `rejected_subscriber_profile_hash` instead; `SubscriberProfile::needsSync()` treats a profile as settled when it matches either column, so a rejected user is re-offered only once their derived profile changes (an email fix, a new tag). To force a retry after fixing a payload bug on our side, null that column for the affected users.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -5,6 +5,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | Applies to | Rule file |
 | --- | --- |
 | app/Http/**, routes/** | .ai/rules/boost/http-routes.md |
+| app/Jobs/Email/**, app/Support/Email/** | .ai/rules/email.md |
 | app/Livewire/**, resources/views/** | .ai/rules/boost/livewire-views.md |
 | app/Models/** | .ai/rules/boost/models.md |
 | tests/** | .ai/rules/boost/tests.md |

--- a/app/Console/Commands/ReconcileSubscribersCommand.php
+++ b/app/Console/Commands/ReconcileSubscribersCommand.php
@@ -15,7 +15,8 @@ use Illuminate\Database\Eloquent\Collection;
 /**
  * The convergence backstop: re-derives every verified user's subscriber
  * profile and syncs the ones that drifted, whatever the cause (a missed
- * event, a failed job, recency decay, a deleted team).
+ * event, a failed job, recency decay, a deleted team). The one exception is
+ * a profile Mailcoach already rejected, which waits until it changes.
  */
 #[Description('Sync Mailcoach subscriber profiles for verified users whose derived profile changed')]
 #[Signature('subscribers:reconcile
@@ -47,7 +48,7 @@ final class ReconcileSubscribersCommand extends Command
 
                     $profile = $deriver->derive($user);
 
-                    if ($profile->matchesStored($user)) {
+                    if (! $profile->needsSync($user)) {
                         continue;
                     }
 

--- a/app/Console/Commands/ReconcileSubscribersCommand.php
+++ b/app/Console/Commands/ReconcileSubscribersCommand.php
@@ -35,11 +35,12 @@ final class ReconcileSubscribersCommand extends Command
         $dryRun = (bool) $this->option('dry-run');
         $limit = $this->option('limit') === null ? null : (int) $this->option('limit');
         $changed = 0;
+        $rejected = 0;
 
         User::query()
             ->whereNotNull('email_verified_at')
             ->with(['ownedTeams', 'teams'])
-            ->chunkById(200, function (Collection $users) use ($deriver, $dryRun, $limit, &$changed): bool {
+            ->chunkById(200, function (Collection $users) use ($deriver, $dryRun, $limit, &$changed, &$rejected): bool {
                 /** @var User $user */
                 foreach ($users as $user) {
                     if ($limit !== null && $changed >= $limit) {
@@ -49,6 +50,10 @@ final class ReconcileSubscribersCommand extends Command
                     $profile = $deriver->derive($user);
 
                     if (! $profile->needsSync($user)) {
+                        if ($profile->wasRejected($user)) {
+                            $rejected++;
+                        }
+
                         continue;
                     }
 
@@ -67,6 +72,10 @@ final class ReconcileSubscribersCommand extends Command
             });
 
         $this->info($dryRun ? "Would sync {$changed} users." : "Dispatched {$changed} sync jobs.");
+
+        if ($rejected > 0) {
+            $this->info("Skipped {$rejected} profiles Mailcoach already rejected.");
+        }
 
         return self::SUCCESS;
     }

--- a/app/Jobs/Email/SyncSubscriberJob.php
+++ b/app/Jobs/Email/SyncSubscriberJob.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Attributes\Backoff;
 use Illuminate\Queue\Attributes\Tries;
 use Illuminate\Support\Facades\Log;
+use Spatie\MailcoachSdk\Exceptions\InvalidData;
 use Spatie\MailcoachSdk\Exceptions\RateLimited;
 use Spatie\MailcoachSdk\Exceptions\ResourceNotFound;
 use Spatie\MailcoachSdk\Facades\Mailcoach;
@@ -68,7 +69,7 @@ final class SyncSubscriberJob implements ShouldBeUnique, ShouldQueue
 
         $profile = $deriver->derive($user);
 
-        if ($profile->matchesStored($user)) {
+        if (! $profile->needsSync($user)) {
             return;
         }
 
@@ -82,11 +83,17 @@ final class SyncSubscriberJob implements ShouldBeUnique, ShouldQueue
             $this->release(max($exception->retryAfter, 10));
 
             return;
+        } catch (InvalidData $exception) {
+            $user->forceFill(['rejected_subscriber_profile_hash' => $profile->hash()])->saveQuietly();
+            $this->fail($exception);
+
+            return;
         }
 
         $user->forceFill([
             'mailcoach_subscriber_uuid' => $uuid,
             'subscriber_profile_hash' => $profile->hash(),
+            'rejected_subscriber_profile_hash' => null,
         ])->saveQuietly();
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -55,6 +55,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property Carbon|null $last_login_at
  * @property string|null $mailcoach_subscriber_uuid
  * @property string|null $subscriber_profile_hash
+ * @property string|null $rejected_subscriber_profile_hash
  * @property string|null $remember_token
  * @property Carbon|null $scheduled_deletion_at
  * @property string|null $two_factor_recovery_codes
@@ -81,6 +82,7 @@ use Laravel\Sanctum\HasApiTokens;
     'two_factor_secret',
     'mailcoach_subscriber_uuid',
     'subscriber_profile_hash',
+    'rejected_subscriber_profile_hash',
 ])]
 #[ObservedBy(UserObserver::class)]
 final class User extends Authenticatable implements FilamentUser, HasAvatar, HasDefaultTenant, HasTenants, MustVerifyEmail, PasskeyUser

--- a/app/Support/Email/SubscriberProfile.php
+++ b/app/Support/Email/SubscriberProfile.php
@@ -29,6 +29,20 @@ final readonly class SubscriberProfile
             && $user->subscriber_profile_hash === $this->hash();
     }
 
+    /**
+     * Mailcoach answered this exact profile with a 422. That is permanent for the
+     * payload, so it is only worth offering again once the profile changes.
+     */
+    public function wasRejected(User $user): bool
+    {
+        return $user->rejected_subscriber_profile_hash === $this->hash();
+    }
+
+    public function needsSync(User $user): bool
+    {
+        return ! $this->matchesStored($user) && ! $this->wasRejected($user);
+    }
+
     public function hash(): string
     {
         return hash('sha256', json_encode(

--- a/database/migrations/2026_09_06_120000_add_rejected_subscriber_profile_hash_to_users_table.php
+++ b/database/migrations/2026_09_06_120000_add_rejected_subscriber_profile_hash_to_users_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->string('rejected_subscriber_profile_hash')->nullable()->after('subscriber_profile_hash');
+        });
+    }
+};

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource.php
@@ -34,6 +34,7 @@ use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\EditUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ViewUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\OwnedTeamsRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\SocialAccountsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\TeamsRelationManager;
 use Relaticle\SystemAdmin\Filament\Support\RecordLink;
 use Relaticle\SystemAdmin\Filament\Support\SafeDelete;
@@ -180,6 +181,15 @@ final class UserResource extends Resource
                     ->sortable(query: fn (Builder $query, string $direction): Builder => $query->orderBy('last_login_at', $direction))
                     ->toggleable()
                     ->placeholder('—'),
+                IconColumn::make('rejected_subscriber_profile_hash')
+                    ->label('Mailcoach Rejected')
+                    ->state(fn (User $record): bool => $record->rejected_subscriber_profile_hash !== null)
+                    ->boolean()
+                    ->trueIcon('heroicon-o-exclamation-triangle')
+                    ->trueColor('warning')
+                    ->falseIcon('heroicon-o-minus-small')
+                    ->falseColor('gray')
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable(),
@@ -190,6 +200,12 @@ final class UserResource extends Resource
             ->filters([
                 TernaryFilter::make('email_verified_at')
                     ->label('Email Verified')
+                    ->nullable(),
+                TernaryFilter::make('rejected_subscriber_profile_hash')
+                    ->label('Mailcoach Rejected')
+                    ->placeholder('All users')
+                    ->trueLabel('Rejected by Mailcoach')
+                    ->falseLabel('Not rejected')
                     ->nullable(),
                 SelectFilter::make('engagement')
                     ->label('Engagement')
@@ -236,6 +252,7 @@ final class UserResource extends Resource
         return [
             OwnedTeamsRelationManager::class,
             TeamsRelationManager::class,
+            SocialAccountsRelationManager::class,
         ];
     }
 

--- a/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/SocialAccountsRelationManager.php
+++ b/packages/SystemAdmin/src/Filament/Resources/UserResource/RelationManagers/SocialAccountsRelationManager.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+final class SocialAccountsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'socialAccounts';
+
+    protected static ?string $title = 'Social Providers';
+
+    protected static string|\BackedEnum|null $icon = 'heroicon-o-key';
+
+    public static function getBadge(Model $ownerRecord, string $pageClass): ?string
+    {
+        $count = $ownerRecord->socialAccounts()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('provider_name')
+            ->columns([
+                // Rendered from the stored string, not SocialiteProvider: rows predate
+                // the enum and hold providers it no longer offers.
+                TextColumn::make('provider_name')
+                    ->label('Provider')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => Str::headline($state))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('provider_id')
+                    ->label('Provider ID')
+                    ->searchable()
+                    ->copyable(),
+                TextColumn::make('created_at')
+                    ->label('Linked')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->emptyStateHeading('No social providers linked');
+    }
+}

--- a/packages/SystemAdmin/src/Policies/UserSocialAccountPolicy.php
+++ b/packages/SystemAdmin/src/Policies/UserSocialAccountPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\SystemAdmin\Policies;
+
+final class UserSocialAccountPolicy
+{
+    public function viewAny(): bool
+    {
+        return true;
+    }
+
+    public function view(): bool
+    {
+        return true;
+    }
+
+    public function create(): bool
+    {
+        return false;
+    }
+
+    public function update(): bool
+    {
+        return false;
+    }
+
+    public function delete(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Feature/Email/ReconcileSubscribersCommandTest.php
+++ b/tests/Feature/Email/ReconcileSubscribersCommandTest.php
@@ -59,6 +59,30 @@ test('dispatches for verified users who never received a subscriber uuid', funct
     Queue::assertPushed(SyncSubscriberJob::class, fn (SyncSubscriberJob $job): bool => invade($job)->userId === (string) $user->id);
 });
 
+test('does not re-dispatch a user whose unchanged profile Mailcoach already rejected', function (): void {
+    $rejected = User::factory()->withTeam()->create(['email_verified_at' => now()]);
+    $rejected->forceFill(['rejected_subscriber_profile_hash' => (new SubscriberProfileDeriver)->derive($rejected)->hash()])->save();
+
+    $this->artisan('subscribers:reconcile')
+        ->expectsOutputToContain('Dispatched 0 sync jobs.')
+        ->assertSuccessful();
+
+    Queue::assertNotPushed(SyncSubscriberJob::class);
+});
+
+test('re-dispatches a rejected user once the derived profile differs from the rejected one', function (): void {
+    $user = User::factory()->withTeam()->create([
+        'email_verified_at' => now(),
+        'rejected_subscriber_profile_hash' => 'hash-of-the-old-dead-address',
+    ]);
+
+    $this->artisan('subscribers:reconcile')
+        ->expectsOutputToContain('Dispatched 1 sync jobs.')
+        ->assertSuccessful();
+
+    Queue::assertPushed(SyncSubscriberJob::class, fn (SyncSubscriberJob $job): bool => invade($job)->userId === (string) $user->id);
+});
+
 test('skips unverified users', function (): void {
     User::factory()->withTeam()->create(['email_verified_at' => null]);
 

--- a/tests/Feature/Email/ReconcileSubscribersCommandTest.php
+++ b/tests/Feature/Email/ReconcileSubscribersCommandTest.php
@@ -65,9 +65,28 @@ test('does not re-dispatch a user whose unchanged profile Mailcoach already reje
 
     $this->artisan('subscribers:reconcile')
         ->expectsOutputToContain('Dispatched 0 sync jobs.')
+        ->expectsOutputToContain('Skipped 1 profiles Mailcoach already rejected.')
         ->assertSuccessful();
 
     Queue::assertNotPushed(SyncSubscriberJob::class);
+});
+
+test('reports the rejected skip count on a dry run too', function (): void {
+    $rejected = User::factory()->withTeam()->create(['email_verified_at' => now()]);
+    $rejected->forceFill(['rejected_subscriber_profile_hash' => (new SubscriberProfileDeriver)->derive($rejected)->hash()])->save();
+
+    $this->artisan('subscribers:reconcile', ['--dry-run' => true])
+        ->expectsOutputToContain('Would sync 0 users.')
+        ->expectsOutputToContain('Skipped 1 profiles Mailcoach already rejected.')
+        ->assertSuccessful();
+});
+
+test('stays silent about rejected profiles when there are none', function (): void {
+    User::factory()->withTeam()->create(['email_verified_at' => now()]);
+
+    $this->artisan('subscribers:reconcile')
+        ->doesntExpectOutputToContain('Mailcoach already rejected')
+        ->assertSuccessful();
 });
 
 test('re-dispatches a rejected user once the derived profile differs from the rejected one', function (): void {

--- a/tests/Feature/Email/SyncSubscriberJobTest.php
+++ b/tests/Feature/Email/SyncSubscriberJobTest.php
@@ -12,6 +12,7 @@ use App\Support\Email\SubscriberProfile;
 use App\Support\Email\SubscriberProfileDeriver;
 use Illuminate\Contracts\Queue\Job as QueueJob;
 use Illuminate\Support\Facades\Queue;
+use Spatie\MailcoachSdk\Exceptions\InvalidData;
 use Spatie\MailcoachSdk\Exceptions\RateLimited;
 use Spatie\MailcoachSdk\Exceptions\ResourceNotFound;
 use Spatie\MailcoachSdk\Facades\Mailcoach;
@@ -340,4 +341,95 @@ test('releases with the retry-after delay when rate limited', function (): void 
     $job->handle(new SubscriberProfileDeriver);
 
     expect($user->refresh()->subscriber_profile_hash)->toBeNull();
+});
+
+function mailcoachRejectsTheEmail(): InvalidData
+{
+    return new InvalidData([
+        'message' => 'The email field must be a valid email address.',
+        'errors' => ['email' => ['The email field must be a valid email address.']],
+    ]);
+}
+
+function syncExpectingPermanentFailure(User $user, InvalidData $exception): void
+{
+    $queueJob = Mockery::mock(QueueJob::class);
+    $queueJob->shouldReceive('fail')->once()->with($exception);
+    $queueJob->shouldReceive('release')->never();
+
+    $job = new SyncSubscriberJob((string) $user->id);
+    $job->setJob($queueJob);
+    $job->handle(new SubscriberProfileDeriver);
+}
+
+test('fails without retrying and records the rejected profile when Mailcoach rejects an update', function (): void {
+    $user = User::factory()->withTeam()->create([
+        'email_verified_at' => now(),
+        'mailcoach_subscriber_uuid' => 'mc-uuid-dead-domain',
+        'subscriber_profile_hash' => 'hash-mailcoach-still-holds',
+    ]);
+    $exception = mailcoachRejectsTheEmail();
+
+    Mailcoach::shouldReceive('subscriber')
+        ->once()
+        ->with('mc-uuid-dead-domain')
+        ->andReturn(new Subscriber(['uuid' => 'mc-uuid-dead-domain', 'email' => $user->email, 'tags' => []]));
+    Mailcoach::shouldReceive('updateSubscriber')->once()->andThrow($exception);
+
+    syncExpectingPermanentFailure($user, $exception);
+
+    $profile = (new SubscriberProfileDeriver)->derive($user->refresh());
+
+    expect($user)
+        ->mailcoach_subscriber_uuid->toBe('mc-uuid-dead-domain')
+        ->subscriber_profile_hash->toBe('hash-mailcoach-still-holds')
+        ->rejected_subscriber_profile_hash->toBe($profile->hash());
+});
+
+test('fails without retrying and records the rejected profile when Mailcoach rejects a create', function (): void {
+    $user = User::factory()->withTeam()->create(['email_verified_at' => now()]);
+    $exception = mailcoachRejectsTheEmail();
+
+    Mailcoach::shouldReceive('findByEmail')->once()->andReturnNull();
+    Mailcoach::shouldReceive('createSubscriber')->once()->andThrow($exception);
+
+    syncExpectingPermanentFailure($user, $exception);
+
+    $profile = (new SubscriberProfileDeriver)->derive($user->refresh());
+
+    expect($user)
+        ->mailcoach_subscriber_uuid->toBeNull()
+        ->subscriber_profile_hash->toBeNull()
+        ->rejected_subscriber_profile_hash->toBe($profile->hash());
+});
+
+test('does not re-offer a rejected profile until it changes', function (): void {
+    $user = User::factory()->withTeam()->create(['email_verified_at' => now()]);
+    $user->forceFill(['rejected_subscriber_profile_hash' => (new SubscriberProfileDeriver)->derive($user)->hash()])->save();
+
+    Mailcoach::shouldReceive('findByEmail')->never();
+    Mailcoach::shouldReceive('createSubscriber')->never();
+
+    syncSubscriberProfile($user);
+
+    expect($user->refresh()->mailcoach_subscriber_uuid)->toBeNull();
+});
+
+test('a rejected profile is offered again once it changes, and success clears the rejection', function (): void {
+    $user = User::factory()->withTeam()->create(['email_verified_at' => now()]);
+    $user->forceFill(['rejected_subscriber_profile_hash' => (new SubscriberProfileDeriver)->derive($user)->hash()])->save();
+
+    $user->forceFill(['email' => 'renamed@example.com'])->save();
+
+    Mailcoach::shouldReceive('findByEmail')->once()->with('test-list-id', 'renamed@example.com')->andReturnNull();
+    Mailcoach::shouldReceive('createSubscriber')
+        ->once()
+        ->andReturn(new Subscriber(['uuid' => 'new-uuid', 'email' => 'renamed@example.com', 'tags' => []]));
+
+    syncSubscriberProfile($user);
+
+    expect($user->refresh())
+        ->mailcoach_subscriber_uuid->toBe('new-uuid')
+        ->subscriber_profile_hash->not->toBeNull()
+        ->rejected_subscriber_profile_hash->toBeNull();
 });

--- a/tests/Feature/SystemAdmin/UserResourceTest.php
+++ b/tests/Feature/SystemAdmin/UserResourceTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 use App\Enums\Notifications\NotificationChannel;
 use App\Enums\Notifications\NotificationType;
+use App\Enums\SocialiteProvider;
 use App\Enums\SubscriberTagEnum;
 use App\Models\Team;
 use App\Models\User;
+use App\Models\UserSocialAccount;
 use Carbon\Carbon;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Auth;
@@ -17,6 +19,7 @@ use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\EditUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ListUsers;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\Pages\ViewUser;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\OwnedTeamsRelationManager;
+use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\SocialAccountsRelationManager;
 use Relaticle\SystemAdmin\Filament\Resources\UserResource\RelationManagers\TeamsRelationManager;
 use Relaticle\SystemAdmin\Models\SystemAdministrator;
 
@@ -194,6 +197,54 @@ describe('team relation managers', function (): void {
     });
 });
 
+describe('social providers relation manager', function (): void {
+    it('lists only the linked providers belonging to the user', function (): void {
+        $user = User::factory()->create();
+        $own = UserSocialAccount::factory()->for($user)->create(['provider_name' => 'google']);
+        $someoneElses = UserSocialAccount::factory()->create(['provider_name' => 'microsoft']);
+
+        livewire(SocialAccountsRelationManager::class, [
+            'ownerRecord' => $user,
+            'pageClass' => ViewUser::class,
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$own])
+            ->assertCanNotSeeTableRecords([$someoneElses]);
+    });
+
+    it('renders a provider the SocialiteProvider enum no longer offers', function (): void {
+        $user = User::factory()->create();
+        UserSocialAccount::factory()->for($user)->create(['provider_name' => 'facebook']);
+
+        expect(SocialiteProvider::tryFrom('facebook'))->toBeNull();
+
+        livewire(SocialAccountsRelationManager::class, [
+            'ownerRecord' => $user,
+            'pageClass' => ViewUser::class,
+        ])
+            ->assertSuccessful()
+            ->assertSee('Facebook');
+    });
+
+    it('is reachable from the user view page', function (): void {
+        $user = User::factory()->create();
+        UserSocialAccount::factory()->for($user)->create(['provider_name' => 'google']);
+
+        livewire(ViewUser::class, ['record' => $user->getKey()])
+            ->assertSuccessful()
+            ->assertSee('Social Providers');
+    });
+
+    it('renders without a table when the user has linked nothing', function (): void {
+        livewire(SocialAccountsRelationManager::class, [
+            'ownerRecord' => User::factory()->create(),
+            'pageClass' => ViewUser::class,
+        ])
+            ->assertSuccessful()
+            ->assertSee('No social providers linked');
+    });
+});
+
 it('deletes a user through the Jetstream deleter so their workspaces are not orphaned', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
     $team = $user->ownedTeams()->firstOrFail();
@@ -231,6 +282,37 @@ it('renders the engagement badge derived from the last login timestamp', functio
         ->assertTableColumnStateSet('engagement', SubscriberTagEnum::Active7d->value, record: $active)
         ->assertTableColumnStateSet('engagement', SubscriberTagEnum::Dormant->value, record: $dormant)
         ->assertTableColumnStateSet('engagement', null, record: $never);
+});
+
+it('filters to exactly the users whose subscriber profile Mailcoach rejected', function (): void {
+    $rejected = User::factory()->create(['rejected_subscriber_profile_hash' => 'hash-of-a-dead-domain']);
+    $healthy = User::factory()->create(['rejected_subscriber_profile_hash' => null]);
+
+    livewire(ListUsers::class)
+        ->filterTable('rejected_subscriber_profile_hash', true)
+        ->assertCanSeeTableRecords([$rejected])
+        ->assertCanNotSeeTableRecords([$healthy]);
+
+    livewire(ListUsers::class)
+        ->filterTable('rejected_subscriber_profile_hash', false)
+        ->assertCanSeeTableRecords([$healthy])
+        ->assertCanNotSeeTableRecords([$rejected]);
+});
+
+it('flags rejected users in the Mailcoach column and leaves healthy ones unflagged', function (): void {
+    $rejected = User::factory()->create(['rejected_subscriber_profile_hash' => 'hash-of-a-dead-domain']);
+    $healthy = User::factory()->create(['rejected_subscriber_profile_hash' => null]);
+
+    livewire(ListUsers::class)
+        ->assertTableColumnStateSet('rejected_subscriber_profile_hash', true, record: $rejected)
+        ->assertTableColumnStateSet('rejected_subscriber_profile_hash', false, record: $healthy);
+});
+
+it('shows both rejected and healthy users when the Mailcoach filter is unset', function (): void {
+    $rejected = User::factory()->create(['rejected_subscriber_profile_hash' => 'hash-of-a-dead-domain']);
+    $healthy = User::factory()->create(['rejected_subscriber_profile_hash' => null]);
+
+    livewire(ListUsers::class)->assertCanSeeTableRecords([$rejected, $healthy]);
 });
 
 it('lists exactly the users whose engagement badge matches the selected filter', function (): void {


### PR DESCRIPTION
Mailcoach validates subscriber emails against DNS and answers with a permanent 422 for addresses whose domain no longer resolves, even ones it already stores, and `email` is required on PATCH so the sync cannot omit it. Ten dormant legacy users with dead domains failed all five attempts every night because `subscribers:reconcile` re-dispatched them daily: ten failed jobs and up to fifty Sentry events per day (PRs #555 and #585 bounded retries and ordering but never the 422 itself).

`SyncSubscriberJob` now treats `InvalidData` as terminal: it records the profile hash in a new `users.rejected_subscriber_profile_hash` column and fails once, while `subscriber_profile_hash` keeps meaning "what Mailcoach holds" and is never written on a failed write. `SubscriberProfile::needsSync()` skips a user whose derived profile matches either column, so the sweep re-offers a rejected user only after their profile changes, which is also how an email fix un-parks them. Covered by six new tests written against the failing behaviour first, plus a `.ai/rules/email.md` entry recording the Mailcoach DNS trap.

Deploy: run the migration before restarting Horizon, then expect exactly ten `failed_jobs` rows on the first 02:00 UTC sweep and none after.
