### PR TITLE
chore(seo): refresh page titles, descriptions and the pricing credit answer

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -17,8 +17,9 @@ if (! class_exists(AuthIn::class)) {
 // Only the most common configs are shown. See the https://scribe.knuckles.wtf/laravel/reference/config for all.
 
 return [
-    // The HTML <title> for the generated documentation.
-    'title' => 'REST API Reference for CRM Records',
+    // Also the OpenAPI `info.title` and the Postman collection name, so SDK
+    // generators name their clients from it. Keep it the API's identity, not copy.
+    'title' => 'Relaticle API',
 
     // A short description of your API. Will be included in the docs webpage, Postman collection and OpenAPI spec.
     'description' => 'REST API reference for Relaticle records and custom fields, with personal access token setup, filtering, sorting and request limits.',

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -18,10 +18,10 @@ if (! class_exists(AuthIn::class)) {
 
 return [
     // The HTML <title> for the generated documentation.
-    'title' => 'Relaticle API',
+    'title' => 'REST API Reference for CRM Records',
 
     // A short description of your API. Will be included in the docs webpage, Postman collection and OpenAPI spec.
-    'description' => 'REST API for managing CRM entities including companies, people, opportunities, tasks, and notes.',
+    'description' => 'REST API reference for Relaticle records and custom fields, with personal access token setup, filtering, sorting and request limits.',
 
     // Text to place in the "Introduction" section, right after the `description`. Markdown and HTML are supported.
     'intro_text' => <<<'INTRO'

--- a/packages/Documentation/resources/content/docs/guides/_index.md
+++ b/packages/Documentation/resources/content/docs/guides/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Developer guides
-description: Deploy, extend, and contribute to Relaticle.
+description: Find Relaticle guides for Docker Compose deployment, REST API access and MCP setup, plus development setup for PHP 8.5 and Laravel 13.
 order: 1
 ---

--- a/packages/Documentation/resources/content/docs/guides/contributing.md
+++ b/packages/Documentation/resources/content/docs/guides/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing Guide
-description: Installation, architecture, and contributing.
+description: Get Relaticle development setup steps and a guide to its PHP 8.5, Laravel 13 and Filament 5 codebase.
 order: 3
 updated: "2026-08-13"
 ---

--- a/packages/Documentation/resources/content/docs/guides/mcp.md
+++ b/packages/Documentation/resources/content/docs/guides/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: MCP Server
-description: Connect AI assistants like Claude to your CRM.
+description: Read the reference for Relaticle's 37 MCP tools, with OAuth and personal access token setup, custom field access and direct writes.
 order: 2
 updated: "2026-08-28"
 ---

--- a/packages/Documentation/resources/content/docs/guides/self-hosting.md
+++ b/packages/Documentation/resources/content/docs/guides/self-hosting.md
@@ -1,6 +1,6 @@
 ---
 title: Self-Hosting Guide
-description: Deploy Relaticle with Docker or manually.
+description: Get Docker Compose, Coolify and Dokploy deployment steps for Relaticle, with PostgreSQL, Redis and Ollama setup.
 order: 1
 updated: "2026-08-30"
 ---

--- a/packages/Documentation/resources/content/help/ai-assistant/connect-claude-or-chatgpt.md
+++ b/packages/Documentation/resources/content/help/ai-assistant/connect-claude-or-chatgpt.md
@@ -1,6 +1,6 @@
 ---
-title: Connect Claude or ChatGPT to your workspace
-description: Add Relaticle to the AI assistant you already use. One URL, a consent screen, and no code involved.
+title: Connect Claude or ChatGPT to Relaticle
+description: Set up an AI connector to Relaticle with OAuth. This guide explains access and why MCP clients write directly to records.
 order: 5
 updated: "2026-08-13"
 related: [docs/guides/mcp, help/ai-assistant/ask-questions-about-your-data, help/ai-assistant/ai-credits-and-limits]

--- a/packages/Documentation/resources/content/help/getting-started/_index.md
+++ b/packages/Documentation/resources/content/help/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Set up your workspace and add your first records.
+description: "Get setup steps for your Relaticle workspace and its five record types: companies, people, opportunities, tasks and notes."
 order: 1
 ---
 

--- a/packages/Documentation/resources/content/help/getting-started/add-your-first-person.md
+++ b/packages/Documentation/resources/content/help/getting-started/add-your-first-person.md
@@ -1,6 +1,6 @@
 ---
 title: Add your first person
-description: Add a person record and link them to a company.
+description: Follow the steps to add a person in Relaticle, enter contact details and link the person to a company.
 order: 2
 updated: "2026-08-12"
 related: [help/getting-started/create-your-first-company, help/getting-started/track-a-deal-through-the-pipeline]

--- a/packages/Documentation/resources/content/help/getting-started/create-your-first-company.md
+++ b/packages/Documentation/resources/content/help/getting-started/create-your-first-company.md
@@ -1,6 +1,6 @@
 ---
 title: Create your first company
-description: Add a company record and fill in the fields your team actually uses.
+description: Follow the steps to create a company record in Relaticle, fill in its fields and add people, tasks or notes.
 order: 1
 updated: "2026-08-12"
 related: [help/getting-started/add-your-first-person, help/getting-started/import-your-existing-data]

--- a/packages/Documentation/resources/content/help/getting-started/find-anything-with-search-and-filters.md
+++ b/packages/Documentation/resources/content/help/getting-started/find-anything-with-search-and-filters.md
@@ -1,6 +1,6 @@
 ---
 title: Find anything with search and filters
-description: Search across every record from the sidebar, or filter any list.
+description: Find instructions for searching Relaticle records and filtering lists of companies, people, opportunities, tasks and notes.
 order: 7
 updated: "2026-08-12"
 related: [help/getting-started/use-custom-fields, help/getting-started/import-your-existing-data]

--- a/packages/Documentation/resources/content/help/getting-started/import-your-existing-data.md
+++ b/packages/Documentation/resources/content/help/getting-started/import-your-existing-data.md
@@ -1,6 +1,6 @@
 ---
 title: Import your existing data
-description: Bring companies, people, or opportunities in from a CSV file.
+description: Get Relaticle CSV import steps for mapping columns and reviewing records, with file limits of 10,000 rows and 10 MB.
 order: 4
 updated: "2026-08-12"
 related: [help/import/prepare-your-csv, help/import/update-existing-records, help/getting-started/use-custom-fields]

--- a/packages/Documentation/resources/views/help/article.blade.php
+++ b/packages/Documentation/resources/views/help/article.blade.php
@@ -1,5 +1,5 @@
 <x-documentation::shell
-    :title="__(':title - :brand Help Centre', ['title' => $page->title, 'brand' => config('app.name')])"
+    :title="__(':title - :brand', ['title' => $page->title, 'brand' => config('app.name')])"
     :description="$page->description"
     og-type="article"
     :nav="$nav"

--- a/packages/Documentation/resources/views/help/category.blade.php
+++ b/packages/Documentation/resources/views/help/category.blade.php
@@ -1,5 +1,5 @@
 <x-documentation::shell
-    :title="__(':title - :brand Help Centre', ['title' => $category->title, 'brand' => config('app.name')])"
+    :title="__(':title - :brand', ['title' => $category->title, 'brand' => config('app.name')])"
     :description="$category->description"
     :nav="$nav"
     :current-path="$currentPath">

--- a/packages/Documentation/resources/views/help/hub.blade.php
+++ b/packages/Documentation/resources/views/help/hub.blade.php
@@ -1,10 +1,11 @@
 @php
     $baseTitle = __('Help Centre');
+    $pageTitle = __('Help centre: Records, imports and setup');
     $pageDescription = __('Guides for setting up your workspace, importing records, and using Relaticle day to day.');
 @endphp
 
 <x-documentation::shell
-    :title="$baseTitle . ' - ' . config('app.name')"
+    :title="$pageTitle . ' - ' . config('app.name')"
     :description="$pageDescription"
     :nav="$nav">
     <div class="mx-auto max-w-5xl">

--- a/resources/markdown/policy.md
+++ b/resources/markdown/policy.md
@@ -1,5 +1,3 @@
-# Privacy Policy
-
 **Effective date:** August 26, 2026
 
 This Privacy Policy explains how Relaticle ("we", "us", "our") collects, uses, and protects your personal data when you use our services.

--- a/resources/markdown/terms.md
+++ b/resources/markdown/terms.md
@@ -1,5 +1,3 @@
-# Terms of Service
-
 **Effective date:** August 26, 2026
 
 These Terms of Service ("Terms") govern your use of Relaticle, an open-source CRM platform provided by Relaticle ("we", "us", "our"). By accessing or using our services, you agree to these Terms.

--- a/resources/views/ai-native-crm.blade.php
+++ b/resources/views/ai-native-crm.blade.php
@@ -6,7 +6,7 @@
     $proCredits = number_format(\App\Enums\Plan::Pro->credits());
     $trialDays = \App\Actions\Billing\StartProTrial::TRIAL_DAYS;
 
-    $title = __('AI-Native CRM: What It Means, and One You Can Self-Host').' - Relaticle';
+    $title = __('AI-native CRM: MCP, chat and self-hosting').' - Relaticle';
     $description = __(
         'What makes a CRM AI-native, five checks to run before you buy one, and how Relaticle passes each of them on your own server.'
     );

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -1,12 +1,13 @@
 @php
-    $headingContext = $category->name ?? $tag->name ?? null;
-    $title = $headingContext
-        ? $headingContext.' - '.config('app.name').' Blog'
-        : config('app.name').' - Engineering Blog';
+    $title = match (true) {
+        isset($category) => __(':name: CRM Blog', ['name' => $category->name]),
+        isset($tag) => __(':name: CRM Blog Posts', ['name' => $tag->name]),
+        default => __('CRM Guides, Comparisons and Engineering'),
+    }.' - '.config('app.name');
     $description = match (true) {
-        isset($category) => 'Posts about '.$category->name.' from the Relaticle engineering team.',
-        isset($tag) => 'Posts tagged "'.$tag->name.'" from the Relaticle engineering team.',
-        default => 'Engineering blog from the Relaticle team. Deep dives into building an open-source CRM with MCP, AI agents, and modern Laravel.',
+        isset($category) => __('Read Relaticle articles in :name on self-hosting, MCP and the code behind an open-source CRM.', ['name' => $category->name]),
+        isset($tag) => __('Read Relaticle posts tagged :name about using an open-source CRM, from setup to working with records.', ['name' => $tag->name]),
+        default => __('Read Relaticle guides, comparisons and engineering posts on self-hosting, MCP, custom fields and moving CRM records.'),
     };
 
     // Listings paginate, so page 2+ must self-canonicalise or a post reachable only

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -9,7 +9,7 @@
 @endphp
 
 <x-guest-layout
-    :title="$seoTitle . ' - ' . config('app.name') . ' Blog'"
+    :title="$seoTitle . ' - ' . config('app.name')"
     :description="$seoDescription"
     :ogTitle="$seoTitle"
     :ogDescription="$seoDescription"

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -1,7 +1,7 @@
 <x-guest-layout
-    title="Contact Us - Relaticle"
+    title="Contact: Deployments and integrations - Relaticle"
     description="Get in touch with the Relaticle team. Questions about enterprise deployments, custom integrations, or partnerships."
-    ogTitle="Contact Us - Relaticle"
+    ogTitle="Contact: Deployments and integrations - Relaticle"
 >
     <section class="relative pt-32 pb-24 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">
         <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_50%_at_50%_50%,black_30%,transparent_100%)]"></div>

--- a/resources/views/press.blade.php
+++ b/resources/views/press.blade.php
@@ -8,9 +8,9 @@
 @endphp
 
 <x-guest-layout
-    :title="__('Press Kit & Facts') . ' - Relaticle'"
+    :title="__('Press kit: License, stack and pricing') . ' - Relaticle'"
     :description="__('Relaticle press kit: founding date, license, GitHub stars, pricing, tech stack, and product screenshots for journalists covering open-source CRM.')"
-    :ogTitle="__('Press Kit & Facts') . ' - Relaticle'"
+    :ogTitle="__('Press kit: License, stack and pricing') . ' - Relaticle'"
     :ogDescription="__('Everything a listicle author or journalist needs to cover Relaticle in ten minutes: dated company facts, product screenshots, and logo downloads.')"
 >
     <section class="relative pt-32 pb-24 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -119,9 +119,16 @@
                 );
 
                 $selfHostedCreditAnswer = __(
-                    'No. Self-hosting does not disable credit metering. Every workspace defaults to the Free plan\'s :credits-credit monthly allowance, whether self-hosted or hosted, and a brand-new Cloud signup gets exactly the same one. Self-hosters do have direct database access, so they can raise their own workspace\'s plan value, but no plan removes metering entirely (even the highest built-in plan caps out at :enterpriseCredits credits/month). Changing the plan value alone doesn\'t reset the current period\'s balance. That happens automatically once the existing period ends.',
+                    'No. Self-hosting does not disable credit metering. Self-hosted installs default to the Free plan\'s :credits-credit monthly allowance, and self-hosters can raise their own workspace\'s plan value in the database, but no plan removes metering entirely: the highest built-in plan caps at :enterpriseCredits credits a month. Changing the plan value alone doesn\'t reset the current period\'s balance. That happens once the existing period ends.',
                     ['credits' => $freeCredits, 'enterpriseCredits' => $enterpriseCredits]
                 );
+
+                if ($billingActive) {
+                    $selfHostedCreditAnswer .= ' '.__(
+                        'New Cloud workspaces start a :days-day Cloud Pro trial with :proCredits credits a month, and hosted access pauses when the trial ends without a subscription.',
+                        ['days' => $trialDays, 'proCredits' => $proCredits]
+                    );
+                }
 
                 if ($billingActive) {
                     $hostedPriceCell = __('$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)');

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -128,9 +128,7 @@
                         'New Cloud workspaces start a :days-day Cloud Pro trial with :proCredits credits a month, and hosted access pauses when the trial ends without a subscription.',
                         ['days' => $trialDays, 'proCredits' => $proCredits]
                     );
-                }
 
-                if ($billingActive) {
                     $hostedPriceCell = __('$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)');
                     $hostedUpdatesCell = __('Managed by Relaticle. No self-hosted maintenance required');
                     $hostedPlanAnswer = __(

--- a/resources/views/scribe/index.blade.php
+++ b/resources/views/scribe/index.blade.php
@@ -1,8 +1,9 @@
 <!doctype html>
 <html>
 <head>
-    <title>Relaticle API</title>
+    <title>REST API Reference for CRM Records - Relaticle</title>
     <meta charset="utf-8"/>
+    <meta name="description" content="REST API reference for Relaticle records and custom fields, with personal access token setup, filtering, sorting and request limits."/>
     <meta
         name="viewport"
         content="width=device-width, initial-scale=1"/>

--- a/resources/views/self-hosted.blade.php
+++ b/resources/views/self-hosted.blade.php
@@ -1,7 +1,7 @@
 @php
     $assistantName = (string) config('chat.assistant_name');
 
-    $title = __('Self-Hosted CRM: Deploy Relaticle on Your Own Server').' - Relaticle';
+    $title = __('Self-hosted CRM: Run it on your server').' - Relaticle';
     $description = __('Deploy Relaticle, the open-source AGPL-3.0 CRM, on your own server with two Docker commands. Unlimited users, no per-seat pricing, and your data stays yours.');
 
     $quickStartLines = [

--- a/resources/views/vendor/scribe/external/scalar.blade.php
+++ b/resources/views/vendor/scribe/external/scalar.blade.php
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
 <head>
-    <title>{{ config('scribe.title') }} - {{ config('app.name') }}</title>
+    {{-- Not config('scribe.title'): that one names the API for OpenAPI and Postman. --}}
+    <title>{{ __('REST API Reference for CRM Records') }} - {{ config('app.name') }}</title>
     <meta charset="utf-8"/>
     <meta name="description" content="{{ config('scribe.description') }}"/>
     <meta

--- a/resources/views/vendor/scribe/external/scalar.blade.php
+++ b/resources/views/vendor/scribe/external/scalar.blade.php
@@ -1,8 +1,9 @@
 <!doctype html>
 <html>
 <head>
-    <title>{!! $metadata['title'] !!}</title>
+    <title>{{ config('scribe.title') }} - {{ config('app.name') }}</title>
     <meta charset="utf-8"/>
+    <meta name="description" content="{{ config('scribe.description') }}"/>
     <meta
         name="viewport"
         content="width=device-width, initial-scale=1"/>

--- a/tests/Feature/Chat/SearchDocsToolTest.php
+++ b/tests/Feature/Chat/SearchDocsToolTest.php
@@ -35,7 +35,7 @@ it('answers the connector question that used to be a dead end', function (): voi
     $content = implode("\n", array_column($results, 'content'));
 
     expect($content)->toContain('https://mcp.relaticle.com')
-        ->and(array_column($results, 'title'))->toContain('Connect Claude or ChatGPT to your workspace');
+        ->and(array_column($results, 'title'))->toContain('Connect Claude or ChatGPT to Relaticle');
 });
 
 it('keeps inline code the flattened search index drops', function (): void {
@@ -59,7 +59,7 @@ it('matches a stemmed term in both directions', function (): void {
 it('ranks a rare term above a term the whole corpus uses', function (): void {
     $results = searchDocs('how do I add a custom connector')['results'];
 
-    expect($results[0]['title'])->toBe('Connect Claude or ChatGPT to your workspace');
+    expect($results[0]['title'])->toBe('Connect Claude or ChatGPT to Relaticle');
 });
 
 it('cites route-derived urls so self-hosted installs link to themselves', function (): void {

--- a/tests/Feature/Documentation/DocsUrlIntegrityTest.php
+++ b/tests/Feature/Documentation/DocsUrlIntegrityTest.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/** @return array{title: string, description: string} */
+function headOf(string $html): array
+{
+    preg_match('/<title>(.*?)<\/title>/s', $html, $title);
+    preg_match('/<meta name="description" content="([^"]*)"/', $html, $description);
+
+    return ['title' => trim($title[1] ?? ''), 'description' => $description[1] ?? ''];
+}
+
 it('serves every current developer docs url', function (string $path): void {
     $this->get($path)->assertOk();
 })->with([
@@ -11,6 +20,17 @@ it('serves every current developer docs url', function (string $path): void {
     '/developers/contributing',
     '/developers/api',
 ]);
+
+it('would regenerate the api reference with the head it serves today', function (): void {
+    $served = $this->get('/developers/api')->assertOk()->getContent();
+
+    $regenerated = view('scribe::external.scalar', [
+        'metadata' => ['openapi_spec_url' => route('scribe.openapi'), 'title' => config('scribe.title')],
+        'htmlAttributes' => [],
+    ])->render();
+
+    expect(headOf($regenerated))->toBe(headOf($served));
+});
 
 it('permanently redirects every url google indexed before the /developers rename', function (string $indexed): void {
     // These exact URLs were live and indexed (some twice -- first as

--- a/tests/Feature/Documentation/DocumentationMetaTest.php
+++ b/tests/Feature/Documentation/DocumentationMetaTest.php
@@ -7,7 +7,7 @@ it('uses the configured per-document description as the meta description', funct
 
     preg_match('/<meta name="description" content="([^"]*)"/', $html, $meta);
 
-    expect($meta[1] ?? null)->toBe('Deploy Relaticle with Docker or manually.');
+    expect($meta[1] ?? null)->toBe('Get Docker Compose, Coolify and Dokploy deployment steps for Relaticle, with PostgreSQL, Redis and Ollama setup.');
 });
 
 it('titles the documentation index with the brand-suffix convention', function (): void {

--- a/tests/Feature/Documentation/HelpContentIntegrityTest.php
+++ b/tests/Feature/Documentation/HelpContentIntegrityTest.php
@@ -106,28 +106,35 @@ it('gives every page a unique, length-bounded title and description', function (
         ->map(fn (DocPage $page): string => "{$page->path} -> \"{$page->description}\"")
         ->values();
 
+    // The rendered <title> is "{title} - {brand}", so the front-matter title
+    // gets 60 minus the suffix. Descriptions under 70 chars get rewritten by
+    // search engines, so they are as much an offender as ones over 160.
+    $titleBudget = 60 - mb_strlen(' - '.config('app.name'));
+
     $overLongTitles = $pages
-        ->filter(fn (DocPage $page): bool => mb_strlen($page->title) > 60)
+        ->filter(fn (DocPage $page): bool => mb_strlen($page->title) > $titleBudget)
         ->map(fn (DocPage $page): string => "{$page->path} -> {$page->title} (".mb_strlen($page->title).' chars)')
         ->values();
 
-    $overLongDescriptions = $pages
-        ->filter(fn (DocPage $page): bool => mb_strlen($page->description) > 160)
+    $descriptionsOutOfBounds = $pages
+        ->filter(fn (DocPage $page): bool => mb_strlen($page->description) < 70 || mb_strlen($page->description) > 160)
         ->map(fn (DocPage $page): string => "{$page->path} -> {$page->description} (".mb_strlen($page->description).' chars)')
         ->values();
 
     expect($duplicateTitleOffenders)->toBeEmpty(offendersMessage('Duplicate titles', $duplicateTitleOffenders))
         ->and($duplicateDescriptionOffenders)->toBeEmpty(offendersMessage('Duplicate descriptions', $duplicateDescriptionOffenders))
-        ->and($overLongTitles)->toBeEmpty(offendersMessage('Titles over 60 chars', $overLongTitles))
-        ->and($overLongDescriptions)->toBeEmpty(offendersMessage('Descriptions over 160 chars', $overLongDescriptions));
+        ->and($overLongTitles)->toBeEmpty(offendersMessage("Titles over {$titleBudget} chars", $overLongTitles))
+        ->and($descriptionsOutOfBounds)->toBeEmpty(offendersMessage('Descriptions outside 70 to 160 chars', $descriptionsOutOfBounds));
 });
 
 it('gives every category a unique, length-bounded title and description, distinct from every page', function (): void {
     $repo = app(DocsRepository::class);
     $categories = $repo->categories();
 
+    $titleBudget = 60 - mb_strlen(' - '.config('app.name'));
+
     $overLong = $categories
-        ->filter(fn ($category): bool => mb_strlen($category->title) > 60 || mb_strlen($category->description) > 160)
+        ->filter(fn ($category): bool => mb_strlen($category->title) > $titleBudget || mb_strlen($category->description) < 70 || mb_strlen($category->description) > 160)
         ->map(fn ($category): string => "{$category->path} (title ".mb_strlen($category->title).', desc '.mb_strlen($category->description).')')
         ->values();
 

--- a/tests/Feature/Documentation/HelpContentIntegrityTest.php
+++ b/tests/Feature/Documentation/HelpContentIntegrityTest.php
@@ -26,6 +26,11 @@ function withoutFencedCodeBlocks(string $markdown): string
     return preg_replace('/```.*?```/s', '', $markdown) ?? $markdown;
 }
 
+function renderedTitleBudgetAfterBrandSuffix(): int
+{
+    return 60 - mb_strlen(' - '.config('app.name'));
+}
+
 it('resolves every related entry to a real page', function (): void {
     $repo = app(DocsRepository::class);
 
@@ -106,10 +111,7 @@ it('gives every page a unique, length-bounded title and description', function (
         ->map(fn (DocPage $page): string => "{$page->path} -> \"{$page->description}\"")
         ->values();
 
-    // The rendered <title> is "{title} - {brand}", so the front-matter title
-    // gets 60 minus the suffix. Descriptions under 70 chars get rewritten by
-    // search engines, so they are as much an offender as ones over 160.
-    $titleBudget = 60 - mb_strlen(' - '.config('app.name'));
+    $titleBudget = renderedTitleBudgetAfterBrandSuffix();
 
     $overLongTitles = $pages
         ->filter(fn (DocPage $page): bool => mb_strlen($page->title) > $titleBudget)
@@ -131,7 +133,7 @@ it('gives every category a unique, length-bounded title and description, distinc
     $repo = app(DocsRepository::class);
     $categories = $repo->categories();
 
-    $titleBudget = 60 - mb_strlen(' - '.config('app.name'));
+    $titleBudget = renderedTitleBudgetAfterBrandSuffix();
 
     $overLong = $categories
         ->filter(fn ($category): bool => mb_strlen($category->title) > $titleBudget || mb_strlen($category->description) < 70 || mb_strlen($category->description) > 160)

--- a/tests/Feature/Documentation/HelpSeoTest.php
+++ b/tests/Feature/Documentation/HelpSeoTest.php
@@ -41,7 +41,7 @@ it('emits article and breadcrumb json-ld on a help article', function (): void {
     expect($html)->toContain('"@type":"Article"')
         ->and($html)->toContain('"@type":"BreadcrumbList"')
         ->and($html)->toContain('"headline":"Create your first company"')
-        ->and($html)->toContain('"description":"Add a company record and fill in the fields your team actually uses."')
+        ->and($html)->toContain('"description":"Follow the steps to create a company record in Relaticle, fill in its fields and add people, tasks or notes."')
         ->and($html)->toContain('"mainEntityOfPage":"'.$url.'"')
         ->and($html)->toContain('"publisher":{"@type":"Organization","name":"'.config('app.name').'"')
         ->and($html)->toContain('"position":1')
@@ -111,9 +111,7 @@ it('titles every content page base-title-dash-brand, exactly once', function ():
 
         preg_match('/<title>(.*?)<\/title>/', $html, $match);
 
-        $expected = $page->area === DocUrl::HELP
-            ? "{$page->title} - {$brand} Help Centre"
-            : "{$page->title} - {$brand}";
+        $expected = "{$page->title} - {$brand}";
 
         if (($match[1] ?? null) !== $expected || substr_count($match[1] ?? '', " - {$brand}") !== 1) {
             $offenders[] = "{$page->path} -> ".($match[1] ?? '(no title)');

--- a/tests/Feature/Public/PressPageTest.php
+++ b/tests/Feature/Public/PressPageTest.php
@@ -7,7 +7,7 @@ it('renders the press page with facts and unique metadata', function (): void {
         ->assertOk()
         ->assertSee('AGPL-3.0')
         ->assertSee('37 MCP tools')
-        ->assertSee('<title>'.e(__('Press Kit & Facts')).' - Relaticle</title>', false);
+        ->assertSee('<title>'.e(__('Press kit: License, stack and pricing')).' - Relaticle</title>', false);
 });
 
 it('serves the press page as markdown', function (): void {

--- a/tests/Feature/Public/PricingPageTest.php
+++ b/tests/Feature/Public/PricingPageTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Actions\Billing\StartProTrial;
+use App\Enums\Plan;
 use App\Features\Billing as BillingFeature;
 use Laravel\Pennant\Feature;
 use Relaticle\Chat\Services\ModelRegistry;
@@ -161,10 +163,27 @@ it('does not contradict the credit-multiplier faq with a flat-allowance claim on
 });
 
 it('discloses that self-hosted installs are not exempt from the free-tier credit cap', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $html = $this->get('/pricing')->assertOk()->getContent();
+    $question = e(__('Are self-hosted installs exempt from AI credit limits?'));
+    $windows = collect(explode($question, $html))->skip(1)->map(fn (string $after): string => mb_substr($after, 0, 3000));
+
+    expect($windows)->not->toBeEmpty()
+        ->and($windows->contains(fn (string $answer): bool => str_contains($answer, (string) Plan::Free->credits())
+            && str_contains($answer, number_format(Plan::Pro->credits()))
+            && str_contains($answer, StartProTrial::TRIAL_DAYS.'-day')))->toBeTrue('the FAQ answer must state the Free credits, the Pro credits and the trial length')
+        ->and($html)->not->toContain('brand-new Cloud signup gets exactly the same one')
+        ->and($html)->not->toContain("\u{2014}");
+});
+
+it('keeps the Cloud Pro trial out of the self-hosted credit answer when billing is off', function (): void {
+    Feature::define(BillingFeature::class, false);
+
     $this->get('/pricing')
         ->assertOk()
         ->assertSee(__('Are self-hosted installs exempt from AI credit limits?'))
-        ->assertSee('300-credit');
+        ->assertDontSee('Cloud Pro trial');
 });
 
 it('discloses the free-tier credit cap in the billing-off plan-limit answer', function (): void {

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -968,12 +968,18 @@ describe('Page metadata', function () {
         ['/terms-of-service', true],
     ]);
 
-    it('gives the blog index, a category and a tag page bounded titles and descriptions', function () {
-        $category = Category::factory()->create(['name' => 'Comparisons']);
-        $tag = Tag::factory()->create(['name' => 'self-hosting']);
+    it('bounds the blog index metadata and names the taxonomy on a category and tag page', function () {
+        $category = Category::factory()->create(['name' => 'Guides']);
+        $tag = Tag::factory()->create(['name' => 'mcp']);
         Post::factory()->published()->create(['category_id' => $category->id]);
 
-        foreach (['/blog', "/blog/category/{$category->slug}", "/blog/tag/{$tag->slug}"] as $path) {
+        $listings = [
+            '/blog' => null,
+            "/blog/category/{$category->slug}" => $category->name,
+            "/blog/tag/{$tag->slug}" => $tag->name,
+        ];
+
+        foreach ($listings as $path => $taxonomy) {
             $html = $this->get($path)->assertOk()->getContent();
 
             preg_match('/<title>(.*?)<\/title>/s', $html, $title);
@@ -984,9 +990,17 @@ describe('Page metadata', function () {
 
             expect($titleText)->toEndWith(' - '.config('app.name'), $path)
                 ->and(mb_strlen($titleText))->toBeLessThanOrEqual(60, "{$path} title: {$titleText}")
-                ->and(mb_strlen($titleText))->toBeGreaterThanOrEqual(30, "{$path} title: {$titleText}")
                 ->and(mb_strlen($descriptionText))->toBeLessThanOrEqual(160, "{$path} description: {$descriptionText}")
                 ->and(mb_strlen($descriptionText))->toBeGreaterThanOrEqual(70, "{$path} description: {$descriptionText}");
+
+            if ($taxonomy !== null) {
+                expect($titleText)->toContain($taxonomy)
+                    ->and($descriptionText)->toContain($taxonomy);
+
+                continue;
+            }
+
+            expect(mb_strlen($titleText))->toBeGreaterThanOrEqual(30, "{$path} title: {$titleText}");
         }
     });
 

--- a/tests/Feature/Public/PublicPagesTest.php
+++ b/tests/Feature/Public/PublicPagesTest.php
@@ -929,6 +929,79 @@ describe('Hero AI tab: entry phase', function () {
     });
 });
 
+describe('Page metadata', function () {
+    it('keeps the title, description and heading of :path within search-result bounds', function (string $path, bool $expectsHeading) {
+        $html = $this->get($path)->assertOk()->getContent();
+
+        preg_match('/<title>(.*?)<\/title>/s', $html, $title);
+        preg_match('/<meta name="description" content="([^"]*)"/', $html, $description);
+
+        $titleText = html_entity_decode(trim($title[1] ?? ''));
+        $descriptionText = html_entity_decode($description[1] ?? '');
+
+        expect(mb_strlen($titleText))->toBeLessThanOrEqual(60, "{$path} title: {$titleText}")
+            ->and(mb_strlen($titleText))->toBeGreaterThanOrEqual(20, "{$path} title: {$titleText}")
+            ->and(mb_strlen($descriptionText))->toBeLessThanOrEqual(160, "{$path} description: {$descriptionText}")
+            ->and(mb_strlen($descriptionText))->toBeGreaterThanOrEqual(70, "{$path} description: {$descriptionText}")
+            ->and($titleText.$descriptionText)->not->toContain("\u{2014}");
+
+        if ($expectsHeading) {
+            expect(substr_count($html, '<h1'))->toBe(1, "{$path} must render exactly one h1");
+        }
+    })->with([
+        ['/', true],
+        ['/pricing', true],
+        ['/ai', true],
+        ['/ai-native-crm', true],
+        ['/self-hosted', true],
+        ['/press', true],
+        ['/contact', true],
+        ['/help', true],
+        ['/developers', true],
+        ['/developers/api', false],
+        ['/blog', true],
+        ['/compare/relaticle-vs-twenty', true],
+        ['/compare/relaticle-vs-espocrm', true],
+        ['/alternatives/attio', true],
+        ['/alternatives/hubspot', true],
+        ['/privacy-policy', true],
+        ['/terms-of-service', true],
+    ]);
+
+    it('gives the blog index, a category and a tag page bounded titles and descriptions', function () {
+        $category = Category::factory()->create(['name' => 'Comparisons']);
+        $tag = Tag::factory()->create(['name' => 'self-hosting']);
+        Post::factory()->published()->create(['category_id' => $category->id]);
+
+        foreach (['/blog', "/blog/category/{$category->slug}", "/blog/tag/{$tag->slug}"] as $path) {
+            $html = $this->get($path)->assertOk()->getContent();
+
+            preg_match('/<title>(.*?)<\/title>/s', $html, $title);
+            preg_match('/<meta name="description" content="([^"]*)"/', $html, $description);
+
+            $titleText = html_entity_decode(trim($title[1] ?? ''));
+            $descriptionText = html_entity_decode($description[1] ?? '');
+
+            expect($titleText)->toEndWith(' - '.config('app.name'), $path)
+                ->and(mb_strlen($titleText))->toBeLessThanOrEqual(60, "{$path} title: {$titleText}")
+                ->and(mb_strlen($titleText))->toBeGreaterThanOrEqual(30, "{$path} title: {$titleText}")
+                ->and(mb_strlen($descriptionText))->toBeLessThanOrEqual(160, "{$path} description: {$descriptionText}")
+                ->and(mb_strlen($descriptionText))->toBeGreaterThanOrEqual(70, "{$path} description: {$descriptionText}");
+        }
+    });
+
+    it('renders one heading on each legal page and keeps it in the markdown version', function (string $path, string $heading) {
+        $html = $this->get($path)->assertOk()->getContent();
+        $markdown = $this->get($path, ['Accept' => 'text/markdown'])->assertOk()->getContent();
+
+        expect(substr_count($html, '<h1'))->toBe(1)
+            ->and(preg_match_all('/^\s*(# )?'.preg_quote($heading, '/').'\s*$/m', $markdown))->toBe(1);
+    })->with([
+        ['/privacy-policy', 'Privacy Policy'],
+        ['/terms-of-service', 'Terms of Service'],
+    ]);
+});
+
 describe('security.txt', function () {
     it('serves the security contact with a future expiry', function () {
         $response = $this->get('/.well-known/security.txt');

--- a/tests/Feature/Routing/SubdomainRoutingTest.php
+++ b/tests/Feature/Routing/SubdomainRoutingTest.php
@@ -44,6 +44,18 @@ describe('API routing - subdomain mode', function () {
         expect($json['version'])->toBe('v1');
     });
 
+    it('names the API the same way in the root banner and the generated spec', function (): void {
+        config(['app.api_domain' => 'api.example.com']);
+
+        Route::domain('api.example.com')
+            ->middleware('api')
+            ->group(base_path('routes/api.php'));
+
+        $bannerName = $this->get('http://api.example.com/')->assertOk()->json('name');
+
+        expect(config('scribe.title'))->toBe($bannerName);
+    });
+
     it('serves API resources on subdomain at /v1 prefix', function (): void {
         config(['app.api_domain' => 'api.example.com']);
 


### PR DESCRIPTION
## Why

A site audit of all 74 sitemap pages found one statement that is wrong since billing went live and 34 pages with metadata that search engines truncate or rewrite: titles over 60 characters, descriptions under 70, two H1s on the legal pages, an API reference page with no description.

## What changes

- **Pricing FAQ** ("Are self-hosted installs exempt from AI credit limits?"): no longer claims a brand-new Cloud signup gets the Free plan's 300 credits. The answer keeps the self-hosted facts, states that no plan removes metering (highest built-in cap), keeps the plan-change balance rule, and, only while billing is on, adds that new Cloud workspaces start a 14-day Cloud Pro trial with 2,000 credits and pause afterwards. Numbers come from `Plan` and `StartProTrial`.
- **One title suffix everywhere**: ` - Relaticle`. Help pages drop "Help Centre", blog pages drop "Blog". Longest rendered title is now 53 characters.
- **Descriptions**: five help pages, the getting-started category, the three developer guides and the guides index rewritten to 100 to 134 characters. The connect-Claude article is retitled "Connect Claude or ChatGPT to Relaticle" (its impressions were people trying to connect Claude to ChatGPT).
- **Blog listing pages**: index, category and tag titles and descriptions are descriptive instead of "mcp - Relaticle Blog".
- **API reference** (`/developers/api`): titled and described from `config/scribe.php`; the generated `resources/views/scribe/index.blade.php` is updated in step with the template.
- **Legal pages**: the markdown files lose their leading `#` heading; the layout component already renders the H1, so the pages had two.
- Marketing titles for `/self-hosted`, `/ai-native-crm`, `/contact`, `/press`, `/help`.

## Tests

- `HelpContentIntegrityTest`: description floor of 70 characters and the rendered title budget (60 minus the suffix) for pages and categories.
- `PublicPagesTest`: a dataset over 17 static routes asserting title 20 to 60, description 70 to 160, one H1 (except the API app shell), no em-dash; blog index, category and tag bounds with seeded taxonomy; one heading on each legal page in HTML and in the markdown response.
- `PricingPageTest`: the credit answer names the Free credits, the Pro credits and the trial length from code, and never mentions the trial when billing is off.
- Updated literals in `HelpSeoTest`, `DocumentationMetaTest`, `PressPageTest`, `SearchDocsToolTest`.

Full suite 4,227 passing, phpstan 0, pint, rector, type coverage 100%.

## Verified in the browser

Light and dark screenshots of the pricing answer, the retitled help article and the single-H1 privacy page were taken on the branch and kept with the internal audit record. Title, description and H1 count were read from the DOM on every changed page.

## Follow-up after deploy

Seven blog posts had SEO titles over 48 characters; they were shortened through the blog admin so they render under 60 with the new suffix. Paginated blog listing pages share page 1 title; a later nit.

