### PR TITLE
Show just-sent mail in the outbox queued list

### DIFF
--- a/config/email-integration.php
+++ b/config/email-integration.php
@@ -80,7 +80,7 @@ return [
             'hourly_send_limit' => (int) env('EMAIL_DEFAULT_HOURLY_LIMIT', 12),
             'daily_send_limit' => (int) env('EMAIL_DEFAULT_DAILY_LIMIT', 200),
         ],
-        'undo_send_window_seconds' => (int) env('EMAIL_UNDO_SEND_WINDOW', 30),
+        'undo_send_window_seconds' => (int) env('EMAIL_UNDO_SEND_WINDOW', 5),
         'max_queued_per_user' => (int) env('EMAIL_MAX_QUEUED_PER_USER', 100),
 
         /*

--- a/lang/en/filament/concerns/email-compose.php
+++ b/lang/en/filament/concerns/email-compose.php
@@ -56,7 +56,7 @@ return [
         ],
         'scheduled_for' => [
             'label' => 'Send at',
-            'helper_text' => 'Leave blank to send with a 30-second undo window.',
+            'helper_text' => 'Leave blank to send with a 5-second undo window.',
         ],
         'signature' => [
             'label' => 'Signature',

--- a/packages/EmailIntegration/src/Actions/CancelQueuedEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/CancelQueuedEmailAction.php
@@ -22,7 +22,7 @@ final readonly class CancelQueuedEmailAction
             $lockedEmail = Email::query()->lockForUpdate()->findOrFail($email->getKey());
 
             // Only QUEUED mail is cancellable. The undo window keeps the email QUEUED
-            // (scheduled_for ~30s out) until the dispatcher claims it, so undo always
+            // (scheduled_for a few seconds out) until the dispatcher claims it, so undo always
             // races against the QUEUED state. Once claimed to SENDING a worker is
             // actively delivering it: send() calls the provider OUTSIDE any row lock,
             // so a "SENDING && provider_message_id === null" check is not a reliable

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -13,7 +13,6 @@ use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
-use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
@@ -22,7 +21,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\HtmlString;
 use Livewire\Attributes\Computed;
-use Relaticle\EmailIntegration\Actions\CancelQueuedEmailAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailPriority;
@@ -34,7 +32,7 @@ use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
-use RuntimeException;
+use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
 trait HasEmailComposeActions
 {
@@ -203,33 +201,7 @@ trait HasEmailComposeActions
             linkToId: $record->getKey(),
         );
 
-        $this->sendQueuedNotification($email);
-    }
-
-    private function sendQueuedNotification(Email $email): void
-    {
-        $notification = Notification::make()
-            ->title(__('filament/concerns/email-compose.notifications.queued.title'))
-            ->body(__('filament/concerns/email-compose.notifications.queued.body'))
-            ->success();
-
-        if ($email->scheduled_for !== null && $email->scheduled_for->isFuture()) {
-            $notification->actions([
-                Action::make('undo')
-                    ->label(__('filament/concerns/email-compose.actions.undo.label'))
-                    ->link()
-                    ->action(function () use ($email): void {
-                        try {
-                            resolve(CancelQueuedEmailAction::class)->execute($email->refresh());
-                            Notification::make()->title(__('filament/concerns/email-compose.notifications.cancelled.title'))->success()->send();
-                        } catch (RuntimeException) {
-                            Notification::make()->title(__('filament/concerns/email-compose.notifications.too_late.title'))->danger()->send();
-                        }
-                    }),
-            ]);
-        }
-
-        $notification->send();
+        resolve(QueuedSendNotifier::class)->send($email);
     }
 
     /**

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -32,6 +32,7 @@ use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPageTab;
+use Relaticle\EmailIntegration\Enums\EmailPriority;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
@@ -46,6 +47,7 @@ use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
+use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
 final class EmailInboxPage extends Page
 {
@@ -502,11 +504,11 @@ final class EmailInboxPage extends Page
             return;
         }
 
-        resolve(SendEmailAction::class)->execute(
+        $email = resolve(SendEmailAction::class)->execute(
             data: $this->buildSendData($data, $source),
         );
 
-        Notification::make()->title(__('filament/pages/email-inbox.reply_forward.notifications.queued.title'))->success()->send();
+        resolve(QueuedSendNotifier::class)->send($email);
     }
 
     /**
@@ -634,6 +636,7 @@ final class EmailInboxPage extends Page
      *     creation_source: EmailCreationSource,
      *     privacy_tier: EmailPrivacyTier,
      *     batch_id: null,
+     *     priority: EmailPriority,
      * }
      */
     private function buildSendData(array $data, EmailCreationSource $source): array
@@ -651,6 +654,7 @@ final class EmailInboxPage extends Page
             'creation_source' => $source,
             'privacy_tier' => $this->resolvePrivacyTier($data['privacy_tier'] ?? null),
             'batch_id' => null,
+            'priority' => EmailPriority::PRIORITY,
             'attachments' => $data['attachments'] ?? [],
             'attachment_file_names' => $data['attachment_file_names'] ?? [],
         ];

--- a/packages/EmailIntegration/src/Livewire/EmailAccessNotificationHandler.php
+++ b/packages/EmailIntegration/src/Livewire/EmailAccessNotificationHandler.php
@@ -7,6 +7,7 @@ namespace Relaticle\EmailIntegration\Livewire;
 use App\Models\User;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\Contracts\View\View;
@@ -15,15 +16,18 @@ use Illuminate\Support\Js;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
 use Livewire\Component;
+use Relaticle\EmailIntegration\Actions\CancelQueuedEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailReaderActions;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
+use RuntimeException;
 
 /**
- * Panel-wide handler so the Emails-tab reader overlay can open from the bell on
- * any page. It is the same `selectedEmailId` overlay as the person Emails tab,
- * not a Filament ViewAction modal.
+ * Panel-wide handler for notification clicks: the Emails-tab reader overlay
+ * from the bell, and Undo on the queued-send toast. It is the same
+ * `selectedEmailId` overlay as the person Emails tab, not a Filament
+ * ViewAction modal.
  *
  * @property-read Email|null $selectedEmail
  * @property-read Collection<int, EmailAccessRequest> $pendingAccessRequests
@@ -108,6 +112,36 @@ final class EmailAccessNotificationHandler extends Component implements HasActio
     public function denyFromNotification(string $requestId): void
     {
         $this->decideOwnedReaderAccessRequest($requestId, approve: false);
+    }
+
+    #[On('undo-queued-send')]
+    public function undoQueuedSend(string $emailId): void
+    {
+        $user = $this->authUser();
+
+        $email = Email::query()
+            ->whereKey($emailId)
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $user->current_team_id)
+            ->first();
+
+        if (! $email instanceof Email) {
+            return;
+        }
+
+        try {
+            resolve(CancelQueuedEmailAction::class)->execute($email);
+            $this->dispatch('outbox:changed');
+            Notification::make()
+                ->title(__('filament/concerns/email-compose.notifications.cancelled.title'))
+                ->success()
+                ->send();
+        } catch (RuntimeException) {
+            Notification::make()
+                ->title(__('filament/concerns/email-compose.notifications.too_late.title'))
+                ->danger()
+                ->send();
+        }
     }
 
     protected function afterOwnedReaderAccessRequestDecided(bool $approved): void

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -57,6 +57,7 @@ use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
+use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
 /**
  * @property-read Action $createSignatureAction
@@ -425,7 +426,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $attachmentPaths = [...$pendingPaths, ...$copiedPaths];
         $attachmentNames = [...$pendingNames, ...$copiedNames];
 
-        resolve(SendEmailAction::class)->execute([
+        $email = resolve(SendEmailAction::class)->execute([
             'connected_account_id' => (string) $this->accountId,
             'subject' => $renderer->renderContent((string) $this->subject),
             'body_html' => $renderer->renderForSending($this->withQuotedBody($bodyHtml)),
@@ -453,10 +454,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             resolve(DeleteEmailDraftAction::class)->executeIfExists($this->authUser(), $this->draftId);
         }
 
-        Notification::make()
-            ->success()
-            ->title(__('filament/emails/composer.notifications.queued.title'))
-            ->send();
+        resolve(QueuedSendNotifier::class)->send($email);
 
         $this->closeComposer();
         $this->dispatch('composer:sent');

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -462,6 +462,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $this->dispatch('composer:sent');
         // A send both removes the draft (if any) and adds an outbox row.
         $this->dispatch('drafts:changed');
+        $this->dispatch('outbox:changed');
     }
 
     private function creationSource(): EmailCreationSource

--- a/packages/EmailIntegration/src/Livewire/OutboxTable.php
+++ b/packages/EmailIntegration/src/Livewire/OutboxTable.php
@@ -92,6 +92,7 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
                     ->schema([
                         DateTimePicker::make('scheduled_for')
                             ->label(__('filament/pages/email-outbox.actions.reschedule_field'))
+                            ->native(false)
                             ->seconds(false)
                             ->minDate(now())
                             ->required(),

--- a/packages/EmailIntegration/src/Livewire/OutboxTable.php
+++ b/packages/EmailIntegration/src/Livewire/OutboxTable.php
@@ -21,7 +21,10 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Relaticle\EmailIntegration\Actions\CancelQueuedEmailAction;
 use Relaticle\EmailIntegration\Actions\RescheduleQueuedEmailAction;
@@ -145,6 +148,13 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
             ]);
     }
 
+    /**
+     * Re-render when a send is queued or cancelled, so the list matches the
+     * outbox badge without a page reload.
+     */
+    #[On('outbox:changed')]
+    public function refresh(): void {}
+
     public function render(): View
     {
         return view('email-integration::livewire.table');
@@ -195,14 +205,26 @@ final class OutboxTable extends Component implements HasActions, HasSchemas, Has
      */
     private function applyStatusTab(Builder $query, OutboxTab $tab): Builder
     {
+        $dueCutoff = $this->queuedDueCutoff();
+
         return match ($tab) {
             OutboxTab::SCHEDULED => $query->where('status', EmailStatus::QUEUED)
-                ->whereNotNull('scheduled_for')->where('scheduled_for', '>', now()),
+                ->whereNotNull('scheduled_for')->where('scheduled_for', '>', $dueCutoff),
             OutboxTab::QUEUED => $query->where('status', EmailStatus::QUEUED)
-                ->where(fn (Builder $dueQuery): Builder => $dueQuery->whereNull('scheduled_for')->orWhere('scheduled_for', '<=', now())),
+                ->where(fn (Builder $dueQuery): Builder => $dueQuery->whereNull('scheduled_for')->orWhere('scheduled_for', '<=', $dueCutoff)),
             OutboxTab::SENDING => $query->where('status', EmailStatus::SENDING),
             OutboxTab::FAILED => $query->where('status', EmailStatus::FAILED),
             OutboxTab::SENT => $query->where('status', EmailStatus::SENT)->where('sent_at', '>=', now()->subDay()),
         };
+    }
+
+    /**
+     * Interactive sends stamp scheduled_for a few seconds ahead so the user can
+     * undo. That delay is not a scheduled send; the queued tab should show it
+     * immediately, matching the outbox badge.
+     */
+    private function queuedDueCutoff(): Carbon
+    {
+        return now()->addSeconds(Config::integer('email-integration.outbox.undo_send_window_seconds'));
     }
 }

--- a/packages/EmailIntegration/src/Support/QueuedSendNotifier.php
+++ b/packages/EmailIntegration/src/Support/QueuedSendNotifier.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Support;
+
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Config;
+use Relaticle\EmailIntegration\Livewire\EmailAccessNotificationHandler;
+use Relaticle\EmailIntegration\Models\Email;
+
+final readonly class QueuedSendNotifier
+{
+    public function send(Email $email): void
+    {
+        $notification = Notification::make()
+            ->title(__('filament/concerns/email-compose.notifications.queued.title'))
+            ->body(__('filament/concerns/email-compose.notifications.queued.body'))
+            ->success();
+
+        if ($email->scheduled_for !== null && $email->scheduled_for->isFuture()) {
+            $notification
+                ->seconds(Config::integer('email-integration.outbox.undo_send_window_seconds'))
+                ->actions([
+                    Action::make('undo')
+                        ->label(__('filament/concerns/email-compose.actions.undo.label'))
+                        ->link()
+                        ->close()
+                        ->dispatchTo(
+                            EmailAccessNotificationHandler::LIVEWIRE_ALIAS,
+                            'undo-queued-send',
+                        )
+                        ->eventData(['emailId' => (string) $email->getKey()]),
+                ]);
+        }
+
+        $notification->send();
+    }
+}

--- a/tests/Feature/EmailIntegration/EmailAccessNotificationHandlerTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccessNotificationHandlerTest.php
@@ -7,16 +7,18 @@ use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Livewire\Livewire;
+use Relaticle\EmailIntegration\Actions\CancelQueuedEmailAction;
 use Relaticle\EmailIntegration\Actions\RequestEmailAccessAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Livewire\EmailAccessNotificationHandler;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Notifications\EmailAccessRequestedNotification;
 
-mutates(EmailAccessNotificationHandler::class, EmailAccessRequestedNotification::class, RequestEmailAccessAction::class);
+mutates(EmailAccessNotificationHandler::class, EmailAccessRequestedNotification::class, RequestEmailAccessAction::class, CancelQueuedEmailAction::class);
 
 beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
@@ -275,5 +277,61 @@ describe('EmailAccessNotificationHandler', function (): void {
             ->assertSet('selectedEmailId', $this->email->getKey())
             ->set('selectedEmailId', null)
             ->assertDispatched('composer:dismiss-inline');
+    });
+});
+
+describe('undo queued send', function (): void {
+    it('cancels the sender\'s queued email from the undo toast', function (): void {
+        $email = Email::factory()->outbound()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->owner->id,
+            'connected_account_id' => $this->account->getKey(),
+            'status' => EmailStatus::QUEUED,
+            'scheduled_for' => now()->addSeconds(5),
+        ]);
+
+        Livewire::test(EmailAccessNotificationHandler::class)
+            ->dispatch('undo-queued-send', emailId: (string) $email->getKey())
+            ->assertNotified(__('filament/concerns/email-compose.notifications.cancelled.title'))
+            ->assertDispatched('outbox:changed');
+
+        expect($email->refresh()->status)->toBe(EmailStatus::CANCELLED);
+    });
+
+    it('does not cancel another user\'s queued email from the undo toast', function (): void {
+        $teammate = User::factory()->create(['current_team_id' => $this->team->id]);
+        $theirAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $teammate->id,
+        ]));
+        $theirs = Email::factory()->outbound()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $teammate->id,
+            'connected_account_id' => $theirAccount->getKey(),
+            'status' => EmailStatus::QUEUED,
+            'scheduled_for' => now()->addSeconds(5),
+        ]);
+
+        Livewire::test(EmailAccessNotificationHandler::class)
+            ->dispatch('undo-queued-send', emailId: (string) $theirs->getKey())
+            ->assertNotNotified();
+
+        expect($theirs->refresh()->status)->toBe(EmailStatus::QUEUED);
+    });
+
+    it('notifies too late when the queued email has already started sending', function (): void {
+        $email = Email::factory()->outbound()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->owner->id,
+            'connected_account_id' => $this->account->getKey(),
+            'status' => EmailStatus::SENDING,
+            'scheduled_for' => now()->subSecond(),
+        ]);
+
+        Livewire::test(EmailAccessNotificationHandler::class)
+            ->dispatch('undo-queued-send', emailId: (string) $email->getKey())
+            ->assertNotified(__('filament/concerns/email-compose.notifications.too_late.title'));
+
+        expect($email->refresh()->status)->toBe(EmailStatus::SENDING);
     });
 });

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -22,6 +22,7 @@ use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
+use Relaticle\EmailIntegration\Livewire\EmailAccessNotificationHandler;
 use Relaticle\EmailIntegration\Livewire\EmailComposer;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -31,10 +32,11 @@ use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
+use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
 use function Pest\Laravel\actingAs;
 
-mutates(EmailComposer::class, SaveEmailDraftAction::class, DeleteEmailDraftAction::class, RecipientSuggestionService::class, ConnectedAccount::class);
+mutates(EmailComposer::class, SaveEmailDraftAction::class, DeleteEmailDraftAction::class, RecipientSuggestionService::class, ConnectedAccount::class, QueuedSendNotifier::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -246,6 +248,31 @@ it('queues an email through SendEmailAction on send with the persisted body and 
         // Interactive sends must keep the priority queue's undo-send window
         // (EmailPriority::PRIORITY), not fall back to the bulk default.
         ->and($email->scheduled_for)->not->toBeNull();
+});
+
+it('offers undo on the queued toast for the undo window', function (): void {
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['lead@example.com'])
+        ->set('subject', 'Undo me')
+        ->set('bodyHtml', '<p>Hello</p>')
+        ->call('send');
+
+    $email = Email::query()->where('subject', 'Undo me')->sole();
+    $notification = collect(session('filament.claimed_notifications'))
+        ->firstWhere('title', __('filament/concerns/email-compose.notifications.queued.title'));
+
+    expect($notification)->not->toBeNull()
+        ->and($notification['duration'])->toBe(5_000)
+        ->and(collect($notification['actions'])->pluck('name')->all())->toContain('undo');
+
+    expect(collect($notification['actions'])->firstWhere('name', 'undo'))
+        ->toMatchArray([
+            'label' => __('filament/concerns/email-compose.actions.undo.label'),
+            'event' => 'undo-queued-send',
+            'eventData' => ['emailId' => (string) $email->getKey()],
+            'dispatchToComponent' => EmailAccessNotificationHandler::LIVEWIRE_ALIAS,
+        ]);
 });
 
 it('includes the default signature content in the sent body_html', function (): void {

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -236,7 +236,8 @@ it('queues an email through SendEmailAction on send with the persisted body and 
         ->set('subject', 'Quarterly sync')
         ->set('bodyHtml', '<p>Hello there</p>')
         ->call('send')
-        ->assertSet('isOpen', false);
+        ->assertSet('isOpen', false)
+        ->assertDispatched('outbox:changed');
 
     $email = Email::query()->where('subject', 'Quarterly sync')->sole();
     expect($email->status)->toBe(EmailStatus::QUEUED)

--- a/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
@@ -68,7 +68,7 @@ it('shows a just-sent email in the queued tab during the undo window', function 
 
     $justSent = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
         'subject' => 'Just composed',
-        'scheduled_for' => now()->addSeconds(30),
+        'scheduled_for' => now()->addSeconds(5),
     ]);
 
     livewire(OutboxTable::class)
@@ -82,7 +82,7 @@ it('refreshes the queued list when a send is queued', function (): void {
 
     $justSent = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
         'subject' => 'Arrived after render',
-        'scheduled_for' => now()->addSeconds(30),
+        'scheduled_for' => now()->addSeconds(5),
     ]);
 
     $component
@@ -94,8 +94,8 @@ it('keeps a later send on the scheduled tab instead of queued', function (): voi
     $this->travelTo(now()->startOfSecond());
 
     $undoWindow = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
-        'subject' => 'Sending in 30 seconds',
-        'scheduled_for' => now()->addSeconds(30),
+        'subject' => 'Sending in 5 seconds',
+        'scheduled_for' => now()->addSeconds(5),
     ]);
     $later = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
         'subject' => 'Send tomorrow',

--- a/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailOutboxPageTest.php
@@ -63,6 +63,53 @@ it('queued tab shows only this user\'s queued OUTBOUND emails', function (): voi
         ->assertCanNotSeeTableRecords([$failed, $theirs]);
 });
 
+it('shows a just-sent email in the queued tab during the undo window', function (): void {
+    $this->travelTo(now()->startOfSecond());
+
+    $justSent = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
+        'subject' => 'Just composed',
+        'scheduled_for' => now()->addSeconds(30),
+    ]);
+
+    livewire(OutboxTable::class)
+        ->assertCanSeeTableRecords([$justSent]);
+});
+
+it('refreshes the queued list when a send is queued', function (): void {
+    $this->travelTo(now()->startOfSecond());
+
+    $component = livewire(OutboxTable::class);
+
+    $justSent = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
+        'subject' => 'Arrived after render',
+        'scheduled_for' => now()->addSeconds(30),
+    ]);
+
+    $component
+        ->dispatch('outbox:changed')
+        ->assertCanSeeTableRecords([$justSent]);
+});
+
+it('keeps a later send on the scheduled tab instead of queued', function (): void {
+    $this->travelTo(now()->startOfSecond());
+
+    $undoWindow = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
+        'subject' => 'Sending in 30 seconds',
+        'scheduled_for' => now()->addSeconds(30),
+    ]);
+    $later = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED, [
+        'subject' => 'Send tomorrow',
+        'scheduled_for' => now()->addDay(),
+    ]);
+
+    livewire(OutboxTable::class)
+        ->assertCanSeeTableRecords([$undoWindow])
+        ->assertCanNotSeeTableRecords([$later])
+        ->filterTable('status_tab', 'scheduled')
+        ->assertCanSeeTableRecords([$later])
+        ->assertCanNotSeeTableRecords([$undoWindow]);
+});
+
 it('failed tab filters to failed emails', function (): void {
     $queued = makeOutboxEmail($this->user, $this->account, EmailStatus::QUEUED);
     $failed = makeOutboxEmail($this->user, $this->account, EmailStatus::FAILED, [

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -22,8 +22,9 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
-mutates(EmailsRelationManager::class, EmailInboxPage::class, EmailComposer::class, HasEmailComposeActions::class, RedirectsToGrantSend::class, ConnectedAccount::class);
+mutates(EmailsRelationManager::class, EmailInboxPage::class, EmailComposer::class, HasEmailComposeActions::class, RedirectsToGrantSend::class, ConnectedAccount::class, QueuedSendNotifier::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -107,6 +108,35 @@ it('reply persists a queued Email with REPLY creation_source', function (): void
     expect($reply->status)->toBe(EmailStatus::QUEUED)
         ->and($reply->thread_id)->toBe($this->inboundEmail->thread_id)
         ->and($reply->in_reply_to)->toBe($this->inboundEmail->rfc_message_id);
+});
+
+it('keeps the undo window when a thread reply is queued from the inbox', function (): void {
+    livewire(EmailInboxPage::class)
+        ->callAction(
+            'replyForwardEmail',
+            data: [
+                'connected_account_id' => $this->account->id,
+                'to' => ['sender@contact.com'],
+                'cc' => [],
+                'bcc' => [],
+                'subject' => 'Re: Original Subject',
+                'body_html' => '<p>Inbox reply</p>',
+                'in_reply_to_email_id' => $this->inboundEmail->id,
+            ],
+            arguments: ['emailId' => $this->inboundEmail->id, 'mode' => 'reply'],
+        );
+
+    $reply = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::REPLY)
+        ->firstOrFail();
+
+    $notification = collect(session('filament.claimed_notifications'))
+        ->firstWhere('title', __('filament/concerns/email-compose.notifications.queued.title'));
+
+    expect($reply->scheduled_for)->not->toBeNull()
+        ->and($notification)->not->toBeNull()
+        ->and(collect($notification['actions'])->pluck('name')->all())->toContain('undo');
 });
 
 it('forward persists a queued Email with FORWARD creation_source', function (): void {

--- a/tests/Feature/EmailIntegration/UndoSendFlowTest.php
+++ b/tests/Feature/EmailIntegration/UndoSendFlowTest.php
@@ -17,7 +17,7 @@ use Relaticle\EmailIntegration\Models\EmailBatch;
 
 mutates(CancelQueuedEmailAction::class, SyncEmailBatchCountersAction::class);
 
-it('cancels a single send within the 30s undo window', function (): void {
+it('cancels a single send within the 5s undo window', function (): void {
     $user = User::factory()->withPersonalTeam()->create();
     $this->actingAs($user);
     $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->for($user)->create([
@@ -40,7 +40,7 @@ it('cancels a single send within the 30s undo window', function (): void {
         'in_reply_to_email_id' => null,
     ]);
 
-    expect((int) round(abs($email->scheduled_for?->diffInSeconds(now()) ?? 0.0)))->toBe(30);
+    expect((int) round(abs($email->scheduled_for?->diffInSeconds(now()) ?? 0.0)))->toBe(5);
 
     resolve(CancelQueuedEmailAction::class)->execute($email->refresh());
 


### PR DESCRIPTION
## Summary
- Interactive sends wait in a short undo window, so `scheduled_for` is a few seconds in the future. The outbox badge counted those rows, but the default Queued filter hid them until the window elapsed.
- Queued now includes the undo window. Mail scheduled later still belongs on Scheduled.
- The composer dispatches `outbox:changed` so the table refreshes as soon as a send lands.

## Test plan
- [x] Compose and send a message, then open Outbox. The new row should be in Queued immediately, matching the badge count.
- [x] Confirm cancel still works during the undo window.
- [x] Schedule a send for later and confirm it appears on Scheduled, not Queued.