### PR TITLE
Hold incremental calendar cursor until store jobs finish

### DIFF
--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -11,6 +11,8 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Bus;
+use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -59,10 +61,42 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        foreach ($result->events as $event) {
-            dispatch(new StoreMeetingJob($account, $event));
+        // Advancing the cursor before the fetched events are stored loses any event
+        // whose StoreMeetingJob exhausts its retries: the next sync starts past it and
+        // it is never retried. So advance the cursor only once the batch has fully stored.
+        // With no events the delta is a read-only window, so advance inline.
+        if ($result->events === []) {
+            self::advanceCursor($account, $result->nextSyncToken);
+
+            return;
         }
 
+        $accountId = (string) $account->getKey();
+        $nextSyncToken = $result->nextSyncToken;
+
+        $jobs = array_map(
+            fn (CalendarEventData $event): StoreMeetingJob => new StoreMeetingJob($account, $event),
+            $result->events,
+        );
+
+        Bus::batch($jobs)
+            ->name("Incremental calendar sync: {$account->email_address}")
+            ->onQueue('emails-sync')
+            ->allowFailures()
+            ->then(static function () use ($accountId, $nextSyncToken): void {
+                $account = ConnectedAccount::query()->whereKey($accountId)->first();
+
+                if (! $account instanceof ConnectedAccount) {
+                    return;
+                }
+
+                self::advanceCursor($account, $nextSyncToken);
+            })
+            ->dispatch();
+    }
+
+    private static function advanceCursor(ConnectedAccount $account, ?string $nextSyncToken): void
+    {
         $update = [
             'last_calendar_synced_at' => now(),
             'status' => EmailAccountStatus::ACTIVE,
@@ -70,8 +104,8 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         ];
 
         // Never overwrite a good cursor with null (see InitialCalendarSyncJob).
-        if ($result->nextSyncToken !== null) {
-            $update['calendar_sync_cursor'] = $result->nextSyncToken;
+        if ($nextSyncToken !== null) {
+            $update['calendar_sync_cursor'] = $nextSyncToken;
         }
 
         $account->update($update);

--- a/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
@@ -37,8 +38,52 @@ it('resets cursor and dispatches initial sync on 410', function (): void {
     Bus::assertDispatched(InitialCalendarSyncJob::class);
 });
 
-it('dispatches StoreMeetingJob per delta event and updates cursor', function (): void {
-    Bus::fake([StoreMeetingJob::class]);
+it('batches a StoreMeetingJob per delta event and does not advance the cursor until the page stores', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => 'valid-token',
+        'last_calendar_synced_at' => null,
+    ]));
+
+    $event = new CalendarEventData(
+        providerEventId: 'evt-delta',
+        providerRecurringEventId: null,
+        iCalUid: null,
+        title: 'Delta event',
+        description: null,
+        startsAt: Carbon::now()->addDay(),
+        endsAt: Carbon::now()->addDay()->addHour(),
+        isAllDay: false,
+        location: null,
+        htmlLink: null,
+        status: 'confirmed',
+        visibility: 'default',
+        organizerEmail: null,
+        organizerName: null,
+        attendees: [],
+    );
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('fetchDelta')->once()->with('valid-token')
+        ->andReturn(new CalendarSyncResult(events: [$event], nextSyncToken: 'new-token'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new IncrementalCalendarSyncJob($account))->handle($factory);
+
+    Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->queue() === 'emails-sync'
+        && $batch->jobs->count() === 1
+        && $batch->jobs->first() instanceof StoreMeetingJob
+    );
+    expect($account->fresh()?->calendar_sync_cursor)->toBe('valid-token')
+        ->and($account->fresh()?->last_calendar_synced_at)->toBeNull();
+});
+
+it('advances the cursor after the store batch completes', function (): void {
+    Bus::fake();
 
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'capabilities' => ['email' => true, 'calendar' => true],
@@ -72,8 +117,59 @@ it('dispatches StoreMeetingJob per delta event and updates cursor', function ():
 
     (new IncrementalCalendarSyncJob($account))->handle($factory);
 
-    Bus::assertDispatched(StoreMeetingJob::class, 1);
-    expect($account->fresh()?->calendar_sync_cursor)->toBe('new-token');
+    Bus::assertBatched(function (PendingBatch $batch): bool {
+        foreach ($batch->thenCallbacks() as $callback) {
+            $callback();
+        }
+
+        return true;
+    });
+
+    expect($account->fresh()?->calendar_sync_cursor)->toBe('new-token')
+        ->and($account->fresh()?->last_calendar_synced_at)->not->toBeNull();
+});
+
+it('advances the cursor immediately when the delta has no events', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => 'valid-token',
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('fetchDelta')->once()->with('valid-token')
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: 'new-token'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new IncrementalCalendarSyncJob($account))->handle($factory);
+
+    Bus::assertNothingBatched();
+    expect($account->fresh()?->calendar_sync_cursor)->toBe('new-token')
+        ->and($account->fresh()?->last_calendar_synced_at)->not->toBeNull();
+});
+
+it('does not overwrite the cursor when an empty delta returns a null token', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => 'valid-token',
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('fetchDelta')->once()->with('valid-token')
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: null));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new IncrementalCalendarSyncJob($account))->handle($factory);
+
+    Bus::assertNothingBatched();
+    expect($account->fresh()?->calendar_sync_cursor)->toBe('valid-token');
 });
 
 it('dispatches initial sync when no cursor exists', function (): void {


### PR DESCRIPTION
## Summary
- Incremental calendar sync queued `StoreMeetingJob`s and then wrote `calendar_sync_cursor` immediately. A job that exhausted retries never stored the event, and Google/Microsoft will not resend it from a consumed delta token.
- Empty deltas still advance the cursor inline. Deltas with events now batch store jobs on `emails-sync` and update the cursor, `last_calendar_synced_at`, status, and `last_error` only in the batch `then()` callback after reloading the account by id.
- A null token still does not overwrite a good cursor. One failed store job holds the window so the next incremental run can refetch; upserts by provider event id make sibling re-dispatch safe.

## Test plan
- [x] `php artisan test --compact tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php`
- [x] Confirm an incremental run with events does not write `calendar_sync_cursor` until the store batch succeeds
- [x] Confirm an empty delta still advances the cursor immediately
- [x] Confirm 410 / missing-cursor still dispatch initial calendar sync