### PR TITLE
Resume initial mailbox and calendar imports after a failed store job

### DIFF
--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -67,7 +67,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             ->name("Initial calendar sync: {$account->email_address}")
             ->onQueue('emails-sync')
             ->allowFailures()
-            ->then(static function () use ($accountId, $nextPageToken, $nextSyncToken): void {
+            ->finally(static function () use ($accountId, $nextPageToken, $nextSyncToken): void {
                 $account = ConnectedAccount::query()->whereKey($accountId)->first();
 
                 if (! $account instanceof ConnectedAccount) {

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -86,7 +86,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
             ->name("Initial sync: {$account->email_address}")
             ->onQueue('emails-sync')
             ->allowFailures()
-            ->then(static function () use ($accountId, $historyCursor, $nextPageToken, $pageCursor): void {
+            ->finally(static function () use ($accountId, $historyCursor, $nextPageToken, $pageCursor): void {
                 $account = ConnectedAccount::query()->whereKey($accountId)->first();
 
                 if (! $account instanceof ConnectedAccount) {

--- a/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
@@ -106,7 +106,10 @@ it('serializes the store-batch continuation without the running queue worker', f
     $syncJob->handle($factory);
 
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        foreach ($batch->thenCallbacks() as $callback) {
+        expect($batch->thenCallbacks())->toBeEmpty()
+            ->and($batch->finallyCallbacks())->not->toBeEmpty();
+
+        foreach ($batch->finallyCallbacks() as $callback) {
             serialize($callback);
         }
 
@@ -150,7 +153,9 @@ it('chains the next calendar page after the store batch completes', function ():
     (new InitialCalendarSyncJob($account))->handle($factory);
 
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        foreach ($batch->thenCallbacks() as $callback) {
+        expect($batch->thenCallbacks())->toBeEmpty();
+
+        foreach ($batch->finallyCallbacks() as $callback) {
             $callback();
         }
 
@@ -282,7 +287,9 @@ it('stores the sync token when the batch completion callback runs', function ():
     (new InitialCalendarSyncJob($account))->handle($factory);
 
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        foreach ($batch->thenCallbacks() as $callback) {
+        expect($batch->thenCallbacks())->toBeEmpty();
+
+        foreach ($batch->finallyCallbacks() as $callback) {
             $closure = $callback instanceof SerializableClosure ? $callback->getClosure() : $callback;
             $closure();
         }

--- a/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
+++ b/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
@@ -122,7 +122,10 @@ it('serializes the store-batch continuation without the running queue worker', f
     $syncJob->handle($factory);
 
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        foreach ($batch->thenCallbacks() as $callback) {
+        expect($batch->thenCallbacks())->toBeEmpty()
+            ->and($batch->finallyCallbacks())->not->toBeEmpty();
+
+        foreach ($batch->finallyCallbacks() as $callback) {
             serialize($callback);
         }
 
@@ -149,7 +152,9 @@ it('chains the next page after the store batch completes', function (): void {
     (new InitialEmailSyncJob($account))->handle($factory);
 
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        foreach ($batch->thenCallbacks() as $callback) {
+        expect($batch->thenCallbacks())->toBeEmpty();
+
+        foreach ($batch->finallyCallbacks() as $callback) {
             $callback();
         }
 
@@ -189,6 +194,43 @@ it('chains the next page when the current page has no new ids', function (): voi
     );
     expect($account->fresh()?->sync_cursor)->toBeNull();
     Notification::assertNothingSent();
+});
+
+it('sets the cursor after the last page store batch finishes', function (): void {
+    Bus::fake();
+    Notification::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(['M1']),
+        nextPageToken: null,
+        cursor: 'history-1',
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    Bus::assertBatched(function (PendingBatch $batch): bool {
+        expect($batch->thenCallbacks())->toBeEmpty();
+
+        foreach ($batch->finallyCallbacks() as $callback) {
+            $callback();
+        }
+
+        return true;
+    });
+
+    expect($account->fresh()?->sync_cursor)->toBe('history-1')
+        ->and($account->fresh()?->last_synced_at)->not->toBeNull();
+
+    Notification::assertSentTo(
+        $account->user,
+        MailboxHistoryImportCompletedNotification::class,
+    );
 });
 
 it('sets the cursor and notifies the owner when the last page is stored', function (): void {

--- a/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
+++ b/tests/Feature/EmailIntegration/SyncQueueRoutingTest.php
@@ -111,9 +111,11 @@ it('dispatches the initial-sync StoreEmailJob batch onto the emails-sync queue',
 function assertBatchCallbacksCarryNoJobInstance(): void
 {
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        expect($batch->thenCallbacks())->not->toBeEmpty();
+        $callbacks = [...$batch->thenCallbacks(), ...$batch->finallyCallbacks()];
 
-        foreach ($batch->thenCallbacks() as $callback) {
+        expect($callbacks)->not->toBeEmpty();
+
+        foreach ($callbacks as $callback) {
             $closure = $callback instanceof SerializableClosure ? $callback->getClosure() : $callback;
 
             expect((new ReflectionFunction($closure))->getClosureThis())->toBeNull();


### PR DESCRIPTION
## Summary
- Initial mailbox and calendar backfill continue after a `StoreEmailJob` or `StoreMeetingJob` exhausts retries.
- Pagination and cursor write now run from the batch `finally()` callback instead of `then()`, so one failed store job cannot leave the account with no cursor and no next page.
- Incremental sync is unchanged: it still holds the cursor until every store job in that delta succeeds.

## Test plan
- [x] Confirm a page of initial mailbox import still chains to the next page when every store job succeeds.
- [x] Confirm a page of initial mailbox import still chains (or writes `sync_cursor` on the last page) when one store job is in failed jobs.
- [x] Confirm the same for initial calendar import and `calendar_sync_cursor`.
- [x] Confirm incremental mailbox and calendar sync still do not advance the cursor when a store job in that batch fails.