### PR TITLE
Allow the same mailbox in a second workspace

### DIFF
--- a/database/migrations/2026_09_07_052008_add_team_id_to_connected_accounts_unique_index.php
+++ b/database/migrations/2026_09_07_052008_add_team_id_to_connected_accounts_unique_index.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->dropUnique('connected_accounts_user_id_provider_email_address_unique');
+            $table->unique(
+                ['user_id', 'team_id', 'provider', 'email_address'],
+                'connected_accounts_user_team_provider_email_unique',
+            );
+        });
+    }
+};

--- a/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/ConnectAccountAction.php
@@ -19,7 +19,9 @@ final readonly class ConnectAccountAction
         $account = DB::transaction(function () use ($data): ConnectedAccount {
             // Match against trashed rows too: the unique index spans soft-deleted
             // records, so a previously disconnected account must be reused and
-            // restored rather than inserted again.
+            // restored rather than inserted again. Uniqueness is per workspace
+            // (user, team, provider, email), so the same mailbox can exist on
+            // another team without colliding.
             $values = [
                 'display_name' => $data->displayName,
                 'provider_account_id' => $data->providerAccountId,

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Team;
 use App\Models\User;
 use App\Providers\AppServiceProvider;
 use Illuminate\Support\Facades\Bus;
@@ -199,6 +200,52 @@ it('dispatches history import when a disconnected account is reconnected', funct
 
     Bus::assertDispatched(InitialEmailSyncJob::class, fn (InitialEmailSyncJob $job): bool => $job->connectedAccount->is($account));
     Bus::assertDispatched(RelinkMailboxHistoryJob::class, fn (RelinkMailboxHistoryJob $job): bool => $job->connectedAccount->is($account));
+});
+
+it('stores a separate connected account when the same mailbox is connected in a second workspace', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $firstTeam = $user->currentTeam;
+    $secondTeam = Team::factory()->create(['user_id' => $user->getKey()]);
+    $user->teams()->attach($secondTeam, ['role' => 'admin']);
+
+    $connect = function () use ($user): void {
+        $social = new SocialiteUser;
+        $social->id = 'gmail-shared-mailbox';
+        $social->email = 'shared@example.com';
+        $social->name = 'Demo';
+        $social->token = 'access-token';
+        $social->refreshToken = 'refresh-token';
+        $social->expiresIn = 3600;
+        $social->approvedScopes = [
+            'https://www.googleapis.com/auth/gmail.readonly',
+            'https://www.googleapis.com/auth/gmail.send',
+        ];
+
+        Socialite::fake('gmail', $social);
+
+        $this->actingAs($user)
+            ->get(route('email-accounts.callback', ['provider' => 'gmail']))
+            ->assertRedirect();
+    };
+
+    $connect();
+
+    $user->forceFill(['current_team_id' => $secondTeam->getKey()])->save();
+    $user->unsetRelation('currentTeam');
+    $connect();
+
+    $accounts = ConnectedAccount::query()
+        ->where('user_id', $user->getKey())
+        ->where('email_address', 'shared@example.com')
+        ->get();
+
+    expect($accounts)->toHaveCount(2)
+        ->and($accounts->pluck('team_id')->all())->toEqualCanonicalizing([
+            $firstTeam->getKey(),
+            $secondTeam->getKey(),
+        ]);
 });
 
 it('makes the first connected account the default and leaves later connections non-default', function (): void {


### PR DESCRIPTION
## Summary
- Unique key on connected accounts now includes `team_id`, matching the connect lookup.
- Connecting the same mailbox in another workspace stores a second account instead of failing the insert.

## Test plan
- [x] Run `php artisan migrate` on a local app database.
- [x] Connect a mailbox in workspace A, switch to workspace B, connect the same mailbox, and confirm both succeed.
- [x] Reconnect the same mailbox in workspace A and confirm it reuses the existing account.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php`