### PR TITLE
Show one mailbox row when teammates synced the same message

### DIFF
--- a/database/migrations/2026_09_07_062243_add_team_user_rfc_message_id_index_to_emails_table.php
+++ b/database/migrations/2026_09_07_062243_add_team_user_rfc_message_id_index_to_emails_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('emails', function (Blueprint $table): void {
+            $table->index(
+                ['team_id', 'user_id', 'rfc_message_id'],
+                'emails_team_user_message_id_idx',
+            );
+        });
+    }
+};

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -29,6 +29,7 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\PreferredEmailCopyService;
 
 abstract class BaseRecordEmailsPage extends Page
 {
@@ -129,6 +130,8 @@ abstract class BaseRecordEmailsPage extends Page
             });
         }
 
+        resolve(PreferredEmailCopyService::class)->restrictToPreferredCopies($query->getQuery(), $user);
+
         return $query->latest('sent_at')->paginate(20);
     }
 
@@ -209,11 +212,16 @@ abstract class BaseRecordEmailsPage extends Page
         /** @var Company|Opportunity|People $record */
         $record = $this->getRecord();
 
-        return $record
+        $user = $this->authUser();
+        $query = $record
             ->emails()
-            ->withGlobalScope('visible', new VisibleEmailScope($this->authUser()))
-            ->unreadFor($this->authUser()->getKey())
-            ->count();
+            ->withGlobalScope('visible', new VisibleEmailScope($user))
+            ->unreadFor($user->getKey());
+
+        resolve(PreferredEmailCopyService::class)
+            ->restrictToPreferredCopies($query->getQuery(), $user);
+
+        return $query->count();
     }
 
     public function selectEmail(string $id): void

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseEmailsRelationManager.php
@@ -32,6 +32,7 @@ use Relaticle\EmailIntegration\Models\EmailLabel;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 use Relaticle\EmailIntegration\Services\EmailSharingService;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\PreferredEmailCopyService;
 
 /**
  * @property-read Email|null $selectedEmail
@@ -92,7 +93,8 @@ abstract class BaseEmailsRelationManager extends RelationManager
                     $query->whereRaw('0 = 1');
                 }
 
-                return $query;
+                return resolve(PreferredEmailCopyService::class)
+                    ->restrictToPreferredCopies($query, $this->authUser());
             })
             ->recordTitleAttribute('subject')
             ->recordAction('view')

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -34,6 +34,8 @@ final class EmailVisibilityService
      */
     private array $workspaceEntryCache = [];
 
+    public function __construct(private readonly PreferredEmailCopyService $preferredCopies) {}
+
     /**
      * @var array<string, array<int, lowercase-string>>
      */
@@ -116,10 +118,13 @@ final class EmailVisibilityService
             return 0;
         }
 
-        return $record
+        $query = $record
             ->emails()
-            ->withGlobalScope('visible', new VisibleEmailScope($viewer))
-            ->count();
+            ->withGlobalScope('visible', new VisibleEmailScope($viewer));
+
+        $this->preferredCopies->restrictToPreferredCopies($query->getQuery(), $viewer);
+
+        return $query->count();
     }
 
     public function visibleEmailCountBadge(Company|Opportunity|People $record, User $viewer): ?string

--- a/packages/EmailIntegration/src/Services/PreferredEmailCopyService.php
+++ b/packages/EmailIntegration/src/Services/PreferredEmailCopyService.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Relaticle\EmailIntegration\Models\Email;
+
+final readonly class PreferredEmailCopyService
+{
+    /**
+     * Keep one visible copy of each RFC Message-ID.
+     *
+     * Two connected mailboxes can store the same message. The record mailbox
+     * should show it once. Prefer the viewer's own copy when they have one.
+     *
+     * @param  Builder<Email>  $query
+     * @return Builder<Email>
+     */
+    public function restrictToPreferredCopies(Builder $query, User $viewer): Builder
+    {
+        $preferred = $query->clone();
+        $base = $preferred->getQuery();
+        $base->orders = null;
+        $base->columns = null;
+        $base->limit = null;
+        $base->offset = null;
+        $base->bindings['select'] = [];
+        $base->bindings['order'] = [];
+
+        $preferred
+            ->selectRaw('distinct on (coalesce(emails.rfc_message_id, emails.id)) emails.id')
+            ->orderByRaw('coalesce(emails.rfc_message_id, emails.id)')
+            ->orderByRaw('case when emails.user_id = ? then 0 else 1 end', [$viewer->getKey()])
+            ->latest('emails.sent_at')
+            ->orderByDesc('emails.id');
+
+        return $query->whereIn($query->qualifyColumn('id'), $preferred);
+    }
+
+    /**
+     * True when this message already exists in the viewer's synced mailbox.
+     */
+    public function viewerHasSyncedCopy(Email $email, User $viewer): bool
+    {
+        if ($email->user_id === $viewer->getKey()) {
+            return true;
+        }
+
+        if (blank($email->rfc_message_id)) {
+            return false;
+        }
+
+        return Email::query()
+            ->where('team_id', $email->team_id)
+            ->where('user_id', $viewer->getKey())
+            ->where('rfc_message_id', $email->rfc_message_id)
+            ->exists();
+    }
+}

--- a/packages/EmailIntegration/src/Services/PrivacyService.php
+++ b/packages/EmailIntegration/src/Services/PrivacyService.php
@@ -6,12 +6,17 @@ namespace Relaticle\EmailIntegration\Services;
 
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailShare;
 
 final readonly class PrivacyService
 {
-    public function __construct(private EmailVisibilityService $visibility) {}
+    public function __construct(
+        private EmailVisibilityService $visibility,
+        private PreferredEmailCopyService $preferredCopies,
+    ) {}
 
     /**
      * Resolve the effective privacy tier this $viewer can see on $email.
@@ -31,16 +36,19 @@ final readonly class PrivacyService
             return null;
         }
 
-        // 3. Per-email share overrides the email's own tier (uses the loaded relation when
-        // eager-loaded, so filtering a list of emails doesn't issue a query per row).
-        $email->loadMissing('shares');
-        $share = $email->shares->firstWhere('shared_with', $viewer->getKey());
+        if ($this->preferredCopies->viewerHasSyncedCopy($email, $viewer)) {
+            return EmailPrivacyTier::FULL;
+        }
 
-        if ($share) {
+        // Per-email share overrides the email's own tier (uses the loaded relation when
+        // eager-loaded, so filtering a list of emails doesn't issue a query per row).
+        $share = $this->shareForViewer($email, $viewer);
+
+        if ($share instanceof EmailShare) {
             return EmailPrivacyTier::from($share->tier);
         }
 
-        // 4. Email's own tier
+        // Email's own tier
         $tier = $email->privacy_tier;
 
         if ($tier === EmailPrivacyTier::PRIVATE) {
@@ -70,5 +78,29 @@ final readonly class PrivacyService
         }
 
         return $team->default_email_sharing_tier ?? EmailPrivacyTier::METADATA_ONLY;
+    }
+
+    private function shareForViewer(Email $email, User $viewer): ?EmailShare
+    {
+        $email->loadMissing('shares');
+        $direct = $email->shares->firstWhere('shared_with', $viewer->getKey());
+
+        if ($direct instanceof EmailShare) {
+            return $direct;
+        }
+
+        if (blank($email->rfc_message_id)) {
+            return null;
+        }
+
+        return EmailShare::query()
+            ->where('team_id', $email->team_id)
+            ->where('shared_with', $viewer->getKey())
+            ->whereHas('email', function (Builder $query) use ($email): void {
+                $query
+                    ->where('team_id', $email->team_id)
+                    ->where('rfc_message_id', $email->rfc_message_id);
+            })
+            ->first();
     }
 }

--- a/tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php
+++ b/tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\PeopleResource\Pages\PeopleEmailsPage;
+use App\Filament\Resources\PeopleResource\Pages\ViewPeople;
+use App\Filament\Resources\PeopleResource\RelationManagers\EmailsRelationManager;
+use App\Models\People;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
+use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\PreferredEmailCopyService;
+use Relaticle\EmailIntegration\Services\PrivacyService;
+
+mutates(
+    PreferredEmailCopyService::class,
+    PrivacyService::class,
+    BaseRecordEmailsPage::class,
+    BaseEmailsRelationManager::class,
+    EmailVisibilityService::class,
+);
+
+/**
+ * @return array{0: User, 1: ConnectedAccount}
+ */
+function createMailboxOwner(Team $team): array
+{
+    $user = User::factory()->create(['current_team_id' => $team->id]);
+    $team->users()->attach($user, ['role' => 'editor']);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]));
+
+    return [$user, $account];
+}
+
+/**
+ * @return array{0: Email, 1: Email}
+ */
+function createSyncedCopies(
+    Team $team,
+    User $first,
+    ConnectedAccount $firstAccount,
+    User $second,
+    ConnectedAccount $secondAccount,
+    string $messageId,
+    string $subject,
+): array {
+    $firstCopy = Email::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $first->id,
+        'connected_account_id' => $firstAccount->getKey(),
+        'rfc_message_id' => $messageId,
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'subject' => $subject,
+        'sent_at' => now(),
+        'is_internal' => false,
+    ]);
+
+    $secondCopy = Email::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $second->id,
+        'connected_account_id' => $secondAccount->getKey(),
+        'rfc_message_id' => $messageId,
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'subject' => $subject,
+        'sent_at' => now()->subMinute(),
+        'is_internal' => false,
+    ]);
+
+    return [$firstCopy, $secondCopy];
+}
+
+beforeEach(function (): void {
+    $this->owner = User::factory()->withTeam()->create();
+    $this->team = $this->owner->currentTeam;
+    $this->ownerAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+    ]));
+
+    [$this->teammate, $this->teammateAccount] = createMailboxOwner($this->team);
+
+    $this->person = People::factory()->create([
+        'team_id' => $this->team->id,
+        'creator_id' => $this->owner->id,
+    ]);
+
+    [$this->ownerCopy, $this->teammateCopy] = createSyncedCopies(
+        $this->team,
+        $this->owner,
+        $this->ownerAccount,
+        $this->teammate,
+        $this->teammateAccount,
+        '<shared-thread@example.com>',
+        'Acme renewal thread',
+    );
+
+    $this->person->emails()->attach([$this->ownerCopy->getKey(), $this->teammateCopy->getKey()]);
+});
+
+it('shows one record mailbox row when two teammates synced the same message', function (): void {
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+
+    $page = livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()]);
+
+    expect(substr_count($page->html(), 'Acme renewal thread'))->toBe(1);
+
+    $page
+        ->assertDontSee(__('filament/pages/email-inbox.list_row.request_access', ['name' => $this->owner->name]))
+        ->assertDontSee(__('filament/pages/email-inbox.list_row.request_access', ['name' => $this->teammate->name]))
+        ->call('selectEmail', $this->ownerCopy->getKey())
+        ->assertSet('selectedEmailId', $this->ownerCopy->getKey());
+});
+
+it('does not ask a teammate to request access when the message is already in their mailbox', function (): void {
+    $this->actingAs($this->teammate);
+    Filament::setTenant($this->team);
+
+    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->assertDontSee(__('filament/pages/email-inbox.list_row.request_access', ['name' => $this->owner->name]))
+        ->assertDontSee(__('filament/pages/email-inbox.list_row.request_access', ['name' => $this->teammate->name]))
+        ->call('selectEmail', $this->teammateCopy->getKey())
+        ->assertSet('selectedEmailId', $this->teammateCopy->getKey());
+});
+
+it('still asks a teammate without a mailbox copy to request access once', function (): void {
+    $outsider = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($outsider, ['role' => 'editor']);
+
+    $this->actingAs($outsider);
+    Filament::setTenant($this->team);
+
+    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->assertSee(__('filament/pages/email-inbox.list_row.request_access', ['name' => $this->owner->name]))
+        ->assertDontSee(__('filament/pages/email-inbox.list_row.request_access', ['name' => $this->teammate->name]));
+});
+
+it('keeps distinct messages as separate record mailbox rows', function (): void {
+    $other = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->ownerAccount->getKey(),
+        'rfc_message_id' => '<other-thread@example.com>',
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'subject' => 'Kickoff notes',
+        'is_internal' => false,
+    ]);
+
+    $this->person->emails()->attach($other->getKey());
+
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+
+    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->assertSee('Acme renewal thread')
+        ->assertSee('Kickoff notes');
+});
+
+it('counts a duplicated synced message once on the emails tab badge', function (): void {
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+
+    expect(EmailsRelationManager::getBadge($this->person, ViewPeople::class))->toBe('1');
+});
+
+it('hides the duplicate table row from the emails relation manager', function (): void {
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+
+    livewire(EmailsRelationManager::class, [
+        'ownerRecord' => $this->person,
+        'pageClass' => ViewPeople::class,
+    ])
+        ->assertCanSeeTableRecords([$this->ownerCopy])
+        ->assertCanNotSeeTableRecords([$this->teammateCopy])
+        ->assertTableActionHidden('requestAccess', $this->ownerCopy);
+});

--- a/tests/Feature/EmailIntegration/EmailPolicyTest.php
+++ b/tests/Feature/EmailIntegration/EmailPolicyTest.php
@@ -57,3 +57,29 @@ it('still allows a teammate to view a shared-tier email in the same workspace', 
         ->and($teammate->can('viewBody', $this->email))->toBeTrue()
         ->and($teammate->can('share', $this->email))->toBeFalse();
 });
+
+it('gives a teammate full access when they already synced the same message', function (): void {
+    $this->email->update(['privacy_tier' => EmailPrivacyTier::METADATA_ONLY]);
+
+    $teammate = User::factory()->create();
+    $teammate->teams()->attach($this->team);
+    $teammate->forceFill(['current_team_id' => $this->team->id])->save();
+
+    $teammateAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+    ]));
+
+    Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'connected_account_id' => $teammateAccount->getKey(),
+        'rfc_message_id' => $this->email->rfc_message_id,
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'is_internal' => false,
+    ]);
+
+    expect($teammate->can('viewBody', $this->email))->toBeTrue()
+        ->and($teammate->can('requestAccess', $this->email))->toBeFalse()
+        ->and($teammate->can('share', $this->email))->toBeFalse();
+});

--- a/tests/Feature/EmailIntegration/PrivacyServiceTest.php
+++ b/tests/Feature/EmailIntegration/PrivacyServiceTest.php
@@ -11,9 +11,10 @@ use Relaticle\EmailIntegration\Models\EmailBlocklist;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
+use Relaticle\EmailIntegration\Services\PreferredEmailCopyService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 
-mutates(PrivacyService::class);
+mutates(PrivacyService::class, PreferredEmailCopyService::class);
 
 beforeEach(function (): void {
     $this->owner = User::factory()->withTeam()->create();
@@ -309,6 +310,100 @@ it('effectiveTier hides a blocked email from its owner', function (): void {
     $tier = $this->service->effectiveTier($email, $this->owner);
 
     expect($tier)->toBeNull();
+});
+
+it('effectiveTier returns FULL for a teammate who already synced the same message', function (): void {
+    $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($viewer, ['role' => 'editor']);
+
+    $viewerAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $viewer->id,
+    ]));
+
+    $email = makePrivacyEmail([
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'rfc_message_id' => '<same-message@example.com>',
+    ]);
+
+    Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $viewer->id,
+        'connected_account_id' => $viewerAccount->getKey(),
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'rfc_message_id' => '<same-message@example.com>',
+        'is_internal' => false,
+    ]);
+
+    $tier = $this->service->effectiveTier($email, $viewer);
+
+    expect($tier)->toBe(EmailPrivacyTier::FULL);
+});
+
+it('effectiveTier does not treat a different message as a mailbox copy', function (): void {
+    $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($viewer, ['role' => 'editor']);
+
+    $viewerAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $viewer->id,
+    ]));
+
+    $email = makePrivacyEmail([
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'rfc_message_id' => '<original@example.com>',
+    ]);
+
+    Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $viewer->id,
+        'connected_account_id' => $viewerAccount->getKey(),
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'rfc_message_id' => '<other@example.com>',
+        'is_internal' => false,
+    ]);
+
+    $tier = $this->service->effectiveTier($email, $viewer);
+
+    expect($tier)->toBe(EmailPrivacyTier::METADATA_ONLY);
+});
+
+it('effectiveTier uses a share on another copy of the same message', function (): void {
+    $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($viewer, ['role' => 'editor']);
+
+    $otherOwner = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($otherOwner, ['role' => 'editor']);
+
+    $otherAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $otherOwner->id,
+    ]));
+
+    $email = makePrivacyEmail([
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'rfc_message_id' => '<shared-copy@example.com>',
+    ]);
+
+    $otherCopy = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $otherOwner->id,
+        'connected_account_id' => $otherAccount->getKey(),
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'rfc_message_id' => '<shared-copy@example.com>',
+        'is_internal' => false,
+    ]);
+
+    EmailShare::factory()->tier(EmailPrivacyTier::FULL)->create([
+        'email_id' => $otherCopy->getKey(),
+        'team_id' => $this->team->id,
+        'shared_by' => $otherOwner->id,
+        'shared_with' => $viewer->id,
+    ]);
+
+    $tier = $this->service->effectiveTier($email, $viewer);
+
+    expect($tier)->toBe(EmailPrivacyTier::FULL);
 });
 
 it('effectiveTier hides a mailbox-blocklisted email from its owner', function (): void {


### PR DESCRIPTION
## Summary
- Record mailbox lists collapse copies of the same RFC Message-ID so two connected mailboxes do not show the same thread twice.
- A teammate who already has that message in their own mailbox gets full access. The request-access prompt is only for people who do not have a copy.
- A share on any copy of the message applies to the other copies as well.

## Test plan
- [x] Connect the same mailbox (or two mailboxes that both received one thread) as two teammates. Open the linked person or company. Confirm one list row, and that neither teammate sees Request access.
- [x] As a third teammate who did not sync that message, confirm one Request access action remains.
- [x] Confirm two different Message-IDs still appear as two rows, and the emails tab badge counts duplicates once.
- [x] Run `php artisan test --compact tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php tests/Feature/EmailIntegration/PrivacyServiceTest.php tests/Feature/EmailIntegration/EmailPolicyTest.php`