### PR TITLE
Fix email and calendar record creation rules and scoped communication metrics

### DIFF
--- a/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
+++ b/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
@@ -20,11 +20,11 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Flex;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
 use Relaticle\ActivityLog\Filament\RelationManagers\ActivityLogRelationManager;
 use Relaticle\CustomFields\Facades\CustomFields;
 use Relaticle\EmailIntegration\Filament\Actions\ViewRecordEmailsAction;
+use Relaticle\EmailIntegration\Filament\Infolists\CommunicationIntelligenceInfolist;
 
 final class ViewCompany extends ViewRecord
 {
@@ -116,40 +116,9 @@ final class ViewCompany extends ViewRecord
                     ])->grow(false),
                 ])->columnSpan('full'),
 
-                Section::make('Communication Intelligence')
-                    ->icon(Heroicon::ChartBar)
-                    ->schema([
-                        TextEntry::make('last_interaction_at')
-                            ->label(__('filament/resources/company.pages.view.communication_intelligence.fields.last_interaction.label'))
-                            ->dateTime()
-                            ->placeholder(__('filament/resources/company.pages.view.communication_intelligence.fields.last_interaction.placeholder')),
-
-                        TextEntry::make('last_email_at')
-                            ->label(__('filament/resources/company.pages.view.communication_intelligence.fields.last_email.label'))
-                            ->dateTime()
-                            ->placeholder(__('filament/resources/company.pages.view.communication_intelligence.fields.last_email.placeholder')),
-
-                        TextEntry::make('days_since_last_email')
-                            ->label(__('filament/resources/company.pages.view.communication_intelligence.fields.days_since_last_email.label'))
-                            ->getStateUsing(fn (Company $record): string => $record->last_email_at
-                                ? __('filament/resources/company.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => (int) now()->diffInDays($record->last_email_at, true)])
-                                : __('filament/resources/company.pages.view.communication_intelligence.fields.days_since_last_email.empty')
-                            ),
-
-                        TextEntry::make('email_count')
-                            ->label(__('filament/resources/company.pages.view.communication_intelligence.fields.email_count.label'))
-                            ->default(0),
-
-                        TextEntry::make('inbound_email_count')
-                            ->label(__('filament/resources/company.pages.view.communication_intelligence.fields.inbound_email_count.label')),
-
-                        TextEntry::make('outbound_email_count')
-                            ->label(__('filament/resources/company.pages.view.communication_intelligence.fields.outbound_email_count.label')),
-                    ])
-                    ->columns(3)
-                    ->columnSpanFull()
-                    ->collapsible()
-                    ->collapsed(fn (Company $record): bool => ($record->email_count ?? 0) === 0),
+                CommunicationIntelligenceInfolist::section(
+                    'filament/resources/company.pages.view.communication_intelligence',
+                ),
 
             ]);
     }

--- a/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
@@ -17,10 +17,10 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Flex;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
 use Relaticle\CustomFields\Facades\CustomFields;
 use Relaticle\EmailIntegration\Filament\Actions\ViewRecordEmailsAction;
+use Relaticle\EmailIntegration\Filament\Infolists\CommunicationIntelligenceInfolist;
 
 final class ViewOpportunity extends ViewRecord
 {
@@ -89,34 +89,10 @@ final class ViewOpportunity extends ViewRecord
                 CustomFields::infolist()->forSchema($schema)->build()->columnSpanFull(),
             ])->columnSpanFull(),
 
-            Section::make('Communication Intelligence')
-                ->icon(Heroicon::ChartBar)
-                ->schema([
-                    TextEntry::make('last_interaction_at')
-                        ->label(__('filament/resources/opportunity.pages.view.communication_intelligence.fields.last_interaction.label'))
-                        ->dateTime()
-                        ->placeholder(__('filament/resources/opportunity.pages.view.communication_intelligence.fields.last_interaction.placeholder')),
-
-                    TextEntry::make('last_email_at')
-                        ->label(__('filament/resources/opportunity.pages.view.communication_intelligence.fields.last_email.label'))
-                        ->dateTime()
-                        ->placeholder(__('filament/resources/opportunity.pages.view.communication_intelligence.fields.last_email.placeholder')),
-
-                    TextEntry::make('days_since_last_email')
-                        ->label(__('filament/resources/opportunity.pages.view.communication_intelligence.fields.days_since_last_email.label'))
-                        ->getStateUsing(fn (Opportunity $record): string => $record->last_email_at
-                            ? __('filament/resources/opportunity.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => (int) now()->diffInDays($record->last_email_at, true)])
-                            : __('filament/resources/opportunity.pages.view.communication_intelligence.fields.days_since_last_email.empty')
-                        ),
-
-                    TextEntry::make('email_count')
-                        ->label(__('filament/resources/opportunity.pages.view.communication_intelligence.fields.email_count.label'))
-                        ->default(0),
-                ])
-                ->columns(2)
-                ->columnSpanFull()
-                ->collapsible()
-                ->collapsed(fn (Opportunity $record): bool => ($record->email_count ?? 0) === 0),
+            CommunicationIntelligenceInfolist::section(
+                'filament/resources/opportunity.pages.view.communication_intelligence',
+                includeDirectionCounts: false,
+            ),
         ]);
     }
 }

--- a/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
+++ b/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
@@ -18,10 +18,10 @@ use Filament\Schemas\Components\Flex;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\TextSize;
-use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
 use Relaticle\CustomFields\Facades\CustomFields;
 use Relaticle\EmailIntegration\Filament\Actions\ViewRecordEmailsAction;
+use Relaticle\EmailIntegration\Filament\Infolists\CommunicationIntelligenceInfolist;
 
 final class ViewPeople extends ViewRecord
 {
@@ -91,40 +91,9 @@ final class ViewPeople extends ViewRecord
                 CustomFields::infolist()->forSchema($schema)->build()->columnSpanFull(),
             ])->columnSpanFull(),
 
-            Section::make('Communication Intelligence')
-                ->icon(Heroicon::ChartBar)
-                ->schema([
-                    TextEntry::make('last_interaction_at')
-                        ->label(__('filament/resources/person.pages.view.communication_intelligence.fields.last_interaction.label'))
-                        ->dateTime()
-                        ->placeholder(__('filament/resources/person.pages.view.communication_intelligence.fields.last_interaction.placeholder')),
-
-                    TextEntry::make('last_email_at')
-                        ->label(__('filament/resources/person.pages.view.communication_intelligence.fields.last_email.label'))
-                        ->dateTime()
-                        ->placeholder(__('filament/resources/person.pages.view.communication_intelligence.fields.last_email.placeholder')),
-
-                    TextEntry::make('days_since_last_email')
-                        ->label(__('filament/resources/person.pages.view.communication_intelligence.fields.days_since_last_email.label'))
-                        ->getStateUsing(fn (People $record): string => $record->last_email_at
-                            ? __('filament/resources/person.pages.view.communication_intelligence.fields.days_since_last_email.value', ['days' => (int) now()->diffInDays($record->last_email_at, true)])
-                            : __('filament/resources/person.pages.view.communication_intelligence.fields.days_since_last_email.empty')
-                        ),
-
-                    TextEntry::make('email_count')
-                        ->label(__('filament/resources/person.pages.view.communication_intelligence.fields.email_count.label'))
-                        ->default(0),
-
-                    TextEntry::make('inbound_email_count')
-                        ->label(__('filament/resources/person.pages.view.communication_intelligence.fields.inbound_email_count.label')),
-
-                    TextEntry::make('outbound_email_count')
-                        ->label(__('filament/resources/person.pages.view.communication_intelligence.fields.outbound_email_count.label')),
-                ])
-                ->columns(3)
-                ->columnSpanFull()
-                ->collapsible()
-                ->collapsed(fn (People $record): bool => ($record->email_count ?? 0) === 0),
+            CommunicationIntelligenceInfolist::section(
+                'filament/resources/person.pages.view.communication_intelligence',
+            ),
         ]);
     }
 }

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -17,6 +17,7 @@ use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
+use Relaticle\EmailIntegration\Models\Scopes\ActiveAccountScope;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 use Relaticle\EmailIntegration\Support\AutomatedSenderMatcher;
 use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
@@ -112,25 +113,34 @@ final readonly class LinkEmailAction
                 $email->connected_account_id,
             );
 
-            // 1. Try to match Company by email domain first, so the person can be born already linked.
+            // 1. Resolve the person before deciding whether to create a company.
+            // Email values are stored as JSON arrays in json_value (e.g. ["user@example.com"])
+            $person = People::query()->where('team_id', $teamId)
+                ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
+                    ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('type', 'email'))
+                    ->whereJsonContains('json_value', $participant->email_address)
+                )
+                ->first();
+
+            $wouldCreatePerson = ! $person
+                && ! $email->is_internal
+                && ! $isAutomatedSender
+                && ! $suppressCreate
+                && $connectedAccount
+                && $team
+                && $this->shouldCreatePerson($team, $participant->email_address, $email);
+
+            // 2. Match or create Company by email host so a new person can be born already linked.
             $company = null;
-            $domain = $this->extractDomain($participant->email_address);
+            $rawDomain = $this->extractDomain($participant->email_address);
+            $host = $rawDomain !== null ? $this->domainMatcher->host($rawDomain) : null;
 
-            if ($domain && $skippedDomains->doesntContain($domain)) {
-                $company = $this->domainMatcher->firstMatching($domain, $teamId);
+            if ($host && $skippedDomains->doesntContain($host)) {
+                $company = $this->domainMatcher->firstMatching($host, $teamId);
 
-                // 2. Auto-create Company when no existing record found. Blocked
-                // addresses must not spawn a company, and creation still follows
-                // the same All / Selective / None rule as people.
-                if (
-                    ! $company
-                    && ! $isAutomatedSender
-                    && ! $suppressCreate
-                    && $connectedAccount
-                    && $team
-                    && $this->shouldCreateCompany($team, $participant->email_address, $email)
-                ) {
-                    $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
+                // 3. Auto-create Company only when a new person would also be created.
+                if (! $company && $wouldCreatePerson && $this->shouldCreateCompany($team, $participant->email_address, $email)) {
+                    $company = $this->autoCreateCompany->execute($host, $teamId, $team);
                 }
 
                 if ($company instanceof Company) {
@@ -143,17 +153,8 @@ final readonly class LinkEmailAction
                 }
             }
 
-            // 3. Try to match existing People record by email address.
-            // Email values are stored as JSON arrays in json_value (e.g. ["user@example.com"])
-            $person = People::query()->where('team_id', $teamId)
-                ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
-                    ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('type', 'email'))
-                    ->whereJsonContains('json_value', $participant->email_address)
-                )
-                ->first();
-
             // 4. Auto-create Person when no existing record found, passing resolved company_id.
-            if (! $person && ! $isAutomatedSender && ! $suppressCreate && $connectedAccount && $team && $this->shouldCreatePerson($team, $participant->email_address, $email)) {
+            if ($wouldCreatePerson) {
                 $person = $this->autoCreatePerson->execute(
                     $participant->name ?? '',
                     $participant->email_address,
@@ -201,8 +202,6 @@ final readonly class LinkEmailAction
     {
         return match ($team->contact_creation_mode) {
             ContactCreationMode::All => true,
-            // The outbound message being linked is itself history: do not depend on a
-            // second query that ActiveAccountScope can hide during mailbox re-import.
             ContactCreationMode::Selective => $email->direction === EmailDirection::OUTBOUND
                 || $this->hasTeamOutboundHistory($team, $emailAddress),
             ContactCreationMode::None => false,
@@ -223,12 +222,13 @@ final readonly class LinkEmailAction
 
     /**
      * True when any connected mailbox on this team has an outbound email involving
-     * the address. The email currently being linked already exists in the table,
-     * so the first send is enough, and a reply is not required.
+     * the address. Includes mail stored under disconnected accounts so a reply
+     * on an active mailbox still creates the person after account churn.
      */
     private function hasTeamOutboundHistory(Team $team, string $emailAddress): bool
     {
         return Email::query()
+            ->withoutGlobalScope(ActiveAccountScope::class)
             ->where('team_id', $team->getKey())
             ->where('direction', EmailDirection::OUTBOUND)
             ->whereHas(

--- a/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
@@ -19,6 +19,7 @@ use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Support\AutomatedSenderMatcher;
 use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
 
 final readonly class LinkMeetingAction
@@ -27,6 +28,7 @@ final readonly class LinkMeetingAction
         private AutoCreateCompanyAction $autoCreateCompany,
         private AutoCreatePersonAction $autoCreatePerson,
         private CompanyDomainMatcher $domainMatcher,
+        private AutomatedSenderMatcher $automatedSender,
         private EmailVisibilityService $visibility,
     ) {}
 
@@ -40,19 +42,36 @@ final readonly class LinkMeetingAction
         $skippedDomains = $this->buildSkippedDomains($teamId);
 
         foreach ($attendees as $attendee) {
-            $company = null;
-            $domain = $this->extractDomain($attendee->email_address);
+            $isAutomatedSender = $this->automatedSender->matches($attendee->email_address);
             $suppressCreate = $this->visibility->suppressesRecordCreation(
                 $attendee->email_address,
                 $teamId,
                 $meeting->connected_account_id,
             );
 
-            if ($domain && $skippedDomains->doesntContain($domain)) {
-                $company = $this->domainMatcher->firstMatching($domain, $teamId);
+            $person = People::query()->where('team_id', $teamId)
+                ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
+                    ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('type', 'email'))
+                    ->whereJsonContains('json_value', $attendee->email_address)
+                )
+                ->first();
 
-                if (! $company && ! $suppressCreate && $team && $team->auto_create_companies && $this->shouldCreatePerson($team)) {
-                    $company = $this->autoCreateCompany->execute($domain, $teamId, $team);
+            $wouldCreatePerson = ! $person
+                && ! $isAutomatedSender
+                && ! $suppressCreate
+                && $account
+                && $team
+                && $this->shouldCreatePerson($team);
+
+            $company = null;
+            $rawDomain = $this->extractDomain($attendee->email_address);
+            $host = $rawDomain !== null ? $this->domainMatcher->host($rawDomain) : null;
+
+            if ($host && $skippedDomains->doesntContain($host)) {
+                $company = $this->domainMatcher->firstMatching($host, $teamId);
+
+                if (! $company && $wouldCreatePerson && $team->auto_create_companies) {
+                    $company = $this->autoCreateCompany->execute($host, $teamId, $team);
                 }
 
                 if ($company instanceof Company) {
@@ -63,14 +82,7 @@ final readonly class LinkMeetingAction
                 }
             }
 
-            $person = People::query()->where('team_id', $teamId)
-                ->whereHas('customFieldValues', fn (Builder $valueQuery) => $valueQuery
-                    ->whereHas('customField', fn (Builder $fieldQuery) => $fieldQuery->where('type', 'email'))
-                    ->whereJsonContains('json_value', $attendee->email_address)
-                )
-                ->first();
-
-            if (! $person && ! $suppressCreate && $account && $team && $this->shouldCreatePerson($team)) {
+            if ($wouldCreatePerson) {
                 $person = $this->autoCreatePerson->execute(
                     $attendee->name ?? '',
                     $attendee->email_address,

--- a/packages/EmailIntegration/src/Data/VisibleCommunicationIntelligence.php
+++ b/packages/EmailIntegration/src/Data/VisibleCommunicationIntelligence.php
@@ -18,11 +18,11 @@ final readonly class VisibleCommunicationIntelligence
 
     public function lastInteractionAt(): ?Carbon
     {
-        if ($this->lastEmailAt === null) {
+        if (! $this->lastEmailAt instanceof Carbon) {
             return $this->lastMeetingAt;
         }
 
-        if ($this->lastMeetingAt === null) {
+        if (! $this->lastMeetingAt instanceof Carbon) {
             return $this->lastEmailAt;
         }
 

--- a/packages/EmailIntegration/src/Data/VisibleCommunicationIntelligence.php
+++ b/packages/EmailIntegration/src/Data/VisibleCommunicationIntelligence.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Data;
+
+use Illuminate\Support\Carbon;
+
+final readonly class VisibleCommunicationIntelligence
+{
+    public function __construct(
+        public int $emailCount = 0,
+        public int $inboundEmailCount = 0,
+        public int $outboundEmailCount = 0,
+        public ?Carbon $lastEmailAt = null,
+        public ?Carbon $lastMeetingAt = null,
+    ) {}
+
+    public function lastInteractionAt(): ?Carbon
+    {
+        if ($this->lastEmailAt === null) {
+            return $this->lastMeetingAt;
+        }
+
+        if ($this->lastMeetingAt === null) {
+            return $this->lastEmailAt;
+        }
+
+        return $this->lastEmailAt->greaterThan($this->lastMeetingAt)
+            ? $this->lastEmailAt
+            : $this->lastMeetingAt;
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Infolists;
+
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
+use App\Models\User;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Facades\Auth;
+use Relaticle\EmailIntegration\Data\VisibleCommunicationIntelligence;
+use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+
+final class CommunicationIntelligenceInfolist
+{
+    public static function section(
+        string $translationKey,
+        bool $includeDirectionCounts = true,
+    ): Section {
+        return Section::make('Communication Intelligence')
+            ->icon(Heroicon::ChartBar)
+            ->schema([
+                TextEntry::make('visible_last_interaction_at')
+                    ->label(__("{$translationKey}.fields.last_interaction.label"))
+                    ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->lastInteractionAt()?->toDateTimeString())
+                    ->dateTime()
+                    ->placeholder(__("{$translationKey}.fields.last_interaction.placeholder")),
+
+                TextEntry::make('visible_last_email_at')
+                    ->label(__("{$translationKey}.fields.last_email.label"))
+                    ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->lastEmailAt?->toDateTimeString())
+                    ->dateTime()
+                    ->placeholder(__("{$translationKey}.fields.last_email.placeholder")),
+
+                TextEntry::make('visible_days_since_last_email')
+                    ->label(__("{$translationKey}.fields.days_since_last_email.label"))
+                    ->getStateUsing(function (People|Company|Opportunity $record) use ($translationKey): string {
+                        $lastEmailAt = self::metrics($record)->lastEmailAt;
+
+                        return $lastEmailAt
+                            ? __("{$translationKey}.fields.days_since_last_email.value", ['days' => (int) now()->diffInDays($lastEmailAt, true)])
+                            : __("{$translationKey}.fields.days_since_last_email.empty");
+                    }),
+
+                TextEntry::make('visible_email_count')
+                    ->label(__("{$translationKey}.fields.email_count.label"))
+                    ->getStateUsing(fn (People|Company|Opportunity $record): int => self::metrics($record)->emailCount)
+                    ->default(0),
+
+                ...($includeDirectionCounts ? [
+                    TextEntry::make('visible_inbound_email_count')
+                        ->label(__("{$translationKey}.fields.inbound_email_count.label"))
+                        ->getStateUsing(fn (People|Company|Opportunity $record): int => self::metrics($record)->inboundEmailCount),
+
+                    TextEntry::make('visible_outbound_email_count')
+                        ->label(__("{$translationKey}.fields.outbound_email_count.label"))
+                        ->getStateUsing(fn (People|Company|Opportunity $record): int => self::metrics($record)->outboundEmailCount),
+                ] : []),
+            ])
+            ->columns($includeDirectionCounts ? 3 : 2)
+            ->columnSpanFull()
+            ->collapsible()
+            ->collapsed(fn (People|Company|Opportunity $record): bool => self::metrics($record)->emailCount === 0);
+    }
+
+    private static function metrics(People|Company|Opportunity $record): VisibleCommunicationIntelligence
+    {
+        /** @var User $viewer */
+        $viewer = Auth::user();
+
+        return resolve(EmailVisibilityService::class)->visibleCommunicationIntelligence($record, $viewer);
+    }
+}

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -172,10 +172,10 @@ final class EmailVisibilityService
             ->max('starts_at');
 
         return new VisibleCommunicationIntelligence(
-            emailCount: (int) ($emailAggregates?->email_count ?? 0),
-            inboundEmailCount: (int) ($emailAggregates?->inbound_email_count ?? 0),
-            outboundEmailCount: (int) ($emailAggregates?->outbound_email_count ?? 0),
-            lastEmailAt: filled($emailAggregates?->last_email_at)
+            emailCount: (int) ($emailAggregates->email_count ?? 0),
+            inboundEmailCount: (int) ($emailAggregates->inbound_email_count ?? 0),
+            outboundEmailCount: (int) ($emailAggregates->outbound_email_count ?? 0),
+            lastEmailAt: filled($emailAggregates->last_email_at)
                 ? Date::parse((string) $emailAggregates->last_email_at)
                 : null,
             lastMeetingAt: filled($lastMeetingAt)

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -15,8 +15,8 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Data\VisibleCommunicationIntelligence;
 use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
@@ -176,10 +176,10 @@ final class EmailVisibilityService
             inboundEmailCount: (int) ($emailAggregates?->inbound_email_count ?? 0),
             outboundEmailCount: (int) ($emailAggregates?->outbound_email_count ?? 0),
             lastEmailAt: filled($emailAggregates?->last_email_at)
-                ? Carbon::parse((string) $emailAggregates->last_email_at)
+                ? Date::parse((string) $emailAggregates->last_email_at)
                 : null,
             lastMeetingAt: filled($lastMeetingAt)
-                ? Carbon::parse((string) $lastMeetingAt)
+                ? Date::parse((string) $lastMeetingAt)
                 : null,
         );
     }

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -15,9 +15,12 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Data\VisibleCommunicationIntelligence;
 use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailVisibilityEnforcement;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -25,6 +28,7 @@ use Relaticle\EmailIntegration\Models\EmailBlocklist;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 
 final class EmailVisibilityService
@@ -143,6 +147,44 @@ final class EmailVisibilityService
     }
 
     /**
+     * Communication-intelligence metrics scoped to mail and meetings the viewer may
+     * see on this record. Denormalized CRM counters include hidden teammate mail.
+     */
+    public function visibleCommunicationIntelligence(Company|Opportunity|People $record, User $viewer): VisibleCommunicationIntelligence
+    {
+        if ($this->hidesRecordMailbox($record)) {
+            return new VisibleCommunicationIntelligence;
+        }
+
+        $emailAggregates = $record->emails()
+            ->withGlobalScope('visible', new VisibleEmailScope($viewer))
+            ->reorder()
+            ->toBase()
+            ->selectRaw('count(*) as email_count')
+            ->selectRaw('coalesce(sum(case when emails.direction = ? then 1 else 0 end), 0) as inbound_email_count', [EmailDirection::INBOUND->value])
+            ->selectRaw('coalesce(sum(case when emails.direction = ? then 1 else 0 end), 0) as outbound_email_count', [EmailDirection::OUTBOUND->value])
+            ->selectRaw('max(emails.sent_at) as last_email_at')
+            ->first();
+
+        $lastMeetingAt = $record->meetings()
+            ->withGlobalScope('visible', new VisibleMeetingScope($viewer))
+            ->reorder()
+            ->max('starts_at');
+
+        return new VisibleCommunicationIntelligence(
+            emailCount: (int) ($emailAggregates?->email_count ?? 0),
+            inboundEmailCount: (int) ($emailAggregates?->inbound_email_count ?? 0),
+            outboundEmailCount: (int) ($emailAggregates?->outbound_email_count ?? 0),
+            lastEmailAt: filled($emailAggregates?->last_email_at)
+                ? Carbon::parse((string) $emailAggregates->last_email_at)
+                : null,
+            lastMeetingAt: filled($lastMeetingAt)
+                ? Carbon::parse((string) $lastMeetingAt)
+                : null,
+        );
+    }
+
+    /**
      * Protected people and companies keep their mailbox empty on the record page,
      * even when mixed threads with unprotected contacts stay visible elsewhere.
      */
@@ -256,10 +298,15 @@ final class EmailVisibilityService
     }
 
     /**
-     * Blocked workspace entries and mailbox-only blocklists must not spawn CRM records.
+     * Blocked workspace entries, workspace member addresses, and mailbox-only
+     * blocklists must not spawn CRM records.
      */
     public function suppressesRecordCreation(string $address, string $teamId, ?string $connectedAccountId): bool
     {
+        if ($this->isTeamMemberEmail($address, $teamId)) {
+            return true;
+        }
+
         if ($this->matchesCustomEntry($address, $teamId, EmailVisibilityEnforcement::Blocked)) {
             return true;
         }

--- a/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
@@ -133,6 +133,137 @@ it('skips person creation when contact_creation_mode=None', function (): void {
     expect(Company::query()->where('team_id', $team->id)->count())->toBe(0);
 });
 
+it('does not auto-create a company when the person already exists', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+    Filament::setTenant($team);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]));
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $person = People::factory()->for($team)->create();
+    savePersonEmail($person, 'known@orphan-corp.com');
+
+    $countBefore = Company::query()->where('team_id', $team->id)->count();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'known@orphan-corp.com',
+        'is_self' => false,
+    ]);
+
+    (app(LinkMeetingAction::class))->execute($meeting->fresh());
+
+    expect(Company::query()->where('team_id', $team->id)->count())->toBe($countBefore);
+});
+
+it('does not auto-create a person or company for an automated attendee', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+    Filament::setTenant($team);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]));
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'noreply@partner.com',
+        'is_self' => false,
+    ]);
+
+    (app(LinkMeetingAction::class))->execute($meeting->fresh());
+
+    expect(People::query()->where('team_id', $team->id)->count())->toBe(0)
+        ->and(Company::query()->where('team_id', $team->id)->count())->toBe(0);
+});
+
+it('does not auto-create a company for a www-prefixed public domain', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+    Filament::setTenant($team);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]));
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $countBefore = Company::query()->where('team_id', $team->id)->count();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'user@www.gmail.com',
+        'is_self' => false,
+    ]);
+
+    (app(LinkMeetingAction::class))->execute($meeting->fresh());
+
+    expect(Company::query()->where('team_id', $team->id)->count())->toBe($countBefore);
+});
+
+it('does not auto-create a person or company when the connected account is soft-deleted', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+    Filament::setTenant($team);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]));
+    $account->delete();
+
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'guest@newcorp.com',
+        'is_self' => false,
+    ]);
+
+    (app(LinkMeetingAction::class))->execute($meeting->fresh());
+
+    expect(People::query()->where('team_id', $team->id)->count())->toBe(0)
+        ->and(Company::query()->where('team_id', $team->id)->count())->toBe(0);
+});
+
 it('auto-creates a person on the first meeting in Selective mode', function (): void {
     $user = User::factory()->withTeam()->create();
     $this->actingAs($user);

--- a/tests/Feature/EmailIntegration/EmailVisibilityServiceTest.php
+++ b/tests/Feature/EmailIntegration/EmailVisibilityServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Relaticle\EmailIntegration\Enums\EmailVisibilityEnforcement;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
@@ -114,4 +115,59 @@ it('prefers blocked over protected when resolving record mailbox copy', function
         ->toBe(EmailVisibilityEnforcement::Blocked)
         ->and($this->service->recordMailboxHiddenCopy($person)['description'])
         ->toBe(__('filament/pages/record-emails.blocked.description'));
+});
+
+it('suppresses record creation for workspace member emails', function (): void {
+    expect($this->service->suppressesRecordCreation(
+        'owner@thefireflytech.com',
+        $this->team->getKey(),
+        null,
+    ))->toBeTrue();
+
+    expect($this->service->suppressesRecordCreation(
+        'external@partner.com',
+        $this->team->getKey(),
+        null,
+    ))->toBeFalse();
+});
+
+it('scopes communication intelligence metrics to mail the viewer can see', function (): void {
+    $person = People::factory()->for($this->team)->create([
+        'email_count' => 99,
+        'inbound_email_count' => 50,
+        'outbound_email_count' => 49,
+    ]);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    $visible = Email::factory()->inbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    $person->emails()->attach($visible->getKey());
+
+    $coworker = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($coworker, ['role' => 'editor']);
+
+    $coworkerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+    ]));
+
+    $private = Email::factory()->private()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+        'connected_account_id' => $coworkerAccount->getKey(),
+    ]);
+    $person->emails()->attach($private->getKey());
+
+    $metrics = $this->service->visibleCommunicationIntelligence($person, $this->user);
+
+    expect($metrics->emailCount)->toBe(1)
+        ->and($metrics->inboundEmailCount)->toBe(1)
+        ->and($metrics->outboundEmailCount)->toBe(0);
 });

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -318,6 +318,62 @@ it('auto-creates a company in Selective mode for outbound addresses', function (
     expect(Company::where('team_id', $this->team->id)->where('name', 'Selective-corp')->exists())->toBeTrue();
 });
 
+it('does not auto-create a company when the person already exists', function (): void {
+    $emailField = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $this->team->getKey())
+        ->where('entity_type', 'people')
+        ->where('code', 'emails')
+        ->first();
+
+    if (! $emailField) {
+        $this->markTestSkipped('No emails custom field seeded for this team.');
+    }
+
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Known Contact',
+        'creator_id' => $this->user->id,
+    ]);
+    $person->saveCustomFieldValue($emailField, ['known@orphan-corp.com'], $this->team);
+
+    $countBefore = Company::where('team_id', $this->team->id)->count();
+
+    $email = makeLinkEmail();
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'known@orphan-corp.com',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore);
+});
+
+it('does not auto-create a company for a www-prefixed public domain', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $countBefore = Company::where('team_id', $this->team->id)->count();
+
+    $email = makeLinkEmail();
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'user@www.gmail.com',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore);
+});
+
 it('auto-creates a company when auto_create_companies is true', function (): void {
     $this->team->update([
         'contact_creation_mode' => ContactCreationMode::All,
@@ -879,6 +935,57 @@ it('does not auto-create a person when Selective and the address has only inboun
     expect(People::where('team_id', $this->team->id)->count())->toBe($countBefore);
 });
 
+it('does not auto-create people or companies for internal email', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    $teammate = User::factory()->create();
+    $this->team->users()->attach($teammate, ['role' => 'editor']);
+
+    $peopleBefore = People::where('team_id', $this->team->id)->count();
+    $companiesBefore = Company::where('team_id', $this->team->id)->count();
+
+    $email = makeLinkEmail(['is_internal' => true]);
+
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => $this->user->email,
+    ]);
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => $teammate->email,
+        'name' => 'Teammate',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(People::where('team_id', $this->team->id)->count())->toBe($peopleBefore)
+        ->and(Company::where('team_id', $this->team->id)->count())->toBe($companiesBefore);
+});
+
+it('does not auto-create a person when Selective outbound only reaches a teammate', function (): void {
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::Selective]);
+
+    $teammate = User::factory()->create();
+    $this->team->users()->attach($teammate, ['role' => 'editor']);
+
+    $countBefore = People::where('team_id', $this->team->id)->count();
+
+    $email = makeLinkEmail(['direction' => EmailDirection::OUTBOUND]);
+
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => $teammate->email,
+        'name' => 'Teammate',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(People::where('team_id', $this->team->id)->count())->toBe($countBefore);
+});
+
 it('auto-creates a person and company on the first outbound email in Selective mode', function (): void {
     $this->team->update([
         'contact_creation_mode' => ContactCreationMode::Selective,
@@ -933,6 +1040,41 @@ it('creates a person in Selective mode when a teammate already sent to the addre
     app(LinkEmailAction::class)->execute($inbound);
 
     expect(People::where('team_id', $this->team->id)->where('name', 'Shared Contact')->exists())->toBeTrue();
+});
+
+it('creates a person in Selective mode when outbound history is on a disconnected account', function (): void {
+    $this->team->update(['contact_creation_mode' => ContactCreationMode::Selective]);
+
+    $disconnectedAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    $address = 'history@partner.com';
+
+    $outbound = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $disconnectedAccount->getKey(),
+        'direction' => EmailDirection::OUTBOUND,
+    ]);
+    EmailParticipant::factory()->to()->create([
+        'email_id' => $outbound->getKey(),
+        'email_address' => $address,
+    ]);
+
+    $disconnectedAccount->delete();
+
+    $inbound = makeLinkEmail(['direction' => EmailDirection::INBOUND]);
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $inbound->getKey(),
+        'email_address' => $address,
+        'name' => 'History Contact',
+    ]);
+
+    app(LinkEmailAction::class)->execute($inbound);
+
+    expect(People::where('team_id', $this->team->id)->where('name', 'History Contact')->exists())->toBeTrue();
 });
 
 it('increments person email_count when linked', function (): void {

--- a/tests/Feature/Filament/RecordHeaderActionsTest.php
+++ b/tests/Feature/Filament/RecordHeaderActionsTest.php
@@ -13,13 +13,15 @@ use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Laravel\Pennant\Feature;
+use Relaticle\EmailIntegration\Data\VisibleCommunicationIntelligence;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Actions\ViewRecordEmailsAction;
+use Relaticle\EmailIntegration\Filament\Infolists\CommunicationIntelligenceInfolist;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
-mutates(ViewCompany::class, ViewPeople::class, ViewOpportunity::class, ViewRecordEmailsAction::class, EmailVisibilityService::class);
+mutates(ViewCompany::class, ViewPeople::class, ViewOpportunity::class, ViewRecordEmailsAction::class, EmailVisibilityService::class, CommunicationIntelligenceInfolist::class, VisibleCommunicationIntelligence::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -208,3 +210,27 @@ it('does not badge private teammate mail or emails linked to another record', fu
 
     expect(emailsHeaderBadge($page, $owner))->toBe('1');
 })->with(recordEmailsHeaderPages());
+
+it('scopes communication intelligence on the person view to visible mail only', function (): void {
+    $person = People::factory()->recycle([$this->user, $this->team])->create([
+        'email_count' => 99,
+        'inbound_email_count' => 50,
+        'outbound_email_count' => 49,
+    ]);
+
+    attachRecordEmail($this->user, $this->team, $person);
+
+    $coworker = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($coworker, ['role' => 'editor']);
+
+    attachRecordEmail($coworker, $this->team, $person, [
+        'privacy_tier' => EmailPrivacyTier::PRIVATE,
+        'is_internal' => false,
+    ]);
+
+    $metrics = resolve(EmailVisibilityService::class)->visibleCommunicationIntelligence($person, $this->user);
+
+    expect($metrics->emailCount)->toBe(1)
+        ->and($metrics->inboundEmailCount)->toBe(1)
+        ->and($metrics->outboundEmailCount)->toBe(0);
+});


### PR DESCRIPTION
## Summary

- Gate company auto-creation on whether a new person would also be created, and normalize email hosts before domain matching so `www.` public domains are filtered correctly.
- Block record creation for internal mail and automated senders in email linking; apply the same automated-sender and connected-account checks in calendar linking; count selective outbound history on disconnected accounts.
- Replace denormalized communication intelligence on person, company, and opportunity views with visibility-scoped aggregates so private teammate mail does not leak into counts.

## Test plan

- [x] `php artisan test --compact tests/Feature/EmailIntegration/LinkEmailActionTest.php`
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailVisibilityServiceTest.php`
- [x] `php artisan test --compact tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php`
- [x] `php artisan test --compact tests/Feature/Filament/RecordHeaderActionsTest.php`