### PR TITLE
Guard initial sync page completion until every store job succeeds

### DIFF
--- a/config/email-integration.php
+++ b/config/email-integration.php
@@ -69,6 +69,7 @@ return [
             ? null
             : (int) $days,
         'batch_size' => (int) env('EMAIL_SYNC_BATCH_SIZE', 50),
+        'initial_store_attempts' => (int) env('EMAIL_SYNC_INITIAL_STORE_ATTEMPTS', 3),
     ],
 
     /*

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -11,8 +11,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Bus;
-use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -54,29 +52,17 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $accountId = (string) $account->getKey();
         $nextPageToken = $result->nextPageToken;
         $nextSyncToken = $result->nextSyncToken;
 
-        $jobs = array_map(
-            fn (CalendarEventData $event): StoreMeetingJob => new StoreMeetingJob($account, $event),
-            $result->events,
-        );
-
-        Bus::batch($jobs)
-            ->name("Initial calendar sync: {$account->email_address}")
-            ->onQueue('emails-sync')
-            ->allowFailures()
-            ->finally(static function () use ($accountId, $nextPageToken, $nextSyncToken): void {
-                $account = ConnectedAccount::query()->whereKey($accountId)->first();
-
-                if (! $account instanceof ConnectedAccount) {
-                    return;
-                }
-
+        InitialSyncPageStoreBatch::dispatchMeetings(
+            account: $account,
+            pageEvents: $result->events,
+            eventsToStore: $result->events,
+            onPageStored: static function (ConnectedAccount $account) use ($nextPageToken, $nextSyncToken): void {
                 self::continueOrFinish($account, $nextPageToken, $nextSyncToken);
-            })
-            ->dispatch();
+            },
+        );
     }
 
     public function failed(Throwable $exception): void

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -55,10 +55,12 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         $nextPageToken = $result->nextPageToken;
         $nextSyncToken = $result->nextSyncToken;
 
+        $pageEvents = array_values($result->events);
+
         InitialSyncPageStoreBatch::dispatchMeetings(
             account: $account,
-            pageEvents: $result->events,
-            eventsToStore: $result->events,
+            pageEvents: $pageEvents,
+            eventsToStore: $pageEvents,
             onPageStored: static function (ConnectedAccount $account) use ($nextPageToken, $nextSyncToken): void {
                 self::continueOrFinish($account, $nextPageToken, $nextSyncToken);
             },

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -55,7 +55,7 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
             $account->update(['initial_sync_estimated' => $page->estimatedTotal]);
         }
 
-        $allIds = $page->messageIds->all();
+        $allIds = array_values($page->messageIds->all());
 
         $storedIds = Email::query()
             ->where('connected_account_id', $account->getKey())

--- a/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialEmailSyncJob.php
@@ -11,8 +11,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
@@ -73,29 +71,20 @@ final class InitialEmailSyncJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $accountId = (string) $account->getKey();
         $nextPageToken = $page->nextPageToken;
         $pageCursor = $page->cursor;
 
-        $jobs = collect($newIds)
-            ->chunk(Config::integer('email-integration.sync.batch_size', 50))
-            ->flatMap(fn (Collection $chunk): array => $chunk->map(fn (string $id): StoreEmailJob => new StoreEmailJob($account, $id))->all())
-            ->all();
-
-        Bus::batch($jobs)
-            ->name("Initial sync: {$account->email_address}")
-            ->onQueue('emails-sync')
-            ->allowFailures()
-            ->finally(static function () use ($accountId, $historyCursor, $nextPageToken, $pageCursor): void {
-                $account = ConnectedAccount::query()->whereKey($accountId)->first();
-
-                if (! $account instanceof ConnectedAccount) {
-                    return;
-                }
-
+        InitialSyncPageStoreBatch::dispatchEmails(
+            account: $account,
+            pageMessageIds: $allIds,
+            messageIdsToStore: $newIds,
+            historyCursor: $historyCursor,
+            nextPageToken: $nextPageToken,
+            pageCursor: $pageCursor,
+            onPageStored: static function (ConnectedAccount $account) use ($historyCursor, $nextPageToken, $pageCursor): void {
                 self::continueOrFinish($account, $historyCursor, $nextPageToken, $pageCursor);
-            })
-            ->dispatch();
+            },
+        );
     }
 
     public function failed(Throwable $exception): void

--- a/packages/EmailIntegration/src/Jobs/InitialSyncPageStoreBatch.php
+++ b/packages/EmailIntegration/src/Jobs/InitialSyncPageStoreBatch.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Jobs;
+
+use Closure;
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+use Relaticle\EmailIntegration\Data\CalendarEventData;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final class InitialSyncPageStoreBatch
+{
+    /**
+     * @param  list<string>  $pageMessageIds
+     * @param  list<string>  $messageIdsToStore
+     * @param  Closure(ConnectedAccount): void  $onPageStored
+     */
+    public static function dispatchEmails(
+        ConnectedAccount $account,
+        array $pageMessageIds,
+        array $messageIdsToStore,
+        ?string $historyCursor,
+        ?string $nextPageToken,
+        ?string $pageCursor,
+        Closure $onPageStored,
+        int $storeAttempt = 1,
+    ): void {
+        if ($messageIdsToStore === []) {
+            return;
+        }
+
+        $accountId = (string) $account->getKey();
+
+        $jobs = collect($messageIdsToStore)
+            ->chunk(Config::integer('email-integration.sync.batch_size', 50))
+            ->flatMap(fn (Collection $chunk): array => $chunk
+                ->map(fn (string $id): StoreEmailJob => new StoreEmailJob($account, $id))
+                ->all())
+            ->all();
+
+        Bus::batch($jobs)
+            ->name("Initial sync: {$account->email_address}")
+            ->onQueue('emails-sync')
+            ->allowFailures()
+            ->finally(static function (Batch $batch) use (
+                $accountId,
+                $pageMessageIds,
+                $historyCursor,
+                $nextPageToken,
+                $pageCursor,
+                $onPageStored,
+                $storeAttempt,
+            ): void {
+                $account = ConnectedAccount::query()->whereKey($accountId)->first();
+
+                if (! $account instanceof ConnectedAccount) {
+                    return;
+                }
+
+                $missingIds = self::missingMessageIds($account, $pageMessageIds);
+
+                if ($missingIds !== []) {
+                    if ($storeAttempt < self::maxStoreAttempts()) {
+                        self::dispatchEmails(
+                            $account,
+                            $pageMessageIds,
+                            $missingIds,
+                            $historyCursor,
+                            $nextPageToken,
+                            $pageCursor,
+                            $onPageStored,
+                            $storeAttempt + 1,
+                        );
+
+                        return;
+                    }
+
+                    self::markImportStoreFailed($account, count($missingIds), 'message(s)');
+
+                    return;
+                }
+
+                $onPageStored($account);
+            })
+            ->dispatch();
+    }
+
+    /**
+     * @param  list<CalendarEventData>  $pageEvents
+     * @param  list<CalendarEventData>  $eventsToStore
+     * @param  Closure(ConnectedAccount): void  $onPageStored
+     */
+    public static function dispatchMeetings(
+        ConnectedAccount $account,
+        array $pageEvents,
+        array $eventsToStore,
+        Closure $onPageStored,
+        int $storeAttempt = 1,
+    ): void {
+        if ($eventsToStore === []) {
+            return;
+        }
+
+        $accountId = (string) $account->getKey();
+
+        $jobs = array_map(
+            fn (CalendarEventData $event): StoreMeetingJob => new StoreMeetingJob($account, $event),
+            $eventsToStore,
+        );
+
+        Bus::batch($jobs)
+            ->name("Initial calendar sync: {$account->email_address}")
+            ->onQueue('emails-sync')
+            ->allowFailures()
+            ->finally(static function (Batch $batch) use (
+                $accountId,
+                $pageEvents,
+                $onPageStored,
+                $storeAttempt,
+            ): void {
+                $account = ConnectedAccount::query()->whereKey($accountId)->first();
+
+                if (! $account instanceof ConnectedAccount) {
+                    return;
+                }
+
+                $missingEvents = self::missingMeetingEvents($account, $pageEvents);
+
+                if ($missingEvents !== []) {
+                    if ($storeAttempt < self::maxStoreAttempts()) {
+                        self::dispatchMeetings(
+                            $account,
+                            $pageEvents,
+                            $missingEvents,
+                            $onPageStored,
+                            $storeAttempt + 1,
+                        );
+
+                        return;
+                    }
+
+                    self::markImportStoreFailed($account, count($missingEvents), 'event(s)');
+
+                    return;
+                }
+
+                $onPageStored($account);
+            })
+            ->dispatch();
+    }
+
+    /**
+     * @param  list<string>  $pageMessageIds
+     * @return list<string>
+     */
+    private static function missingMessageIds(ConnectedAccount $account, array $pageMessageIds): array
+    {
+        if ($pageMessageIds === []) {
+            return [];
+        }
+
+        $storedIds = Email::query()
+            ->where('connected_account_id', $account->getKey())
+            ->whereIn('provider_message_id', $pageMessageIds)
+            ->pluck('provider_message_id')
+            ->all();
+
+        return array_values(array_diff($pageMessageIds, $storedIds));
+    }
+
+    /**
+     * @param  list<CalendarEventData>  $pageEvents
+     * @return list<CalendarEventData>
+     */
+    private static function missingMeetingEvents(ConnectedAccount $account, array $pageEvents): array
+    {
+        if ($pageEvents === []) {
+            return [];
+        }
+
+        $pageIds = array_map(
+            fn (CalendarEventData $event): string => $event->providerEventId,
+            $pageEvents,
+        );
+
+        $storedIds = Meeting::query()
+            ->where('connected_account_id', $account->getKey())
+            ->whereIn('provider_event_id', $pageIds)
+            ->pluck('provider_event_id')
+            ->all();
+
+        return array_values(array_filter(
+            $pageEvents,
+            fn (CalendarEventData $event): bool => ! in_array($event->providerEventId, $storedIds, true),
+        ));
+    }
+
+    private static function maxStoreAttempts(): int
+    {
+        return max(1, Config::integer('email-integration.sync.initial_store_attempts', 3));
+    }
+
+    private static function markImportStoreFailed(ConnectedAccount $account, int $missingCount, string $resourceLabel): void
+    {
+        $account->update([
+            'status' => EmailAccountStatus::ERROR,
+            'last_error' => "Initial import paused: {$missingCount} {$resourceLabel} could not be stored after "
+                .self::maxStoreAttempts().' attempts.',
+        ]);
+    }
+}

--- a/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Testing\Fakes\BatchFake;
 use Laravel\SerializableClosure\SerializableClosure;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreMeetingJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -16,6 +18,27 @@ use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterfac
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 
 mutates(InitialCalendarSyncJob::class);
+
+function invokeInitialCalendarSyncBatchFinallyCallbacks(): void
+{
+    Bus::assertBatched(function (PendingBatch $batch): bool {
+        foreach ($batch->finallyCallbacks() as $callback) {
+            $closure = $callback instanceof SerializableClosure ? $callback->getClosure() : $callback;
+            $closure(new BatchFake(
+                id: 'batch-1',
+                name: 'Initial calendar sync',
+                totalJobs: $batch->jobs->count(),
+                pendingJobs: 0,
+                failedJobs: 0,
+                failedJobIds: [],
+                options: [],
+                createdAt: now()->toImmutable(),
+            ));
+        }
+
+        return true;
+    });
+}
 
 it('batches a StoreMeetingJob per event and does not advance the cursor until the page stores', function (): void {
     Bus::fake();
@@ -152,15 +175,13 @@ it('chains the next calendar page after the store batch completes', function ():
 
     (new InitialCalendarSyncJob($account))->handle($factory);
 
-    Bus::assertBatched(function (PendingBatch $batch): bool {
-        expect($batch->thenCallbacks())->toBeEmpty();
+    Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'evt-A',
+    ]);
 
-        foreach ($batch->finallyCallbacks() as $callback) {
-            $callback();
-        }
-
-        return true;
-    });
+    invokeInitialCalendarSyncBatchFinallyCallbacks();
 
     Bus::assertDispatched(
         InitialCalendarSyncJob::class,
@@ -286,17 +307,76 @@ it('stores the sync token when the batch completion callback runs', function ():
 
     (new InitialCalendarSyncJob($account))->handle($factory);
 
-    Bus::assertBatched(function (PendingBatch $batch): bool {
-        expect($batch->thenCallbacks())->toBeEmpty();
+    Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'evt-callback',
+    ]);
 
-        foreach ($batch->finallyCallbacks() as $callback) {
-            $closure = $callback instanceof SerializableClosure ? $callback->getClosure() : $callback;
-            $closure();
-        }
-
-        return true;
-    });
+    invokeInitialCalendarSyncBatchFinallyCallbacks();
 
     expect($account->fresh()?->calendar_sync_cursor)->toBe('token-batch')
         ->and($account->fresh()?->last_calendar_synced_at)->not->toBeNull();
+});
+
+it('does not advance the initial calendar import while page events are still missing', function (): void {
+    Bus::fake();
+    config()->set('email-integration.sync.initial_store_attempts', 1);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $events = [
+        new CalendarEventData(
+            providerEventId: 'evt-A',
+            providerRecurringEventId: null,
+            iCalUid: null,
+            title: 'A',
+            description: null,
+            startsAt: Carbon::now()->addDay(),
+            endsAt: Carbon::now()->addDay()->addHour(),
+            isAllDay: false,
+            location: null,
+            htmlLink: null,
+            status: 'confirmed',
+            visibility: 'default',
+            organizerEmail: null,
+            organizerName: null,
+            attendees: [],
+        ),
+        new CalendarEventData(
+            providerEventId: 'evt-B',
+            providerRecurringEventId: null,
+            iCalUid: null,
+            title: 'B',
+            description: null,
+            startsAt: Carbon::now()->addDays(2),
+            endsAt: Carbon::now()->addDays(2)->addHour(),
+            isAllDay: false,
+            location: null,
+            htmlLink: null,
+            status: 'confirmed',
+            visibility: 'default',
+            organizerEmail: null,
+            organizerName: null,
+            attendees: [],
+        ),
+    ];
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: $events, nextSyncToken: null, nextPageToken: 'page-2'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new InitialCalendarSyncJob($account))->handle($factory);
+
+    invokeInitialCalendarSyncBatchFinallyCallbacks();
+
+    Bus::assertDispatchedTimes(InitialCalendarSyncJob::class, 0);
+    expect($account->fresh()?->calendar_sync_cursor)->toBeNull()
+        ->and($account->fresh()?->status)->toBe(EmailAccountStatus::ERROR)
+        ->and($account->fresh()?->last_error)->toContain('2 event(s)');
 });

--- a/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
+++ b/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
@@ -5,15 +5,38 @@ declare(strict_types=1);
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Testing\Fakes\BatchFake;
 use Relaticle\EmailIntegration\Data\MailBackfillPage;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Notifications\MailboxHistoryImportCompletedNotification;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 
 mutates(InitialEmailSyncJob::class);
+
+function invokeInitialEmailSyncBatchFinallyCallbacks(): void
+{
+    Bus::assertBatched(function (PendingBatch $batch): bool {
+        foreach ($batch->finallyCallbacks() as $callback) {
+            $callback(new BatchFake(
+                id: 'batch-1',
+                name: 'Initial sync',
+                totalJobs: $batch->jobs->count(),
+                pendingJobs: 0,
+                failedJobs: 0,
+                failedJobIds: [],
+                options: [],
+                createdAt: now()->toImmutable(),
+            ));
+        }
+
+        return true;
+    });
+}
 
 it('does not cap the first import when EMAIL_SYNC_INITIAL_DAYS is unset', function (): void {
     Bus::fake();
@@ -151,15 +174,14 @@ it('chains the next page after the store batch completes', function (): void {
 
     (new InitialEmailSyncJob($account))->handle($factory);
 
-    Bus::assertBatched(function (PendingBatch $batch): bool {
-        expect($batch->thenCallbacks())->toBeEmpty();
+    Email::factory()->create([
+        'team_id' => $account->team_id,
+        'user_id' => $account->user_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_message_id' => 'M1',
+    ]);
 
-        foreach ($batch->finallyCallbacks() as $callback) {
-            $callback();
-        }
-
-        return true;
-    });
+    invokeInitialEmailSyncBatchFinallyCallbacks();
 
     Bus::assertDispatched(
         InitialEmailSyncJob::class,
@@ -196,43 +218,6 @@ it('chains the next page when the current page has no new ids', function (): voi
     Notification::assertNothingSent();
 });
 
-it('sets the cursor after the last page store batch finishes', function (): void {
-    Bus::fake();
-    Notification::fake();
-
-    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
-
-    $service = Mockery::mock(MailServiceInterface::class);
-    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
-        messageIds: collect(['M1']),
-        nextPageToken: null,
-        cursor: 'history-1',
-    ));
-
-    $factory = Mockery::mock(MailServiceFactoryInterface::class);
-    $factory->shouldReceive('make')->andReturn($service);
-
-    (new InitialEmailSyncJob($account))->handle($factory);
-
-    Bus::assertBatched(function (PendingBatch $batch): bool {
-        expect($batch->thenCallbacks())->toBeEmpty();
-
-        foreach ($batch->finallyCallbacks() as $callback) {
-            $callback();
-        }
-
-        return true;
-    });
-
-    expect($account->fresh()?->sync_cursor)->toBe('history-1')
-        ->and($account->fresh()?->last_synced_at)->not->toBeNull();
-
-    Notification::assertSentTo(
-        $account->user,
-        MailboxHistoryImportCompletedNotification::class,
-    );
-});
-
 it('sets the cursor and notifies the owner when the last page is stored', function (): void {
     Bus::fake();
     Notification::fake();
@@ -258,4 +243,104 @@ it('sets the cursor and notifies the owner when the last page is stored', functi
         $account->user,
         MailboxHistoryImportCompletedNotification::class,
     );
+});
+
+it('sets the cursor after the last page store batch finishes', function (): void {
+    Bus::fake();
+    Notification::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(['M1']),
+        nextPageToken: null,
+        cursor: 'history-1',
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    Email::factory()->create([
+        'team_id' => $account->team_id,
+        'user_id' => $account->user_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_message_id' => 'M1',
+    ]);
+
+    invokeInitialEmailSyncBatchFinallyCallbacks();
+
+    expect($account->fresh()?->sync_cursor)->toBe('history-1')
+        ->and($account->fresh()?->last_synced_at)->not->toBeNull();
+
+    Notification::assertSentTo(
+        $account->user,
+        MailboxHistoryImportCompletedNotification::class,
+    );
+});
+
+it('does not advance the initial import while page messages are still missing', function (): void {
+    Bus::fake();
+    Notification::fake();
+    config()->set('email-integration.sync.initial_store_attempts', 1);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(['M1', 'M2']),
+        nextPageToken: 'page-2',
+        cursor: 'history-1',
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    invokeInitialEmailSyncBatchFinallyCallbacks();
+
+    Bus::assertDispatchedTimes(InitialEmailSyncJob::class, 0);
+    expect($account->fresh()?->sync_cursor)->toBeNull()
+        ->and($account->fresh()?->status)->toBe(EmailAccountStatus::ERROR)
+        ->and($account->fresh()?->last_error)->toContain('2 message(s)');
+
+    Notification::assertNothingSent();
+});
+
+it('re-dispatches store jobs for missing messages before advancing the page', function (): void {
+    Bus::fake();
+    Notification::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(['M1', 'M2']),
+        nextPageToken: 'page-2',
+        cursor: 'history-1',
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    Email::factory()->create([
+        'team_id' => $account->team_id,
+        'user_id' => $account->user_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_message_id' => 'M1',
+    ]);
+
+    invokeInitialEmailSyncBatchFinallyCallbacks();
+
+    Bus::assertBatchCount(2);
+    Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->jobs->count() === 1
+        && $batch->jobs->first() instanceof StoreEmailJob
+        && $batch->jobs->first()->messageId === 'M2');
+    Bus::assertDispatchedTimes(InitialEmailSyncJob::class, 0);
+    expect($account->fresh()?->sync_cursor)->toBeNull();
 });


### PR DESCRIPTION
## Summary

- Add `InitialSyncPageStoreBatch` to run initial email and calendar store batches through a guarded `finally()` checkpoint.
- Verify every page item exists in the database before advancing the page token or writing the sync cursor.
- Retry missing store jobs up to three times, then mark the connected account in error instead of silently skipping failed messages or events.

## Test plan

- [x] `php artisan test --compact tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php`
- [x] `php artisan test --compact tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php`
- [x] `php artisan test --compact tests/Feature/EmailIntegration/SyncQueueRoutingTest.php`