### PR TITLE
Count preferred mailbox copies in communication metrics

### DIFF
--- a/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
+++ b/app/Filament/Resources/CompanyResource/Pages/ViewCompany.php
@@ -116,9 +116,7 @@ final class ViewCompany extends ViewRecord
                     ])->grow(false),
                 ])->columnSpan('full'),
 
-                CommunicationIntelligenceInfolist::section(
-                    'filament/resources/company.pages.view.communication_intelligence',
-                ),
+                CommunicationIntelligenceInfolist::section(),
 
             ]);
     }

--- a/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
@@ -89,10 +89,7 @@ final class ViewOpportunity extends ViewRecord
                 CustomFields::infolist()->forSchema($schema)->build()->columnSpanFull(),
             ])->columnSpanFull(),
 
-            CommunicationIntelligenceInfolist::section(
-                'filament/resources/opportunity.pages.view.communication_intelligence',
-                includeDirectionCounts: false,
-            ),
+            CommunicationIntelligenceInfolist::section(),
         ]);
     }
 }

--- a/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
+++ b/app/Filament/Resources/PeopleResource/Pages/ViewPeople.php
@@ -91,9 +91,7 @@ final class ViewPeople extends ViewRecord
                 CustomFields::infolist()->forSchema($schema)->build()->columnSpanFull(),
             ])->columnSpanFull(),
 
-            CommunicationIntelligenceInfolist::section(
-                'filament/resources/person.pages.view.communication_intelligence',
-            ),
+            CommunicationIntelligenceInfolist::section(),
         ]);
     }
 }

--- a/database/migrations/2026_09_08_021826_normalize_emailables_morph_aliases.php
+++ b/database/migrations/2026_09_08_021826_normalize_emailables_morph_aliases.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CrmEntity;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        foreach ([CrmEntity::People, CrmEntity::Company, CrmEntity::Opportunity] as $entity) {
+            DB::table('emailables')
+                ->where('emailable_type', $entity->model())
+                ->update(['emailable_type' => $entity->value]);
+        }
+    }
+};

--- a/lang/en/filament/communication-intelligence.php
+++ b/lang/en/filament/communication-intelligence.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'heading' => 'Communication Intelligence',
+    'groups' => [
+        'connection' => 'Connection',
+        'email' => 'Email',
+        'calendar' => 'Calendar',
+    ],
+    'fields' => [
+        'first_interaction' => [
+            'label' => 'First interaction',
+            'placeholder' => 'Never',
+        ],
+        'last_interaction' => [
+            'label' => 'Last interaction',
+            'placeholder' => 'Never',
+        ],
+        'connection_strength' => [
+            'label' => 'Strength',
+        ],
+        'strongest_connection' => [
+            'label' => 'Strongest teammate',
+            'placeholder' => 'Nobody',
+        ],
+        'first_email' => [
+            'label' => 'First',
+            'placeholder' => 'Never',
+        ],
+        'last_email' => [
+            'label' => 'Last',
+            'placeholder' => 'Never',
+        ],
+        'first_calendar' => [
+            'label' => 'First',
+            'placeholder' => 'Never',
+        ],
+        'last_calendar' => [
+            'label' => 'Last',
+            'placeholder' => 'Never',
+        ],
+        'next_calendar' => [
+            'label' => 'Next',
+            'placeholder' => 'None',
+        ],
+    ],
+    'connection_strength' => [
+        'none' => 'No connection',
+        'very_weak' => 'Very weak',
+        'weak' => 'Weak',
+        'good' => 'Good',
+        'strong' => 'Strong',
+        'very_strong' => 'Very strong',
+    ],
+];

--- a/lang/en/filament/pages/email-inbox.php
+++ b/lang/en/filament/pages/email-inbox.php
@@ -70,6 +70,8 @@ return [
     ],
     'list_row' => [
         'via' => 'via :name',
+        'via_mailboxes' => '{1}via 1 mailbox|[2,*]via :count mailboxes',
+        'access_granted_via' => 'Access granted via',
         'timestamp_yesterday' => 'Yesterday, :time',
         'request_access' => 'Request access from :name',
         'requested' => 'Requested',

--- a/lang/en/filament/resources/company.php
+++ b/lang/en/filament/resources/company.php
@@ -86,33 +86,6 @@ return [
                     ],
                 ],
             ],
-            'communication_intelligence' => [
-                'heading' => 'Communication Intelligence',
-                'fields' => [
-                    'last_interaction' => [
-                        'label' => 'Last Interaction',
-                        'placeholder' => 'Never',
-                    ],
-                    'last_email' => [
-                        'label' => 'Last Email',
-                        'placeholder' => 'Never',
-                    ],
-                    'days_since_last_email' => [
-                        'label' => 'Days Since Last Email',
-                        'value' => ':days days ago',
-                        'empty' => 'No emails yet',
-                    ],
-                    'email_count' => [
-                        'label' => 'Total Emails',
-                    ],
-                    'inbound_email_count' => [
-                        'label' => 'Received',
-                    ],
-                    'outbound_email_count' => [
-                        'label' => 'Sent',
-                    ],
-                ],
-            ],
             'activity_log' => [
                 'description' => 'All activity for this company, grouped by week.',
             ],

--- a/lang/en/filament/resources/company.php
+++ b/lang/en/filament/resources/company.php
@@ -87,6 +87,7 @@ return [
                 ],
             ],
             'communication_intelligence' => [
+                'heading' => 'Communication Intelligence',
                 'fields' => [
                     'last_interaction' => [
                         'label' => 'Last Interaction',

--- a/lang/en/filament/resources/opportunity.php
+++ b/lang/en/filament/resources/opportunity.php
@@ -76,6 +76,7 @@ return [
                 ],
             ],
             'communication_intelligence' => [
+                'heading' => 'Communication Intelligence',
                 'fields' => [
                     'last_interaction' => [
                         'label' => 'Last Interaction',

--- a/lang/en/filament/resources/opportunity.php
+++ b/lang/en/filament/resources/opportunity.php
@@ -75,27 +75,6 @@ return [
                     ],
                 ],
             ],
-            'communication_intelligence' => [
-                'heading' => 'Communication Intelligence',
-                'fields' => [
-                    'last_interaction' => [
-                        'label' => 'Last Interaction',
-                        'placeholder' => 'Never',
-                    ],
-                    'last_email' => [
-                        'label' => 'Last Email',
-                        'placeholder' => 'Never',
-                    ],
-                    'days_since_last_email' => [
-                        'label' => 'Days Since Last Email',
-                        'value' => ':days days ago',
-                        'empty' => 'No emails yet',
-                    ],
-                    'email_count' => [
-                        'label' => 'Total Emails',
-                    ],
-                ],
-            ],
         ],
     ],
 ];

--- a/lang/en/filament/resources/person.php
+++ b/lang/en/filament/resources/person.php
@@ -81,6 +81,7 @@ return [
                 ],
             ],
             'communication_intelligence' => [
+                'heading' => 'Communication Intelligence',
                 'fields' => [
                     'last_interaction' => [
                         'label' => 'Last Interaction',

--- a/lang/en/filament/resources/person.php
+++ b/lang/en/filament/resources/person.php
@@ -80,33 +80,6 @@ return [
                     ],
                 ],
             ],
-            'communication_intelligence' => [
-                'heading' => 'Communication Intelligence',
-                'fields' => [
-                    'last_interaction' => [
-                        'label' => 'Last Interaction',
-                        'placeholder' => 'Never',
-                    ],
-                    'last_email' => [
-                        'label' => 'Last Email',
-                        'placeholder' => 'Never',
-                    ],
-                    'days_since_last_email' => [
-                        'label' => 'Days Since Last Email',
-                        'value' => ':days days ago',
-                        'empty' => 'No emails yet',
-                    ],
-                    'email_count' => [
-                        'label' => 'Total Emails',
-                    ],
-                    'inbound_email_count' => [
-                        'label' => 'Received',
-                    ],
-                    'outbound_email_count' => [
-                        'label' => 'Sent',
-                    ],
-                ],
-            ],
         ],
     ],
 ];

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -246,11 +246,11 @@ final readonly class LinkEmailAction
     private function buildSkippedDomains(string $teamId): Collection
     {
         $configDomains = collect((array) config('email-integration.public_domains', []))
-            ->map(fn (mixed $d): string => strtolower((string) $d));
+            ->map(fn (mixed $d): string => strtolower($this->domainMatcher->host((string) $d)));
 
         $teamDomains = PublicEmailDomain::query()->where('team_id', $teamId)
             ->pluck('domain')
-            ->map(fn (mixed $d): string => strtolower((string) $d));
+            ->map(fn (mixed $d): string => strtolower($this->domainMatcher->host((string) $d)));
 
         return $configDomains->merge($teamDomains)->unique()->values();
     }

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -19,6 +19,7 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 use Relaticle\EmailIntegration\Models\Scopes\ActiveAccountScope;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\RecordCommunicationMetrics;
 use Relaticle\EmailIntegration\Support\AutomatedSenderMatcher;
 use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
 
@@ -30,6 +31,7 @@ final readonly class LinkEmailAction
         private CompanyDomainMatcher $domainMatcher,
         private AutomatedSenderMatcher $automatedSender,
         private EmailVisibilityService $visibility,
+        private RecordCommunicationMetrics $metrics,
     ) {}
 
     /**
@@ -77,7 +79,9 @@ final readonly class LinkEmailAction
                 return;
             }
 
-            $this->link($email);
+            $applyMetricsForPrelinkedRecords = $locked->linked_at === null;
+
+            $this->link($email, $applyMetricsForPrelinkedRecords);
 
             if ($locked->linked_at === null) {
                 $locked->updateQuietly(['linked_at' => now()]);
@@ -85,7 +89,7 @@ final readonly class LinkEmailAction
         });
     }
 
-    private function link(Email $email): void
+    private function link(Email $email, bool $applyMetricsForPrelinkedRecords): void
     {
         $participants = $email->participants()->with('contact', 'company')->get();
         $teamId = $email->team_id;
@@ -148,7 +152,7 @@ final readonly class LinkEmailAction
 
                     if ($this->autoAttach($email->companies(), $company->getKey()) && ! isset($countedCompanies[$company->getKey()])) {
                         $countedCompanies[$company->getKey()] = true;
-                        $this->incrementEmailMetrics($company, $email);
+                        $this->metrics->incrementEmailMetrics($company, $email);
                     }
                 }
             }
@@ -169,7 +173,7 @@ final readonly class LinkEmailAction
 
                 if ($this->autoAttach($email->people(), $person->getKey()) && ! isset($countedPeople[$person->getKey()])) {
                     $countedPeople[$person->getKey()] = true;
-                    $this->incrementEmailMetrics($person, $email);
+                    $this->metrics->incrementEmailMetrics($person, $email);
                 }
 
                 if ($person->company_id) {
@@ -183,10 +187,19 @@ final readonly class LinkEmailAction
                 foreach ($opportunities as $opportunity) {
                     if ($this->autoAttach($email->opportunities(), $opportunity->getKey()) && ! isset($countedOpportunities[$opportunity->getKey()])) {
                         $countedOpportunities[$opportunity->getKey()] = true;
-                        $this->incrementEmailMetrics($opportunity, $email);
+                        $this->metrics->incrementEmailMetrics($opportunity, $email);
                     }
                 }
             }
+        }
+
+        if ($applyMetricsForPrelinkedRecords) {
+            $this->metrics->incrementEmailMetricsForPrelinkedRecords(
+                $email,
+                $countedCompanies,
+                $countedPeople,
+                $countedOpportunities,
+            );
         }
     }
 
@@ -280,52 +293,5 @@ final readonly class LinkEmailAction
         $relation->attach($relatedId, ['link_source' => 'auto']);
 
         return true;
-    }
-
-    /**
-     * Increment the shared email-interaction counters on a linked CRM record
-     * (People, Company, or Opportunity, all of which expose the same metric columns).
-     *
-     * Counters use atomic SQL increments so concurrent StoreEmailJob workers
-     * don't lose updates. The timestamps use GREATEST so an older email linked
-     * after a newer one (out-of-order parallel backfill) never moves
-     * last_email_at backwards.
-     */
-    private function incrementEmailMetrics(Model $record, Email $email): void
-    {
-        if (! $this->visibility->countsTowardCommunicationIntelligence($email)) {
-            return;
-        }
-
-        $isInbound = $email->direction->value === EmailDirection::INBOUND->value;
-
-        // Raw, parameterised UPDATE: counters increment atomically (no lost updates
-        // under concurrent StoreEmailJob workers) and the timestamps use GREATEST so
-        // an older email linked after a newer one (out-of-order parallel backfill)
-        // never moves last_email_at backwards. Bindings keep the date out of the SQL
-        // string; the table/key come from model metadata, never user input.
-        $sets = [
-            'email_count = email_count + 1',
-            'inbound_email_count = inbound_email_count + ?',
-            'outbound_email_count = outbound_email_count + ?',
-            'updated_at = ?',
-        ];
-
-        /** @var list<mixed> $bindings */
-        $bindings = [$isInbound ? 1 : 0, $isInbound ? 0 : 1, now()];
-
-        if ($email->sent_at !== null) {
-            $sets[] = 'last_email_at = GREATEST(last_email_at, ?)';
-            $sets[] = 'last_interaction_at = GREATEST(last_interaction_at, ?)';
-            $bindings[] = $email->sent_at;
-            $bindings[] = $email->sent_at;
-        }
-
-        $bindings[] = $record->getKey();
-
-        DB::update(
-            'update '.$record->getTable().' set '.implode(', ', $sets).' where '.$record->getKeyName().' = ?',
-            $bindings,
-        );
     }
 }

--- a/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
@@ -11,14 +11,12 @@ use App\Models\Team;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Database\Query\Builder as QueryBuilder;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\RecordCommunicationMetrics;
 use Relaticle\EmailIntegration\Support\AutomatedSenderMatcher;
 use Relaticle\EmailIntegration\Support\CompanyDomainMatcher;
 
@@ -30,6 +28,7 @@ final readonly class LinkMeetingAction
         private CompanyDomainMatcher $domainMatcher,
         private AutomatedSenderMatcher $automatedSender,
         private EmailVisibilityService $visibility,
+        private RecordCommunicationMetrics $metrics,
     ) {}
 
     public function execute(Meeting $meeting): void
@@ -77,7 +76,7 @@ final readonly class LinkMeetingAction
                 if ($company instanceof Company) {
                     $attendee->update(['company_id' => $company->getKey()]);
                     if ($this->autoAttach($meeting->companies(), $company->getKey()) && $countsTowardIntelligence) {
-                        $this->updateCompanyMetrics($company, $meeting);
+                        $this->metrics->incrementMeetingMetrics($company, $meeting);
                     }
                 }
             }
@@ -95,7 +94,7 @@ final readonly class LinkMeetingAction
             if ($person) {
                 $attendee->update(['contact_id' => $person->getKey()]);
                 if ($this->autoAttach($meeting->people(), $person->getKey()) && $countsTowardIntelligence) {
-                    $this->updatePersonMetrics($person, $meeting);
+                    $this->metrics->incrementMeetingMetrics($person, $meeting);
                 }
 
                 if ($person->company_id) {
@@ -108,7 +107,7 @@ final readonly class LinkMeetingAction
 
                 foreach ($opportunities as $opportunity) {
                     if ($this->autoAttach($meeting->opportunities(), $opportunity->getKey()) && $countsTowardIntelligence) {
-                        $this->updateOpportunityMetrics($opportunity, $meeting);
+                        $this->metrics->incrementMeetingMetrics($opportunity, $meeting);
                     }
                 }
             }
@@ -144,47 +143,6 @@ final readonly class LinkMeetingAction
         $relation->attach($relatedId, ['link_source' => 'auto']);
 
         return true;
-    }
-
-    private function updatePersonMetrics(People $person, Meeting $meeting): void
-    {
-        $this->advanceMetrics($person->getTable(), $person->getKey(), $meeting->starts_at);
-    }
-
-    private function updateCompanyMetrics(Company $company, Meeting $meeting): void
-    {
-        $this->advanceMetrics($company->getTable(), $company->getKey(), $meeting->starts_at);
-    }
-
-    private function updateOpportunityMetrics(Opportunity $opportunity, Meeting $meeting): void
-    {
-        $this->advanceMetrics($opportunity->getTable(), $opportunity->getKey(), $meeting->starts_at);
-    }
-
-    /**
-     * Increments `meeting_count` and monotonically advances `last_meeting_at` / `last_interaction_at`.
-     * The timestamps are guarded at the SQL level so parallel workers processing events out of
-     * chronological order (e.g. the 90-day backfill) cannot regress a newer value to an older one.
-     */
-    private function advanceMetrics(string $table, string $id, Carbon $startsAt): void
-    {
-        DB::table($table)
-            ->where('id', $id)
-            ->update(['meeting_count' => DB::raw('meeting_count + 1')]);
-
-        $this->advanceTimestamp($table, $id, 'last_meeting_at', $startsAt);
-        $this->advanceTimestamp($table, $id, 'last_interaction_at', $startsAt);
-    }
-
-    private function advanceTimestamp(string $table, string $id, string $column, Carbon $startsAt): void
-    {
-        DB::table($table)
-            ->where('id', $id)
-            ->where(fn (QueryBuilder $q) => $q
-                ->whereNull($column)
-                ->orWhere($column, '<', $startsAt)
-            )
-            ->update([$column => $startsAt]);
     }
 
     /** @return Collection<int, lowercase-string> */

--- a/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingAction.php
@@ -191,11 +191,11 @@ final readonly class LinkMeetingAction
     private function buildSkippedDomains(string $teamId): Collection
     {
         $configDomains = collect((array) config('email-integration.public_domains', []))
-            ->map(fn (mixed $d): string => strtolower((string) $d));
+            ->map(fn (mixed $d): string => strtolower($this->domainMatcher->host((string) $d)));
 
         $teamDomains = PublicEmailDomain::query()->where('team_id', $teamId)
             ->pluck('domain')
-            ->map(fn (mixed $d): string => strtolower((string) $d));
+            ->map(fn (mixed $d): string => strtolower($this->domainMatcher->host((string) $d)));
 
         return $configDomains->merge($teamDomains)->unique()->values();
     }

--- a/packages/EmailIntegration/src/Actions/LinkMeetingToRecordAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkMeetingToRecordAction.php
@@ -10,9 +10,12 @@ use App\Models\People;
 use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\RecordCommunicationMetrics;
 
 final readonly class LinkMeetingToRecordAction
 {
+    public function __construct(private RecordCommunicationMetrics $metrics) {}
+
     public function execute(Meeting $meeting, Model $record): void
     {
         // Tenant boundary: a meeting may only be linked to a record in its own team.
@@ -24,15 +27,23 @@ final readonly class LinkMeetingToRecordAction
             'Cannot link a meeting to a record from another team.',
         );
 
-        $relation = match (true) {
-            $record instanceof People => $meeting->people(),
-            $record instanceof Company => $meeting->companies(),
-            $record instanceof Opportunity => $meeting->opportunities(),
+        [$relation, $scorable] = match (true) {
+            $record instanceof People => [$meeting->people(), $record],
+            $record instanceof Company => [$meeting->companies(), $record],
+            $record instanceof Opportunity => [$meeting->opportunities(), $record],
             default => throw new InvalidArgumentException('Unsupported record type: '.$record::class),
         };
+
+        $wasAlreadyLinked = $relation->whereKey($record->getKey())->exists();
 
         $relation->syncWithoutDetaching([
             $record->getKey() => ['link_source' => 'manual'],
         ]);
+
+        if ($wasAlreadyLinked) {
+            return;
+        }
+
+        $this->metrics->incrementMeetingMetrics($scorable, $meeting);
     }
 }

--- a/packages/EmailIntegration/src/Actions/SendEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailAction.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
 use App\Models\User;
 use DateTimeInterface;
 use Illuminate\Support\Carbon;
@@ -138,15 +141,15 @@ final readonly class SendEmailAction
 
             $this->storeAttachments($email, $attachmentPaths, $data['attachment_file_names'] ?? []);
 
-            if ($linkToType !== null && $linkToId !== null) {
-                DB::table('emailables')->insert([
-                    'email_id' => $email->getKey(),
-                    'emailable_type' => $linkToType,
-                    'emailable_id' => $linkToId,
-                    'link_source' => 'manual',
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
+            if ($linkToType !== null && $linkToId !== null && in_array($linkToType, [Company::class, Opportunity::class, People::class], true)) {
+                $linked = $linkToType::query()->whereKey($linkToId)->first();
+
+                if ($linked instanceof Company || $linked instanceof Opportunity || $linked instanceof People) {
+                    // Attach through the record relation so emailable_type is the
+                    // morph alias (`people`), not the class name. Relation::enforceMorphMap
+                    // means `$person->emails()` would miss a fully-qualified class name.
+                    $linked->emails()->attach($email->getKey(), ['link_source' => 'manual']);
+                }
             }
 
             return $email;

--- a/packages/EmailIntegration/src/Actions/StoreEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreEmailAction.php
@@ -16,6 +16,7 @@ use Relaticle\EmailIntegration\Models\EmailLabel;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailRead;
 use Relaticle\EmailIntegration\Services\EmailClassifier;
+use Symfony\Component\Mime\MimeTypes;
 use Throwable;
 
 final readonly class StoreEmailAction
@@ -75,7 +76,7 @@ final readonly class StoreEmailAction
                 foreach ($data->attachments as $attachment) {
                     EmailAttachment::query()->create([
                         'email_id' => $email->getKey(),
-                        'filename' => $attachment['filename'],
+                        'filename' => $this->persistableAttachmentFilename($attachment),
                         'mime_type' => $attachment['mime_type'],
                         'size' => $attachment['size'],
                         'content_id' => $attachment['content_id'],
@@ -130,6 +131,34 @@ final readonly class StoreEmailAction
 
             throw $exception;
         }
+    }
+
+    /**
+     * Providers often omit a filename on CID inline images. The column is not
+     * nullable, so invent a stable name from the part's mime type.
+     *
+     * @param  array{filename: string|null, mime_type: string|null, size: int, content_id: string|null, attachment_id: string|null, inline_data: string|null, is_inline?: bool}  $attachment
+     */
+    private function persistableAttachmentFilename(array $attachment): string
+    {
+        if (filled($attachment['filename'])) {
+            return (string) $attachment['filename'];
+        }
+
+        $stem = ($attachment['is_inline'] ?? false) ? 'inline' : 'attachment';
+
+        return "{$stem}.{$this->extensionFromMimeType($attachment['mime_type'])}";
+    }
+
+    private function extensionFromMimeType(?string $mimeType): string
+    {
+        if (blank($mimeType)) {
+            return 'bin';
+        }
+
+        $extensions = MimeTypes::getDefault()->getExtensions($mimeType);
+
+        return $extensions[0] ?? 'bin';
     }
 
     /**

--- a/packages/EmailIntegration/src/Data/VisibleCommunicationIntelligence.php
+++ b/packages/EmailIntegration/src/Data/VisibleCommunicationIntelligence.php
@@ -5,16 +5,25 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Data;
 
 use Illuminate\Support\Carbon;
+use Relaticle\EmailIntegration\Enums\ConnectionStrength;
 
 final readonly class VisibleCommunicationIntelligence
 {
     public function __construct(
         public int $emailCount = 0,
-        public int $inboundEmailCount = 0,
-        public int $outboundEmailCount = 0,
+        public ?Carbon $firstEmailAt = null,
         public ?Carbon $lastEmailAt = null,
+        public ?Carbon $firstMeetingAt = null,
         public ?Carbon $lastMeetingAt = null,
+        public ?Carbon $nextMeetingAt = null,
+        public ConnectionStrength $connectionStrength = ConnectionStrength::None,
+        public ?string $strongestConnectionName = null,
     ) {}
+
+    public function firstInteractionAt(): ?Carbon
+    {
+        return $this->earlier($this->firstEmailAt, $this->firstMeetingAt);
+    }
 
     public function lastInteractionAt(): ?Carbon
     {
@@ -29,5 +38,18 @@ final readonly class VisibleCommunicationIntelligence
         return $this->lastEmailAt->greaterThan($this->lastMeetingAt)
             ? $this->lastEmailAt
             : $this->lastMeetingAt;
+    }
+
+    private function earlier(?Carbon $left, ?Carbon $right): ?Carbon
+    {
+        if (! $left instanceof Carbon) {
+            return $right;
+        }
+
+        if (! $right instanceof Carbon) {
+            return $left;
+        }
+
+        return $left->lessThan($right) ? $left : $right;
     }
 }

--- a/packages/EmailIntegration/src/Enums/ConnectionStrength.php
+++ b/packages/EmailIntegration/src/Enums/ConnectionStrength.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum ConnectionStrength: string implements HasLabel
+{
+    case None = 'none';
+    case VeryWeak = 'very_weak';
+    case Weak = 'weak';
+    case Good = 'good';
+    case Strong = 'strong';
+    case VeryStrong = 'very_strong';
+
+    public function getLabel(): string
+    {
+        return __('filament/communication-intelligence.connection_strength.'.$this->value);
+    }
+
+    public static function fromScore(float $score): self
+    {
+        return match (true) {
+            $score <= 0.0 => self::None,
+            $score < 3.0 => self::VeryWeak,
+            $score < 8.0 => self::Weak,
+            $score < 20.0 => self::Good,
+            $score < 40.0 => self::Strong,
+            default => self::VeryStrong,
+        };
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -65,7 +65,12 @@ trait HasEmailComposeActions
             ->tooltip(__('filament/concerns/email-compose.actions.compose.tooltip'))
             ->visible(fn (): bool => $this->hasActiveConnectedAccount())
             ->action(function (): void {
-                $this->dispatch('composer:open');
+                $record = $this->getCrmRecord();
+
+                $this->dispatch('composer:open', payload: [
+                    'linkRecordType' => $record::class,
+                    'linkRecordId' => (string) $record->getKey(),
+                ]);
             });
     }
 

--- a/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
@@ -21,7 +21,7 @@ final class CommunicationIntelligenceInfolist
         string $translationKey,
         bool $includeDirectionCounts = true,
     ): Section {
-        return Section::make('Communication Intelligence')
+        return Section::make(__("{$translationKey}.heading"))
             ->icon(Heroicon::ChartBar)
             ->schema([
                 TextEntry::make('visible_last_interaction_at')
@@ -67,11 +67,33 @@ final class CommunicationIntelligenceInfolist
             ->collapsed(fn (People|Company|Opportunity $record): bool => self::metrics($record)->emailCount === 0);
     }
 
+    /**
+     * Filament evaluates each TextEntry and the collapsed callback separately, and
+     * schema components do not share loaded infolist state. Cache on the current
+     * request, keyed by record and viewer, so one render runs the aggregates once
+     * without leaking across records, users, Livewire requests, or tests.
+     */
     private static function metrics(People|Company|Opportunity $record): VisibleCommunicationIntelligence
     {
         /** @var User $viewer */
         $viewer = Auth::user();
 
-        return resolve(EmailVisibilityService::class)->visibleCommunicationIntelligence($record, $viewer);
+        $key = sprintf(
+            'email-integration.visible-communication-intelligence.%s.%s.%s',
+            $record::class,
+            $record->getKey(),
+            $viewer->getKey(),
+        );
+
+        $cached = request()->attributes->get($key);
+
+        if ($cached instanceof VisibleCommunicationIntelligence) {
+            return $cached;
+        }
+
+        $metrics = resolve(EmailVisibilityService::class)->visibleCommunicationIntelligence($record, $viewer);
+        request()->attributes->set($key, $metrics);
+
+        return $metrics;
     }
 }

--- a/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
@@ -12,6 +12,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Relaticle\EmailIntegration\Data\VisibleCommunicationIntelligence;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
@@ -96,7 +97,7 @@ final class CommunicationIntelligenceInfolist
             ->columns(1)
             ->columnSpanFull()
             ->collapsible()
-            ->collapsed(fn (People|Company|Opportunity $record): bool => self::metrics($record)->lastInteractionAt() === null);
+            ->collapsed(fn (People|Company|Opportunity $record): bool => ! self::metrics($record)->lastInteractionAt() instanceof Carbon);
     }
 
     /**

--- a/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
@@ -9,6 +9,7 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\Auth;
@@ -17,54 +18,85 @@ use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
 final class CommunicationIntelligenceInfolist
 {
-    public static function section(
-        string $translationKey,
-        bool $includeDirectionCounts = true,
-    ): Section {
+    public static function section(): Section
+    {
+        $translationKey = 'filament/communication-intelligence';
+
         return Section::make(__("{$translationKey}.heading"))
             ->icon(Heroicon::ChartBar)
             ->schema([
-                TextEntry::make('visible_last_interaction_at')
-                    ->label(__("{$translationKey}.fields.last_interaction.label"))
-                    ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->lastInteractionAt()?->toDateTimeString())
-                    ->dateTime()
-                    ->placeholder(__("{$translationKey}.fields.last_interaction.placeholder")),
+                Section::make(__("{$translationKey}.groups.connection"))
+                    ->schema([
+                        TextEntry::make('visible_first_interaction_at')
+                            ->label(__("{$translationKey}.fields.first_interaction.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->firstInteractionAt()?->toDateTimeString())
+                            ->dateTime()
+                            ->placeholder(__("{$translationKey}.fields.first_interaction.placeholder")),
 
-                TextEntry::make('visible_last_email_at')
-                    ->label(__("{$translationKey}.fields.last_email.label"))
-                    ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->lastEmailAt?->toDateTimeString())
-                    ->dateTime()
-                    ->placeholder(__("{$translationKey}.fields.last_email.placeholder")),
+                        TextEntry::make('visible_last_interaction_at')
+                            ->label(__("{$translationKey}.fields.last_interaction.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->lastInteractionAt()?->toDateTimeString())
+                            ->dateTime()
+                            ->placeholder(__("{$translationKey}.fields.last_interaction.placeholder")),
 
-                TextEntry::make('visible_days_since_last_email')
-                    ->label(__("{$translationKey}.fields.days_since_last_email.label"))
-                    ->getStateUsing(function (People|Company|Opportunity $record) use ($translationKey): string {
-                        $lastEmailAt = self::metrics($record)->lastEmailAt;
+                        TextEntry::make('visible_connection_strength')
+                            ->label(__("{$translationKey}.fields.connection_strength.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): string => self::metrics($record)->connectionStrength->getLabel()),
 
-                        return $lastEmailAt
-                            ? __("{$translationKey}.fields.days_since_last_email.value", ['days' => (int) now()->diffInDays($lastEmailAt, true)])
-                            : __("{$translationKey}.fields.days_since_last_email.empty");
-                    }),
+                        TextEntry::make('visible_strongest_connection')
+                            ->label(__("{$translationKey}.fields.strongest_connection.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->strongestConnectionName)
+                            ->placeholder(__("{$translationKey}.fields.strongest_connection.placeholder")),
+                    ])
+                    ->columns(2)
+                    ->columnSpanFull()
+                    ->collapsible()
+                    ->collapsed(),
 
-                TextEntry::make('visible_email_count')
-                    ->label(__("{$translationKey}.fields.email_count.label"))
-                    ->getStateUsing(fn (People|Company|Opportunity $record): int => self::metrics($record)->emailCount)
-                    ->default(0),
+                Fieldset::make(__("{$translationKey}.groups.email"))
+                    ->schema([
+                        TextEntry::make('visible_first_email_at')
+                            ->label(__("{$translationKey}.fields.first_email.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->firstEmailAt?->toDateTimeString())
+                            ->dateTime()
+                            ->placeholder(__("{$translationKey}.fields.first_email.placeholder")),
 
-                ...($includeDirectionCounts ? [
-                    TextEntry::make('visible_inbound_email_count')
-                        ->label(__("{$translationKey}.fields.inbound_email_count.label"))
-                        ->getStateUsing(fn (People|Company|Opportunity $record): int => self::metrics($record)->inboundEmailCount),
+                        TextEntry::make('visible_last_email_at')
+                            ->label(__("{$translationKey}.fields.last_email.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->lastEmailAt?->toDateTimeString())
+                            ->dateTime()
+                            ->placeholder(__("{$translationKey}.fields.last_email.placeholder")),
+                    ])
+                    ->columns(2)
+                    ->columnSpanFull(),
 
-                    TextEntry::make('visible_outbound_email_count')
-                        ->label(__("{$translationKey}.fields.outbound_email_count.label"))
-                        ->getStateUsing(fn (People|Company|Opportunity $record): int => self::metrics($record)->outboundEmailCount),
-                ] : []),
+                Fieldset::make(__("{$translationKey}.groups.calendar"))
+                    ->schema([
+                        TextEntry::make('visible_first_calendar_at')
+                            ->label(__("{$translationKey}.fields.first_calendar.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->firstMeetingAt?->toDateTimeString())
+                            ->dateTime()
+                            ->placeholder(__("{$translationKey}.fields.first_calendar.placeholder")),
+
+                        TextEntry::make('visible_last_calendar_at')
+                            ->label(__("{$translationKey}.fields.last_calendar.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->lastMeetingAt?->toDateTimeString())
+                            ->dateTime()
+                            ->placeholder(__("{$translationKey}.fields.last_calendar.placeholder")),
+
+                        TextEntry::make('visible_next_calendar_at')
+                            ->label(__("{$translationKey}.fields.next_calendar.label"))
+                            ->getStateUsing(fn (People|Company|Opportunity $record): ?string => self::metrics($record)->nextMeetingAt?->toDateTimeString())
+                            ->dateTime()
+                            ->placeholder(__("{$translationKey}.fields.next_calendar.placeholder")),
+                    ])
+                    ->columns(3)
+                    ->columnSpanFull(),
             ])
-            ->columns($includeDirectionCounts ? 3 : 2)
+            ->columns(1)
             ->columnSpanFull()
             ->collapsible()
-            ->collapsed(fn (People|Company|Opportunity $record): bool => self::metrics($record)->emailCount === 0);
+            ->collapsed(fn (People|Company|Opportunity $record): bool => self::metrics($record)->lastInteractionAt() === null);
     }
 
     /**

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -52,6 +52,22 @@ abstract class BaseRecordEmailsPage extends Page
         $this->record = $this->resolveRecord($record);
     }
 
+    /**
+     * A send from this record belongs on All, not Inbox. Inbox is inbound only
+     * and would hide the just-queued outbound copy.
+     */
+    public function showQueuedSendOnRecord(?string $emailId = null): void
+    {
+        $this->folder = EmailFolder::All;
+        $this->search = '';
+
+        if (filled($emailId)) {
+            $this->selectedEmailId = $emailId;
+        }
+
+        unset($this->emails);
+    }
+
     protected function getCrmRecord(): Model
     {
         return $this->getRecord();
@@ -76,7 +92,10 @@ abstract class BaseRecordEmailsPage extends Page
      */
     protected function getListeners(): array
     {
-        return ['reply-email' => 'openReplyModal'];
+        return [
+            'reply-email' => 'openReplyModal',
+            'composer:sent' => 'showQueuedSendOnRecord',
+        ];
     }
 
     /**
@@ -132,7 +151,11 @@ abstract class BaseRecordEmailsPage extends Page
 
         resolve(PreferredEmailCopyService::class)->restrictToPreferredCopies($query->getQuery(), $user);
 
-        return $query->latest('sent_at')->paginate(20);
+        $paginator = $query->latest('sent_at')->paginate(20);
+
+        resolve(PreferredEmailCopyService::class)->hydrateMailboxAccess($paginator->getCollection(), $user, $record);
+
+        return $paginator;
     }
 
     /**

--- a/packages/EmailIntegration/src/Jobs/Concerns/ReleasesOnProviderRateLimit.php
+++ b/packages/EmailIntegration/src/Jobs/Concerns/ReleasesOnProviderRateLimit.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Jobs\Concerns;
+
+use Relaticle\EmailIntegration\Services\ProviderRateLimit;
+use Throwable;
+
+trait ReleasesOnProviderRateLimit
+{
+    protected function releaseIfProviderCoolingDown(string $accountId): bool
+    {
+        $seconds = ProviderRateLimit::remainingSeconds($accountId);
+
+        if ($seconds === null) {
+            return false;
+        }
+
+        $this->release($seconds);
+
+        return true;
+    }
+
+    protected function releaseIfProviderRateLimited(string $accountId, Throwable $exception): bool
+    {
+        $seconds = ProviderRateLimit::retryAfterSeconds($exception);
+
+        if ($seconds === null) {
+            return false;
+        }
+
+        ProviderRateLimit::trip($accountId, $seconds);
+        $this->release($seconds);
+
+        return true;
+    }
+}

--- a/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Relaticle\EmailIntegration\Actions\StoreEmailAction;
+use Relaticle\EmailIntegration\Jobs\Concerns\ReleasesOnProviderRateLimit;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
@@ -21,7 +22,7 @@ use Throwable;
 #[DeleteWhenMissingModels]
 final class StoreEmailJob implements ShouldBeUnique, ShouldQueue
 {
-    use Batchable, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Batchable, Dispatchable, InteractsWithQueue, Queueable, ReleasesOnProviderRateLimit, SerializesModels;
 
     public int $tries = 5;
 
@@ -59,7 +60,21 @@ final class StoreEmailJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $fetched = $mailFactory->make($this->connectedAccount)->fetchMessage($this->messageId);
+        $accountId = (string) $this->connectedAccount->getKey();
+
+        if ($this->releaseIfProviderCoolingDown($accountId)) {
+            return;
+        }
+
+        try {
+            $fetched = $mailFactory->make($this->connectedAccount)->fetchMessage($this->messageId);
+        } catch (Throwable $exception) {
+            if ($this->releaseIfProviderRateLimited($accountId, $exception)) {
+                return;
+            }
+
+            throw $exception;
+        }
 
         // Honour the account's inbox/sent toggles. Gated here rather than in a
         // provider service so it covers Gmail and Microsoft, and both the initial

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -7,6 +7,7 @@ namespace Relaticle\EmailIntegration\Livewire;
 use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\CustomFieldValue;
+use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use App\Services\AvatarService;
@@ -126,6 +127,14 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
     public ?string $accountId = null;
 
+    /**
+     * Record this compose was opened from. The queued send is linked immediately
+     * so it appears on that record's Emails tab without waiting for Gmail import.
+     */
+    public ?string $linkRecordType = null;
+
+    public ?string $linkRecordId = null;
+
     /** @var list<string> */
     public array $to = [];
 
@@ -183,7 +192,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * A same-named `$payload['draftId']` entry is never populated by either
      * caller; only a literal `draftId` parameter is.
      *
-     * @param  array{to?: list<string>}  $payload
+     * @param  array{to?: list<string>, linkRecordType?: class-string, linkRecordId?: string}  $payload
      */
     #[On('composer:open')]
     public function open(array $payload = [], ?string $draftId = null): void
@@ -212,6 +221,8 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
         $this->accountId = (string) $account->getKey();
         $this->to = $payload['to'] ?? [];
+        $this->linkRecordType = $payload['linkRecordType'] ?? null;
+        $this->linkRecordId = $payload['linkRecordId'] ?? null;
         $this->privacyTier = resolve(PrivacyService::class)
             ->defaultTierForUser($this->authUser())->value;
 
@@ -429,23 +440,29 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $attachmentPaths = [...$pendingPaths, ...$copiedPaths];
         $attachmentNames = [...$pendingNames, ...$copiedNames];
 
-        $email = resolve(SendEmailAction::class)->execute([
-            'connected_account_id' => (string) $this->accountId,
-            'subject' => $renderer->renderContent((string) $this->subject),
-            'body_html' => $renderer->renderForSending($this->withQuotedBody($bodyHtml)),
-            'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->to),
-            'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->cc),
-            'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->bcc),
-            'in_reply_to_email_id' => $this->inReplyToEmailId,
-            'creation_source' => $this->creationSource(),
-            'privacy_tier' => EmailPrivacyTier::from((string) $this->privacyTier),
-            'batch_id' => null,
-            // Interactive sends from the composer keep the undo-send window (matches
-            // the surface being replaced, HasEmailComposeActions::buildSendData()).
-            'priority' => EmailPriority::PRIORITY,
-            'attachments' => $attachmentPaths,
-            'attachment_file_names' => $attachmentNames,
-        ]);
+        $linkRecord = $this->linkRecord();
+
+        $email = resolve(SendEmailAction::class)->execute(
+            data: [
+                'connected_account_id' => (string) $this->accountId,
+                'subject' => $renderer->renderContent((string) $this->subject),
+                'body_html' => $renderer->renderForSending($this->withQuotedBody($bodyHtml)),
+                'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->to),
+                'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->cc),
+                'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->bcc),
+                'in_reply_to_email_id' => $this->inReplyToEmailId,
+                'creation_source' => $this->creationSource(),
+                'privacy_tier' => EmailPrivacyTier::from((string) $this->privacyTier),
+                'batch_id' => null,
+                // Interactive sends from the composer keep the undo-send window (matches
+                // the surface being replaced, HasEmailComposeActions::buildSendData()).
+                'priority' => EmailPriority::PRIORITY,
+                'attachments' => $attachmentPaths,
+                'attachment_file_names' => $attachmentNames,
+            ],
+            linkToType: $linkRecord === null ? null : $linkRecord::class,
+            linkToId: $linkRecord?->getKey(),
+        );
 
         if ($this->draftId !== null) {
             // Best-effort: two tabs open on the same draft, or a retried request,
@@ -460,7 +477,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         resolve(QueuedSendNotifier::class)->send($email);
 
         $this->closeComposer();
-        $this->dispatch('composer:sent');
+        $this->dispatch('composer:sent', emailId: $email->getKey());
         // A send both removes the draft (if any) and adds an outbox row.
         $this->dispatch('drafts:changed');
         $this->dispatch('outbox:changed');
@@ -1458,8 +1475,33 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
     private function resetComposerState(): void
     {
-        $this->reset(['draftId', 'to', 'cc', 'bcc', 'showCc', 'showBcc', 'subject', 'bodyHtml', 'signatureId', 'attachments', 'savedAttachments', 'replyMode', 'sourceEmailId', 'inReplyToEmailId', 'quotedBodyHtml']);
+        $this->reset(['draftId', 'to', 'cc', 'bcc', 'showCc', 'showBcc', 'subject', 'bodyHtml', 'signatureId', 'attachments', 'savedAttachments', 'replyMode', 'sourceEmailId', 'inReplyToEmailId', 'quotedBodyHtml', 'linkRecordType', 'linkRecordId']);
         $this->resetErrorBag();
+    }
+
+    private function linkRecord(): Company|Opportunity|People|null
+    {
+        $type = $this->linkRecordType;
+        $id = $this->linkRecordId;
+
+        if (! is_string($type) || $id === null || $id === '') {
+            return null;
+        }
+
+        if (! in_array($type, [Company::class, Opportunity::class, People::class], true)) {
+            return null;
+        }
+
+        $record = $type::query()
+            ->whereKey($id)
+            ->where('team_id', $this->authUser()->current_team_id)
+            ->first();
+
+        if ($record instanceof Company || $record instanceof Opportunity || $record instanceof People) {
+            return $record;
+        }
+
+        return null;
     }
 
     private function defaultSignatureFor(?string $accountId): ?EmailSignature

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -295,6 +295,14 @@ final class Email extends Model
     }
 
     /**
+     * Connected mailboxes that hold a visible copy of this message. Email is
+     * the mailbox address, never the Relaticle login.
+     *
+     * @var list<array{name: string, mailbox_email: string}>
+     */
+    public array $accessMailboxes = [];
+
+    /**
      * @return EloquentCollection<int, EmailAttachment>
      */
     public function inlineAttachments(): EloquentCollection

--- a/packages/EmailIntegration/src/Models/Scopes/VisibleMeetingScope.php
+++ b/packages/EmailIntegration/src/Models/Scopes/VisibleMeetingScope.php
@@ -35,7 +35,7 @@ final readonly class VisibleMeetingScope implements Scope
         $teamId = $this->viewer->current_team_id;
 
         $builder
-            ->where('team_id', $teamId)
+            ->where($model->qualifyColumn('team_id'), $teamId)
             ->where(function (Builder $visibilityQuery) use ($viewerId, $teamId): void {
                 $this->excludeMeetingsMatchingMailboxBlocklist($visibilityQuery);
                 $this->excludeMeetingsWithBlockedOrganizerMatchingMailboxBlocklist($visibilityQuery);

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -743,7 +743,7 @@ final class EmailVisibilityService
 
     private function timestampOrNull(mixed $value): ?Carbon
     {
-        if (! filled($value)) {
+        if (blank($value)) {
             return null;
         }
 

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -15,12 +15,13 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Data\VisibleCommunicationIntelligence;
+use Relaticle\EmailIntegration\Enums\ConnectionStrength;
 use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
-use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailVisibilityEnforcement;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -149,6 +150,9 @@ final class EmailVisibilityService
     /**
      * Communication-intelligence metrics scoped to mail and meetings the viewer may
      * see on this record. Denormalized CRM counters include hidden teammate mail.
+     *
+     * Includes first and last interaction, email and calendar timestamps, the next
+     * meeting, connection strength, and the teammate with the strongest tie.
      */
     public function visibleCommunicationIntelligence(Company|Opportunity|People $record, User $viewer): VisibleCommunicationIntelligence
     {
@@ -166,26 +170,32 @@ final class EmailVisibilityService
             ->reorder()
             ->toBase()
             ->selectRaw('count(*) as email_count')
-            ->selectRaw('coalesce(sum(case when emails.direction = ? then 1 else 0 end), 0) as inbound_email_count', [EmailDirection::INBOUND->value])
-            ->selectRaw('coalesce(sum(case when emails.direction = ? then 1 else 0 end), 0) as outbound_email_count', [EmailDirection::OUTBOUND->value])
+            ->selectRaw('min(emails.sent_at) as first_email_at')
             ->selectRaw('max(emails.sent_at) as last_email_at')
             ->first();
 
-        $lastMeetingAt = $record->meetings()
+        $now = now();
+
+        $meetingAggregates = $record->meetings()
             ->withGlobalScope('visible', new VisibleMeetingScope($viewer))
             ->reorder()
-            ->max('starts_at');
+            ->toBase()
+            ->selectRaw('min(starts_at) as first_meeting_at')
+            ->selectRaw('max(starts_at) as last_meeting_at')
+            ->selectRaw('min(case when starts_at > ? then starts_at end) as next_meeting_at', [$now])
+            ->first();
+
+        [$connectionStrength, $strongestConnectionName] = $this->connectionFor($record, $viewer, $now);
 
         return new VisibleCommunicationIntelligence(
             emailCount: (int) ($emailAggregates->email_count ?? 0),
-            inboundEmailCount: (int) ($emailAggregates->inbound_email_count ?? 0),
-            outboundEmailCount: (int) ($emailAggregates->outbound_email_count ?? 0),
-            lastEmailAt: filled($emailAggregates->last_email_at)
-                ? Date::parse((string) $emailAggregates->last_email_at)
-                : null,
-            lastMeetingAt: filled($lastMeetingAt)
-                ? Date::parse((string) $lastMeetingAt)
-                : null,
+            firstEmailAt: $this->timestampOrNull($emailAggregates->first_email_at ?? null),
+            lastEmailAt: $this->timestampOrNull($emailAggregates->last_email_at ?? null),
+            firstMeetingAt: $this->timestampOrNull($meetingAggregates->first_meeting_at ?? null),
+            lastMeetingAt: $this->timestampOrNull($meetingAggregates->last_meeting_at ?? null),
+            nextMeetingAt: $this->timestampOrNull($meetingAggregates->next_meeting_at ?? null),
+            connectionStrength: $connectionStrength,
+            strongestConnectionName: $strongestConnectionName,
         );
     }
 
@@ -729,5 +739,92 @@ final class EmailVisibilityService
         $domain = Str::afterLast($email, '@');
 
         return $domain !== '' ? $domain : null;
+    }
+
+    private function timestampOrNull(mixed $value): ?Carbon
+    {
+        if (! filled($value)) {
+            return null;
+        }
+
+        return Date::parse((string) $value);
+    }
+
+    /**
+     * Recency-weighted frequency of visible emails and meetings, per teammate.
+     * Connection strength is the workspace total. Strongest connection is the
+     * teammate with the highest score among mail the viewer can see.
+     *
+     * @return array{0: ConnectionStrength, 1: ?string}
+     */
+    private function connectionFor(Company|Opportunity|People $record, User $viewer, Carbon $now): array
+    {
+        $emailScores = $record->emails()
+            ->withGlobalScope('visible', new VisibleEmailScope($viewer))
+            ->reorder()
+            ->toBase()
+            ->select('emails.user_id')
+            ->selectRaw('coalesce(sum(case when emails.sent_at > ? then 5 when emails.sent_at > ? then 3 when emails.sent_at > ? then 2 when emails.sent_at > ? then 1 else 0.25 end), 0) as score', [
+                $now->copy()->subDays(7),
+                $now->copy()->subDays(30),
+                $now->copy()->subDays(90),
+                $now->copy()->subDays(365),
+            ])
+            ->whereNotNull('emails.sent_at')
+            ->groupBy('emails.user_id')
+            ->pluck('score', 'user_id');
+
+        $meetingAccountScores = $record->meetings()
+            ->withGlobalScope('visible', new VisibleMeetingScope($viewer))
+            ->reorder()
+            ->toBase()
+            ->select('meetings.connected_account_id')
+            ->selectRaw('coalesce(sum(case when meetings.starts_at > ? then 5 when meetings.starts_at > ? then 3 when meetings.starts_at > ? then 2 when meetings.starts_at > ? then 1 else 0.25 end), 0) as score', [
+                $now->copy()->subDays(7),
+                $now->copy()->subDays(30),
+                $now->copy()->subDays(90),
+                $now->copy()->subDays(365),
+            ])
+            ->groupBy('meetings.connected_account_id')
+            ->pluck('score', 'connected_account_id');
+
+        $accountUserIds = $meetingAccountScores->isEmpty()
+            ? collect()
+            : ConnectedAccount::query()
+                ->whereIn('id', $meetingAccountScores->keys())
+                ->pluck('user_id', 'id');
+
+        $scores = [];
+
+        foreach ($emailScores as $userId => $score) {
+            $scores[(string) $userId] = (float) $score;
+        }
+
+        foreach ($meetingAccountScores as $accountId => $score) {
+            $userId = $accountUserIds->get($accountId);
+
+            if ($userId === null) {
+                continue;
+            }
+
+            $key = (string) $userId;
+            $scores[$key] = ($scores[$key] ?? 0.0) + (float) $score;
+        }
+
+        $total = array_sum($scores);
+
+        if ($scores === []) {
+            return [ConnectionStrength::None, null];
+        }
+
+        arsort($scores);
+        $strongestUserId = array_key_first($scores);
+
+        $strongest = User::query()->whereKey($strongestUserId)->value('name');
+
+        return [
+            ConnectionStrength::fromScore($total),
+            is_string($strongest) && $strongest !== '' ? $strongest : null,
+        ];
     }
 }

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -156,8 +156,13 @@ final class EmailVisibilityService
             return new VisibleCommunicationIntelligence;
         }
 
-        $emailAggregates = $record->emails()
-            ->withGlobalScope('visible', new VisibleEmailScope($viewer))
+        $emailsQuery = $record
+            ->emails()
+            ->withGlobalScope('visible', new VisibleEmailScope($viewer));
+
+        $this->preferredCopies->restrictToPreferredCopies($emailsQuery->getQuery(), $viewer);
+
+        $emailAggregates = $emailsQuery
             ->reorder()
             ->toBase()
             ->selectRaw('count(*) as email_count')

--- a/packages/EmailIntegration/src/Services/PreferredEmailCopyService.php
+++ b/packages/EmailIntegration/src/Services/PreferredEmailCopyService.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services;
 
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 
 final readonly class PreferredEmailCopyService
 {
@@ -58,5 +64,86 @@ final readonly class PreferredEmailCopyService
             ->where('user_id', $viewer->getKey())
             ->where('rfc_message_id', $email->rfc_message_id)
             ->exists();
+    }
+
+    /**
+     * Attach the connected mailboxes that hold a visible copy of each listed
+     * message. The address is the mailbox, not the Relaticle login.
+     *
+     * @param  iterable<int, Email>  $emails
+     */
+    public function hydrateMailboxAccess(iterable $emails, User $viewer, Company|Opportunity|People $record): void
+    {
+        $items = collect($emails);
+
+        if ($items->isEmpty()) {
+            return;
+        }
+
+        $messageIds = $items
+            ->pluck('rfc_message_id')
+            ->filter(fn (mixed $id): bool => is_string($id) && $id !== '')
+            ->unique()
+            ->values();
+
+        $copies = $messageIds->isEmpty()
+            ? collect()
+            : $record->emails()
+                ->with(['connectedAccount.user'])
+                ->withGlobalScope('visible', new VisibleEmailScope($viewer))
+                ->whereIn('rfc_message_id', $messageIds)
+                ->get();
+
+        $grouped = $copies->groupBy('rfc_message_id');
+
+        foreach ($items as $email) {
+            $siblings = filled($email->rfc_message_id)
+                ? $grouped->get($email->rfc_message_id, collect())
+                : collect();
+
+            if ($siblings->isEmpty()) {
+                $siblings = collect([$email]);
+            }
+
+            $email->accessMailboxes = $this->uniqueMailboxRows($siblings);
+        }
+    }
+
+    /**
+     * @param  Collection<int, Email>  $copies
+     * @return list<array{name: string, mailbox_email: string}>
+     */
+    private function uniqueMailboxRows(Collection $copies): array
+    {
+        $mailboxes = [];
+        $seen = [];
+
+        foreach ($copies as $copy) {
+            $account = $copy->connectedAccount;
+
+            if ($account === null) {
+                continue;
+            }
+
+            $mailboxEmail = $account->email_address;
+
+            if ($mailboxEmail === '') {
+                continue;
+            }
+
+            $key = Str::lower($mailboxEmail);
+
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $mailboxes[] = [
+                'name' => $account->user?->name ?: ($account->display_name ?: $mailboxEmail),
+                'mailbox_email' => $mailboxEmail,
+            ];
+        }
+
+        return $mailboxes;
     }
 }

--- a/packages/EmailIntegration/src/Services/ProviderRateLimit.php
+++ b/packages/EmailIntegration/src/Services/ProviderRateLimit.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+/**
+ * Per-mailbox cooldown for Gmail/Graph user-rate limits. One 429 on a connected
+ * account must park every other fetch for that mailbox until Retry-After, or
+ * workers keep calling the API and Google slides the lock forward.
+ */
+final readonly class ProviderRateLimit
+{
+    private const int MIN_SECONDS = 10;
+
+    private const int MAX_SECONDS = 1800;
+
+    private const int FALLBACK_SECONDS = 60;
+
+    public static function remainingSeconds(string $accountId): ?int
+    {
+        $until = Cache::get(self::key($accountId));
+
+        if (! is_numeric($until)) {
+            return null;
+        }
+
+        $remaining = (int) $until - now()->getTimestamp();
+
+        return $remaining > 0 ? $remaining : null;
+    }
+
+    public static function trip(string $accountId, int $seconds): void
+    {
+        $seconds = self::clamp($seconds);
+
+        Cache::put(self::key($accountId), now()->addSeconds($seconds)->getTimestamp(), $seconds);
+    }
+
+    public static function retryAfterSeconds(Throwable $exception): ?int
+    {
+        $current = $exception;
+
+        while ($current instanceof Throwable) {
+            $seconds = self::secondsFor($current);
+
+            if ($seconds !== null) {
+                return $seconds;
+            }
+
+            $current = $current->getPrevious();
+        }
+
+        return null;
+    }
+
+    private static function secondsFor(Throwable $exception): ?int
+    {
+        if (! self::isRateLimit($exception)) {
+            return null;
+        }
+
+        $fromHeader = self::headerSeconds($exception);
+
+        if ($fromHeader !== null) {
+            return self::clamp($fromHeader);
+        }
+
+        $message = $exception->getMessage();
+
+        if (preg_match('/Retry after (\d{4}-\d{2}-\d{2}T[\d:.]+Z)/i', $message, $matches) === 1) {
+            $until = Date::parse($matches[1]);
+            $seconds = $until->getTimestamp() - now()->getTimestamp();
+
+            return self::clamp($seconds > 0 ? $seconds : self::FALLBACK_SECONDS);
+        }
+
+        return self::clamp(self::FALLBACK_SECONDS);
+    }
+
+    private static function isRateLimit(Throwable $exception): bool
+    {
+        $status = self::httpStatus($exception);
+
+        if ($status === 429) {
+            return true;
+        }
+
+        if ($status !== 403) {
+            return false;
+        }
+
+        $message = strtolower($exception->getMessage());
+
+        return str_contains($message, 'ratelimitexceeded')
+            || str_contains($message, 'rate limit exceeded');
+    }
+
+    private static function headerSeconds(Throwable $exception): ?int
+    {
+        $value = self::retryAfterHeader($exception);
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        $until = Date::parse($value);
+        $seconds = $until->getTimestamp() - now()->getTimestamp();
+
+        return $seconds > 0 ? $seconds : self::FALLBACK_SECONDS;
+    }
+
+    private static function retryAfterHeader(Throwable $exception): ?string
+    {
+        if ($exception instanceof RequestException) {
+            $header = $exception->response->header('Retry-After');
+
+            return $header !== '' ? $header : null;
+        }
+
+        if (! method_exists($exception, 'getResponse')) {
+            return null;
+        }
+
+        $response = $exception->getResponse();
+
+        if (! $response instanceof ResponseInterface) {
+            return null;
+        }
+
+        $header = $response->getHeaderLine('Retry-After');
+
+        return $header !== '' ? $header : null;
+    }
+
+    private static function httpStatus(Throwable $exception): ?int
+    {
+        if ($exception instanceof RequestException) {
+            return $exception->response->status();
+        }
+
+        if (method_exists($exception, 'getResponse')) {
+            $response = $exception->getResponse();
+
+            if ($response instanceof ResponseInterface) {
+                return $response->getStatusCode();
+            }
+        }
+
+        $code = $exception->getCode();
+
+        return is_int($code) && $code >= 100 && $code < 600 ? $code : null;
+    }
+
+    private static function clamp(int $seconds): int
+    {
+        return max(self::MIN_SECONDS, min(self::MAX_SECONDS, $seconds));
+    }
+
+    private static function key(string $accountId): string
+    {
+        return "email-integration:provider-rate-limit:{$accountId}";
+    }
+}

--- a/packages/EmailIntegration/src/Services/RecordCommunicationMetrics.php
+++ b/packages/EmailIntegration/src/Services/RecordCommunicationMetrics.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final readonly class RecordCommunicationMetrics
+{
+    public function __construct(private EmailVisibilityService $visibility) {}
+
+    public function incrementEmailMetrics(Model $record, Email $email): void
+    {
+        if (! $this->visibility->countsTowardCommunicationIntelligence($email)) {
+            return;
+        }
+
+        $isInbound = $email->direction->value === EmailDirection::INBOUND->value;
+
+        $sets = [
+            'email_count = email_count + 1',
+            'inbound_email_count = inbound_email_count + ?',
+            'outbound_email_count = outbound_email_count + ?',
+            'updated_at = ?',
+        ];
+
+        /** @var list<mixed> $bindings */
+        $bindings = [$isInbound ? 1 : 0, $isInbound ? 0 : 1, now()];
+
+        if ($email->sent_at !== null) {
+            $sets[] = 'last_email_at = GREATEST(last_email_at, ?)';
+            $sets[] = 'last_interaction_at = GREATEST(last_interaction_at, ?)';
+            $bindings[] = $email->sent_at;
+            $bindings[] = $email->sent_at;
+        }
+
+        $bindings[] = $record->getKey();
+
+        DB::update(
+            'update '.$record->getTable().' set '.implode(', ', $sets).' where '.$record->getKeyName().' = ?',
+            $bindings,
+        );
+    }
+
+    public function incrementMeetingMetrics(People|Company|Opportunity $record, Meeting $meeting): void
+    {
+        if (! $this->visibility->meetingCountsTowardCommunicationIntelligence($meeting)) {
+            return;
+        }
+
+        $this->advanceMeetingMetrics($record->getTable(), $record->getKey(), $meeting->starts_at);
+    }
+
+    /**
+     * @param  array<string, true>  $countedCompanies
+     * @param  array<string, true>  $countedPeople
+     * @param  array<string, true>  $countedOpportunities
+     */
+    public function incrementEmailMetricsForPrelinkedRecords(
+        Email $email,
+        array $countedCompanies,
+        array $countedPeople,
+        array $countedOpportunities,
+    ): void {
+        $email->loadMissing(['people', 'companies', 'opportunities']);
+
+        foreach ($email->people as $person) {
+            if (isset($countedPeople[$person->getKey()])) {
+                continue;
+            }
+
+            $this->incrementEmailMetrics($person, $email);
+        }
+
+        foreach ($email->companies as $company) {
+            if (isset($countedCompanies[$company->getKey()])) {
+                continue;
+            }
+
+            $this->incrementEmailMetrics($company, $email);
+        }
+
+        foreach ($email->opportunities as $opportunity) {
+            if (isset($countedOpportunities[$opportunity->getKey()])) {
+                continue;
+            }
+
+            $this->incrementEmailMetrics($opportunity, $email);
+        }
+    }
+
+    private function advanceMeetingMetrics(string $table, string $id, Carbon $startsAt): void
+    {
+        DB::table($table)
+            ->where('id', $id)
+            ->update(['meeting_count' => DB::raw('meeting_count + 1')]);
+
+        $this->advanceTimestamp($table, $id, 'last_meeting_at', $startsAt);
+        $this->advanceTimestamp($table, $id, 'last_interaction_at', $startsAt);
+    }
+
+    private function advanceTimestamp(string $table, string $id, string $column, Carbon $startsAt): void
+    {
+        DB::table($table)
+            ->where('id', $id)
+            ->where(fn (QueryBuilder $query) => $query
+                ->whereNull($column)
+                ->orWhere($column, '<', $startsAt)
+            )
+            ->update([$column => $startsAt]);
+    }
+}

--- a/resources/views/components/emails/list-row-wide.blade.php
+++ b/resources/views/components/emails/list-row-wide.blade.php
@@ -99,7 +99,38 @@
             </span>
 
             <span class="flex shrink-0 items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
-                @if (filled($mailboxViaName))
+                @if (count($email->accessMailboxes) >= 2)
+                    <span
+                        x-data="{ open: false }"
+                        x-on:mouseenter="open = true"
+                        x-on:mouseleave="open = false"
+                        x-on:click.stop
+                        class="relative flex min-w-0 items-center gap-1 text-gray-500 dark:text-gray-400"
+                    >
+                        <x-heroicon-m-envelope class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
+                        <span class="whitespace-nowrap">{{ trans_choice('filament/pages/email-inbox.list_row.via_mailboxes', count($email->accessMailboxes), ['count' => count($email->accessMailboxes)]) }}</span>
+                        <span
+                            x-cloak
+                            x-show="open"
+                            x-transition
+                            class="absolute right-0 top-full z-30 mt-1 w-64 rounded-lg bg-gray-900 p-3 text-left text-white shadow-lg"
+                            role="tooltip"
+                        >
+                            <span class="mb-2 block text-[11px] font-medium text-gray-300">{{ __('filament/pages/email-inbox.list_row.access_granted_via') }}</span>
+                            @foreach ($email->accessMailboxes as $mailbox)
+                                <span class="flex items-center gap-2 py-1">
+                                    <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-700 text-[10px] font-semibold">
+                                        {{ mb_strtoupper(mb_substr($mailbox['name'], 0, 1)) }}
+                                    </span>
+                                    <span class="min-w-0">
+                                        <span class="block truncate text-xs font-medium">{{ $mailbox['name'] }}</span>
+                                        <span class="block truncate text-[11px] text-gray-400">{{ $mailbox['mailbox_email'] }}</span>
+                                    </span>
+                                </span>
+                            @endforeach
+                        </span>
+                    </span>
+                @elseif (filled($mailboxViaName))
                     <span class="flex min-w-0 items-center gap-1 text-gray-500 dark:text-gray-400">
                         <x-heroicon-m-envelope class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" aria-hidden="true" />
                         <span class="max-w-[7rem] truncate">{{ __('filament/pages/email-inbox.list_row.via', ['name' => $mailboxViaName]) }}</span>

--- a/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingPersonTest.php
@@ -14,6 +14,7 @@ use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
+use Relaticle\EmailIntegration\Models\PublicEmailDomain;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 
 mutates(LinkMeetingAction::class);
@@ -229,6 +230,84 @@ it('does not auto-create a company for a www-prefixed public domain', function (
     (app(LinkMeetingAction::class))->execute($meeting->fresh());
 
     expect(Company::query()->where('team_id', $team->id)->count())->toBe($countBefore);
+});
+
+it('does not auto-create a company for a www-prefixed configured public domain', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+    Filament::setTenant($team);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]));
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    config()->set('email-integration.public_domains', [
+        ...((array) config('email-integration.public_domains', [])),
+        'www.example.com',
+    ]);
+
+    $countBefore = Company::query()->where('team_id', $team->id)->count();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'user@www.example.com',
+        'name' => 'Public Domain Attendee',
+        'is_self' => false,
+    ]);
+
+    (app(LinkMeetingAction::class))->execute($meeting->fresh());
+
+    expect(Company::query()->where('team_id', $team->id)->count())->toBe($countBefore)
+        ->and(People::query()->where('team_id', $team->id)->where('name', 'Public Domain Attendee')->exists())->toBeTrue();
+});
+
+it('does not auto-create a company for a www-prefixed team public domain', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    $team = $user->currentTeam;
+    Filament::setTenant($team);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+    ]));
+    $team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    PublicEmailDomain::factory()->create([
+        'team_id' => $team->id,
+        'domain' => 'www.example.com',
+    ]);
+
+    $countBefore = Company::query()->where('team_id', $team->id)->count();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+    ]);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'user@www.example.com',
+        'name' => 'Team Public Domain Attendee',
+        'is_self' => false,
+    ]);
+
+    (app(LinkMeetingAction::class))->execute($meeting->fresh());
+
+    expect(Company::query()->where('team_id', $team->id)->count())->toBe($countBefore)
+        ->and(People::query()->where('team_id', $team->id)->where('name', 'Team Public Domain Attendee')->exists())->toBeTrue();
 });
 
 it('does not auto-create a person or company when the connected account is soft-deleted', function (): void {

--- a/tests/Feature/CalendarIntegration/LinkMeetingToRecordActionTest.php
+++ b/tests/Feature/CalendarIntegration/LinkMeetingToRecordActionTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 use App\Models\People;
 use App\Models\Team;
+use Illuminate\Support\Carbon;
+use Relaticle\EmailIntegration\Actions\LinkMeetingAction;
 use Relaticle\EmailIntegration\Actions\LinkMeetingToRecordAction;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 
-mutates(LinkMeetingToRecordAction::class);
+mutates(LinkMeetingToRecordAction::class, LinkMeetingAction::class);
 
 it('creates a manual link row', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
@@ -51,4 +53,63 @@ it('is idempotent', function (): void {
     (app(LinkMeetingToRecordAction::class))->execute($meeting, $person);
 
     expect($meeting->people()->count())->toBe(1);
+});
+
+it('increments meeting metrics on a new manual link', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'owner@acmecorp.com',
+    ]));
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+        'organizer_email' => 'guest@clientcorp.com',
+    ]);
+    $person = People::factory()->for($meeting->team)->create([
+        'meeting_count' => 0,
+        'last_meeting_at' => null,
+        'last_interaction_at' => null,
+    ]);
+
+    app(LinkMeetingToRecordAction::class)->execute($meeting, $person);
+
+    $person->refresh();
+
+    expect($person->meeting_count)->toBe(1)
+        ->and(Carbon::parse($person->last_meeting_at)->timestamp)->toBe($meeting->starts_at->timestamp)
+        ->and(Carbon::parse($person->last_interaction_at)->timestamp)->toBe($meeting->starts_at->timestamp);
+});
+
+it('does not double-count metrics when the same manual link is applied twice', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'owner@acmecorp.com',
+    ]));
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+        'organizer_email' => 'guest@clientcorp.com',
+    ]);
+    $person = People::factory()->for($meeting->team)->create(['meeting_count' => 0]);
+
+    $action = app(LinkMeetingToRecordAction::class);
+    $action->execute($meeting, $person);
+    $action->execute($meeting, $person);
+
+    expect($person->fresh()->meeting_count)->toBe(1);
+});
+
+it('does not double-count metrics when automatic linking runs after a manual link', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'owner@acmecorp.com',
+    ]));
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+        'organizer_email' => 'guest@clientcorp.com',
+    ]);
+    $person = People::factory()->for($meeting->team)->create(['meeting_count' => 0]);
+
+    app(LinkMeetingToRecordAction::class)->execute($meeting, $person);
+    app(LinkMeetingAction::class)->execute($meeting->fresh());
+
+    expect($person->fresh()->meeting_count)->toBe(1);
 });

--- a/tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php
+++ b/tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php
@@ -9,6 +9,7 @@ use App\Models\People;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
 use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
@@ -184,4 +185,15 @@ it('hides the duplicate table row from the emails relation manager', function ()
         ->assertCanSeeTableRecords([$this->ownerCopy])
         ->assertCanNotSeeTableRecords([$this->teammateCopy])
         ->assertTableActionHidden('requestAccess', $this->ownerCopy);
+});
+
+it('moves the record mailbox to All after a compose send', function (): void {
+    $this->actingAs($this->owner);
+    Filament::setTenant($this->team);
+
+    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->set('folder', EmailFolder::Inbox)
+        ->dispatch('composer:sent', emailId: $this->ownerCopy->getKey())
+        ->assertSet('folder', EmailFolder::All)
+        ->assertSet('selectedEmailId', $this->ownerCopy->getKey());
 });

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -250,6 +250,45 @@ it('queues an email through SendEmailAction on send with the persisted body and 
         ->and($email->scheduled_for)->not->toBeNull();
 });
 
+it('links a queued send to the record the composer was opened from', function (): void {
+    $person = People::factory()->recycle([$this->user, $this->user->currentTeam])->create();
+
+    Livewire::test(EmailComposer::class)
+        ->call('open', [
+            'linkRecordType' => People::class,
+            'linkRecordId' => $person->getKey(),
+        ])
+        ->assertSet('linkRecordType', People::class)
+        ->set('to', ['lead@example.com'])
+        ->set('subject', 'Linked to person')
+        ->set('bodyHtml', '<p>Hello</p>')
+        ->call('send')
+        ->assertDispatched('composer:sent');
+
+    $email = Email::query()->where('subject', 'Linked to person')->sole();
+
+    expect($person->emails()->whereKey($email->getKey())->exists())->toBeTrue();
+});
+
+it('does not link a queued send to a record from another workspace', function (): void {
+    $foreign = User::factory()->withTeam()->create();
+    $person = People::factory()->recycle([$foreign, $foreign->currentTeam])->create();
+
+    Livewire::test(EmailComposer::class)
+        ->call('open', [
+            'linkRecordType' => People::class,
+            'linkRecordId' => $person->getKey(),
+        ])
+        ->set('to', ['lead@example.com'])
+        ->set('subject', 'Should not link')
+        ->set('bodyHtml', '<p>Hello</p>')
+        ->call('send');
+
+    $email = Email::query()->where('subject', 'Should not link')->sole();
+
+    expect($person->emails()->whereKey($email->getKey())->exists())->toBeFalse();
+});
+
 it('offers undo on the queued toast for the undo window', function (): void {
     Livewire::test(EmailComposer::class)
         ->dispatch('composer:open')

--- a/tests/Feature/EmailIntegration/EmailVisibilityServiceTest.php
+++ b/tests/Feature/EmailIntegration/EmailVisibilityServiceTest.php
@@ -7,13 +7,16 @@ use App\Models\CustomField;
 use App\Models\People;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use Relaticle\EmailIntegration\Enums\ConnectionStrength;
 use Relaticle\EmailIntegration\Enums\EmailVisibilityEnforcement;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
-mutates(EmailVisibilityService::class);
+mutates(EmailVisibilityService::class, VisibleMeetingScope::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create([
@@ -168,8 +171,35 @@ it('scopes communication intelligence metrics to mail the viewer can see', funct
     $metrics = $this->service->visibleCommunicationIntelligence($person, $this->user);
 
     expect($metrics->emailCount)->toBe(1)
-        ->and($metrics->inboundEmailCount)->toBe(1)
-        ->and($metrics->outboundEmailCount)->toBe(0);
+        ->and($metrics->lastEmailAt)->not->toBeNull()
+        ->and($metrics->firstEmailAt)->not->toBeNull()
+        ->and($metrics->connectionStrength)->not->toBe(ConnectionStrength::None);
+});
+
+it('computes calendar intelligence without an ambiguous team_id join', function (): void {
+    $person = People::factory()->for($this->team)->create();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    $startsAt = now()->addDay();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $account->getKey(),
+        'starts_at' => $startsAt,
+        'ends_at' => $startsAt->copy()->addHour(),
+    ]);
+
+    $person->meetings()->attach($meeting->getKey());
+
+    $metrics = $this->service->visibleCommunicationIntelligence($person, $this->user);
+
+    expect($metrics->nextMeetingAt?->toDateTimeString())->toBe($startsAt->toDateTimeString())
+        ->and($metrics->lastMeetingAt?->toDateTimeString())->toBe($startsAt->toDateTimeString())
+        ->and($metrics->strongestConnectionName)->toBe($this->user->name);
 });
 
 it('counts one preferred copy when the same rfc message is synced twice', function (): void {
@@ -214,7 +244,48 @@ it('counts one preferred copy when the same rfc message is synced twice', functi
 
     expect($metrics->emailCount)->toBe(1)
         ->and($metrics->emailCount)->toBe($this->service->visibleEmailCount($person, $this->user))
-        ->and($metrics->inboundEmailCount)->toBe(1)
-        ->and($metrics->outboundEmailCount)->toBe(0)
+        ->and($metrics->firstEmailAt?->toDateTimeString())->toBe($preferredSentAt->toDateTimeString())
         ->and($metrics->lastEmailAt?->toDateTimeString())->toBe($preferredSentAt->toDateTimeString());
+});
+
+it('counts one preferred copy for every viewer of the same rfc message', function (): void {
+    $person = People::factory()->for($this->team)->create();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    $coworker = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($coworker, ['role' => 'editor']);
+
+    $coworkerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+    ]));
+
+    $messageId = '<workspace-sent@example.com>';
+
+    $ownerInbound = Email::factory()->inbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $account->getKey(),
+        'rfc_message_id' => $messageId,
+        'is_internal' => false,
+    ]);
+    $coworkerOutbound = Email::factory()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+        'connected_account_id' => $coworkerAccount->getKey(),
+        'rfc_message_id' => $messageId,
+        'is_internal' => false,
+    ]);
+
+    $person->emails()->attach([$ownerInbound->getKey(), $coworkerOutbound->getKey()]);
+
+    $ownerMetrics = $this->service->visibleCommunicationIntelligence($person, $this->user);
+    $coworkerMetrics = $this->service->visibleCommunicationIntelligence($person, $coworker);
+
+    expect($ownerMetrics->emailCount)->toBe(1)
+        ->and($coworkerMetrics->emailCount)->toBe(1);
 });

--- a/tests/Feature/EmailIntegration/EmailVisibilityServiceTest.php
+++ b/tests/Feature/EmailIntegration/EmailVisibilityServiceTest.php
@@ -171,3 +171,50 @@ it('scopes communication intelligence metrics to mail the viewer can see', funct
         ->and($metrics->inboundEmailCount)->toBe(1)
         ->and($metrics->outboundEmailCount)->toBe(0);
 });
+
+it('counts one preferred copy when the same rfc message is synced twice', function (): void {
+    $person = People::factory()->for($this->team)->create();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    $coworker = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($coworker, ['role' => 'editor']);
+
+    $coworkerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+    ]));
+
+    $messageId = '<preferred-metrics@example.com>';
+    $preferredSentAt = now()->subHour();
+
+    $preferred = Email::factory()->inbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $account->getKey(),
+        'rfc_message_id' => $messageId,
+        'sent_at' => $preferredSentAt,
+        'is_internal' => false,
+    ]);
+    $duplicate = Email::factory()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+        'connected_account_id' => $coworkerAccount->getKey(),
+        'rfc_message_id' => $messageId,
+        'sent_at' => now(),
+        'is_internal' => false,
+    ]);
+
+    $person->emails()->attach([$preferred->getKey(), $duplicate->getKey()]);
+
+    $metrics = $this->service->visibleCommunicationIntelligence($person, $this->user);
+
+    expect($metrics->emailCount)->toBe(1)
+        ->and($metrics->emailCount)->toBe($this->service->visibleEmailCount($person, $this->user))
+        ->and($metrics->inboundEmailCount)->toBe(1)
+        ->and($metrics->outboundEmailCount)->toBe(0)
+        ->and($metrics->lastEmailAt?->toDateTimeString())->toBe($preferredSentAt->toDateTimeString());
+});

--- a/tests/Feature/EmailIntegration/LinkEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/LinkEmailActionTest.php
@@ -374,6 +374,58 @@ it('does not auto-create a company for a www-prefixed public domain', function (
     expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore);
 });
 
+it('does not auto-create a company for a www-prefixed configured public domain', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    config()->set('email-integration.public_domains', [
+        ...((array) config('email-integration.public_domains', [])),
+        'www.example.com',
+    ]);
+
+    $countBefore = Company::where('team_id', $this->team->id)->count();
+
+    $email = makeLinkEmail();
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'user@www.example.com',
+        'name' => 'Public Domain Contact',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore)
+        ->and(People::where('team_id', $this->team->id)->where('name', 'Public Domain Contact')->exists())->toBeTrue();
+});
+
+it('does not auto-create a company for a www-prefixed team public domain', function (): void {
+    $this->team->update([
+        'contact_creation_mode' => ContactCreationMode::All,
+        'auto_create_companies' => true,
+    ]);
+
+    PublicEmailDomain::factory()->create([
+        'team_id' => $this->team->id,
+        'domain' => 'www.example.com',
+    ]);
+
+    $countBefore = Company::where('team_id', $this->team->id)->count();
+
+    $email = makeLinkEmail();
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'user@www.example.com',
+        'name' => 'Team Public Domain Contact',
+    ]);
+
+    app(LinkEmailAction::class)->execute($email);
+
+    expect(Company::where('team_id', $this->team->id)->count())->toBe($countBefore)
+        ->and(People::where('team_id', $this->team->id)->where('name', 'Team Public Domain Contact')->exists())->toBeTrue();
+});
+
 it('auto-creates a company when auto_create_companies is true', function (): void {
     $this->team->update([
         'contact_creation_mode' => ContactCreationMode::All,

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -147,7 +147,7 @@ it('skips people with no known email address', function (): void {
 
     $this->assertDatabaseHas('emailables', [
         'email_id' => $email->getKey(),
-        'emailable_type' => People::class,
+        'emailable_type' => $withEmail->getMorphClass(),
         'emailable_id' => $withEmail->id,
     ]);
 });

--- a/tests/Feature/EmailIntegration/RecordEmailsEmptyStateTest.php
+++ b/tests/Feature/EmailIntegration/RecordEmailsEmptyStateTest.php
@@ -30,8 +30,9 @@ use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\PreferredEmailCopyService;
 
-mutates(BaseRecordEmailsPage::class, BaseEmailsRelationManager::class, EmailVisibilityService::class, HasEmailReaderActions::class);
+mutates(BaseRecordEmailsPage::class, BaseEmailsRelationManager::class, EmailVisibilityService::class, HasEmailReaderActions::class, PreferredEmailCopyService::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -537,6 +538,68 @@ it('keeps the emails tab visible on an opportunity', function (): void {
     livewire(OpportunityEmailsPage::class, ['record' => $opportunity->getKey()])
         ->assertSee('Visible on the deal')
         ->assertDontSee(__('filament/pages/record-emails.protected.heading'));
+});
+
+it('shows via two mailboxes using connected mailbox addresses not workspace logins', function (): void {
+    $this->user->update(['email' => 'owner@relaticle.test']);
+
+    $coworker = User::factory()->create([
+        'current_team_id' => $this->team->id,
+        'email' => 'editor@relaticle.test',
+    ]);
+    $this->team->users()->attach($coworker, ['role' => 'editor']);
+
+    $ownerAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'email_address' => 'whitesharkdevs@gmail.com',
+        'display_name' => 'White Shark',
+    ]));
+
+    $coworkerAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+        'display_name' => 'Editor Mailbox',
+    ]));
+
+    $messageId = '<via-two-mailboxes@example.com>';
+
+    $ownerCopy = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $ownerAccount->getKey(),
+        'rfc_message_id' => $messageId,
+        'subject' => 'Shared thread',
+        'is_internal' => false,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    $coworkerCopy = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $coworker->id,
+        'connected_account_id' => $coworkerAccount->getKey(),
+        'rfc_message_id' => $messageId,
+        'subject' => 'Shared thread',
+        'is_internal' => false,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    EmailParticipant::query()->create([
+        'email_id' => $ownerCopy->getKey(),
+        'email_address' => 'petter.qa@gmail.com',
+        'name' => 'Petter',
+        'role' => EmailParticipantRole::FROM,
+    ]);
+
+    $this->person->emails()->attach([$ownerCopy->getKey(), $coworkerCopy->getKey()]);
+
+    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->assertSee(trans_choice('filament/pages/email-inbox.list_row.via_mailboxes', 2, ['count' => 2]))
+        ->assertSee('whitesharkdevs@gmail.com')
+        ->assertSee('mail2asmitnepali99@gmail.com')
+        ->assertDontSee('owner@relaticle.test')
+        ->assertDontSee('editor@relaticle.test');
 });
 
 it('shows the imported mailbox name on record email list rows', function (): void {

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -229,10 +229,12 @@ it('links the queued email to a CRM record via emailables', function (): void {
 
     $this->assertDatabaseHas('emailables', [
         'email_id' => $email->getKey(),
-        'emailable_type' => People::class,
+        'emailable_type' => $person->getMorphClass(),
         'emailable_id' => $person->id,
         'link_source' => 'manual',
     ]);
+
+    expect($person->emails()->whereKey($email->getKey())->exists())->toBeTrue();
 });
 
 it('rejects sending through a connected account owned by another user', function (): void {

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -8,6 +8,7 @@ use Filament\Facades\Filament;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Relaticle\EmailIntegration\Actions\LinkEmailAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
@@ -22,7 +23,7 @@ use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 use Relaticle\EmailIntegration\Services\EmailSendingService;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-mutates(SendEmailAction::class, EmailSendingService::class, ConnectedAccount::class);
+mutates(SendEmailAction::class, LinkEmailAction::class, EmailSendingService::class, ConnectedAccount::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -235,6 +236,53 @@ it('links the queued email to a CRM record via emailables', function (): void {
     ]);
 
     expect($person->emails()->whereKey($email->getKey())->exists())->toBeTrue();
+});
+
+it('updates record metrics after a manually linked queued send is delivered', function (): void {
+    $this->account->update([
+        'email_address' => 'sender@acmecorp.com',
+        'display_name' => 'Test Sender',
+    ]);
+
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Jane Doe',
+        'creator_id' => $this->user->id,
+        'email_count' => 0,
+        'outbound_email_count' => 0,
+    ]);
+
+    $sendData = [
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Hello',
+        'body_html' => '<p>Hi</p>',
+        'to' => [['email' => 'jane@clientcorp.com', 'name' => 'Jane']],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ];
+
+    $email = app(SendEmailAction::class)->execute($sendData, People::class, $person->id);
+
+    expect($person->fresh()->email_count)->toBe(0);
+
+    $sentAt = now()->subHour();
+    $email->update([
+        'status' => EmailStatus::SENT,
+        'sent_at' => $sentAt,
+    ]);
+
+    app(LinkEmailAction::class)->execute($email->fresh());
+
+    $person->refresh();
+
+    expect($person->email_count)->toBe(1)
+        ->and($person->outbound_email_count)->toBe(1)
+        ->and($person->last_email_at?->timestamp)->toBe($sentAt->timestamp)
+        ->and($person->last_interaction_at?->timestamp)->toBe($sentAt->timestamp);
 });
 
 it('rejects sending through a connected account owned by another user', function (): void {

--- a/tests/Feature/EmailIntegration/StoreEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailActionTest.php
@@ -268,6 +268,56 @@ it('stores inline attachment metadata', function (): void {
         ->assertExists((string) $attachment->storage_path);
 });
 
+it('stores a nameless inline cid image with a generated filename', function (): void {
+    $data = makeFetchedEmailData([
+        'attachments' => [
+            [
+                'filename' => null,
+                'mime_type' => 'image/png',
+                'size' => 2769,
+                'content_id' => '64dde1dcdd71c_619bcc205105b@9fe1defa658f4522965e4f05974e142d-527074092.mail',
+                'attachment_id' => 'ANGjdJ_C0D5OGQiXtzOJg0HWAuQuorPLxx4bmjkY1a6C7rYa4ts9PBKBZ7ZSite2',
+                'inline_data' => null,
+                'is_inline' => true,
+            ],
+        ],
+    ]);
+
+    $email = resolve(StoreEmailAction::class)->execute($this->account, $data);
+
+    $attachment = $email->attachments()->sole();
+
+    expect($attachment->filename)->toBe('inline.png')
+        ->and($attachment->mime_type)->toBe('image/png')
+        ->and($attachment->content_id)->toBe('64dde1dcdd71c_619bcc205105b@9fe1defa658f4522965e4f05974e142d-527074092.mail')
+        ->and($attachment->is_inline)->toBeTrue()
+        ->and($attachment->provider_attachment_id)->toBe('ANGjdJ_C0D5OGQiXtzOJg0HWAuQuorPLxx4bmjkY1a6C7rYa4ts9PBKBZ7ZSite2');
+});
+
+it('stores a nameless file attachment with a generated filename', function (): void {
+    $data = makeFetchedEmailData([
+        'hasAttachments' => true,
+        'attachments' => [
+            [
+                'filename' => null,
+                'mime_type' => 'application/pdf',
+                'size' => 204800,
+                'content_id' => null,
+                'attachment_id' => 'att-unnamed',
+                'inline_data' => null,
+            ],
+        ],
+    ]);
+
+    $email = resolve(StoreEmailAction::class)->execute($this->account, $data);
+
+    $attachment = $email->attachments()->sole();
+
+    expect($attachment->filename)->toBe('attachment.pdf')
+        ->and($attachment->is_inline)->toBeFalse()
+        ->and($attachment->provider_attachment_id)->toBe('att-unnamed');
+});
+
 it('cleans up stored inline files when storing the email rolls back', function (): void {
     Storage::fake(EmailAttachment::DISK);
 

--- a/tests/Feature/EmailIntegration/StoreEmailJobTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailJobTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use Google\Service\Exception as GoogleServiceException;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Contracts\Queue\Job as QueueJob;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Relaticle\EmailIntegration\Actions\StoreEmailAction;
+use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
+use Relaticle\EmailIntegration\Support\ProviderRateLimit;
+
+mutates(StoreEmailJob::class, ProviderRateLimit::class);
+
+function gmailUserRateLimited(string $retryAfterIso): GoogleServiceException
+{
+    $message = <<<JSON
+{
+  "error": {
+    "code": 429,
+    "message": "User-rate limit exceeded.  Retry after {$retryAfterIso}",
+    "errors": [
+      {
+        "message": "User-rate limit exceeded.  Retry after {$retryAfterIso}",
+        "domain": "global",
+        "reason": "rateLimitExceeded"
+      }
+    ],
+    "status": "RESOURCE_EXHAUSTED"
+  }
+}
+JSON;
+
+    return new GoogleServiceException($message, 429);
+}
+
+function runStoreEmailJobWithQueue(
+    ConnectedAccount $account,
+    string $messageId,
+    MailServiceFactoryInterface $factory,
+    QueueJob $queueJob,
+): void {
+    $job = new StoreEmailJob($account, $messageId);
+    $job->setJob($queueJob);
+    $job->handle($factory, resolve(StoreEmailAction::class));
+}
+
+it('releases until Google retry-after instead of failing a 429', function (): void {
+    $this->travelTo('2026-09-07 14:36:30');
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchMessage')
+        ->once()
+        ->andThrow(gmailUserRateLimited('2026-09-07T14:51:30.000Z'));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    $queueJob = Mockery::mock(QueueJob::class);
+    $queueJob->shouldReceive('release')->once()->with(900);
+
+    runStoreEmailJobWithQueue($account, 'msg-429', $factory, $queueJob);
+
+    expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(0);
+});
+
+it('does not call the mailbox for other messages while that account is cooling down', function (): void {
+    $this->travelTo('2026-09-07 14:36:30');
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchMessage')
+        ->once()
+        ->with('msg-first')
+        ->andThrow(gmailUserRateLimited('2026-09-07T14:51:30.000Z'));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    $firstQueue = Mockery::mock(QueueJob::class);
+    $firstQueue->shouldReceive('release')->once()->with(900);
+
+    runStoreEmailJobWithQueue($account, 'msg-first', $factory, $firstQueue);
+
+    $quietFactory = Mockery::mock(MailServiceFactoryInterface::class);
+    $quietFactory->shouldReceive('make')->never();
+
+    $secondQueue = Mockery::mock(QueueJob::class);
+    $secondQueue->shouldReceive('release')->once()->with(900);
+
+    runStoreEmailJobWithQueue($account, 'msg-second', $quietFactory, $secondQueue);
+});
+
+it('still fails when the provider error is not a rate limit', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchMessage')
+        ->once()
+        ->andThrow(new GoogleServiceException('Backend Error', 500));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    $queueJob = Mockery::mock(QueueJob::class);
+    $queueJob->shouldReceive('release')->never();
+
+    $job = new StoreEmailJob($account, 'msg-500');
+    $job->setJob($queueJob);
+
+    $job->handle($factory, resolve(StoreEmailAction::class));
+})->throws(GoogleServiceException::class, 'Backend Error');
+
+it('releases using the Retry-After header from Microsoft Graph', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $exception = new RequestException(new Response(new Psr7Response(429, ['Retry-After' => '120'], '{}')));
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchMessage')->once()->andThrow($exception);
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    $queueJob = Mockery::mock(QueueJob::class);
+    $queueJob->shouldReceive('release')->once()->with(120);
+
+    runStoreEmailJobWithQueue($account, 'msg-graph', $factory, $queueJob);
+});

--- a/tests/Feature/EmailIntegration/StoreEmailJobTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailJobTest.php
@@ -8,14 +8,15 @@ use Illuminate\Contracts\Queue\Job as QueueJob;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Relaticle\EmailIntegration\Actions\StoreEmailAction;
+use Relaticle\EmailIntegration\Jobs\Concerns\ReleasesOnProviderRateLimit;
 use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
-use Relaticle\EmailIntegration\Support\ProviderRateLimit;
+use Relaticle\EmailIntegration\Services\ProviderRateLimit;
 
-mutates(StoreEmailJob::class, ProviderRateLimit::class);
+mutates(StoreEmailJob::class, ProviderRateLimit::class, ReleasesOnProviderRateLimit::class);
 
 function gmailUserRateLimited(string $retryAfterIso): GoogleServiceException
 {

--- a/tests/Feature/Filament/RecordHeaderActionsTest.php
+++ b/tests/Feature/Filament/RecordHeaderActionsTest.php
@@ -12,6 +12,7 @@ use App\Models\People;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\DB;
 use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Data\VisibleCommunicationIntelligence;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
@@ -211,7 +212,7 @@ it('does not badge private teammate mail or emails linked to another record', fu
     expect(emailsHeaderBadge($page, $owner))->toBe('1');
 })->with(recordEmailsHeaderPages());
 
-it('scopes communication intelligence on the person view to visible mail only', function (): void {
+it('renders scoped communication intelligence once on the person view', function (): void {
     $person = People::factory()->recycle([$this->user, $this->team])->create([
         'email_count' => 99,
         'inbound_email_count' => 50,
@@ -228,9 +229,27 @@ it('scopes communication intelligence on the person view to visible mail only', 
         'is_internal' => false,
     ]);
 
-    $metrics = resolve(EmailVisibilityService::class)->visibleCommunicationIntelligence($person, $this->user);
+    DB::flushQueryLog();
+    DB::enableQueryLog();
 
-    expect($metrics->emailCount)->toBe(1)
-        ->and($metrics->inboundEmailCount)->toBe(1)
-        ->and($metrics->outboundEmailCount)->toBe(0);
+    livewire(ViewPeople::class, ['record' => $person->getKey()])
+        ->assertOk()
+        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.heading'))
+        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.email_count.label'))
+        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.inbound_email_count.label'))
+        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.outbound_email_count.label'))
+        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.last_email.label'))
+        ->assertSchemaStateSet([
+            'visible_email_count' => 1,
+            'visible_inbound_email_count' => 1,
+            'visible_outbound_email_count' => 0,
+        ]);
+
+    $emailCountAggregates = collect(DB::getQueryLog())
+        ->filter(fn (array $query): bool => str_contains((string) $query['query'], 'as email_count'))
+        ->count();
+
+    DB::disableQueryLog();
+
+    expect($emailCountAggregates)->toBe(1);
 });

--- a/tests/Feature/Filament/RecordHeaderActionsTest.php
+++ b/tests/Feature/Filament/RecordHeaderActionsTest.php
@@ -234,15 +234,19 @@ it('renders scoped communication intelligence once on the person view', function
 
     livewire(ViewPeople::class, ['record' => $person->getKey()])
         ->assertOk()
-        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.heading'))
-        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.email_count.label'))
-        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.inbound_email_count.label'))
-        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.outbound_email_count.label'))
-        ->assertSee(__('filament/resources/person.pages.view.communication_intelligence.fields.last_email.label'))
+        ->assertSee(__('filament/communication-intelligence.heading'))
+        ->assertSee(__('filament/communication-intelligence.groups.connection'))
+        ->assertSee(__('filament/communication-intelligence.groups.email'))
+        ->assertSee(__('filament/communication-intelligence.groups.calendar'))
+        ->assertSeeHtml('isCollapsed: true')
+        ->assertSee(__('filament/communication-intelligence.fields.last_interaction.label'))
+        ->assertSee(__('filament/communication-intelligence.fields.last_email.label'))
+        ->assertSee(__('filament/communication-intelligence.fields.connection_strength.label'))
+        ->assertSee(__('filament/communication-intelligence.fields.strongest_connection.label'))
+        ->assertDontSee('Total Emails')
         ->assertSchemaStateSet([
-            'visible_email_count' => 1,
-            'visible_inbound_email_count' => 1,
-            'visible_outbound_email_count' => 0,
+            'visible_connection_strength' => __('filament/communication-intelligence.connection_strength.weak'),
+            'visible_strongest_connection' => $this->user->name,
         ]);
 
     $emailCountAggregates = collect(DB::getQueryLog())


### PR DESCRIPTION
## Summary
- Communication intelligence now counts one preferred mailbox copy per RFC Message-ID, matching the record mailbox badge.
- The record infolist computes those metrics once per render and translates the section heading.
- Email and calendar linking skip `www.`-prefixed public domains from config and team settings. People can still be created.

Follow-up to #639 re-review findings.

## Test plan
- [x] Open a person with the same message synced in two mailboxes. Total emails is 1, and inbound/outbound follow the viewer's copy.
- [x] Reload a company or person view. Communication Intelligence still shows scoped counts, not denormalized `email_count`.
- [x] Sync `user@www.example.com` with `www.example.com` in public domains. No company is created. A person still is.
- [x] Repeat with a team `PublicEmailDomain` of `www.example.com`, for both email and calendar.
- [x] Confirm existing `www.gmail.com` and sibling-subdomain company behavior is unchanged.