### PR TITLE
chore(ci): add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      composer:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      composer-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      npm:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      docker:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Part of the same cleanup as relaticle/custom-fields#217, which covered the packages. This repository had no `.github/dependabot.yml` at all.

## What was missing

Nothing opened update pull requests here. Four ecosystems apply and none were configured:

| Ecosystem | Manifest |
|---|---|
| `composer` | `composer.lock` |
| `npm` | `pnpm-lock.yaml` |
| `docker` | `Dockerfile` |
| `github-actions` | `.github/workflows/**` |

`security-audit.yml` already fails a PR on `composer audit --locked` and a pnpm audit, so an advisory that reaches the lock file gets caught. This is what stops it reaching the lock file in the first place, and it covers the two ecosystems the audit workflow does not: base images and workflow actions.

## Grouping

Every ecosystem gets a `version-updates` group and a `security-updates` group. `applies-to` defaults to version updates, so a config with only the first delivers one pull request per advisory. In `relaticle/custom-fields` that produced four separate PRs for a single package's advisories.

`cooldown: 7` days on all four, matching the packages, so a release has to settle before Dependabot proposes it. Cooldown does not apply to security updates.

## Deliberately not included

No `auto-merge.yml`. The packages have one, but the `Protect main` ruleset here declares no required status checks, so `gh pr merge --auto` would merge the moment it was enabled rather than waiting for `tests.yml`. That needs required checks configured first, and it is a separate decision.