### PR TITLE
feat(mail): prefill the reply subject on contact submission emails

### DIFF
--- a/app/Mail/NewContactSubmissionMail.php
+++ b/app/Mail/NewContactSubmissionMail.php
@@ -35,6 +35,7 @@ final class NewContactSubmissionMail extends Mailable implements ShouldQueue
         return new Content(
             markdown: 'mail.new-contact-submission',
             with: [
+                'replyUrl' => 'mailto:'.$this->data['email'].'?subject='.rawurlencode('Re: '.$this->envelope()->subject),
                 'preheader' => $company === null || $company === ''
                     ? __('mail.contact_submission.preheader_without_company', ['email' => $this->data['email']])
                     : __('mail.contact_submission.preheader', ['company' => $company, 'email' => $this->data['email']]),

--- a/resources/views/mail/new-contact-submission.blade.php
+++ b/resources/views/mail/new-contact-submission.blade.php
@@ -8,7 +8,7 @@
 {{ $data['message'] }}
 </x-mail::panel>
 
-<x-mail::button :url="'mailto:'.$data['email']">
+<x-mail::button :url="$replyUrl">
 {{ __('mail.contact_submission.cta', ['name' => $data['name']]) }}
 </x-mail::button>
 </x-mail::message>

--- a/tests/Feature/Email/NewContactSubmissionMailTest.php
+++ b/tests/Feature/Email/NewContactSubmissionMailTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use App\Mail\NewContactSubmissionMail;
 
+mutates(NewContactSubmissionMail::class);
+
 it('lists the submission fields and offers a reply link', function (): void {
     $mail = new NewContactSubmissionMail([
         'name' => 'Ana Reyes',
@@ -16,9 +18,22 @@ it('lists the submission fields and offers a reply link', function (): void {
     $mail->assertHasReplyTo('ana@example.com');
     $mail->assertSeeInHtml(__('mail.contact_submission.preheader', ['company' => 'Acme', 'email' => 'ana@example.com']));
     $mail->assertSeeInHtml('We need SSO.');
-    $mail->assertSeeInHtml('href="mailto:ana@example.com"', escape: false);
+    $mail->assertSeeInHtml('href="mailto:ana@example.com?subject=Re%3A%20New%20contact%3A%20Ana%20Reyes"', escape: false);
     $mail->assertSeeInText(__('mail.contact_submission.email').': ana@example.com');
-    $mail->assertSeeInText(__('mail.contact_submission.cta', ['name' => 'Ana Reyes']).': mailto:ana@example.com');
+    $mail->assertSeeInText(__('mail.contact_submission.cta', ['name' => 'Ana Reyes']).': mailto:ana@example.com?subject=Re%3A%20New%20contact%3A%20Ana%20Reyes');
+});
+
+it('encodes contact names in the reply subject without adding mailto parameters', function (): void {
+    $mail = new NewContactSubmissionMail([
+        'name' => 'Zoë & cc=other@example.com #1',
+        'email' => 'zoe+crm@example.com',
+        'message' => 'We would like to discuss licensing.',
+    ]);
+
+    $replyUrl = 'mailto:zoe+crm@example.com?subject=Re%3A%20New%20contact%3A%20Zo%C3%AB%20%26%20cc%3Dother%40example.com%20%231';
+
+    $mail->assertSeeInHtml('href="'.$replyUrl.'"', escape: false);
+    $mail->assertSeeInText($replyUrl);
 });
 
 it('falls back to the email-only preheader without a company', function (): void {


### PR DESCRIPTION
The reply button on the new contact submission email now opens a draft with the subject already filled in as `Re: New contact: <name>`, so answering an inbound lead takes one less step.

The contact's name goes through `rawurlencode`, so a name containing `&`, `=`, or a newline cannot inject extra mailto parameters such as `cc`. A dedicated test covers that encoding alongside the existing reply-link assertions.
