### PR TITLE
Improve mailbox import progress UI

### DIFF
--- a/packages/EmailIntegration/resources/views/livewire/mailbox-import-status.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/mailbox-import-status.blade.php
@@ -71,14 +71,24 @@
             x-show="cardVisible()"
         >
             <div class="flex items-start justify-between gap-2 px-4 pt-4">
-                <div class="flex min-w-0 items-center gap-1.5">
+                <div class="flex min-w-0 items-center gap-2">
                     @if ($anyImporting)
                         <x-filament::icon
                             icon="heroicon-m-arrow-path"
                             class="h-4 w-4 shrink-0 text-primary-600 motion-safe:animate-spin dark:text-primary-400"
                         />
+                    @else
+                        <x-filament::icon
+                            icon="heroicon-m-check-circle"
+                            data-mailbox-import-complete-icon
+                            class="h-5 w-5 shrink-0 text-success-600 dark:text-success-400"
+                        />
                     @endif
-                    <p class="text-sm font-medium text-gray-950 dark:text-white">
+                    <p @class([
+                        'text-sm font-medium',
+                        'text-gray-950 dark:text-white' => $anyImporting,
+                        'text-success-700 dark:text-success-400' => ! $anyImporting,
+                    ])>
                         {{ $anyImporting
                             ? __('filament/pages/email-accounts.sync_status.title_syncing')
                             : __('filament/pages/email-accounts.sync_status.title_complete') }}
@@ -102,12 +112,12 @@
                     >
                         <a
                             href="{{ $mailbox['settings_url'] }}"
-                            class="block px-4 py-3 hover:bg-gray-50 dark:hover:bg-white/5"
+                            class="block px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-white/5"
                             title="{{ __('filament/pages/email-accounts.sync_status.open_settings') }}"
                         >
                             <div class="flex items-center justify-between gap-3">
                                 <p class="truncate text-sm text-gray-700 dark:text-gray-300">{{ $mailbox['email'] }}</p>
-                                <span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                                <span class="shrink-0 rounded-full bg-primary-50 px-2 py-0.5 text-xs font-semibold tabular-nums text-primary-700 dark:bg-primary-400/10 dark:text-primary-300">
                                     {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $mailbox['percent']]) }}
                                 </span>
                             </div>
@@ -120,14 +130,17 @@
                                 {{ trans_choice('filament/pages/email-accounts.sync_status.emails_processed', $mailbox['imported'], ['count' => $mailbox['imported']]) }}
                             </p>
                             <div
-                                class="mt-2 h-1.5 overflow-hidden rounded-full bg-gray-200 dark:bg-white/10"
+                                class="mt-2 h-2 overflow-hidden rounded-full bg-primary-100 dark:bg-primary-400/15"
                                 role="progressbar"
                                 aria-valuenow="{{ $mailbox['percent'] }}"
                                 aria-valuemin="0"
                                 aria-valuemax="100"
                                 aria-label="{{ __('filament/pages/email-accounts.importing') }}"
                             >
-                                <div class="h-full rounded-full bg-primary-600" style="width: {{ $mailbox['percent'] }}%"></div>
+                                <div
+                                    class="h-full rounded-full bg-primary-600 transition-[width] duration-500 ease-out"
+                                    style="width: {{ $mailbox['percent'] }}%"
+                                ></div>
                             </div>
                         </a>
                     </div>

--- a/tests/Feature/EmailIntegration/MailboxImportStatusTest.php
+++ b/tests/Feature/EmailIntegration/MailboxImportStatusTest.php
@@ -84,6 +84,8 @@ it('keeps a completed import visible until dismiss on this instance', function (
 
     $component->call('refreshStatus')
         ->assertSee(__('filament/pages/email-accounts.sync_status.title_complete'))
+        ->assertSee('data-mailbox-import-complete-icon', false)
+        ->assertSee('text-success-600', false)
         ->assertSee(trans_choice('filament/pages/email-accounts.sync_status.emails_processed', 643, ['count' => 643]));
 });
 


### PR DESCRIPTION
## Summary

- Strengthen the mailbox import progress indicator and percentage badge.
- Show completed imports with a green check and success styling.
- Cover the completed state in the import-status feature test.

## Verification

- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/rector --dry-run`
- `vendor/bin/phpstan analyse`
- `composer test:type-coverage`
- `php artisan test --compact tests/Feature/EmailIntegration/MailboxImportStatusTest.php`
- `pnpm run build`