### PR TITLE
Improve meeting detail layout

### DIFF
--- a/lang/en/filament/resources/meeting.php
+++ b/lang/en/filament/resources/meeting.php
@@ -4,6 +4,37 @@ declare(strict_types=1);
 
 return [
     'navigation_label' => 'Meetings',
+    'view' => [
+        'heading' => 'Meeting',
+    ],
+    'time' => [
+        'all_day' => 'All day',
+    ],
+    'sections' => [
+        'participants' => [
+            'heading' => 'Participants',
+            'empty' => 'No participants',
+        ],
+        'linked_records' => [
+            'heading' => 'Linked records',
+        ],
+        'description' => [
+            'heading' => 'Description',
+        ],
+    ],
+    'attendees' => [
+        'host' => 'Host',
+    ],
+    'actions' => [
+        'link_records' => [
+            'label' => 'Link records',
+        ],
+    ],
+    'linked_record_types' => [
+        'people' => 'Person',
+        'companies' => 'Company',
+        'opportunities' => 'Opportunity',
+    ],
     'fields' => [
         'organizer' => [
             'label' => 'Organizer',
@@ -12,7 +43,7 @@ return [
             'label' => 'Email',
         ],
         'html_link' => [
-            'label' => 'Open in Google Calendar',
+            'label' => 'Open in calendar',
         ],
     ],
 

--- a/packages/EmailIntegration/resources/views/filament/infolists/meeting-attendee.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/infolists/meeting-attendee.blade.php
@@ -1,0 +1,29 @@
+@php
+    $state = $getState();
+@endphp
+
+<div class="flex items-center gap-3">
+    <img
+        src="{{ $state['avatar'] }}"
+        alt="{{ $state['name'] }}"
+        class="size-8 shrink-0 rounded-full"
+    />
+
+    <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2">
+            <span class="font-medium">{{ $state['name'] }}</span>
+
+            @if ($state['is_organizer'])
+                <span class="rounded-full bg-gray-100 px-2 py-0.5 text-pico text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                    {{ __('filament/resources/meeting.attendees.host') }}
+                </span>
+            @endif
+        </div>
+
+        <div class="text-sm text-gray-500">{{ $state['email'] }}</div>
+    </div>
+
+    @if ($state['response_status'] !== null)
+        @include('email-integration::filament.infolists.partials.rsvp-pill', ['status' => $state['response_status']])
+    @endif
+</div>

--- a/packages/EmailIntegration/resources/views/filament/infolists/meeting-header.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/infolists/meeting-header.blade.php
@@ -1,0 +1,16 @@
+@php
+    $state = $getState();
+@endphp
+
+<div class="flex items-center gap-4">
+    <div class="flex flex-col items-center justify-center rounded-lg border border-[var(--surface-block-border)] px-3 py-2 text-pico">
+        <span class="font-medium uppercase">{{ $state['month'] }}</span>
+        <span class="text-xl font-semibold">{{ $state['day'] }}</span>
+    </div>
+
+    <h2 class="flex-1 text-xl font-semibold">{{ $state['title'] }}</h2>
+
+    @if ($state['response_status'] !== null)
+        @include('email-integration::filament.infolists.partials.rsvp-pill', ['status' => $state['response_status']])
+    @endif
+</div>

--- a/packages/EmailIntegration/resources/views/filament/infolists/meeting-linked-records.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/infolists/meeting-linked-records.blade.php
@@ -1,0 +1,13 @@
+@php
+    /** @var list<array{name: string, type: string}> $items */
+    $items = $getState();
+@endphp
+
+<div class="space-y-2">
+    @foreach ($items as $item)
+        <div class="flex items-center justify-between gap-3">
+            <span class="truncate font-medium text-gray-950 dark:text-white">{{ $item['name'] }}</span>
+            <span class="shrink-0 text-sm text-gray-500 dark:text-gray-400">{{ $item['type'] }}</span>
+        </div>
+    @endforeach
+</div>

--- a/packages/EmailIntegration/resources/views/filament/infolists/partials/rsvp-pill.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/infolists/partials/rsvp-pill.blade.php
@@ -1,0 +1,13 @@
+@php
+    $dotColor = match ($status->getColor()) {
+        'success' => 'bg-emerald-500',
+        'danger' => 'bg-red-500',
+        'warning' => 'bg-amber-500',
+        default => 'bg-gray-400',
+    };
+@endphp
+
+<span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--surface-block-border)] bg-[var(--surface-block-bg)] px-2.5 py-1 text-xs">
+    <span class="size-1.5 rounded-full {{ $dotColor }}"></span>
+    {{ $status->getLabel() }}
+</span>

--- a/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingAttendeeEntry.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingAttendeeEntry.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Infolists\Entries;
+
+use App\Models\People;
+use App\Services\AvatarService;
+use Filament\Infolists\Components\Entry;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Models\MeetingAttendee;
+
+final class MeetingAttendeeEntry extends Entry
+{
+    protected string $view = 'email-integration::filament.infolists.meeting-attendee';
+
+    /**
+     * @return array{name: string, email: string, avatar: string, is_organizer: bool, response_status: AttendeeResponseStatus|null}
+     */
+    public function getState(): array
+    {
+        $record = $this->getRecord();
+
+        if (! $record instanceof MeetingAttendee) {
+            return [
+                'name' => '',
+                'email' => '',
+                'avatar' => '',
+                'is_organizer' => false,
+                'response_status' => null,
+            ];
+        }
+
+        $name = $record->name ?: $record->email_address;
+        $contact = $record->getRelationValue('contact');
+
+        return [
+            'name' => $name,
+            'email' => $record->email_address,
+            'avatar' => ($contact instanceof People ? $contact->avatar : null) ?? resolve(AvatarService::class)->generateAuto(name: $name, initialCount: 1),
+            'is_organizer' => $record->is_organizer,
+            'response_status' => $record->response_status,
+        ];
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Infolists\Entries;
+
+use Filament\Infolists\Components\Entry;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final class MeetingHeaderEntry extends Entry
+{
+    protected string $view = 'email-integration::filament.infolists.meeting-header';
+
+    /**
+     * @return array{title: string, month: string, day: string, response_status: AttendeeResponseStatus|null}
+     */
+    public function getState(): array
+    {
+        $record = $this->getRecord();
+
+        if (! $record instanceof Meeting) {
+            return [
+                'title' => '',
+                'month' => '',
+                'day' => '',
+                'response_status' => null,
+            ];
+        }
+
+        return [
+            'title' => $record->title,
+            'month' => strtoupper($record->starts_at->format('M')),
+            'day' => $record->starts_at->format('j'),
+            'response_status' => $record->response_status,
+        ];
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingLinkedRecordsEntry.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingLinkedRecordsEntry.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Infolists\Entries;
+
+use Filament\Infolists\Components\Entry;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final class MeetingLinkedRecordsEntry extends Entry
+{
+    protected string $view = 'email-integration::filament.infolists.meeting-linked-records';
+
+    /**
+     * @return list<array{name: string, type: string}>
+     */
+    public function getState(): array
+    {
+        $record = $this->getRecord();
+
+        if (! $record instanceof Meeting) {
+            return [];
+        }
+
+        $items = [];
+
+        foreach ($record->people as $person) {
+            $items[] = [
+                'name' => $person->name,
+                'type' => __('filament/resources/meeting.linked_record_types.people'),
+            ];
+        }
+
+        foreach ($record->companies as $company) {
+            $items[] = [
+                'name' => $company->name,
+                'type' => __('filament/resources/meeting.linked_record_types.companies'),
+            ];
+        }
+
+        foreach ($record->opportunities as $opportunity) {
+            $items[] = [
+                'name' => $opportunity->name,
+                'type' => __('filament/resources/meeting.linked_record_types.opportunities'),
+            ];
+        }
+
+        return $items;
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Infolists;
+
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
+use Filament\Actions\Action;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\Select;
+use Filament\Infolists\Components\RepeatableEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+use Relaticle\EmailIntegration\Actions\LinkMeetingToRecordAction;
+use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingAttendeeEntry;
+use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingHeaderEntry;
+use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingLinkedRecordsEntry;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final class MeetingDetailInfolist
+{
+    public static function viewAction(): ViewAction
+    {
+        return ViewAction::make()
+            ->modalHeading(__('filament/resources/meeting.view.heading'))
+            ->modalWidth(Width::Large)
+            ->schema(fn (Schema $schema): Schema => self::configure($schema))
+            ->registerModalActions([
+                self::linkRecordsAction('linkRecordsEmpty'),
+            ]);
+    }
+
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema->components(function (Schema $schema): array {
+            $record = $schema->getRecord();
+
+            if ($record instanceof Meeting) {
+                $record->loadMissing(['attendees.contact', 'people', 'companies', 'opportunities']);
+            }
+
+            return [
+                MeetingHeaderEntry::make('header')->hiddenLabel(),
+                TextEntry::make('time_row')
+                    ->hiddenLabel()
+                    ->icon(Heroicon::OutlinedClock)
+                    ->state(function (Meeting $record): string {
+                        if ($record->all_day) {
+                            return $record->starts_at->format('M j').' ('.__('filament/resources/meeting.time.all_day').')';
+                        }
+
+                        return $record->starts_at->format('M j').'  '.$record->starts_at->format('g:i A').' → '.$record->ends_at->format('g:i A').' ('.self::compactDuration($record).')';
+                    }),
+                TextEntry::make('html_link')
+                    ->hiddenLabel()
+                    ->icon(Heroicon::OutlinedLink)
+                    ->url(fn (Meeting $record): ?string => $record->html_link, shouldOpenInNewTab: true)
+                    ->visible(fn (Meeting $record): bool => filled($record->html_link)),
+                TextEntry::make('location')
+                    ->hiddenLabel()
+                    ->icon(Heroicon::OutlinedMapPin)
+                    ->visible(fn (Meeting $record): bool => filled($record->location)),
+                Section::make(__('filament/resources/meeting.sections.participants.heading'))
+                    ->afterHeader([
+                        TextEntry::make('attendees_badge')
+                            ->hiddenLabel()
+                            ->badge()
+                            ->state(fn (Meeting $record): int => $record->attendees->count()),
+                    ])
+                    ->schema([
+                        RepeatableEntry::make('attendees')
+                            ->hiddenLabel()
+                            ->schema([
+                                MeetingAttendeeEntry::make('attendee')->hiddenLabel(),
+                            ]),
+                        TextEntry::make('attendees_empty')
+                            ->hiddenLabel()
+                            ->state(__('filament/resources/meeting.sections.participants.empty'))
+                            ->visible(fn (Meeting $record): bool => $record->attendees->isEmpty()),
+                    ]),
+                Section::make(__('filament/resources/meeting.sections.linked_records.heading'))
+                    ->afterHeader([
+                        TextEntry::make('linked_badge')
+                            ->hiddenLabel()
+                            ->badge()
+                            ->state(fn (Meeting $record): int => self::linkedCount($record)),
+                    ])
+                    ->headerActions([
+                        self::linkRecordsAction('linkRecords')->iconButton(),
+                    ])
+                    ->schema([
+                        MeetingLinkedRecordsEntry::make('linked_records')
+                            ->hiddenLabel()
+                            ->visible(fn (Meeting $record): bool => self::linkedCount($record) > 0),
+                        self::linkRecordsAction('linkRecordsEmpty')
+                            ->visible(fn (Meeting $record): bool => self::linkedCount($record) === 0),
+                    ]),
+                Section::make(__('filament/resources/meeting.sections.description.heading'))
+                    ->schema([
+                        TextEntry::make('description')->hiddenLabel()->html(),
+                    ])
+                    ->visible(fn (Meeting $record): bool => filled($record->description)),
+            ];
+        });
+    }
+
+    public static function compactDuration(Meeting $meeting): string
+    {
+        $minutes = (int) $meeting->starts_at->diffInMinutes($meeting->ends_at);
+
+        if ($minutes < 60) {
+            return $minutes.'m';
+        }
+
+        $hours = intdiv($minutes, 60);
+        $remainder = $minutes % 60;
+
+        if ($remainder === 0) {
+            return $hours.'h';
+        }
+
+        return $hours.'h '.$remainder.'m';
+    }
+
+    public static function linkedCount(Meeting $meeting): int
+    {
+        return $meeting->people->count() + $meeting->companies->count() + $meeting->opportunities->count();
+    }
+
+    public static function linkRecordsAction(string $name): Action
+    {
+        return Action::make($name)
+            ->label(__('filament/resources/meeting.actions.link_records.label'))
+            ->icon(Heroicon::Plus)
+            ->schema([
+                Select::make('target_type')
+                    ->options([
+                        'People' => __('filament/resources/meeting.linked_record_types.people'),
+                        'Company' => __('filament/resources/meeting.linked_record_types.companies'),
+                        'Opportunity' => __('filament/resources/meeting.linked_record_types.opportunities'),
+                    ])
+                    ->required()
+                    ->live(),
+                Select::make('target_id')
+                    ->options(function (Get $get): array {
+                        $teamId = filament()->getTenant()?->getKey();
+
+                        return match ((string) $get('target_type')) {
+                            'People' => People::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+                            'Company' => Company::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+                            'Opportunity' => Opportunity::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+                            default => [],
+                        };
+                    })
+                    ->searchable()
+                    ->required(),
+            ])
+            ->action(function (array $data, Meeting $record): void {
+                $target = self::resolveLinkTarget(
+                    (string) $data['target_type'],
+                    (string) $data['target_id'],
+                );
+
+                resolve(LinkMeetingToRecordAction::class)->execute($record, $target);
+
+                Notification::make()
+                    ->success()
+                    ->title(__('filament/relation-managers/meetings.notifications.linked.title'))
+                    ->send();
+            });
+    }
+
+    private static function resolveLinkTarget(string $type, string $id): Model
+    {
+        $teamId = filament()->getTenant()?->getKey();
+
+        return match ($type) {
+            'People' => People::query()->where('team_id', $teamId)->findOrFail($id),
+            'Company' => Company::query()->where('team_id', $teamId)->findOrFail($id),
+            'Opportunity' => Opportunity::query()->where('team_id', $teamId)->findOrFail($id),
+            default => throw new InvalidArgumentException('Unsupported type: '.$type),
+        };
+    }
+}

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -9,16 +9,10 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Actions\Action;
-use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Select;
-use Filament\Infolists\Components\RepeatableEntry;
-use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
-use Filament\Schemas\Components\Grid;
-use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
-use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
@@ -27,6 +21,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\EmailIntegration\Actions\LinkMeetingToRecordAction;
 use Relaticle\EmailIntegration\Actions\UnlinkMeetingFromRecordAction;
+use Relaticle\EmailIntegration\Filament\Infolists\MeetingDetailInfolist;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
@@ -86,8 +81,7 @@ abstract class BaseMeetingsRelationManager extends RelationManager
                     ->query(fn (Builder $q): Builder => $q->where('starts_at', '<', now())),
             ])
             ->recordActions([
-                ViewAction::make()
-                    ->schema(fn (Schema $schema): Schema => $this->detailSchema($schema)),
+                MeetingDetailInfolist::viewAction(),
                 Action::make('linkToRecord')
                     ->label(__('filament/relation-managers/meetings.actions.link_to_record.label'))
                     ->icon(Heroicon::Link)
@@ -131,54 +125,6 @@ abstract class BaseMeetingsRelationManager extends RelationManager
                             ->send();
                     }),
             ]);
-    }
-
-    protected function detailSchema(Schema $schema): Schema
-    {
-        return $schema->components([
-            Grid::make(['default' => 1, 'md' => 2])
-                ->columnSpanFull()
-                ->schema([
-                    Grid::make(1)->schema([
-                        Section::make('Meeting')
-                            ->icon(Heroicon::OutlinedCalendar)
-                            ->compact()
-                            ->schema([
-                                TextEntry::make('title'),
-                                TextEntry::make('starts_at')->dateTime('M j, Y · g:i a'),
-                                TextEntry::make('ends_at')->dateTime('M j, Y · g:i a'),
-                                TextEntry::make('location')->default('—'),
-                                TextEntry::make('organizer_name')->label(__('filament/relation-managers/meetings.fields.organizer.label')),
-                            ]),
-                        Section::make('Description')
-                            ->icon(Heroicon::OutlinedDocumentText)
-                            ->compact()
-                            ->schema([
-                                TextEntry::make('description')->html()->default('(no description)'),
-                            ]),
-                    ]),
-                    Grid::make(1)->schema([
-                        Section::make('Attendees')
-                            ->icon(Heroicon::OutlinedUsers)
-                            ->compact()
-                            ->schema([
-                                RepeatableEntry::make('attendees')->schema([
-                                    TextEntry::make('name')->default(fn (Model $record): string => $record->email_address),  // @phpstan-ignore-line
-                                    TextEntry::make('email_address')->label(__('filament/relation-managers/meetings.fields.email_address.label')),
-                                    TextEntry::make('response_status')->badge(),
-                                ]),
-                            ]),
-                        Section::make('Link')
-                            ->icon(Heroicon::OutlinedLink)
-                            ->compact()
-                            ->schema([
-                                TextEntry::make('html_link')
-                                    ->label(__('filament/relation-managers/meetings.fields.html_link.label'))
-                                    ->url(fn (Model $record): ?string => $record->html_link, shouldOpenInNewTab: true),  // @phpstan-ignore-line
-                            ]),
-                    ]),
-                ]),
-        ]);
     }
 
     /** @return array<string, string> */

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -15,6 +15,7 @@ use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
@@ -135,28 +136,48 @@ abstract class BaseMeetingsRelationManager extends RelationManager
     protected function detailSchema(Schema $schema): Schema
     {
         return $schema->components([
-            Section::make('Meeting')->schema([
-                TextEntry::make('title'),
-                TextEntry::make('starts_at')->dateTime('M j, Y · g:i a'),
-                TextEntry::make('ends_at')->dateTime('M j, Y · g:i a'),
-                TextEntry::make('location')->default('—'),
-                TextEntry::make('organizer_name')->label(__('filament/relation-managers/meetings.fields.organizer.label')),
-            ]),
-            Section::make('Attendees')->schema([
-                RepeatableEntry::make('attendees')->schema([
-                    TextEntry::make('name')->default(fn (Model $record): string => $record->email_address),  // @phpstan-ignore-line
-                    TextEntry::make('email_address')->label(__('filament/relation-managers/meetings.fields.email_address.label')),
-                    TextEntry::make('response_status')->badge(),
+            Grid::make(['default' => 1, 'md' => 2])
+                ->columnSpanFull()
+                ->schema([
+                    Grid::make(1)->schema([
+                        Section::make('Meeting')
+                            ->icon(Heroicon::OutlinedCalendar)
+                            ->compact()
+                            ->schema([
+                                TextEntry::make('title'),
+                                TextEntry::make('starts_at')->dateTime('M j, Y · g:i a'),
+                                TextEntry::make('ends_at')->dateTime('M j, Y · g:i a'),
+                                TextEntry::make('location')->default('—'),
+                                TextEntry::make('organizer_name')->label(__('filament/relation-managers/meetings.fields.organizer.label')),
+                            ]),
+                        Section::make('Description')
+                            ->icon(Heroicon::OutlinedDocumentText)
+                            ->compact()
+                            ->schema([
+                                TextEntry::make('description')->html()->default('(no description)'),
+                            ]),
+                    ]),
+                    Grid::make(1)->schema([
+                        Section::make('Attendees')
+                            ->icon(Heroicon::OutlinedUsers)
+                            ->compact()
+                            ->schema([
+                                RepeatableEntry::make('attendees')->schema([
+                                    TextEntry::make('name')->default(fn (Model $record): string => $record->email_address),  // @phpstan-ignore-line
+                                    TextEntry::make('email_address')->label(__('filament/relation-managers/meetings.fields.email_address.label')),
+                                    TextEntry::make('response_status')->badge(),
+                                ]),
+                            ]),
+                        Section::make('Link')
+                            ->icon(Heroicon::OutlinedLink)
+                            ->compact()
+                            ->schema([
+                                TextEntry::make('html_link')
+                                    ->label(__('filament/relation-managers/meetings.fields.html_link.label'))
+                                    ->url(fn (Model $record): ?string => $record->html_link, shouldOpenInNewTab: true),  // @phpstan-ignore-line
+                            ]),
+                    ]),
                 ]),
-            ]),
-            Section::make('Description')->schema([
-                TextEntry::make('description')->html()->default('(no description)'),
-            ]),
-            Section::make('Link')->schema([
-                TextEntry::make('html_link')
-                    ->label(__('filament/relation-managers/meetings.fields.html_link.label'))
-                    ->url(fn (Model $record): ?string => $record->html_link, shouldOpenInNewTab: true),  // @phpstan-ignore-line
-            ]),
         ]);
     }
 

--- a/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
@@ -6,15 +6,8 @@ namespace Relaticle\EmailIntegration\Filament\Resources;
 
 use App\Models\Team;
 use App\Models\User;
-use Filament\Actions\ViewAction;
-use Filament\Infolists\Components\RepeatableEntry;
-use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Resource;
-use Filament\Schemas\Components\Grid;
-use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Filament\Support\Enums\IconPosition;
-use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
@@ -25,10 +18,10 @@ use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
 use Relaticle\EmailIntegration\Filament\Actions\ConfigureMailboxAction;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
+use Relaticle\EmailIntegration\Filament\Infolists\MeetingDetailInfolist;
 use Relaticle\EmailIntegration\Filament\Resources\MeetingResource\Pages\ListMeetings;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
-use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
 
 final class MeetingResource extends Resource
@@ -55,53 +48,7 @@ final class MeetingResource extends Resource
 
     public static function infolist(Schema $schema): Schema
     {
-        return $schema->components([
-            Grid::make(['default' => 1, 'md' => 2])
-                ->columnSpanFull()
-                ->schema([
-                    Grid::make(1)->schema([
-                        Section::make('Meeting')
-                            ->icon(Heroicon::OutlinedCalendar)
-                            ->compact()
-                            ->schema([
-                                TextEntry::make('title'),
-                                TextEntry::make('starts_at')->dateTime('M j, Y · g:i a'),
-                                TextEntry::make('ends_at')->dateTime('M j, Y · g:i a'),
-                                TextEntry::make('location')->default('—'),
-                                TextEntry::make('organizer_name')->label(__('filament/resources/meeting.fields.organizer.label')),
-                            ]),
-                        Section::make('Description')
-                            ->icon(Heroicon::OutlinedDocumentText)
-                            ->compact()
-                            ->schema([
-                                TextEntry::make('description')->html()->default('(no description)'),
-                            ]),
-                    ]),
-                    Grid::make(1)->schema([
-                        Section::make('Attendees')
-                            ->icon(Heroicon::OutlinedUsers)
-                            ->compact()
-                            ->schema([
-                                RepeatableEntry::make('attendees')->schema([
-                                    TextEntry::make('name')->default(fn (MeetingAttendee $record): string => $record->email_address),
-                                    TextEntry::make('email_address')->label(__('filament/resources/meeting.fields.email_address.label')),
-                                    TextEntry::make('response_status')->badge(),
-                                ]),
-                            ]),
-                        Section::make('Link')
-                            ->icon(Heroicon::OutlinedLink)
-                            ->compact()
-                            ->schema([
-                                TextEntry::make('html_link')
-                                    ->label(__('filament/resources/meeting.fields.html_link.label'))
-                                    ->color('primary')
-                                    ->icon('heroicon-o-arrow-top-right-on-square')
-                                    ->iconPosition(IconPosition::After)
-                                    ->url(fn (Meeting $record): ?string => $record->html_link, shouldOpenInNewTab: true),
-                            ]),
-                    ]),
-                ]),
-        ]);
+        return MeetingDetailInfolist::configure($schema);
     }
 
     public static function table(Table $table): Table
@@ -157,7 +104,7 @@ final class MeetingResource extends Resource
                     ->options(AttendeeResponseStatus::class),
             ])
             ->recordActions([
-                ViewAction::make(),
+                MeetingDetailInfolist::viewAction(),
             ])
             ->emptyStateIcon('heroicon-o-calendar-days')
             ->emptyStateHeading(fn (): string => self::hasMailbox()

--- a/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
@@ -10,9 +10,11 @@ use Filament\Actions\ViewAction;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\IconPosition;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
@@ -54,31 +56,51 @@ final class MeetingResource extends Resource
     public static function infolist(Schema $schema): Schema
     {
         return $schema->components([
-            Section::make('Meeting')->schema([
-                TextEntry::make('title'),
-                TextEntry::make('starts_at')->dateTime('M j, Y · g:i a'),
-                TextEntry::make('ends_at')->dateTime('M j, Y · g:i a'),
-                TextEntry::make('location')->default('—'),
-                TextEntry::make('organizer_name')->label(__('filament/resources/meeting.fields.organizer.label')),
-            ]),
-            Section::make('Attendees')->schema([
-                RepeatableEntry::make('attendees')->schema([
-                    TextEntry::make('name')->default(fn (MeetingAttendee $record): string => $record->email_address),
-                    TextEntry::make('email_address')->label(__('filament/resources/meeting.fields.email_address.label')),
-                    TextEntry::make('response_status')->badge(),
+            Grid::make(['default' => 1, 'md' => 2])
+                ->columnSpanFull()
+                ->schema([
+                    Grid::make(1)->schema([
+                        Section::make('Meeting')
+                            ->icon(Heroicon::OutlinedCalendar)
+                            ->compact()
+                            ->schema([
+                                TextEntry::make('title'),
+                                TextEntry::make('starts_at')->dateTime('M j, Y · g:i a'),
+                                TextEntry::make('ends_at')->dateTime('M j, Y · g:i a'),
+                                TextEntry::make('location')->default('—'),
+                                TextEntry::make('organizer_name')->label(__('filament/resources/meeting.fields.organizer.label')),
+                            ]),
+                        Section::make('Description')
+                            ->icon(Heroicon::OutlinedDocumentText)
+                            ->compact()
+                            ->schema([
+                                TextEntry::make('description')->html()->default('(no description)'),
+                            ]),
+                    ]),
+                    Grid::make(1)->schema([
+                        Section::make('Attendees')
+                            ->icon(Heroicon::OutlinedUsers)
+                            ->compact()
+                            ->schema([
+                                RepeatableEntry::make('attendees')->schema([
+                                    TextEntry::make('name')->default(fn (MeetingAttendee $record): string => $record->email_address),
+                                    TextEntry::make('email_address')->label(__('filament/resources/meeting.fields.email_address.label')),
+                                    TextEntry::make('response_status')->badge(),
+                                ]),
+                            ]),
+                        Section::make('Link')
+                            ->icon(Heroicon::OutlinedLink)
+                            ->compact()
+                            ->schema([
+                                TextEntry::make('html_link')
+                                    ->label(__('filament/resources/meeting.fields.html_link.label'))
+                                    ->color('primary')
+                                    ->icon('heroicon-o-arrow-top-right-on-square')
+                                    ->iconPosition(IconPosition::After)
+                                    ->url(fn (Meeting $record): ?string => $record->html_link, shouldOpenInNewTab: true),
+                            ]),
+                    ]),
                 ]),
-            ]),
-            Section::make('Description')->schema([
-                TextEntry::make('description')->html()->default('(no description)'),
-            ]),
-            Section::make('Link')->schema([
-                TextEntry::make('html_link')
-                    ->label(__('filament/resources/meeting.fields.html_link.label'))
-                    ->color('primary')
-                    ->icon('heroicon-o-arrow-top-right-on-square')
-                    ->iconPosition(IconPosition::After)
-                    ->url(fn (Meeting $record): ?string => $record->html_link, shouldOpenInNewTab: true),
-            ]),
         ]);
     }
 

--- a/packages/EmailIntegration/src/Models/MeetingAttendee.php
+++ b/packages/EmailIntegration/src/Models/MeetingAttendee.php
@@ -23,6 +23,9 @@ use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
  * @property bool $is_self
  * @property string|null $contact_id
  * @property string|null $company_id
+ * @property People|null $contact
+ * @property Company|null $company
+ * @property Meeting $meeting
  */
 final class MeetingAttendee extends Model
 {

--- a/tests/Feature/CalendarIntegration/MeetingResourceListTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingResourceListTest.php
@@ -2,21 +2,31 @@
 
 declare(strict_types=1);
 
+use App\Models\Company;
+use App\Models\Opportunity;
+use App\Models\People;
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Illuminate\Support\Carbon;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingAttendeeEntry;
+use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingLinkedRecordsEntry;
+use Relaticle\EmailIntegration\Filament\Infolists\MeetingDetailInfolist;
 use Relaticle\EmailIntegration\Filament\Resources\MeetingResource;
 use Relaticle\EmailIntegration\Filament\Resources\MeetingResource\Pages\ListMeetings;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\MeetingAttendee;
 
-mutates(MeetingResource::class);
+mutates(MeetingResource::class, MeetingDetailInfolist::class, MeetingAttendeeEntry::class, MeetingLinkedRecordsEntry::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
     $this->actingAs($this->user);
     $this->team = $this->user->currentTeam;
     Filament::setTenant($this->team);
+    Filament::setCurrentPanel(Filament::getPanel('app'));
 
     $this->account = ConnectedAccount::withoutEvents(
         fn () => ConnectedAccount::factory()->create([
@@ -58,6 +68,230 @@ it('filters upcoming meetings', function (): void {
         ->filterTable('upcoming')
         ->assertCanSeeTableRecords([$future])
         ->assertCanNotSeeTableRecords([$past]);
+});
+
+it('shows title, time range, duration, and rsvp in the view modal', function (): void {
+    $starts = Carbon::parse('2026-09-30 05:30:00');
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'New Meeting',
+        'starts_at' => $starts,
+        'ends_at' => $starts->copy()->addHour(),
+        'all_day' => false,
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+        'html_link' => 'https://meet.example.test/abc',
+        'location' => 'HQ',
+        'description' => '<p>Agenda</p>',
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('New Meeting')
+        ->assertMountedActionModalSee('Sep 30')
+        ->assertMountedActionModalSee('5:30 AM')
+        ->assertMountedActionModalSee('6:30 AM')
+        ->assertMountedActionModalSee('(1h)')
+        ->assertMountedActionModalSee(AttendeeResponseStatus::ACCEPTED->getLabel())
+        ->assertMountedActionModalSee('https://meet.example.test/abc')
+        ->assertMountedActionModalSee('HQ')
+        ->assertMountedActionModalSee('Agenda')
+        ->assertMountedActionModalSee(__('filament/resources/meeting.sections.description.heading'));
+});
+
+it('shows all-day meetings without a clock range', function (): void {
+    $starts = Carbon::parse('2026-09-30 00:00:00');
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Offsite',
+        'starts_at' => $starts,
+        'ends_at' => $starts->copy()->addDay(),
+        'all_day' => true,
+        'response_status' => AttendeeResponseStatus::TENTATIVE,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('Offsite')
+        ->assertMountedActionModalSee(__('filament/resources/meeting.time.all_day'))
+        ->assertMountedActionModalDontSee('→');
+});
+
+it('hides the rsvp pill when response status is null', function (): void {
+    $starts = Carbon::parse('2026-09-30 05:30:00');
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'No RSVP Meeting',
+        'starts_at' => $starts,
+        'ends_at' => $starts->copy()->addHour(),
+        'all_day' => false,
+        'response_status' => null,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('No RSVP Meeting')
+        ->assertMountedActionModalDontSee('Accepted');
+});
+
+it('hides link, location, and description when they are empty', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'html_link' => null,
+        'location' => null,
+        'description' => null,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalDontSee('https://meet.example.test/abc')
+        ->assertMountedActionModalDontSee('Rooftop Terrace 7B')
+        ->assertMountedActionModalDontSee('Kickoff notes')
+        ->assertMountedActionModalDontSee(__('filament/resources/meeting.sections.description.heading'));
+});
+
+it('lists attendees with host and rsvp in the view modal', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => 'Asmit Magan',
+        'email_address' => 'asmit@example.test',
+        'is_organizer' => true,
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+    ]);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => 'Asmit Nepali',
+        'email_address' => 'guest@example.test',
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee(__('filament/resources/meeting.sections.participants.heading'))
+        ->assertMountedActionModalSee('Asmit Magan')
+        ->assertMountedActionModalSee('asmit@example.test')
+        ->assertMountedActionModalSee(__('filament/resources/meeting.attendees.host'))
+        ->assertMountedActionModalSee(AttendeeResponseStatus::ACCEPTED->getLabel())
+        ->assertMountedActionModalSee('Asmit Nepali')
+        ->assertMountedActionModalSee('guest@example.test')
+        ->assertMountedActionModalSee(AttendeeResponseStatus::NEEDS_ACTION->getLabel());
+});
+
+it('shows an empty participants line when there are no attendees', function (): void {
+    $starts = Carbon::parse('2026-09-15 11:11:00');
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'starts_at' => $starts,
+        'ends_at' => $starts->copy()->addMinutes(75),
+        'all_day' => false,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee(__('filament/resources/meeting.sections.participants.heading'))
+        ->assertMountedActionModalSee('0')
+        ->assertMountedActionModalSee(__('filament/resources/meeting.sections.participants.empty'));
+});
+
+it('shows the current user attendee row when is_self is true', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => 'Current User',
+        'email_address' => 'self@example.test',
+        'is_self' => true,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('Current User')
+        ->assertMountedActionModalSee('self@example.test')
+        ->assertMountedActionModalSee(AttendeeResponseStatus::ACCEPTED->getLabel());
+});
+
+it('shows link, location, and description when they are filled', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'html_link' => 'https://meet.example.test/abc',
+        'location' => 'Rooftop Terrace 7B',
+        'description' => '<p>Kickoff notes</p>',
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('https://meet.example.test/abc')
+        ->assertMountedActionModalSee('Rooftop Terrace 7B')
+        ->assertMountedActionModalSee('Kickoff notes')
+        ->assertMountedActionModalSee(__('filament/resources/meeting.sections.description.heading'));
+});
+
+it('lists linked people, companies, and opportunities in the view modal', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+    $person = People::factory()->for($this->team)->create(['name' => 'Linked Person']);
+    $company = Company::factory()->for($this->team)->create(['name' => 'Linked Co']);
+    $opportunity = Opportunity::factory()->for($this->team)->create(['name' => 'Linked Deal']);
+
+    $meeting->people()->attach($person, ['link_source' => 'manual']);
+    $meeting->companies()->attach($company, ['link_source' => 'manual']);
+    $meeting->opportunities()->attach($opportunity, ['link_source' => 'manual']);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee(__('filament/resources/meeting.sections.linked_records.heading'))
+        ->assertMountedActionModalSee('Linked Person')
+        ->assertMountedActionModalSee('Linked Co')
+        ->assertMountedActionModalSee('Linked Deal');
+});
+
+it('shows link records when nothing is linked', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee(__('filament/resources/meeting.actions.link_records.label'));
+});
+
+it('links a record from the meeting view modal', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+    $person = People::factory()->for($this->team)->create();
+
+    livewire(ListMeetings::class)
+        ->callAction([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('linkRecordsEmpty'),
+        ], [
+            'target_type' => 'People',
+            'target_id' => $person->getKey(),
+        ])
+        ->assertNotified();
+
+    expect($meeting->fresh()?->people()->count())->toBe(1);
 });
 
 it('filters past meetings', function (): void {

--- a/tests/Feature/CalendarIntegration/MeetingsRelationManagerTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsRelationManagerTest.php
@@ -8,19 +8,24 @@ use App\Filament\Resources\PeopleResource\RelationManagers\MeetingsRelationManag
 use App\Models\CustomField;
 use App\Models\People;
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Filament\Infolists\MeetingDetailInfolist;
 use Relaticle\EmailIntegration\Filament\RelationManagers\BaseMeetingsRelationManager;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
-mutates(MeetingsRelationManager::class, BaseMeetingsRelationManager::class, EmailVisibilityService::class);
+mutates(MeetingsRelationManager::class, BaseMeetingsRelationManager::class, EmailVisibilityService::class, MeetingDetailInfolist::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
     $this->actingAs($this->user);
     $this->team = $this->user->currentTeam;
     Filament::setTenant($this->team);
+    Filament::setCurrentPanel(Filament::getPanel('app'));
 
     $this->account = ConnectedAccount::withoutEvents(
         fn () => ConnectedAccount::factory()->create([
@@ -87,4 +92,34 @@ it('hides meetings on a protected person', function (): void {
     ])
         ->assertSee(__('filament/pages/record-emails.protected.heading'))
         ->assertCanNotSeeTableRecords([$meeting]);
+});
+
+it('shows the shared meeting detail in the relation manager view modal', function (): void {
+    $person = People::factory()->for($this->team)->create();
+    $starts = now()->startOfHour();
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Shared Detail Meeting',
+        'starts_at' => $starts,
+        'ends_at' => $starts->copy()->addHour(),
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+    ]);
+    $meeting->people()->attach($person, ['link_source' => 'manual']);
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => 'Host Person',
+        'is_organizer' => true,
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+    ]);
+
+    livewire(MeetingsRelationManager::class, [
+        'ownerRecord' => $person,
+        'pageClass' => ViewPeople::class,
+    ])
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('Shared Detail Meeting')
+        ->assertMountedActionModalSee('Host Person')
+        ->assertMountedActionModalSee(__('filament/resources/meeting.attendees.host'))
+        ->assertMountedActionModalSee($person->name);
 });


### PR DESCRIPTION
## Summary
- Arrange meeting details and attendees as independent responsive columns.
- Move description and link below their related sections.
- Add compact section headers with consistent outline icons.

## Testing
- Not run per request.