### PR TITLE
Add column controls to all sysadmin tables

### DIFF
--- a/packages/SystemAdmin/src/SystemAdminPanelProvider.php
+++ b/packages/SystemAdmin/src/SystemAdminPanelProvider.php
@@ -14,6 +14,7 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Schemas\Schema;
 use Filament\Support\Colors\Color;
+use Filament\Tables\Columns\Column;
 use Filament\Tables\Table;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\Auth\Authenticatable;
@@ -74,10 +75,16 @@ final class SystemAdminPanelProvider extends PanelProvider
             Gate::policy($model, $policy);
         }
 
-        // Table and Schema configuration is global, so both callbacks have to check
-        // which panel is actually serving the request before they touch the format.
+        Column::configureUsing(fn (Column $column): Column => $this->isCurrentPanel()
+            ? $column->toggleable()
+            : $column);
+
+        // Filament configuration is global, so panel-specific callbacks must guard
+        // against changing customer-facing components.
         Table::configureUsing(fn (Table $table): Table => $this->isCurrentPanel()
-            ? $table->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+            ? $table
+                ->defaultDateTimeDisplayFormat(self::DATE_TIME_FORMAT)
+                ->reorderableColumns()
             : $table);
 
         Schema::configureUsing(fn (Schema $schema): Schema => $this->isCurrentPanel()

--- a/tests/Feature/SystemAdmin/SystemAdminPanelProviderTest.php
+++ b/tests/Feature/SystemAdmin/SystemAdminPanelProviderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\CompanyResource\Pages\ListCompanies as ListAppCompanies;
+use Filament\Facades\Filament;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Relaticle\SystemAdmin\Filament\Resources\CompanyResource\Pages\ListCompanies as ListSystemAdminCompanies;
+use Relaticle\SystemAdmin\SystemAdminPanelProvider;
+
+mutates(SystemAdminPanelProvider::class);
+
+it('lets administrators reorder sysadmin table columns', function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+
+    $table = Table::make(new ListSystemAdminCompanies);
+
+    expect($table->hasReorderableColumns())->toBeTrue();
+});
+
+it('lets administrators toggle every sysadmin table column', function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('sysadmin'));
+
+    $column = TextColumn::make('name');
+
+    expect($column->isToggleable())->toBeTrue();
+});
+
+it('leaves customer table column management unchanged', function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+
+    $table = Table::make(new ListAppCompanies);
+    $column = TextColumn::make('name');
+
+    expect($table->hasReorderableColumns())->toBeFalse()
+        ->and($column->isToggleable())->toBeFalse();
+});


### PR DESCRIPTION
Enables column reordering and visibility controls across sysadmin tables. Keeps customer tables unchanged. Adds regression coverage and passes 4,289 tests.