### PR TITLE
feat(pricing): add Enterprise offering and refine billing

### DIFF
--- a/.claude/skills/agent-browser-relaticle/SKILL.md
+++ b/.claude/skills/agent-browser-relaticle/SKILL.md
@@ -244,3 +244,13 @@ Never use tinker or DB writes to fix or fake a result. An on-screen error is a f
 
 For any deliverable screenshot, invoke `Skill('screenshot-with-callout')` per shot
 (annotate → verify-crop → shoot → read-back). Throwaway debug shots exempt.
+
+## 9. Eval and rendering hints (verified: 2026-09-07)
+
+- `agent-browser eval` runs every call in the same page scope. A top-level `const x`
+  declared in one eval throws `Identifier 'x' has already been declared` in the next.
+  Wrap evals in an IIFE: `agent-browser eval '(()=>{ const x=...; return JSON.stringify(x) })()'`.
+- To screenshot a feature-flag branch without flipping the shared `.env`, render it to
+  a file and open that: `php artisan tinker --execute '\Laravel\Pennant\Feature::define(\App\Features\Billing::class, false); file_put_contents(".context/off.html", view("pricing")->render());'`
+  then `agent-browser open "file://$(pwd)/.context/off.html"`. Vite assets resolve to the
+  absolute `APP_URL`, so the page styles correctly from `file://`.

--- a/app/Actions/Billing/NotifyWorkspaceOfPaymentFailure.php
+++ b/app/Actions/Billing/NotifyWorkspaceOfPaymentFailure.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Billing;
 
+use App\Enums\Plan;
 use App\Filament\Pages\Billing;
 use App\Models\Team;
 use App\Models\User;
@@ -29,7 +30,9 @@ final readonly class NotifyWorkspaceOfPaymentFailure
 
         Notification::make()
             ->title(__('billing.payment_failed.notification_title', ['workspace' => $team->name]))
-            ->body(__('billing.payment_failed.notification_body'))
+            ->body($team->plan === Plan::Enterprise
+                ? __('billing.enterprise.previous_subscription_past_due')
+                : __('billing.payment_failed.notification_body'))
             ->icon(Heroicon::OutlinedExclamationTriangle)
             ->iconColor('danger')
             ->actions([

--- a/app/Actions/Billing/SyncTeamPlanFromSubscription.php
+++ b/app/Actions/Billing/SyncTeamPlanFromSubscription.php
@@ -63,6 +63,10 @@ final readonly class SyncTeamPlanFromSubscription
 
     private function targetPlan(Team $team, Subscription $subscription, Plan $subscriptionPlan): ?Plan
     {
+        if ($team->plan === Plan::Enterprise && $subscriptionPlan !== Plan::Enterprise) {
+            return null;
+        }
+
         if ($subscription->valid()) {
             return $subscriptionPlan;
         }

--- a/app/Filament/Pages/Billing.php
+++ b/app/Filament/Pages/Billing.php
@@ -88,7 +88,7 @@ final class Billing extends Page
     {
         $team = $this->team();
 
-        if (! $this->user()->ownsTeam($team) || $team->subscribed()) {
+        if (! $this->user()->ownsTeam($team) || $team->subscribed() || $team->plan === Plan::Enterprise) {
             return;
         }
 
@@ -161,7 +161,7 @@ final class Billing extends Page
             'hasHostedAccess' => $hasHostedAccess,
             'isGrandfathered' => $isGrandfathered,
             'balance' => AiCreditBalance::query()->where('team_id', $team->getKey())->first(),
-            'activating' => $this->checkout === 'success' && ! $team->subscribed(),
+            'activating' => $this->checkout === 'success' && ! $team->subscribed() && $team->plan !== Plan::Enterprise,
             'creditsFulfilling' => $this->credits === 'success',
             'availablePacks' => resolve(CreditPackCatalog::class)->purchasable(),
         ];

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Features\Billing;
 use App\Http\Requests\ContactRequest;
 use App\Mail\NewContactSubmissionMail;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\View\View;
+use Laravel\Pennant\Feature;
 
 final readonly class ContactController
 {
-    public function show(): View
+    public function show(Request $request): View
     {
-        return view('contact');
+        return view('contact', [
+            'enterpriseInquiry' => $request->query('plan') === 'enterprise' && Feature::active(Billing::class),
+        ]);
     }
 
     public function store(ContactRequest $request): RedirectResponse

--- a/config/relaticle.php
+++ b/config/relaticle.php
@@ -8,6 +8,10 @@ return [
         'email' => env('CONTACT_EMAIL', 'hello@relaticle.com'),
     ],
 
+    'enterprise' => [
+        'starting_price_yearly' => 20_000,
+    ],
+
     'company' => [
         'name' => env('RELATICLE_COMPANY_NAME', 'Relaticle'),
         'address' => env('RELATICLE_COMPANY_ADDRESS', ''),

--- a/database/seeders/Personas/PersonaCatalog.php
+++ b/database/seeders/Personas/PersonaCatalog.php
@@ -89,6 +89,16 @@ final class PersonaCatalog
             ),
 
             new Persona(
+                slug: 'enterprise',
+                email: 'enterprise@'.self::DOMAIN,
+                name: 'Elena Enterprise',
+                workspace: 'Northstar Operations',
+                purpose: 'Managed Enterprise access, usage, and support contact without self-service checkout.',
+                expect: BillingStatus::Enterprise,
+                team: ['plan' => Plan::Enterprise],
+            ),
+
+            new Persona(
                 slug: 'pro',
                 email: 'pro@'.self::DOMAIN,
                 name: 'Pedro Pro',

--- a/lang/en/billing.php
+++ b/lang/en/billing.php
@@ -114,11 +114,12 @@ return [
         'body' => 'Your plan is managed by Relaticle. Contact us for changes.',
         'tagline' => 'Implementation and support, scoped to your team.',
         'starting_price' => 'From $:price / year',
-        'billing' => 'Billed annually. Never per seat.',
+        'billing' => 'Billed yearly · never per seat',
         'includes' => 'Everything in Cloud Pro, plus',
         'features' => [
             'Implementation scoped to your workflow',
             'Custom integrations by agreement',
+            'AI usage agreed with your team',
             'Ongoing maintenance and support',
             'Direct access to the founding team',
         ],

--- a/lang/en/billing.php
+++ b/lang/en/billing.php
@@ -20,8 +20,11 @@ return [
         'managed' => 'Managed',
     ],
     'usage' => [
-        'title' => 'AI credits this period',
+        'title' => 'AI allowance this period',
         'resets' => 'Resets :date',
+        'available' => ':credits credits available',
+        'total_used' => ':credits credits used this period',
+        'empty' => 'Your credit balance will appear when your allowance starts.',
     ],
     'packs' => [
         'buy' => 'Buy :credits credits',
@@ -64,7 +67,7 @@ return [
         'features' => [
             'Unlimited users and records',
             '2,000 AI credits / month',
-            'All AI models, including premium',
+            'Premium AI models included',
             'REST API and 37-tool MCP server',
             'Email support',
         ],
@@ -109,6 +112,40 @@ return [
     'enterprise' => [
         'title' => 'Enterprise plan',
         'body' => 'Your plan is managed by Relaticle. Contact us for changes.',
+        'tagline' => 'Implementation and support, scoped to your team.',
+        'starting_price' => 'From $:price / year',
+        'billing' => 'Billed annually. Never per seat.',
+        'includes' => 'Everything in Cloud Pro, plus',
+        'features' => [
+            'Implementation scoped to your workflow',
+            'Custom integrations by agreement',
+            'Ongoing maintenance and support',
+            'Direct access to the founding team',
+        ],
+        'terms' => 'Scope, usage, support, and delivery milestones agreed before signing.',
+        'contact' => 'Talk to us',
+        'manage' => 'Contact your Relaticle team',
+        'previous_subscription_canceling' => 'Your previous subscription ends on :date. Your Enterprise access is unchanged.',
+        'previous_subscription_past_due' => 'Your previous subscription has a payment issue. Your Enterprise access is unchanged. Contact us to resolve the previous subscription.',
+        'faq_title' => 'What does Enterprise include?',
+        'faq_body' => 'Enterprise starts at $:price a year. It includes Cloud Pro with a scoped implementation project, agreed integrations, and ongoing maintenance and support. We agree deliverables, AI usage, support terms, and milestones before signing. Additional work requires a separate quote.',
+        'timeline_title' => 'How does an Enterprise project start?',
+        'timeline_body' => 'Tell us about your workflow, integrations, and target date. We assess the requirements together, then agree scope and delivery milestones. Development starts after agreement. Features under discussion are not included until their scope is confirmed.',
+    ],
+    'managed' => [
+        'title' => 'Your plan is managed by Relaticle',
+        'tagline' => 'Contact us for plan and billing changes.',
+    ],
+    'comparison' => [
+        'integrations' => 'Integrations',
+        'support' => 'Support',
+    ],
+    'inquiry' => [
+        'title' => 'Let’s plan your Enterprise workspace',
+        'body' => 'Tell us what your team needs to accomplish. We will review your workflow and integrations, then agree the scope together.',
+        'message_label' => 'What would you like to build with Relaticle?',
+        'message' => "We are interested in Relaticle Enterprise.\n\nWorkflow and integrations we need:\n\nTeam size:\n\nTarget timeline:",
+        'submit' => 'Discuss Enterprise',
     ],
     'member' => [
         'ask_owner' => 'Billing is managed by :owner, the workspace owner.',

--- a/packages/Chat/src/Services/CreditService.php
+++ b/packages/Chat/src/Services/CreditService.php
@@ -419,24 +419,11 @@ final readonly class CreditService
         });
     }
 
-    /**
-     * The allowance a workspace is refilled with when its period rolls over.
-     *
-     * A past-due workspace refills at the Free allowance rather than the one it
-     * has stopped paying for. keepPastDueSubscriptionsActive() leaves valid()
-     * true throughout dunning, so the plan column still reads Pro and this is
-     * the only place that can tell the difference. Without it, a workspace that
-     * has stopped paying is granted a fresh paid-tier allowance every period,
-     * for as long as Stripe leaves the subscription past due.
-     *
-     * Purchased packs are untouched by this and by resetPeriod: that money
-     * already changed hands.
-     */
     public function allowanceFor(Team $team): int
     {
         $team->loadMissing('subscriptions');
 
-        if ($team->subscription()?->pastDue() === true) {
+        if ($team->plan !== Plan::Enterprise && $team->subscription()?->pastDue() === true) {
             return Plan::Free->credits();
         }
 

--- a/resources/views/components/billing/interval-toggle.blade.php
+++ b/resources/views/components/billing/interval-toggle.blade.php
@@ -1,8 +1,15 @@
-<div {{ $attributes->class('inline-flex items-center rounded-lg bg-[var(--surface-input-bg)] p-1 ring-1 ring-inset ring-[var(--surface-input-border)]') }} role="group" aria-label="{{ __('Billing interval') }}">
-    <button type="button" @click="yearly = true" :aria-pressed="yearly" :class="yearly ? 'bg-white text-gray-950 shadow-sm dark:bg-gray-700 dark:text-white' : 'text-gray-600 dark:text-gray-400'" class="min-h-9 rounded-md px-4 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
+@php
+    $segment = 'inline-flex min-h-9 cursor-pointer items-center gap-2 rounded-full px-4 text-sm font-medium transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary';
+    $active = 'bg-white text-gray-950 shadow-[0_1px_2px_rgba(0,0,0,0.06)] ring-1 ring-gray-200/80 dark:bg-gray-800 dark:text-white dark:ring-white/[0.08]';
+    $inactive = 'text-gray-600 hover:text-gray-950 dark:text-gray-400 dark:hover:text-white';
+@endphp
+
+<div {{ $attributes->class('inline-flex items-center rounded-full bg-gray-100 p-1 dark:bg-white/[0.06]') }} role="group" aria-label="{{ __('Billing interval') }}">
+    <button type="button" @click="yearly = true" :aria-pressed="yearly" :class="yearly ? @js($active) : @js($inactive)" class="{{ $segment }}">
         {{ __('billing.pro_plan.yearly') }}
+        <span :class="yearly ? 'bg-primary/[0.1] text-primary-700 dark:bg-primary/[0.25] dark:text-primary-300' : 'bg-gray-200/80 text-gray-600 dark:bg-white/[0.08] dark:text-gray-400'" class="rounded-full px-1.5 py-0.5 text-[11px] font-semibold leading-none transition-colors duration-200">{{ __('billing.pro_plan.yearly_save') }}</span>
     </button>
-    <button type="button" @click="yearly = false" :aria-pressed="!yearly" :class="!yearly ? 'bg-white text-gray-950 shadow-sm dark:bg-gray-700 dark:text-white' : 'text-gray-600 dark:text-gray-400'" class="min-h-9 rounded-md px-4 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
+    <button type="button" @click="yearly = false" :aria-pressed="!yearly" :class="yearly ? @js($inactive) : @js($active)" class="{{ $segment }}">
         {{ __('billing.pro_plan.monthly') }}
     </button>
 </div>

--- a/resources/views/components/billing/interval-toggle.blade.php
+++ b/resources/views/components/billing/interval-toggle.blade.php
@@ -1,0 +1,8 @@
+<div {{ $attributes->class('inline-flex items-center rounded-lg bg-[var(--surface-input-bg)] p-1 ring-1 ring-inset ring-[var(--surface-input-border)]') }} role="group" aria-label="{{ __('Billing interval') }}">
+    <button type="button" @click="yearly = true" :aria-pressed="yearly" :class="yearly ? 'bg-white text-gray-950 shadow-sm dark:bg-gray-700 dark:text-white' : 'text-gray-600 dark:text-gray-400'" class="min-h-9 rounded-md px-4 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
+        {{ __('billing.pro_plan.yearly') }}
+    </button>
+    <button type="button" @click="yearly = false" :aria-pressed="!yearly" :class="!yearly ? 'bg-white text-gray-950 shadow-sm dark:bg-gray-700 dark:text-white' : 'text-gray-600 dark:text-gray-400'" class="min-h-9 rounded-md px-4 text-sm font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
+        {{ __('billing.pro_plan.monthly') }}
+    </button>
+</div>

--- a/resources/views/components/icons/plan-cloud-pro.blade.php
+++ b/resources/views/components/icons/plan-cloud-pro.blade.php
@@ -1,0 +1,9 @@
+@props([])
+
+{{-- Cloud Pro plan icon: a hosted cloud carrying a bolt, on the 24-grid at the
+     Remix line weight so it sits beside the site's other line icons. --}}
+
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" {{ $attributes }}>
+    <path d="M7.25 18.5h9.9a3.6 3.6 0 0 0 .6-7.15 5.6 5.6 0 0 0-10.8-1.55A4.35 4.35 0 0 0 7.25 18.5Z" />
+    <path d="M12.9 9.75 10.75 13.25h2.5l-2.15 3.5" />
+</svg>

--- a/resources/views/components/icons/plan-enterprise.blade.php
+++ b/resources/views/components/icons/plan-enterprise.blade.php
@@ -1,0 +1,11 @@
+@props([])
+
+{{-- Enterprise plan icon: two office towers on a shared ground line, on the
+     24-grid at the Remix line weight so it sits beside the site's other line icons. --}}
+
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" {{ $attributes }}>
+    <path d="M3 20.25h18" />
+    <path d="M5.75 20.25V7.9a1 1 0 0 1 .62-.93l5-2.05a1 1 0 0 1 1.38.93v14.4" />
+    <path d="M12.75 11.25 17.6 12.9a1 1 0 0 1 .65.95v6.4" />
+    <path d="M8.5 10h.01M8.5 13.25h.01M8.5 16.5h.01M15.5 15.5h.01M15.5 18h.01" stroke-width="2" />
+</svg>

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -3,21 +3,33 @@
     description="Get in touch with the Relaticle team. Questions about enterprise deployments, custom integrations, or partnerships."
     ogTitle="Contact: Deployments and integrations - Relaticle"
 >
-    <section class="relative pt-32 pb-24 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">
-        <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_50%_at_50%_50%,black_30%,transparent_100%)]"></div>
+    <section class="pt-28 pb-20 sm:pt-32 sm:pb-24 bg-white dark:bg-gray-950">
 
         <div class="relative max-w-5xl mx-auto px-6 lg:px-8">
-            <div class="grid grid-cols-1 lg:grid-cols-5 gap-16 lg:gap-20">
+            <div class="grid grid-cols-1 gap-10 lg:grid-cols-5 lg:gap-16">
 
-                {{-- Left: heading --}}
                 <div class="lg:col-span-2">
-                    <h1 class="font-display text-4xl sm:text-5xl font-bold text-gray-950 dark:text-white tracking-[-0.03em] leading-[1.1]">
-                        Get in Touch
+                    @if($enterpriseInquiry)
+                        <a href="{{ route('pricing') }}" class="mb-6 inline-flex items-center gap-2 text-sm text-gray-600 hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary dark:text-gray-400 dark:hover:text-primary-300">
+                            <x-ri-arrow-left-line class="size-4" />
+                            {{ __('Back to pricing') }}
+                        </a>
+                    @endif
+                    <h1 class="font-display text-3xl sm:text-4xl font-bold text-gray-950 dark:text-white tracking-tight leading-tight">
+                        {{ $enterpriseInquiry ? __('billing.inquiry.title') : __('Get in touch') }}
                     </h1>
                     <p class="mt-5 text-base text-gray-500 dark:text-gray-400 leading-relaxed max-w-sm">
-                        Questions about enterprise deployments, custom integrations, or partnerships? We'd love to hear from you.
+                        {{ $enterpriseInquiry ? __('billing.inquiry.body') : __('Questions about deployments, integrations, or partnerships? Get in touch with our team.') }}
                     </p>
 
+                    @if($enterpriseInquiry)
+                        <div class="mt-6 border-t border-[var(--surface-card-border)] pt-6">
+                            <p class="font-display text-xl font-semibold text-gray-950 dark:text-white">{{ __('billing.enterprise.starting_price', ['price' => number_format(config('relaticle.enterprise.starting_price_yearly'))]) }}</p>
+                            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('billing.enterprise.terms') }}</p>
+                        </div>
+                    @endif
+
+                    @if(! $enterpriseInquiry)
                     <div class="mt-8 space-y-4">
                         @feature(App\Features\Documentation::class)
                         <a href="{{ route('help.index') }}" class="flex items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary-400 transition-colors">
@@ -38,9 +50,9 @@
                             GitHub repository
                         </a>
                     </div>
+                    @endif
                 </div>
 
-                {{-- Right: form --}}
                 <div class="lg:col-span-3">
                     @if(session('success'))
                         <div class="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] p-10 text-center">
@@ -51,20 +63,20 @@
                             <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ session('success') }}</p>
                         </div>
                     @else
-                        <form method="POST" action="{{ route('contact') }}" class="space-y-6">
+                        <form method="POST" action="{{ route('contact', $enterpriseInquiry ? ['plan' => 'enterprise'] : []) }}" class="space-y-6">
                             @csrf
                             <x-honeypot />
 
-                            <x-marketing.input label="Name" :required="true" type="text" name="name" id="name" required :value="old('name')" placeholder="Your name"/>
+                            <x-marketing.input label="Name" :required="true" type="text" name="name" id="name" autocomplete="name" required :value="old('name')" placeholder="Your name"/>
 
-                            <x-marketing.input label="Work email" :required="true" type="email" name="email" id="email" required :value="old('email')" placeholder="you@company.com"/>
+                            <x-marketing.input label="Work email" :required="true" type="email" name="email" id="email" autocomplete="email" required :value="old('email')" placeholder="you@company.com"/>
 
-                            <x-marketing.input label="Company" type="text" name="company" id="company" :value="old('company')" placeholder="Your company"/>
+                            <x-marketing.input label="Company" type="text" name="company" id="company" autocomplete="organization" :value="old('company')" placeholder="Your company"/>
 
-                            <x-marketing.textarea label="How can we help?" :required="true" name="message" id="message" rows="5" required placeholder="Tell us about your project, team size, and any specific requirements...">{{ old('message') }}</x-marketing.textarea>
+                            <x-marketing.textarea :label="$enterpriseInquiry ? __('billing.inquiry.message_label') : __('How can we help?')" :required="true" name="message" id="message" :rows="$enterpriseInquiry ? 8 : 5" required placeholder="Tell us about your project, team size, and any specific requirements...">{{ old('message', $enterpriseInquiry ? __('billing.inquiry.message') : '') }}</x-marketing.textarea>
 
-                            <x-marketing.button type="submit">
-                                Send message
+                            <x-marketing.button type="submit" class="w-full sm:w-auto focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
+                                {{ $enterpriseInquiry ? __('billing.inquiry.submit') : __('Send message') }}
                             </x-marketing.button>
                         </form>
                     @endif

--- a/resources/views/filament/pages/billing.blade.php
+++ b/resources/views/filament/pages/billing.blade.php
@@ -2,31 +2,36 @@
     @php
         $purchased = (int) ($balance?->purchased_credits ?? 0);
         $used = (int) ($balance?->credits_used ?? 0);
+        $monthlyUsed = min($used, $allowance);
+        $remaining = (int) ($balance?->credits_remaining ?? 0);
+        $isEnterprise = $team->plan === \App\Enums\Plan::Enterprise;
         $usedPercent = $allowance > 0 ? min(100, (int) round($used / $allowance * 100)) : 0;
 
         $isSubscribed = $subscription?->valid() ?? false;
         $canManageSubscription = $subscription && ($subscription->valid() || $pastDue);
-        $onTrial = $team->onGenericTrial();
+        $onTrial = ! $isEnterprise && $team->onGenericTrial();
         $onLegacyFree = $isGrandfathered
             && $team->plan === \App\Enums\Plan::Free
             && ! $onTrial
             && ! $isSubscribed;
         $isPaused = ! $hasHostedAccess;
-        $isManagedPlan = ! $subscription
+        $isManagedPlan = $isEnterprise || (! $subscription
             && ! $onTrial
             && ! $isPaused
             && ! $onLegacyFree
-            && $team->plan !== \App\Enums\Plan::Free;
+            && $team->plan !== \App\Enums\Plan::Free);
+        $showEnterpriseOffer = $isOwner && ! $isEnterprise && ! $pastDue && ! $onGrace && ! $activating;
         $trialDaysLeft = $onTrial ? max(0, (int) ceil(now()->floatDiffInDays($team->trial_ends_at))) : 0;
 
         $planLabel = match (true) {
             $isPaused => __('billing.plans.cloud_pro'),
             $onLegacyFree => __('billing.plans.legacy_free'),
             $team->plan === \App\Enums\Plan::Enterprise => __('billing.plans.enterprise'),
-            default => __('billing.plans.pro'),
+            default => __('billing.plans.cloud_pro'),
         };
 
         [$statusLabel, $statusClasses] = match (true) {
+            $isEnterprise => [__('billing.status.managed'), 'bg-gray-100 text-gray-600 dark:bg-white/10 dark:text-gray-300'],
             $pastDue => [__('billing.status.past_due'), 'bg-danger-50 text-danger-700 dark:bg-danger-400/10 dark:text-danger-400'],
             $onGrace => [__('billing.status.canceling'), 'bg-warning-50 text-warning-700 dark:bg-warning-400/10 dark:text-warning-400'],
             $onTrial => [__('billing.status.trialing'), 'bg-primary-50 text-primary-700 dark:bg-primary-400/10 dark:text-primary-400'],
@@ -42,7 +47,7 @@
             default => 'bg-primary',
         };
 
-        $card = 'rounded-2xl border border-gray-200/80 dark:border-white/[0.06] bg-white dark:bg-white/[0.02] shadow-[0_2px_16px_-6px_rgba(0,0,0,0.05)] dark:shadow-none';
+        $card = 'rounded-2xl border border-[var(--surface-card-border)] bg-white shadow-sm dark:bg-[var(--surface-card-bg)] dark:shadow-none';
     @endphp
 
     <div
@@ -76,7 +81,7 @@
             </div>
         @endif
 
-        <section class="{{ $card }} overflow-hidden">
+        <section class="{{ $card }} overflow-hidden" aria-label="{{ __('billing.title') }}">
             <div class="grid gap-px bg-gray-200/60 sm:grid-cols-5 dark:bg-white/[0.06]">
                 <div class="bg-white p-6 sm:col-span-3 dark:bg-transparent">
                     <div class="flex items-center gap-3">
@@ -88,13 +93,15 @@
                                 <h2 class="font-display text-2xl font-semibold leading-none text-gray-900 dark:text-white">
                                     {{ $planLabel }}
                                 </h2>
-                                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold {{ $statusClasses }}">
+                                <span class="inline-flex items-center rounded-full px-2 py-0.5 text-micro font-semibold {{ $statusClasses }}">
                                     {{ $statusLabel }}
                                 </span>
                             </div>
 
                             <p class="mt-1.5 text-sm text-gray-500 dark:text-gray-400">
-                                @if($onTrial)
+                                @if($isManagedPlan)
+                                    {{ __('billing.managed.tagline') }}
+                                @elseif($onTrial)
                                     {{ __('billing.trial.active_title') }} ({{ trans_choice('billing.trial.days_left', $trialDaysLeft, ['days' => $trialDaysLeft]) }})
                                 @elseif($onGrace)
                                     {{ $isGrandfathered
@@ -132,24 +139,33 @@
                     <div class="bg-white p-6 sm:col-span-2 dark:bg-transparent">
                         <div class="flex items-center justify-between">
                             <span class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('billing.usage.title') }}</span>
-                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $usedPercent }}%</span>
+                            <span class="text-xs text-gray-500 dark:text-gray-400">{{ $usedPercent }}%</span>
                         </div>
 
                         <div class="mt-2.5 flex items-baseline gap-1.5">
-                            <span class="font-display text-xl font-semibold text-gray-900 dark:text-white">{{ number_format($used) }}</span>
-                            <span class="text-sm text-gray-400 dark:text-gray-500">/ {{ number_format($allowance) }}</span>
+                            <span class="font-display text-xl font-semibold text-gray-900 dark:text-white">{{ number_format($monthlyUsed) }}</span>
+                            <span class="text-sm text-gray-500 dark:text-gray-400">/ {{ number_format($allowance) }}</span>
                         </div>
 
-                        <div class="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-gray-200/80 dark:bg-white/[0.08]">
+                        <div role="progressbar" aria-label="{{ __('billing.usage.title') }}" aria-valuenow="{{ $usedPercent }}" aria-valuemin="0" aria-valuemax="100" class="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-gray-200/80 dark:bg-white/[0.08]">
                             <div class="h-full rounded-full {{ $meterColor }} transition-all duration-500" style="width: {{ $usedPercent }}%"></div>
                         </div>
 
+                        @if($balance)
+                            <p class="mt-3 text-sm font-medium text-gray-900 dark:text-white">{{ __('billing.usage.available', ['credits' => number_format($remaining)]) }}</p>
+                            @if($used > $allowance)
+                                <p class="mt-1 text-xs text-gray-600 dark:text-gray-400">{{ __('billing.usage.total_used', ['credits' => number_format($used)]) }}</p>
+                            @endif
+                        @else
+                            <p class="mt-3 text-xs text-gray-600 dark:text-gray-400">{{ __('billing.usage.empty') }}</p>
+                        @endif
+
                         @if($balance?->period_ends_at)
-                            <p class="mt-2 text-xs text-gray-400 dark:text-gray-500">{{ __('billing.usage.resets', ['date' => $balance->period_ends_at->toFormattedDateString()]) }}</p>
+                            <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">{{ __('billing.usage.resets', ['date' => $balance->period_ends_at->toFormattedDateString()]) }}</p>
                         @endif
 
                         @if($purchased > 0)
-                            <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">{{ __('billing.packs.balance_split', ['purchased' => number_format($purchased)]) }}</p>
+                            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ __('billing.packs.balance_split', ['purchased' => number_format($purchased)]) }}</p>
                         @endif
 
                         @if($isOwner && $availablePacks !== [])
@@ -172,7 +188,7 @@
                     <x-ri-error-warning-fill class="mt-0.5 h-5 w-5 shrink-0 text-danger-500 dark:text-danger-400" />
                     <div class="flex-1">
                         <h3 class="text-sm font-semibold text-danger-800 dark:text-danger-300">{{ __('billing.manage.past_due_title') }}</h3>
-                        <p class="mt-0.5 text-sm text-danger-700/80 dark:text-danger-400/70">{{ __('billing.manage.past_due_body') }}</p>
+                        <p class="mt-0.5 text-sm text-danger-700/80 dark:text-danger-400/70">{{ $isEnterprise ? __('billing.enterprise.previous_subscription_past_due') : __('billing.manage.past_due_body') }}</p>
                         @if($isOwner)
                             <div class="mt-3">
                                 <x-filament::button color="danger" wire:click="managePortal">{{ __('billing.manage.button') }}</x-filament::button>
@@ -190,9 +206,11 @@
                     <div class="flex-1">
                         <h3 class="text-sm font-semibold text-warning-800 dark:text-warning-300">{{ __('billing.manage.cancel_scheduled_title') }}</h3>
                         <p class="mt-0.5 text-sm text-warning-700/80 dark:text-warning-400/70">
-                            {{ $isGrandfathered
+                            {{ $isEnterprise
+                                ? __('billing.enterprise.previous_subscription_canceling', ['date' => $subscription?->ends_at?->toFormattedDateString()])
+                                : ($isGrandfathered
                                 ? __('billing.manage.cancel_scheduled_legacy_body', ['date' => $subscription?->ends_at?->toFormattedDateString()])
-                                : __('billing.manage.cancel_scheduled_body', ['date' => $subscription?->ends_at?->toFormattedDateString()]) }}
+                                : __('billing.manage.cancel_scheduled_body', ['date' => $subscription?->ends_at?->toFormattedDateString()])) }}
                         </p>
                     </div>
                 </div>
@@ -206,13 +224,16 @@
             </div>
         @elseif($isManagedPlan)
             <div class="{{ $card }} p-6">
-                <h3 class="font-display text-lg font-semibold text-gray-900 dark:text-white">{{ __('billing.enterprise.title') }}</h3>
-                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('billing.enterprise.body') }}</p>
+                <h3 class="font-display text-lg font-semibold text-gray-900 dark:text-white">{{ $isEnterprise ? __('billing.enterprise.title') : __('billing.managed.title') }}</h3>
+                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.body') }}</p>
+                <div class="mt-5 flex flex-wrap gap-3">
+                    <x-filament::button tag="a" color="gray" :href="route('contact')">{{ __('billing.enterprise.manage') }}</x-filament::button>
+                    @if($canManageSubscription && ! $pastDue)
+                        <x-filament::button color="gray" wire:click="managePortal">{{ __('billing.manage.button') }}</x-filament::button>
+                    @endif
+                </div>
             </div>
         @elseif($pastDue)
-            {{-- The past-due panel above already states the problem and carries
-                 the portal button. Claiming "You're on Pro" underneath it, in a
-                 success card, contradicts the panel it sits below. --}}
         @elseif($canManageSubscription)
             <div class="{{ $card }} p-6">
                 <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -253,7 +274,7 @@
 
             <div
                 x-data="{ yearly: true, confirming: false }"
-                class="relative flex w-full flex-col rounded-2xl border border-primary/25 bg-white p-7 shadow-[0_6px_36px_-14px_rgba(124,58,237,0.18)] sm:p-8 dark:border-primary/20 dark:bg-primary/[0.03] dark:shadow-none"
+                class="relative flex w-full flex-col rounded-2xl border border-primary-200 bg-white p-6 shadow-sm sm:p-8 dark:border-primary-400/25 dark:bg-[var(--surface-card-bg)] dark:shadow-none"
             >
                 <div class="flex flex-1 flex-col">
                     <h3 class="font-display text-xl font-semibold text-gray-900 dark:text-white">{{ __('billing.plans.cloud_pro') }}</h3>
@@ -263,18 +284,12 @@
                         <div>
                             <div class="flex items-baseline gap-1.5">
                                 <span class="font-display text-4xl font-bold tracking-tight text-gray-950 dark:text-white" x-text="yearly ? '$19' : '$24'">$19</span>
-                                <span class="text-sm text-gray-400 dark:text-gray-500">/mo</span>
+                                <span class="text-sm text-gray-500 dark:text-gray-400">/mo</span>
                             </div>
-                            <p class="mt-1.5 text-xs text-gray-400 dark:text-gray-500">{{ __('billing.pro_plan.per_workspace') }}</p>
+                            <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">{{ __('billing.pro_plan.per_workspace') }}</p>
                         </div>
 
-                        <div class="inline-flex w-fit items-center gap-1 rounded-full border border-gray-200/80 p-1 text-xs dark:border-white/[0.08]">
-                            <button type="button" @click="yearly = true" :aria-pressed="yearly" :class="yearly ? 'bg-primary text-white shadow-sm' : 'text-gray-500 dark:text-gray-400'" class="rounded-full px-3 py-1 font-medium transition">
-                                {{ __('billing.pro_plan.yearly') }}
-                                <span class="ml-1 text-[10px]" :class="yearly ? 'text-white/80' : 'text-primary-600 dark:text-primary-300'">{{ __('billing.pro_plan.yearly_save') }}</span>
-                            </button>
-                            <button type="button" @click="yearly = false" :aria-pressed="!yearly" :class="!yearly ? 'bg-primary text-white shadow-sm' : 'text-gray-500 dark:text-gray-400'" class="rounded-full px-3 py-1 font-medium transition">{{ __('billing.pro_plan.monthly') }}</button>
-                        </div>
+                        <x-billing.interval-toggle />
                     </div>
 
                     <div class="mt-6 h-px w-full bg-gray-100 dark:bg-white/[0.06]"></div>
@@ -306,8 +321,8 @@
                                         : ($isPaused ? __('billing.upgrade.unlock') : __('billing.upgrade.button')) }}
                                 </x-filament::button>
                             @endif
-                            <p class="mt-3 text-center text-xs text-gray-400 dark:text-gray-500"
-                                x-text="yearly ? '{{ __('billing.pro_plan.billed_yearly') }}' : '{{ __('billing.pro_plan.billed_monthly') }}'">
+                            <p class="mt-3 text-center text-xs text-gray-500 dark:text-gray-400"
+                                x-text="yearly ? @js(__('billing.pro_plan.billed_yearly')) : @js(__('billing.pro_plan.billed_monthly'))">
                                 {{ __('billing.pro_plan.billed_yearly') }}
                             </p>
                         </div>
@@ -316,12 +331,12 @@
                             <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ __('billing.upgrade.confirm_title') }}</p>
                             <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">{{ __('billing.upgrade.confirm_body', ['workspace' => $team->name]) }}</p>
                             <p class="mt-2 text-sm font-medium text-gray-900 dark:text-white"
-                                x-text="yearly ? '{{ __('billing.pro_plan.billed_yearly') }}' : '{{ __('billing.pro_plan.billed_monthly') }}'">
+                                x-text="yearly ? @js(__('billing.pro_plan.billed_yearly')) : @js(__('billing.pro_plan.billed_monthly'))">
                                 {{ __('billing.pro_plan.billed_yearly') }}
                             </p>
                             <div class="mt-4 flex flex-col gap-2 sm:flex-row-reverse">
                                 <x-filament::button type="button" class="justify-center"
-                                    x-on:click="$wire.upgrade(yearly ? 'yearly' : 'monthly')">
+                                    wire:loading.attr="disabled" wire:target="upgrade" x-on:click="$wire.upgrade(yearly ? 'yearly' : 'monthly')">
                                     {{ __('billing.upgrade.confirm_button', ['workspace' => $team->name]) }}
                                 </x-filament::button>
                                 <x-filament::button type="button" color="gray" class="justify-center"
@@ -333,6 +348,18 @@
                     </div>
                 </div>
             </div>
+        @endif
+        @if($showEnterpriseOffer)
+            <section class="{{ $card }} p-6" aria-label="{{ __('billing.plans.enterprise') }}">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                    <div>
+                        <h3 class="text-base font-semibold text-gray-900 dark:text-white">{{ __('billing.plans.enterprise') }}</h3>
+                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.starting_price', ['price' => number_format(config('relaticle.enterprise.starting_price_yearly'))]) }}</p>
+                    </div>
+                    <x-filament::button tag="a" color="gray" :href="route('contact', ['plan' => 'enterprise'])">{{ __('billing.enterprise.contact') }}</x-filament::button>
+                </div>
+                <p class="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.tagline') }} {{ __('billing.enterprise.terms') }}</p>
+            </section>
         @endif
     </div>
 </x-filament-panels::page>

--- a/resources/views/partials/pricing-plans.blade.php
+++ b/resources/views/partials/pricing-plans.blade.php
@@ -1,87 +1,103 @@
 <div x-data="{ yearly: true }" class="mx-auto max-w-4xl">
-    <div class="mb-6 flex flex-wrap items-center justify-center gap-4">
+    <div class="mb-8 flex justify-center">
         <x-billing.interval-toggle />
-        <span class="text-sm text-gray-600 dark:text-gray-400">{{ __('Save $60 a year on Cloud Pro') }}</span>
     </div>
 
-    <div id="pricing-plans" class="grid gap-6 md:grid-cols-2">
-        <section class="flex flex-col rounded-2xl border border-primary-200 bg-white dark:border-primary-400/30 dark:bg-[var(--surface-card-bg)]">
+    <div id="pricing-plans" class="grid gap-5 md:grid-cols-2">
+        <section class="relative flex flex-col rounded-2xl border border-primary-300 bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04),0_6px_20px_-10px_rgba(124,58,237,0.25)] dark:border-primary-400/40 dark:bg-white/[0.03] dark:shadow-none">
             <div class="p-6 sm:p-8">
-                <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white">{{ __('billing.plans.cloud_pro') }}</h2>
-                <p class="mt-2 min-h-10 text-sm leading-5 text-gray-600 dark:text-gray-400">{{ __('A ready-to-use CRM for your whole team. Hosting included.') }}</p>
+                <div class="flex items-center justify-between gap-3">
+                    <div class="flex items-center gap-3">
+                        <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/[0.08] dark:bg-primary/[0.15]">
+                            <x-icons.plan-cloud-pro class="size-5 text-primary dark:text-primary-400" />
+                        </div>
+                        <h2 class="font-display text-xl font-semibold tracking-tight text-gray-950 dark:text-white">{{ __('billing.plans.cloud_pro') }}</h2>
+                    </div>
+                    <span class="shrink-0 rounded-full bg-primary px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider text-white">{{ __('Recommended') }}</span>
+                </div>
+                <p class="mt-4 min-h-10 text-sm leading-5 text-gray-600 dark:text-gray-400">{{ __('A ready-to-use CRM for your whole team. Hosting included.') }}</p>
 
-                <div class="mt-6">
-                    <p class="text-sm text-gray-600 dark:text-gray-400">{{ __('Per workspace') }}</p>
-                    <p class="mt-1 flex items-baseline gap-2" aria-live="polite">
-                        <span class="font-display text-5xl font-bold tracking-tight text-gray-950 dark:text-white" x-text="yearly ? '$19' : '$24'">$19</span>
-                        <span class="text-sm text-gray-600 dark:text-gray-400">{{ __('/ month') }}</span>
+                <div class="mt-8">
+                    <p class="text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ __('Per workspace') }}</p>
+                    <p class="mt-2 flex items-baseline gap-1.5" aria-live="polite">
+                        <span class="font-display text-5xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white" x-text="yearly ? '$19' : '$24'">$19</span>
+                        <span class="text-sm text-gray-500 dark:text-gray-400">{{ __('/ month') }}</span>
                     </p>
-                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400" x-text="yearly ? @js(__('billing.pro_plan.billed_yearly')) : @js(__('billing.pro_plan.billed_monthly'))">{{ __('billing.pro_plan.billed_yearly') }}</p>
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-400" x-text="yearly ? @js(__('billing.pro_plan.billed_yearly')) : @js(__('billing.pro_plan.billed_monthly'))">{{ __('billing.pro_plan.billed_yearly') }}</p>
                 </div>
 
-                <x-marketing.button :href="route('login')" iconTrailing="ri-arrow-right-line" class="mt-6 w-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
+                <x-marketing.button :href="route('login')" iconTrailing="ri-arrow-right-line" class="mt-8 w-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
                     {{ __('Start for free') }}
                 </x-marketing.button>
-                <p class="mt-3 text-center text-xs text-gray-600 dark:text-gray-400">{{ __('14-day trial. No card required.') }}</p>
+                <p class="mt-3 text-center text-xs text-gray-500 dark:text-gray-400">{{ __('14-day trial. No card required.') }}</p>
             </div>
 
-            <div class="flex flex-1 flex-col border-t border-[var(--surface-card-border)] p-6 sm:px-8">
-                <p class="mb-4 text-sm font-semibold text-gray-900 dark:text-white">{{ __('Your workspace includes') }}</p>
+            <div class="flex flex-1 flex-col border-t border-gray-100 p-6 dark:border-white/[0.06] sm:px-8">
+                <p class="mb-4 text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ __('Your workspace includes') }}</p>
                 <ul class="space-y-3">
                     @foreach(__('billing.pro_plan.features') as $feature)
-                        <li class="flex items-start gap-3 text-sm leading-5 text-gray-600 dark:text-gray-300">
+                        <li class="flex items-start gap-3 text-sm leading-5 text-gray-700 dark:text-gray-300">
                             <x-ri-check-line class="mt-0.5 size-4 shrink-0 text-primary dark:text-primary-400" />
                             {{ $feature }}
                         </li>
                     @endforeach
                 </ul>
-                <p class="mt-auto pt-6 text-xs leading-5 text-gray-600 dark:text-gray-400">{{ __('Need more AI credits? Prepaid top-ups are available.') }}</p>
+                <p class="mt-auto pt-6 text-xs leading-5 text-gray-500 dark:text-gray-400">{{ __('Need more AI credits? Prepaid top-ups are available.') }}</p>
             </div>
         </section>
 
-        <section id="enterprise-plan" class="flex flex-col rounded-2xl border border-[var(--surface-card-border)] bg-white dark:bg-[var(--surface-card-bg)]">
+        <section id="enterprise-plan" class="flex flex-col rounded-2xl border border-gray-200/80 bg-white dark:border-white/[0.08] dark:bg-white/[0.02]">
             <div class="p-6 sm:p-8">
-                <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white">{{ __('billing.plans.enterprise') }}</h2>
-                <p class="mt-2 min-h-10 text-sm leading-5 text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.tagline') }}</p>
+                <div class="flex items-center gap-3">
+                    <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-white/[0.06]">
+                        <x-icons.plan-enterprise class="size-5 text-gray-700 dark:text-gray-300" />
+                    </div>
+                    <h2 class="font-display text-xl font-semibold tracking-tight text-gray-950 dark:text-white">{{ __('billing.plans.enterprise') }}</h2>
+                </div>
+                <p class="mt-4 min-h-10 text-sm leading-5 text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.tagline') }}</p>
 
-                <div class="mt-6" aria-label="{{ __('billing.enterprise.starting_price', ['price' => number_format(config('relaticle.enterprise.starting_price_yearly'))]) }}">
-                    <p class="text-sm text-gray-600 dark:text-gray-400">{{ __('Starting at') }}</p>
-                    <p class="mt-1 flex flex-wrap items-baseline gap-x-2">
-                        <span class="font-display text-5xl font-bold tracking-tight text-gray-950 dark:text-white">${{ number_format(config('relaticle.enterprise.starting_price_yearly')) }}</span>
-                        <span class="text-sm text-gray-600 dark:text-gray-400">{{ __('/ year') }}</span>
+                <div class="mt-8" aria-label="{{ __('billing.enterprise.starting_price', ['price' => $enterprisePrice]) }}">
+                    <p class="text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ __('Starting at') }}</p>
+                    <p class="mt-2 flex flex-wrap items-baseline gap-x-1.5">
+                        <span class="font-display text-5xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white">${{ $enterprisePrice }}</span>
+                        <span class="text-sm text-gray-500 dark:text-gray-400">{{ __('/ year') }}</span>
                     </p>
-                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.billing') }}</p>
+                    <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('billing.enterprise.billing') }}</p>
                 </div>
 
-                <x-marketing.button variant="secondary" :href="route('contact', ['plan' => 'enterprise'])" class="mt-6 w-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
+                <x-marketing.button variant="secondary" :href="route('contact', ['plan' => 'enterprise'])" class="mt-8 w-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
                     {{ __('billing.enterprise.contact') }}
                 </x-marketing.button>
-                <p class="mt-3 text-center text-xs text-gray-600 dark:text-gray-400">{{ __('Tell us about your project.') }}</p>
+                <p class="mt-3 text-center text-xs text-gray-500 dark:text-gray-400">{{ __('No commitment until scope is agreed.') }}</p>
             </div>
 
-            <div class="flex flex-1 flex-col border-t border-[var(--surface-card-border)] p-6 sm:px-8">
-                <p class="mb-4 text-sm font-semibold text-gray-900 dark:text-white">{{ __('billing.enterprise.includes') }}</p>
+            <div class="flex flex-1 flex-col border-t border-gray-100 p-6 dark:border-white/[0.06] sm:px-8">
+                <p class="mb-4 text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ __('billing.enterprise.includes') }}</p>
                 <ul class="space-y-3">
                     @foreach(__('billing.enterprise.features') as $feature)
-                        <li class="flex items-start gap-3 text-sm leading-5 text-gray-600 dark:text-gray-300">
-                            <x-ri-check-line class="mt-0.5 size-4 shrink-0 text-gray-500 dark:text-gray-400" />
+                        <li class="flex items-start gap-3 text-sm leading-5 text-gray-700 dark:text-gray-300">
+                            <x-ri-check-line class="mt-0.5 size-4 shrink-0 text-gray-400 dark:text-gray-500" />
                             {{ $feature }}
                         </li>
                     @endforeach
                 </ul>
-                <p class="mt-auto pt-6 text-xs leading-5 text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.terms') }}</p>
+                <p class="mt-auto pt-6 text-xs leading-5 text-gray-500 dark:text-gray-400">{{ __('billing.enterprise.terms') }}</p>
             </div>
         </section>
     </div>
 
-    <div id="self-hosting" class="mt-6 flex flex-col items-start justify-between gap-4 px-1 text-sm sm:flex-row sm:items-center">
-        <p class="flex items-center gap-2 text-gray-600 dark:text-gray-400">
-            <x-ri-github-fill class="size-4 shrink-0" />
-            {{ __('Prefer to self-host? It’s free.') }}
-        </p>
-        <a href="{{ route('selfHosted') }}" class="inline-flex items-center gap-2 font-medium text-gray-900 hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary dark:text-gray-200 dark:hover:text-primary-300">
+    <div id="self-hosting" class="mt-5 flex flex-col gap-4 rounded-2xl border border-gray-200/80 bg-gray-50 p-5 dark:border-white/[0.06] dark:bg-white/[0.02] sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <div class="flex items-start gap-4">
+            <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] ring-1 ring-gray-200/80 dark:bg-white/[0.06] dark:shadow-none dark:ring-white/[0.08]">
+                <x-ri-github-fill class="size-5 text-gray-700 dark:text-gray-300" />
+            </div>
+            <div>
+                <p class="font-display text-base font-semibold text-gray-950 dark:text-white">{{ __('Prefer to self-host? It’s free.') }}</p>
+                <p class="mt-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">{{ __('AGPL-3.0 open source. Unlimited users and records on your own server, forever.') }}</p>
+            </div>
+        </div>
+        <x-marketing.button variant="secondary" size="sm" :href="route('selfHosted')" iconTrailing="ri-arrow-right-line" class="shrink-0 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
             {{ __('Explore self-hosting') }}
-            <x-ri-arrow-right-line class="size-4" />
-        </a>
+        </x-marketing.button>
     </div>
 </div>

--- a/resources/views/partials/pricing-plans.blade.php
+++ b/resources/views/partials/pricing-plans.blade.php
@@ -1,123 +1,87 @@
-{{-- Pricing cards (managed Cloud + open-source self-hosting) --}}
-<div class="mx-auto grid max-w-4xl grid-cols-1 gap-6 md:grid-cols-2">
-    {{-- Managed Cloud Pro --}}
-    <div
-        x-data="{ yearly: true }"
-        class="relative flex flex-col overflow-hidden rounded-2xl border border-primary/20 bg-white shadow-[0_4px_32px_-8px_rgba(124,58,237,0.08)] dark:border-primary/15 dark:bg-white/[0.02] dark:shadow-[0_4px_32px_-8px_rgba(124,58,237,0.15)]"
-    >
-        <div class="h-1 bg-gradient-to-r from-primary via-purple-500 to-pink-500"></div>
-        <div class="flex flex-1 flex-col p-8">
-            <div class="absolute right-5 top-6">
-                <span class="inline-flex items-center gap-1 rounded-full bg-primary/[0.08] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-primary-700 dark:bg-primary/[0.15] dark:text-primary-300">
-                    <x-ri-star-fill class="h-3 w-3" />
-                    Recommended
-                </span>
+<div x-data="{ yearly: true }" class="mx-auto max-w-4xl">
+    <div class="mb-6 flex flex-wrap items-center justify-center gap-4">
+        <x-billing.interval-toggle />
+        <span class="text-sm text-gray-600 dark:text-gray-400">{{ __('Save $60 a year on Cloud Pro') }}</span>
+    </div>
+
+    <div id="pricing-plans" class="grid gap-6 md:grid-cols-2">
+        <section class="flex flex-col rounded-2xl border border-primary-200 bg-white dark:border-primary-400/30 dark:bg-[var(--surface-card-bg)]">
+            <div class="p-6 sm:p-8">
+                <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white">{{ __('billing.plans.cloud_pro') }}</h2>
+                <p class="mt-2 min-h-10 text-sm leading-5 text-gray-600 dark:text-gray-400">{{ __('A ready-to-use CRM for your whole team. Hosting included.') }}</p>
+
+                <div class="mt-6">
+                    <p class="text-sm text-gray-600 dark:text-gray-400">{{ __('Per workspace') }}</p>
+                    <p class="mt-1 flex items-baseline gap-2" aria-live="polite">
+                        <span class="font-display text-5xl font-bold tracking-tight text-gray-950 dark:text-white" x-text="yearly ? '$19' : '$24'">$19</span>
+                        <span class="text-sm text-gray-600 dark:text-gray-400">{{ __('/ month') }}</span>
+                    </p>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400" x-text="yearly ? @js(__('billing.pro_plan.billed_yearly')) : @js(__('billing.pro_plan.billed_monthly'))">{{ __('billing.pro_plan.billed_yearly') }}</p>
+                </div>
+
+                <x-marketing.button :href="route('login')" iconTrailing="ri-arrow-right-line" class="mt-6 w-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
+                    {{ __('Start for free') }}
+                </x-marketing.button>
+                <p class="mt-3 text-center text-xs text-gray-600 dark:text-gray-400">{{ __('14-day trial. No card required.') }}</p>
             </div>
 
-            <div class="relative mb-6">
-                <div class="flex items-center gap-2.5">
-                    <div class="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/[0.08] dark:bg-primary/[0.15]">
-                        <x-ri-cloud-line class="h-4.5 w-4.5 text-primary dark:text-primary-400" />
-                    </div>
-                    <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white">Cloud Pro</h2>
-                </div>
-                <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Managed by us. Ready in minutes.</p>
-            </div>
-
-            <div class="relative mb-6">
-                <div class="flex items-baseline gap-1">
-                    <span class="text-5xl font-bold tracking-tight text-gray-950 dark:text-white" x-text="yearly ? '$19' : '$24'">$19</span>
-                    <span class="text-sm text-gray-400 dark:text-gray-500">/mo</span>
-                </div>
-                <p class="mt-1.5 text-xs text-gray-400 dark:text-gray-500">Per workspace. Never per seat.</p>
-
-                <div class="mt-4 inline-flex items-center gap-2 rounded-full border border-gray-200/80 p-1 text-xs dark:border-white/[0.08]">
-                    <button type="button" @click="yearly = true" :aria-pressed="yearly" :class="yearly ? 'bg-primary text-white' : 'text-gray-500 dark:text-gray-400'" class="rounded-full px-3 py-1 font-medium transition">
-                        Yearly
-                        <span class="ml-1 text-[10px]" :class="yearly ? 'text-white/80' : 'text-primary-600 dark:text-primary-300'">Save 21%</span>
-                    </button>
-                    <button type="button" @click="yearly = false" :aria-pressed="!yearly" :class="!yearly ? 'bg-primary text-white' : 'text-gray-500 dark:text-gray-400'" class="rounded-full px-3 py-1 font-medium transition">Monthly</button>
-                </div>
-            </div>
-
-            <div class="relative mb-8 flex-1">
+            <div class="flex flex-1 flex-col border-t border-[var(--surface-card-border)] p-6 sm:px-8">
+                <p class="mb-4 text-sm font-semibold text-gray-900 dark:text-white">{{ __('Your workspace includes') }}</p>
                 <ul class="space-y-3">
-                    @foreach([
-                        'Unlimited users and records',
-                        '2,000 AI credits / month',
-                        'Premium AI models included',
-                        'REST API and 37-tool MCP server',
-                        'Email support',
-                    ] as $feature)
-                        <li class="flex items-start gap-2.5 text-sm text-gray-600 dark:text-gray-400">
-                            <x-ri-check-line class="mt-0.5 h-4 w-4 shrink-0 text-primary dark:text-primary-400" />
+                    @foreach(__('billing.pro_plan.features') as $feature)
+                        <li class="flex items-start gap-3 text-sm leading-5 text-gray-600 dark:text-gray-300">
+                            <x-ri-check-line class="mt-0.5 size-4 shrink-0 text-primary dark:text-primary-400" />
                             {{ $feature }}
                         </li>
                     @endforeach
                 </ul>
+                <p class="mt-auto pt-6 text-xs leading-5 text-gray-600 dark:text-gray-400">{{ __('Need more AI credits? Prepaid top-ups are available.') }}</p>
             </div>
+        </section>
 
-            <x-marketing.button href="{{ route('login') }}">
-                Start your 14-day trial, no card
-            </x-marketing.button>
-            <p class="mt-3 text-center text-xs text-gray-400 dark:text-gray-500" x-text="yearly ? '$228 billed yearly · save $60' : 'Billed monthly · cancel anytime'">
-                $228 billed yearly · save $60
-            </p>
-        </div>
-    </div>
+        <section id="enterprise-plan" class="flex flex-col rounded-2xl border border-[var(--surface-card-border)] bg-white dark:bg-[var(--surface-card-bg)]">
+            <div class="p-6 sm:p-8">
+                <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white">{{ __('billing.plans.enterprise') }}</h2>
+                <p class="mt-2 min-h-10 text-sm leading-5 text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.tagline') }}</p>
 
-    {{-- Open-source self-hosting --}}
-    <div class="relative flex flex-col overflow-hidden rounded-2xl border border-gray-200/80 bg-white shadow-[0_2px_16px_-6px_rgba(0,0,0,0.05)] dark:border-white/[0.06] dark:bg-white/[0.02] dark:shadow-none">
-        <div class="h-1 bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 dark:from-white/10 dark:via-white/20 dark:to-white/10"></div>
-        <div class="flex flex-1 flex-col p-8">
-            <div class="mb-6">
-                <div class="flex items-center gap-2.5">
-                    <div class="flex h-9 w-9 items-center justify-center rounded-xl bg-gray-100 dark:bg-white/[0.06]">
-                        <x-ri-server-line class="h-4.5 w-4.5 text-gray-600 dark:text-gray-400" />
-                    </div>
-                    <h2 class="font-display text-xl font-semibold text-gray-900 dark:text-white">Self-Hosted</h2>
+                <div class="mt-6" aria-label="{{ __('billing.enterprise.starting_price', ['price' => number_format(config('relaticle.enterprise.starting_price_yearly'))]) }}">
+                    <p class="text-sm text-gray-600 dark:text-gray-400">{{ __('Starting at') }}</p>
+                    <p class="mt-1 flex flex-wrap items-baseline gap-x-2">
+                        <span class="font-display text-5xl font-bold tracking-tight text-gray-950 dark:text-white">${{ number_format(config('relaticle.enterprise.starting_price_yearly')) }}</span>
+                        <span class="text-sm text-gray-600 dark:text-gray-400">{{ __('/ year') }}</span>
+                    </p>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.billing') }}</p>
                 </div>
-                <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Your server, your data, your rules.</p>
+
+                <x-marketing.button variant="secondary" :href="route('contact', ['plan' => 'enterprise'])" class="mt-6 w-full focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary">
+                    {{ __('billing.enterprise.contact') }}
+                </x-marketing.button>
+                <p class="mt-3 text-center text-xs text-gray-600 dark:text-gray-400">{{ __('Tell us about your project.') }}</p>
             </div>
 
-            <div class="mb-8">
-                <div class="flex items-baseline gap-1">
-                    <span class="text-5xl font-bold tracking-tight text-gray-950 dark:text-white">Free</span>
-                    <span class="text-sm text-gray-400 dark:text-gray-500">forever</span>
-                </div>
-                <p class="mt-1.5 text-xs text-gray-400 dark:text-gray-500">AGPL-3.0 open source</p>
-            </div>
-
-            <div class="mb-8 flex-1">
+            <div class="flex flex-1 flex-col border-t border-[var(--surface-card-border)] p-6 sm:px-8">
+                <p class="mb-4 text-sm font-semibold text-gray-900 dark:text-white">{{ __('billing.enterprise.includes') }}</p>
                 <ul class="space-y-3">
-                    @foreach([
-                        'Unlimited users and records',
-                        'Full source code access',
-                        'Docker Compose deployment',
-                        'Data never leaves your server',
-                        'Community support on Discord',
-                    ] as $feature)
-                        <li class="flex items-start gap-2.5 text-sm text-gray-600 dark:text-gray-400">
-                            <x-ri-check-line class="mt-0.5 h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500" />
+                    @foreach(__('billing.enterprise.features') as $feature)
+                        <li class="flex items-start gap-3 text-sm leading-5 text-gray-600 dark:text-gray-300">
+                            <x-ri-check-line class="mt-0.5 size-4 shrink-0 text-gray-500 dark:text-gray-400" />
                             {{ $feature }}
                         </li>
                     @endforeach
                 </ul>
+                <p class="mt-auto pt-6 text-xs leading-5 text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.terms') }}</p>
             </div>
-
-            <x-marketing.button variant="secondary" href="https://github.com/relaticle/relaticle" icon="ri-github-fill" external>
-                View on GitHub
-            </x-marketing.button>
-        </div>
+        </section>
     </div>
-</div>
 
-<div class="mx-auto mt-8 max-w-4xl space-y-3 text-center">
-    <p class="text-sm text-gray-500 dark:text-gray-400">
-        Need higher AI allowances or custom invoicing?
-        <a href="{{ route('contact') }}" class="font-medium text-primary-600 hover:underline dark:text-primary-400">Talk to us</a>.
-    </p>
-    <p class="text-xs text-gray-400 dark:text-gray-500">
-        Credit cost varies by model and tool calls. A simple reply is 1 credit; a premium one costs more. Allowances may evolve with notice.
-    </p>
+    <div id="self-hosting" class="mt-6 flex flex-col items-start justify-between gap-4 px-1 text-sm sm:flex-row sm:items-center">
+        <p class="flex items-center gap-2 text-gray-600 dark:text-gray-400">
+            <x-ri-github-fill class="size-4 shrink-0" />
+            {{ __('Prefer to self-host? It’s free.') }}
+        </p>
+        <a href="{{ route('selfHosted') }}" class="inline-flex items-center gap-2 font-medium text-gray-900 hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary dark:text-gray-200 dark:hover:text-primary-300">
+            {{ __('Explore self-hosting') }}
+            <x-ri-arrow-right-line class="size-4" />
+        </a>
+    </div>
 </div>

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -1,52 +1,40 @@
 @php
+    $billingActive = \Laravel\Pennant\Feature::active(\App\Features\Billing::class);
     $mcpToolCount = \App\Support\CompetitorFacts::mcpToolCount();
+    $enterprisePrice = number_format(config('relaticle.enterprise.starting_price_yearly'));
 @endphp
 
 <x-guest-layout
     title="Pricing - $19/mo flat, unlimited users - Relaticle"
-    description="No per-seat pricing. One flat workspace plan at $19/mo billed yearly, with unlimited users and records. 14-day trial, no card. Self-host free forever."
+    :description="$billingActive
+        ? __('Cloud Pro is $19/mo billed yearly. Enterprise implementation from $:price/year. Unlimited users and records. Self-host free.', ['price' => $enterprisePrice])
+        : __('Self-host for free, or let us run Relaticle for you. Unlimited users and records. No per-seat pricing.')"
     ogTitle="Pricing - $19/mo flat, unlimited users - Relaticle"
 >
-    <section class="relative pt-32 pb-24 md:pt-40 md:pb-32 bg-white dark:bg-gray-950 overflow-hidden">
-        <div class="absolute inset-0 bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_50%_at_50%_50%,black_30%,transparent_100%)]"></div>
-
-        <div class="relative max-w-5xl mx-auto px-6 lg:px-8">
-
-            {{-- Badge --}}
-            <div class="flex justify-center mb-6">
-                <div class="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full border border-gray-200/80 dark:border-white/[0.08] bg-white/80 dark:bg-white/[0.04] backdrop-blur-sm shadow-[0_1px_2px_rgba(0,0,0,0.03)]">
-                    <x-ri-heart-pulse-line class="h-3.5 w-3.5 text-primary dark:text-primary-400"/>
-                    <span class="uppercase tracking-wider text-[10px] font-medium text-gray-500 dark:text-gray-400">Simple pricing</span>
-                </div>
-            </div>
-
-            {{-- Header --}}
-            <div class="text-center max-w-2xl mx-auto mb-16 md:mb-20">
-                <h1 class="font-display text-4xl sm:text-5xl font-bold text-gray-950 dark:text-white tracking-[-0.03em] leading-[1.1]">
-                    No per-seat pricing. Ever.
+    <section class="bg-white pb-20 pt-28 dark:bg-gray-950 sm:pt-32 lg:pb-24">
+        <div class="mx-auto max-w-6xl px-5 sm:px-8">
+            <div class="mx-auto mb-10 max-w-3xl text-center">
+                <h1 class="text-balance font-display text-4xl font-bold leading-tight tracking-tight text-gray-950 dark:text-white sm:text-5xl">
+                    @if($billingActive)
+                        {{ __('One price for your whole team.') }}
+                    @else
+                        {{ __('No per-seat pricing. Ever.') }}
+                    @endif
                 </h1>
-                <p class="mt-5 text-base md:text-lg text-gray-500 dark:text-gray-400 leading-relaxed">
-                    Unlimited users. Unlimited data. Self-host for free forever, or let us run it for you.
+                <p class="mx-auto mt-4 max-w-xl text-balance text-base leading-relaxed text-gray-600 dark:text-gray-400">
+                    {{ $billingActive
+                        ? __('Unlimited users and records. Start with Cloud Pro, or work with us on a tailored implementation.')
+                        : __('Unlimited users. Unlimited records. Self-host for free, or let us run it for you.') }}
                 </p>
             </div>
 
             @php
-                $billingActive = \Laravel\Pennant\Feature::active(\App\Features\Billing::class);
                 $freeCredits = number_format(\App\Enums\Plan::Free->credits());
                 $proCredits = number_format(\App\Enums\Plan::Pro->credits());
                 $enterpriseCredits = number_format(\App\Enums\Plan::Enterprise->credits());
                 $freeRateLimit = \App\Enums\Plan::Free->rateLimit();
                 $proRateLimit = \App\Enums\Plan::Pro->rateLimit();
                 $trialDays = \App\Actions\Billing\StartProTrial::TRIAL_DAYS;
-
-
-                // offered(), not available(): this list can never name a model the app won't
-                // serve, because it drops the entries whose measured capabilities say they
-                // cannot call tools (both Gemini models today) and AiModelResolver::pick()
-                // can never select those. It deliberately does NOT drop models whose provider
-                // has no key on this install: what Cloud Pro includes is not a function of
-                // whether the web host currently holds an Anthropic key, and filtering on
-                // that renders these sentences with a hole where the model names belong.
                 $toolCapableCloudModels = collect(resolve(\Relaticle\Chat\Services\ModelRegistry::class)->offered())
                     ->map(fn (\Relaticle\Chat\Support\ModelDescriptor $model): array => [
                         'label' => $model->displayLabel(),
@@ -55,12 +43,6 @@
                     ]);
                 $freeCloudModels = $toolCapableCloudModels->where('min_plan', 'free')->pluck('label')->join(', ', ' and ');
                 $paidCloudModels = $toolCapableCloudModels->where('min_plan', 'pro')->pluck('label')->join(', ', ' and ');
-
-                // Grouped, not three hardcoded tiers. The catalog is editable at runtime, so
-                // asking for the 1.0 / 1.5 / 3.0 buckets by name printed "3x for )" the moment
-                // an operator retired the only 3x model, and silently omitted any model priced
-                // at a fourth multiplier. Self-hosted models ride the 1x bucket because
-                // ModelRegistry gives them that multiplier.
                 $multiplierClauses = $toolCapableCloudModels
                     ->groupBy(fn (array $model): string => rtrim(rtrim(number_format($model['credit_multiplier'], 2, '.', ''), '0'), '.'))
                     ->map(fn (\Illuminate\Support\Collection $group): string => $group->pluck('label')->join(', ', ' and '));
@@ -73,10 +55,6 @@
                     ->sortKeys(SORT_NUMERIC)
                     ->map(fn (string $models, string $multiplier): string => __(':multiplierx for :models', ['multiplier' => $multiplier, 'models' => $models]))
                     ->join('; ');
-
-                // The worked example names the cheapest and dearest models the catalog
-                // actually offers, so retiring either cannot leave the sentence describing a
-                // model nobody can pick.
                 $sortedByCost = $toolCapableCloudModels->sortBy('credit_multiplier')->values();
                 $cheapestModel = $sortedByCost->first()['label'] ?? __('a 1x model');
                 $dearestEntry = $sortedByCost->last() ?? ['label' => __('a higher-multiplier model'), 'credit_multiplier' => 1.0];
@@ -91,19 +69,7 @@
                         'dearestCost' => $dearestReplyCost,
                     ]
                 );
-
-                // "Cloud Pro" is the billing-on marketing name only. Under billing-off there is
-                // no self-service path onto a paid plan at all (CreateTeam only auto-starts a
-                // trial when Feature::active(Billing), and the billing page 403s otherwise), so
-                // these two facts use the generic "a paid plan" label when billing is off.
                 $paidPlanLabel = $billingActive ? __('Cloud Pro') : __('a paid plan');
-
-                // No Enterprise plan card or checkout path exists anywhere in the codebase, so
-                // whether it's an actual purchasable offering isn't something the code can
-                // confirm. It is mentioned nowhere in this page's visible copy for that reason.
-                // Two independent sentences rather than one with two holes in it: a catalog
-                // with no free-tier model rendered "Every plan can use  and any self-hosted
-                // model you connect yourself", which is the failure this shape removes.
                 $modelsUnlockAnswer = trim(implode(' ', array_filter([
                     $freeCloudModels === ''
                         ? __('Every plan can use any self-hosted model you connect yourself.')
@@ -138,9 +104,6 @@
                             'credits' => $proCredits,
                             'cheapestModel' => $cheapestModel,
                             'dearestModel' => $dearestEntry['label'],
-                            // Settlement formula, packages/Chat/src/Services/CreditService.php
-                            // ::calculateCredits(): max(1, ceil(multiplier + toolCalls * toolBonus)).
-                            // Before tool calls that is just the multiplier.
                             'dearestReplies' => number_format(intdiv((int) \App\Enums\Plan::Pro->credits(), max(1, (int) ceil($dearestEntry['credit_multiplier'])))),
                             'days' => $trialDays,
                         ]
@@ -165,25 +128,57 @@
             @else
                 @include('partials.pricing-legacy')
             @endif
-
-            {{-- Self-hosted vs hosted comparison --}}
+            @if($billingActive)
+                <div class="mx-auto mt-20 max-w-4xl border-t border-[var(--surface-card-border)] pt-12">
+                    <div class="mb-6">
+                        <div>
+                            <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">{{ __('Choose how you get started') }}</h2>
+                        </div>
+                        <p class="mt-3 text-sm leading-relaxed text-gray-600 dark:text-gray-400">{{ __('The same CRM at the core. A different level of help around it.') }}</p>
+                    </div>
+                    <div class="overflow-hidden rounded-xl border border-[var(--surface-card-border)]" role="region" aria-label="{{ __('Compare Cloud Pro and Enterprise') }}">
+                        <table class="w-full table-fixed text-left text-xs sm:text-sm">
+                            <caption class="sr-only">{{ __('Compare Cloud Pro and Enterprise') }}</caption>
+                            <thead class="border-b border-[var(--surface-card-border)] bg-[var(--surface-card-bg)]">
+                                <tr>
+                                    <th scope="col" class="px-3 py-4 sm:px-5 font-medium text-gray-500 dark:text-gray-400">{{ __('What’s included') }}</th>
+                                    <th scope="col" class="px-3 py-4 sm:px-5 font-semibold text-primary-700 dark:text-primary-300">{{ __('billing.plans.cloud_pro') }}</th>
+                                    <th scope="col" class="px-3 py-4 sm:px-5 font-semibold text-gray-950 dark:text-white">{{ __('billing.plans.enterprise') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-[var(--surface-card-border)]">
+                                @foreach([
+                                    [__('Users and records'), __('Unlimited'), __('Unlimited')],
+                                    [__('AI assistant'), __('2,000 credits each month'), __('Usage agreed with your team')],
+                                    [__('Getting started'), __('Self-service setup'), __('Scoped implementation project')],
+                                    [__('billing.comparison.integrations'), __('REST API and MCP server'), __('Custom integrations by agreement')],
+                                    [__('Hosting and updates'), __('Managed by Relaticle'), __('Agreed deployment and maintenance')],
+                                    [__('billing.comparison.support'), __('Email support'), __('Agreed support with the founding team')],
+                                ] as [$feature, $pro, $enterprise])
+                                    <tr>
+                                        <th scope="row" class="px-3 py-4 sm:px-5 font-medium text-gray-900 dark:text-gray-200">{{ $feature }}</th>
+                                        <td class="px-3 py-4 sm:px-5 text-gray-500 dark:text-gray-400">{{ $pro }}</td>
+                                        <td class="px-3 py-4 sm:px-5 text-gray-500 dark:text-gray-400">{{ $enterprise }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="mt-4 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                        {{ __('AI credits depend on the model and tool calls.') }}
+                        <a href="#pricing-faq" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('How credits work') }}</a>
+                    </p>
+                </div>
+            @else
             <div class="mt-16 max-w-4xl mx-auto">
                 <div class="mx-auto mb-10 max-w-2xl text-center">
-                    <h2 class="font-display text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white sm:text-3xl">
+                    <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
                         {{ __('Self-hosted or hosted: how to choose') }}
                     </h2>
                     <p class="mt-4 text-base leading-relaxed text-gray-500 dark:text-gray-400">
                         {{ __('Both options run the identical open-source Relaticle codebase, with unlimited users and unlimited records on every plan. The real differences are who operates the server and how AI usage is metered.') }}
                     </p>
                 </div>
-
-                {{--
-                    List layout kept for responsive styling; tables DO convert to
-                    markdown since the TableAwareLeagueDriver landed. <ul>/<li>/<p>
-                    (category names are CSS-bold, not <strong>, so no semantic-bold
-                    tag is used) were verified to survive conversion. Each row
-                    below reads as "Category" / "Self-Hosted: X" / "Hosted: Y" in markdown.
-                --}}
                 <ul class="divide-y divide-gray-100 rounded-2xl border border-gray-200/80 bg-white dark:divide-white/[0.04] dark:border-white/[0.06] dark:bg-white/[0.02]">
                     <li class="px-4 py-3 sm:px-6 sm:py-4">
                         <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ __('Price') }}</p>
@@ -207,11 +202,10 @@
                     </li>
                 </ul>
             </div>
-
-            {{-- FAQ --}}
-            <div class="mt-16 max-w-3xl mx-auto">
-                <div class="mx-auto mb-6 max-w-2xl text-center">
-                    <h2 class="font-display text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white sm:text-3xl">
+            @endif
+            <div id="pricing-faq" class="mt-16 max-w-4xl mx-auto scroll-mt-24 border-t border-[var(--surface-card-border)] pt-12">
+                <div class="mb-6">
+                    <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
                         {{ __('Pricing questions, answered') }}
                     </h2>
                 </div>
@@ -239,6 +233,8 @@
                     ];
 
                     if ($billingActive) {
+                        $pricingFaqs[] = [__('billing.enterprise.faq_title'), __('billing.enterprise.faq_body', ['price' => $enterprisePrice])];
+                        $pricingFaqs[] = [__('billing.enterprise.timeline_title'), __('billing.enterprise.timeline_body')];
                         $pricingFaqs[] = [
                             __('What happens after my trial ends?'),
                             __(
@@ -251,47 +247,15 @@
 
                 <x-marketing.faq-accordion :faqs="$pricingFaqs" id-prefix="pricing-faq" />
             </div>
-
-            {{-- Trust signals --}}
-            <div class="mt-16 max-w-4xl mx-auto">
-                <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-                    @foreach([
-                        ['ri-shield-check-line', '2,000+', 'Automated Tests'],
-                        ['ri-robot-2-line', (string) $mcpToolCount, 'MCP Tools'],
-                        ['ri-stack-line', '22', 'Field Types'],
-                        ['ri-lock-line', '5-Layer', 'Authorization'],
-                    ] as [$icon, $value, $label])
-                        <div class="rounded-xl border border-gray-200/80 dark:border-white/[0.06] bg-white dark:bg-white/[0.02] px-5 py-4 text-center">
-                            <x-dynamic-component :component="$icon" class="w-5 h-5 text-primary dark:text-primary-400 mx-auto mb-2"/>
-                            <div class="text-lg font-semibold text-gray-900 dark:text-white tracking-tight">{{ $value }}</div>
-                            <div class="text-[11px] text-gray-400 dark:text-gray-500 mt-0.5 uppercase tracking-wider font-medium">{{ $label }}</div>
-                        </div>
-                    @endforeach
-                </div>
-
-                {{-- Two of the tiles above are the whole subject of a page each. --}}
-                <p class="mt-4 text-center text-xs text-gray-500 dark:text-gray-400">
-                    <a href="{{ route('ai') }}" class="underline decoration-gray-300 dark:decoration-gray-600 underline-offset-2 hover:text-primary dark:hover:text-primary-400">{{ __('What the AI assistant and MCP server do') }}</a>
-                    <span class="px-1.5 text-gray-300 dark:text-gray-600" aria-hidden="true">&middot;</span>
-                    <a href="{{ route('selfHosted') }}" class="underline decoration-gray-300 dark:decoration-gray-600 underline-offset-2 hover:text-primary dark:hover:text-primary-400">{{ __('Run it free on your own server') }}</a>
-                </p>
-            </div>
-
-            {{-- Help CTA --}}
-            <div class="mt-8 max-w-4xl mx-auto">
-                <div class="relative rounded-2xl border border-gray-200/80 dark:border-white/[0.06] bg-gray-50/50 dark:bg-white/[0.015] p-8 flex flex-col sm:flex-row items-center gap-6 overflow-hidden">
-                    <div class="absolute -bottom-10 -left-10 w-40 h-40 bg-primary/[0.04] dark:bg-primary/[0.08] rounded-full blur-3xl pointer-events-none" aria-hidden="true"></div>
-                    <div class="relative flex-1 text-left">
-                        <h3 class="font-display text-lg font-semibold text-gray-900 dark:text-white">Need help choosing?</h3>
-                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
-                            Not sure which option fits? Have questions about deployment or migration? We're happy to help.
-                        </p>
-                    </div>
-                    <x-marketing.button variant="secondary" href="{{ route('contact') }}" class="relative shrink-0">
-                        Get in touch
-                    </x-marketing.button>
-                </div>
-            </div>
+            <p class="mx-auto mt-10 max-w-4xl border-t border-[var(--surface-card-border)] pt-6 text-sm text-gray-600 dark:text-gray-400">
+                <a href="{{ route('ai') }}" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('Explore the AI assistant and :count MCP tools', ['count' => $mcpToolCount]) }}</a>
+                <span class="mx-2" aria-hidden="true">·</span>
+                @if(! $billingActive)
+                    <a href="{{ route('selfHosted') }}" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('Explore self-hosting') }}</a>
+                    <span class="mx-2" aria-hidden="true">·</span>
+                @endif
+                <a href="{{ route('contact') }}" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('Questions? Talk to us.') }}</a>
+            </p>
 
         </div>
     </section>
@@ -324,6 +288,14 @@
                             ->availability(\Spatie\SchemaOrg\ItemAvailability::InStock)
                             ->url(route('pricing'))
                             ->description('Per workspace, billed yearly at $228/year ($19/mo); $24/mo billed monthly.'),
+                        \Spatie\SchemaOrg\Schema::offer()
+                            ->name('Enterprise')
+                            ->priceSpecification(\Spatie\SchemaOrg\Schema::unitPriceSpecification()
+                                ->minPrice(config('relaticle.enterprise.starting_price_yearly'))
+                                ->priceCurrency('USD')
+                                ->unitText('year'))
+                            ->url(route('contact', ['plan' => 'enterprise']))
+                            ->description(__('billing.enterprise.faq_body', ['price' => $enterprisePrice])),
                     ]
                     : [
                         \Spatie\SchemaOrg\Schema::offer()

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -11,23 +11,32 @@
         : __('Self-host for free, or let us run Relaticle for you. Unlimited users and records. No per-seat pricing.')"
     ogTitle="Pricing - $19/mo flat, unlimited users - Relaticle"
 >
-    <section class="bg-white pb-20 pt-28 dark:bg-gray-950 sm:pt-32 lg:pb-24">
-        <div class="mx-auto max-w-6xl px-5 sm:px-8">
-            <div class="mx-auto mb-10 max-w-3xl text-center">
-                <h1 class="text-balance font-display text-4xl font-bold leading-tight tracking-tight text-gray-950 dark:text-white sm:text-5xl">
-                    @if($billingActive)
-                        {{ __('One price for your whole team.') }}
-                    @else
-                        {{ __('No per-seat pricing. Ever.') }}
-                    @endif
-                </h1>
-                <p class="mx-auto mt-4 max-w-xl text-balance text-base leading-relaxed text-gray-600 dark:text-gray-400">
-                    {{ $billingActive
-                        ? __('Unlimited users and records. Start with Cloud Pro, or work with us on a tailored implementation.')
-                        : __('Unlimited users. Unlimited records. Self-host for free, or let us run it for you.') }}
-                </p>
+    <section class="relative overflow-hidden bg-white pb-16 pt-32 dark:bg-gray-950 md:pb-20 md:pt-40">
+        <div class="absolute inset-x-0 top-0 h-[36rem] bg-[linear-gradient(to_right,rgba(0,0,0,0.015)_1px,transparent_1px),linear-gradient(to_bottom,rgba(0,0,0,0.015)_1px,transparent_1px)] bg-[size:3rem_3rem] [mask-image:radial-gradient(ellipse_70%_60%_at_50%_0%,black_20%,transparent_100%)] dark:bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)]"></div>
+
+        <div class="relative mx-auto max-w-3xl px-6 text-center lg:px-8">
+            <div class="mb-6 flex justify-center">
+                <div class="inline-flex items-center gap-2 rounded-full border border-gray-200/80 bg-white/80 px-3.5 py-1.5 shadow-[0_1px_2px_rgba(0,0,0,0.03)] backdrop-blur-sm dark:border-white/[0.08] dark:bg-white/[0.04]">
+                    <x-ri-price-tag-3-line class="h-3.5 w-3.5 text-primary dark:text-primary-400" />
+                    <span class="text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ __('Pricing') }}</span>
+                </div>
             </div>
 
+            <h1 class="text-balance font-display text-4xl font-bold leading-[1.1] tracking-[-0.03em] text-gray-950 dark:text-white sm:text-5xl">
+                @if($billingActive)
+                    {{ __('One price for your whole team.') }}
+                @else
+                    {{ __('No per-seat pricing. Ever.') }}
+                @endif
+            </h1>
+            <p class="mx-auto mt-5 max-w-2xl text-pretty text-base leading-relaxed text-gray-500 dark:text-gray-400 md:text-lg">
+                {{ $billingActive
+                    ? __('Unlimited users and records on every plan. Start with Cloud Pro, or work with us on a tailored implementation.')
+                    : __('Unlimited users. Unlimited records. Self-host for free, or let us run it for you.') }}
+            </p>
+        </div>
+
+        <div class="relative mx-auto mt-12 max-w-4xl px-6 lg:px-8">
             @php
                 $freeCredits = number_format(\App\Enums\Plan::Free->credits());
                 $proCredits = number_format(\App\Enums\Plan::Pro->credits());
@@ -128,51 +137,51 @@
             @else
                 @include('partials.pricing-legacy')
             @endif
+        </div>
+    </section>
+
+    <section class="bg-gray-50 py-20 dark:bg-gray-950 md:py-28">
+        <div class="mx-auto max-w-4xl px-6 lg:px-8">
             @if($billingActive)
-                <div class="mx-auto mt-20 max-w-4xl border-t border-[var(--surface-card-border)] pt-12">
-                    <div class="mb-6">
-                        <div>
-                            <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">{{ __('Choose how you get started') }}</h2>
-                        </div>
-                        <p class="mt-3 text-sm leading-relaxed text-gray-600 dark:text-gray-400">{{ __('The same CRM at the core. A different level of help around it.') }}</p>
-                    </div>
-                    <div class="overflow-hidden rounded-xl border border-[var(--surface-card-border)]" role="region" aria-label="{{ __('Compare Cloud Pro and Enterprise') }}">
-                        <table class="w-full table-fixed text-left text-xs sm:text-sm">
-                            <caption class="sr-only">{{ __('Compare Cloud Pro and Enterprise') }}</caption>
-                            <thead class="border-b border-[var(--surface-card-border)] bg-[var(--surface-card-bg)]">
-                                <tr>
-                                    <th scope="col" class="px-3 py-4 sm:px-5 font-medium text-gray-500 dark:text-gray-400">{{ __('What’s included') }}</th>
-                                    <th scope="col" class="px-3 py-4 sm:px-5 font-semibold text-primary-700 dark:text-primary-300">{{ __('billing.plans.cloud_pro') }}</th>
-                                    <th scope="col" class="px-3 py-4 sm:px-5 font-semibold text-gray-950 dark:text-white">{{ __('billing.plans.enterprise') }}</th>
-                                </tr>
-                            </thead>
-                            <tbody class="divide-y divide-[var(--surface-card-border)]">
-                                @foreach([
-                                    [__('Users and records'), __('Unlimited'), __('Unlimited')],
-                                    [__('AI assistant'), __('2,000 credits each month'), __('Usage agreed with your team')],
-                                    [__('Getting started'), __('Self-service setup'), __('Scoped implementation project')],
-                                    [__('billing.comparison.integrations'), __('REST API and MCP server'), __('Custom integrations by agreement')],
-                                    [__('Hosting and updates'), __('Managed by Relaticle'), __('Agreed deployment and maintenance')],
-                                    [__('billing.comparison.support'), __('Email support'), __('Agreed support with the founding team')],
-                                ] as [$feature, $pro, $enterprise])
-                                    <tr>
-                                        <th scope="row" class="px-3 py-4 sm:px-5 font-medium text-gray-900 dark:text-gray-200">{{ $feature }}</th>
-                                        <td class="px-3 py-4 sm:px-5 text-gray-500 dark:text-gray-400">{{ $pro }}</td>
-                                        <td class="px-3 py-4 sm:px-5 text-gray-500 dark:text-gray-400">{{ $enterprise }}</td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
-                    <p class="mt-4 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
-                        {{ __('AI credits depend on the model and tool calls.') }}
-                        <a href="#pricing-faq" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('How credits work') }}</a>
-                    </p>
+                <div class="mx-auto mb-12 max-w-2xl text-center">
+                    <h2 class="font-display text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white sm:text-3xl">{{ __('Choose how you get started') }}</h2>
+                    <p class="mt-4 text-base leading-relaxed text-gray-500 dark:text-gray-400">{{ __('The same CRM at the core. A different level of help around it.') }}</p>
                 </div>
+                <div class="overflow-hidden rounded-2xl border border-gray-200/80 bg-white dark:border-white/[0.06] dark:bg-white/[0.02]" role="region" aria-label="{{ __('Compare Cloud Pro and Enterprise') }}">
+                    <table class="w-full text-left text-sm">
+                        <caption class="sr-only">{{ __('Compare Cloud Pro and Enterprise') }}</caption>
+                        <thead class="hidden border-b border-gray-100 dark:border-white/[0.06] sm:table-header-group">
+                            <tr>
+                                <th scope="col" class="w-[30%] px-5 py-4 text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ __('What’s included') }}</th>
+                                <th scope="col" class="w-[35%] bg-primary/[0.04] px-5 py-4 font-semibold text-primary-700 dark:bg-primary/[0.08] dark:text-primary-300">{{ __('billing.plans.cloud_pro') }}</th>
+                                <th scope="col" class="w-[35%] px-5 py-4 font-semibold text-gray-950 dark:text-white">{{ __('billing.plans.enterprise') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100 dark:divide-white/[0.06]">
+                            @foreach([
+                                [__('Users and records'), __('Unlimited'), __('Unlimited')],
+                                [__('AI assistant'), __('2,000 credits each month'), __('Usage agreed with your team')],
+                                [__('Getting started'), __('Self-service setup'), __('Scoped implementation project')],
+                                [__('billing.comparison.integrations'), __('REST API and MCP server'), __('Custom integrations by agreement')],
+                                [__('Hosting and updates'), __('Managed by Relaticle'), __('Agreed deployment and maintenance')],
+                                [__('billing.comparison.support'), __('Email support'), __('Agreed support with the founding team')],
+                            ] as [$feature, $pro, $enterprise])
+                                <tr class="block px-5 py-4 sm:table-row sm:p-0">
+                                    <th scope="row" class="block pb-2 text-left font-semibold text-gray-900 dark:text-white sm:table-cell sm:px-5 sm:py-4 sm:align-top sm:font-medium">{{ $feature }}</th>
+                                    <td data-label="{{ __('billing.plans.cloud_pro') }}:" class="block py-0.5 text-gray-600 before:mr-1.5 before:font-medium before:text-primary-700 before:content-[attr(data-label)] dark:text-gray-400 dark:before:text-primary-300 sm:table-cell sm:bg-primary/[0.04] sm:px-5 sm:py-4 sm:align-top sm:before:content-none dark:sm:bg-primary/[0.08]">{{ $pro }}</td>
+                                    <td data-label="{{ __('billing.plans.enterprise') }}:" class="block py-0.5 text-gray-600 before:mr-1.5 before:font-medium before:text-gray-900 before:content-[attr(data-label)] dark:text-gray-400 dark:before:text-white sm:table-cell sm:px-5 sm:py-4 sm:align-top sm:before:content-none">{{ $enterprise }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                <p class="mt-4 text-center text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                    {{ __('AI credits depend on the model and tool calls.') }}
+                    <a href="#pricing-faq" class="font-medium text-gray-700 underline underline-offset-4 hover:text-primary dark:text-gray-300 dark:hover:text-primary-300">{{ __('How credits work') }}</a>
+                </p>
             @else
-            <div class="mt-16 max-w-4xl mx-auto">
-                <div class="mx-auto mb-10 max-w-2xl text-center">
-                    <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
+                <div class="mx-auto mb-12 max-w-2xl text-center">
+                    <h2 class="font-display text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white sm:text-3xl">
                         {{ __('Self-hosted or hosted: how to choose') }}
                     </h2>
                     <p class="mt-4 text-base leading-relaxed text-gray-500 dark:text-gray-400">
@@ -201,62 +210,90 @@
                         <p class="text-sm text-gray-600 dark:text-gray-400"><span class="font-medium text-gray-500 dark:text-gray-400">{{ __('Hosted') }}:</span> {{ __('Email support') }}</p>
                     </li>
                 </ul>
-            </div>
             @endif
-            <div id="pricing-faq" class="mt-16 max-w-4xl mx-auto scroll-mt-24 border-t border-[var(--surface-card-border)] pt-12">
-                <div class="mb-6">
-                    <h2 class="font-display text-2xl font-bold tracking-tight text-gray-950 dark:text-white sm:text-3xl">
-                        {{ __('Pricing questions, answered') }}
-                    </h2>
-                </div>
+        </div>
+    </section>
 
-                @php
-                    $pricingFaqs = [
-                        [
-                            __('Is Relaticle really free to self-host?'),
-                            __('Yes. Self-hosting is fully open source under the AGPL-3.0 license, with unlimited users and unlimited records and no credit card required. Deploy it yourself with the published Docker Compose file. Your data stays on your own server the entire time.'),
-                        ],
-                        [
-                            __('Do you charge per seat?'),
-                            __('No. Relaticle has never charged per seat. Every plan, self-hosted or hosted, is priced per workspace, so you can add as many teammates as you need without the bill changing.'),
-                        ],
-                        [__("What's included in the hosted plan?"), $hostedPlanAnswer],
-                        [__('What happens when I hit a plan limit?'), $planLimitAnswer],
-                        [__('What counts as an AI credit?'), $creditFaqAnswer],
-                        [__('Which AI models does my plan unlock?'), $modelsUnlockAnswer],
-                        [__('Is there a message rate limit?'), $rateLimitAnswer],
-                        [__('Are self-hosted installs exempt from AI credit limits?'), $selfHostedCreditAnswer],
-                        [
-                            __('Can I switch between self-hosted and cloud?'),
-                            __('Yes. Both options run the identical open-source codebase against the same PostgreSQL schema, so neither locks you in. Companies, people, opportunities, tasks, and notes each have a built-in CSV export, and the import wizard on the other side accepts CSV. Moving between a self-hosted install and the hosted plan is a standard export and re-import, not a proprietary migration.'),
-                        ],
-                    ];
-
-                    if ($billingActive) {
-                        $pricingFaqs[] = [__('billing.enterprise.faq_title'), __('billing.enterprise.faq_body', ['price' => $enterprisePrice])];
-                        $pricingFaqs[] = [__('billing.enterprise.timeline_title'), __('billing.enterprise.timeline_body')];
-                        $pricingFaqs[] = [
-                            __('What happens after my trial ends?'),
-                            __(
-                                'New workspaces start a :days-day trial automatically, with no card required. If a payment method isn\'t added before the trial ends, hosted access pauses and you\'re redirected to the billing page to subscribe. Self-hosting the exact same open-source codebase is always available as a fallback.',
-                                ['days' => $trialDays]
-                            ),
-                        ];
-                    }
-                @endphp
-
-                <x-marketing.faq-accordion :faqs="$pricingFaqs" id-prefix="pricing-faq" />
+    <section id="pricing-faq" class="scroll-mt-24 bg-white py-20 dark:bg-gray-950 md:py-28">
+        <div class="mx-auto max-w-3xl px-6 lg:px-8">
+            <div class="mb-10 text-center">
+                <h2 class="font-display text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white sm:text-3xl">
+                    {{ __('Pricing questions, answered') }}
+                </h2>
             </div>
-            <p class="mx-auto mt-10 max-w-4xl border-t border-[var(--surface-card-border)] pt-6 text-sm text-gray-600 dark:text-gray-400">
-                <a href="{{ route('ai') }}" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('Explore the AI assistant and :count MCP tools', ['count' => $mcpToolCount]) }}</a>
-                <span class="mx-2" aria-hidden="true">·</span>
-                @if(! $billingActive)
-                    <a href="{{ route('selfHosted') }}" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('Explore self-hosting') }}</a>
-                    <span class="mx-2" aria-hidden="true">·</span>
-                @endif
-                <a href="{{ route('contact') }}" class="underline underline-offset-4 hover:text-primary dark:hover:text-primary-300">{{ __('Questions? Talk to us.') }}</a>
-            </p>
 
+            @php
+                $trialFaq = [
+                    __('What happens after my trial ends?'),
+                    __(
+                        'New workspaces start a :days-day trial automatically, with no card required. If a payment method isn\'t added before the trial ends, hosted access pauses and you\'re redirected to the billing page to subscribe. Self-hosting the exact same open-source codebase is always available as a fallback.',
+                        ['days' => $trialDays]
+                    ),
+                ];
+
+                $pricingFaqs = [
+                    [
+                        __('Is Relaticle really free to self-host?'),
+                        __('Yes. Self-hosting is fully open source under the AGPL-3.0 license, with unlimited users and unlimited records and no credit card required. Deploy it yourself with the published Docker Compose file. Your data stays on your own server the entire time.'),
+                    ],
+                    [
+                        __('Do you charge per seat?'),
+                        __('No. Relaticle has never charged per seat. Every plan, self-hosted or hosted, is priced per workspace, so you can add as many teammates as you need without the bill changing.'),
+                    ],
+                    [__("What's included in the hosted plan?"), $hostedPlanAnswer],
+                    ...($billingActive ? [$trialFaq] : []),
+                    [__('What happens when I hit a plan limit?'), $planLimitAnswer],
+                    [__('What counts as an AI credit?'), $creditFaqAnswer],
+                    [__('Which AI models does my plan unlock?'), $modelsUnlockAnswer],
+                    [__('Is there a message rate limit?'), $rateLimitAnswer],
+                    [__('Are self-hosted installs exempt from AI credit limits?'), $selfHostedCreditAnswer],
+                    [
+                        __('Can I switch between self-hosted and cloud?'),
+                        __('Yes. Both options run the identical open-source codebase against the same PostgreSQL schema, so neither locks you in. Companies, people, opportunities, tasks, and notes each have a built-in CSV export, and the import wizard on the other side accepts CSV. Moving between a self-hosted install and the hosted plan is a standard export and re-import, not a proprietary migration.'),
+                    ],
+                ];
+
+                if ($billingActive) {
+                    $pricingFaqs[] = [__('billing.enterprise.faq_title'), __('billing.enterprise.faq_body', ['price' => $enterprisePrice])];
+                    $pricingFaqs[] = [__('billing.enterprise.timeline_title'), __('billing.enterprise.timeline_body')];
+                }
+            @endphp
+
+            <x-marketing.faq-accordion :faqs="$pricingFaqs" id-prefix="pricing-faq" />
+        </div>
+    </section>
+
+    <section id="pricing-cta" class="bg-gray-50 py-20 dark:bg-gray-950 md:py-28">
+        <div class="mx-auto max-w-xl px-6 text-center lg:px-8">
+            <h2 class="font-display text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white sm:text-3xl">
+                {{ $billingActive ? __('Start with a 14-day trial') : __('Start for free today') }}
+            </h2>
+            <p class="mt-4 text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                {{ $billingActive
+                    ? __('No card required. Unlimited users from day one, and the same open-source codebase to self-host whenever you want.')
+                    : __('Unlimited users and records. Hosted by us, or on your own server.') }}
+            </p>
+            <div class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <x-marketing.button :href="route('login')">
+                    {{ __('Start for free') }}
+                </x-marketing.button>
+                @if($billingActive)
+                    <x-marketing.button variant="secondary" :href="route('contact')">
+                        {{ __('Talk to us') }}
+                    </x-marketing.button>
+                @else
+                    <x-marketing.button variant="secondary" :href="route('selfHosted')">
+                        {{ __('Explore self-hosting') }}
+                    </x-marketing.button>
+                @endif
+            </div>
+            <p class="mt-6 text-sm text-gray-500 dark:text-gray-400">
+                <a href="{{ route('ai') }}" class="font-medium text-gray-700 underline underline-offset-4 hover:text-primary dark:text-gray-300 dark:hover:text-primary-300">{{ __('Explore the AI assistant and :count MCP tools', ['count' => $mcpToolCount]) }}</a>
+                @if(! $billingActive)
+                    <span class="mx-2" aria-hidden="true">·</span>
+                    <a href="{{ route('contact') }}" class="font-medium text-gray-700 underline underline-offset-4 hover:text-primary dark:text-gray-300 dark:hover:text-primary-300">{{ __('Questions? Talk to us.') }}</a>
+                @endif
+            </p>
         </div>
     </section>
 

--- a/tests/Feature/Billing/BillingPageTest.php
+++ b/tests/Feature/Billing/BillingPageTest.php
@@ -356,3 +356,115 @@ it('names the workspace in the upgrade confirmation step', function (): void {
         ->assertSee(__('billing.upgrade.confirm_title'))
         ->assertSee(__('billing.upgrade.confirm_button', ['workspace' => 'Acme Manufacturing']));
 });
+
+it('offers owners an Enterprise conversation without changing their plan', function (): void {
+    [, $team] = billingPageOwner();
+
+    livewire(Billing::class)
+        ->assertSee('From $20,000 / year')
+        ->assertSeeHtml('href="'.e(route('contact', ['plan' => 'enterprise'])).'"');
+
+    expect($team->refresh()->plan)->toBe(Plan::Free);
+});
+
+it('does not offer Enterprise purchases to workspace members', function (): void {
+    [, $team] = billingPageOwner();
+    $member = User::factory()->create();
+    $team->users()->attach($member, ['role' => 'editor']);
+    test()->actingAs($member);
+    Filament::setTenant($team->refresh());
+
+    livewire(Billing::class)
+        ->assertDontSee('From $20,000 / year');
+});
+
+it('keeps an Enterprise grant managed after an older subscription ended', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['plan' => Plan::Enterprise])->save();
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_old_pro',
+        'stripe_status' => 'canceled',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+        'ends_at' => now()->subDay(),
+    ]);
+
+    livewire(Billing::class)
+        ->assertSee(__('billing.enterprise.body'))
+        ->assertSee('Contact your Relaticle team')
+        ->assertDontSee(__('billing.upgrade.button'))
+        ->assertDontSee('From $20,000 / year');
+});
+
+it('does not send an Enterprise workspace through Pro checkout', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['plan' => Plan::Enterprise])->save();
+
+    livewire(Billing::class)
+        ->call('upgrade', 'yearly')
+        ->assertNoRedirect()
+        ->assertNotNotified();
+
+    expect($team->refresh()->plan)->toBe(Plan::Enterprise);
+});
+
+it('keeps Enterprise access clear while an older Pro subscription is canceling', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['plan' => Plan::Enterprise, 'trial_ends_at' => now()->addDays(5)])->save();
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_enterprise_old_grace',
+        'stripe_status' => 'active',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+        'ends_at' => now()->addDays(9),
+    ]);
+
+    livewire(Billing::class)
+        ->assertSee(__('billing.status.managed'))
+        ->assertSee('Your Enterprise access is unchanged.')
+        ->assertDontSee('After that, workspace access pauses.')
+        ->assertDontSee(__('billing.trial.active_title'));
+});
+
+it('shows the Enterprise allowance when an older Pro subscription is past due', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['plan' => Plan::Enterprise])->save();
+    $team->subscriptions()->create([
+        'type' => 'default',
+        'stripe_id' => 'sub_enterprise_old_due',
+        'stripe_status' => 'past_due',
+        'stripe_price' => 'price_pro_monthly_test',
+        'quantity' => 1,
+    ]);
+
+    livewire(Billing::class)
+        ->assertSee('/ 10,000')
+        ->assertSee('Your previous subscription has a payment issue.')
+        ->assertDontSee(__('billing.manage.past_due_body'));
+});
+
+it('identifies a manually managed Pro plan without calling it Enterprise', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['plan' => Plan::Pro])->save();
+
+    livewire(Billing::class)
+        ->assertSee('Your plan is managed by Relaticle')
+        ->assertDontSee(__('billing.enterprise.title'));
+});
+
+it('shows spendable credits separately after the monthly allowance is exhausted', function (): void {
+    [, $team] = billingPageOwner();
+    $team->forceFill(['plan' => Plan::Pro])->save();
+    AiCreditBalance::query()->where('team_id', $team->getKey())->update([
+        'credits_remaining' => 150,
+        'credits_used' => 2050,
+        'purchased_credits' => 150,
+    ]);
+
+    livewire(Billing::class)
+        ->assertSee('150 credits available')
+        ->assertSee('2,050 credits used this period')
+        ->assertSee('100%');
+});

--- a/tests/Feature/Billing/StripeWebhookTest.php
+++ b/tests/Feature/Billing/StripeWebhookTest.php
@@ -185,6 +185,21 @@ it('preserves a sysadmin-granted plan when an unrelated subscription ends', func
         ->and($balance->credits_remaining)->toBe(Plan::Enterprise->credits());
 });
 
+it('preserves an Enterprise grant when an older Pro subscription sends an update', function (string $status): void {
+    $team = stripeBillingTeam();
+    sendStripeWebhook(stripeSubscriptionEvent($team, 'created'))->assertSuccessful();
+    $team->refresh()->forceFill(['plan' => Plan::Enterprise])->save();
+    app(CreditService::class)->resetPeriod($team);
+
+    sendStripeWebhook(stripeSubscriptionEvent($team, 'updated', ['status' => $status]))->assertSuccessful();
+
+    expect($team->refresh()->plan)->toBe(Plan::Enterprise);
+
+    app(CreditService::class)->resetPeriod($team);
+
+    expect(AiCreditBalance::query()->where('team_id', $team->getKey())->sole()->credits_remaining)->toBe(10_000);
+})->with(['active', 'past_due']);
+
 it('leaves the plan untouched for a price that maps to no plan', function (): void {
     $team = stripeBillingTeam();
 
@@ -436,6 +451,18 @@ it('notifies the workspace owner when a renewal charge fails', function (): void
 
     expect($notification->data['title'])->toContain($team->name)
         ->and($notification->data['body'])->toBe(__('billing.payment_failed.notification_body'));
+});
+
+it('keeps Enterprise access clear in an older subscription payment notification', function (): void {
+    $team = stripeBillingTeam();
+    $team->forceFill(['plan' => Plan::Enterprise])->save();
+
+    sendStripeWebhook(invoicePaymentFailedEvent($team))->assertOk();
+
+    $notification = $team->owner->notifications()->sole();
+
+    expect($notification->data['body'])->toContain('Your Enterprise access is unchanged.')
+        ->not->toContain('to keep Pro');
 });
 
 it('notifies once per invoice, not once per Stripe retry attempt', function (): void {

--- a/tests/Feature/Public/ContactFormTest.php
+++ b/tests/Feature/Public/ContactFormTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use App\Features\Billing as BillingFeature;
 use App\Http\Controllers\ContactController;
 use App\Http\Requests\ContactRequest;
 use App\Mail\NewContactSubmissionMail;
 use Illuminate\Support\Facades\Mail;
+use Laravel\Pennant\Feature;
 use Spatie\Honeypot\EncryptedTime;
 
 mutates(ContactController::class, ContactRequest::class);
@@ -14,6 +16,55 @@ it('displays the contact form', function () {
     $this->get('/contact')
         ->assertOk()
         ->assertViewIs('contact');
+});
+
+it('carries the Enterprise offer into the inquiry form', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $this->get('/contact?plan=enterprise')
+        ->assertSee('Let’s plan your Enterprise workspace')
+        ->assertSee('From $20,000 / year')
+        ->assertSee('Workflow and integrations we need:');
+});
+
+it('preserves the visitor message when an Enterprise inquiry fails validation', function (): void {
+    Mail::fake();
+    Feature::define(BillingFeature::class, true);
+
+    $this->from('/contact?plan=enterprise')->post('/contact?plan=enterprise', honeypotFields() + [
+        'name' => 'Maya Chen',
+        'email' => 'invalid-email',
+        'message' => 'Keep our Salesforce migration requirements.',
+    ])->assertRedirect('/contact?plan=enterprise')->assertSessionHasErrors('email');
+
+    $this->get('/contact?plan=enterprise')
+        ->assertSee('Keep our Salesforce migration requirements.')
+        ->assertDontSee('Workflow and integrations we need:');
+
+    Mail::assertNothingQueued();
+});
+
+it('delivers the Enterprise inquiry details through the contact workflow', function (): void {
+    Mail::fake();
+    Feature::define(BillingFeature::class, true);
+    $message = "We are interested in Relaticle Enterprise.\nIntegrate our Salesforce pipeline with our operations system.\nTeam size: 40.\nTarget timeline: November.";
+
+    $this->post('/contact?plan=enterprise', honeypotFields() + [
+        'name' => 'Maya Chen',
+        'email' => 'maya@gmail.com',
+        'company' => 'Northstar Operations',
+        'message' => $message,
+    ])->assertRedirect('/contact')->assertSessionHas('success');
+
+    Mail::assertQueued(NewContactSubmissionMail::class, fn (NewContactSubmissionMail $mail): bool => $mail->data['message'] === $message
+        && $mail->data['company'] === 'Northstar Operations');
+});
+
+it('keeps general contact inquiries free of Enterprise sales copy', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $this->get('/contact?plan=other')
+        ->assertDontSee('From $20,000 / year');
 });
 
 it('submits the contact form successfully', function () {

--- a/tests/Feature/Public/PricingPageTest.php
+++ b/tests/Feature/Public/PricingPageTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 use App\Actions\Billing\StartProTrial;
 use App\Enums\Plan;
 use App\Features\Billing as BillingFeature;
+use App\Support\CompetitorFacts;
 use Laravel\Pennant\Feature;
 use Relaticle\Chat\Services\ModelRegistry;
 use Symfony\Component\DomCrawler\Crawler;
+
+mutates(Plan::class, ModelRegistry::class, CompetitorFacts::class);
 
 it('shows the legacy two-card page when billing is off', function (): void {
     Feature::define(BillingFeature::class, false);
@@ -23,28 +26,38 @@ it('shows the pro tier when billing is on', function (): void {
 
     $this->get('/pricing')
         ->assertOk()
-        ->assertSee('No per-seat pricing. Ever.')
+        ->assertSee('One price for your whole team.')
         ->assertSee('$19')
         ->assertSee('$24')
         ->assertSee('$228 billed yearly')
-        ->assertSee('Save 21%')
+        ->assertSee('Save $60 a year')
         ->assertSee('2,000 AI credits')
         ->assertSee('Cloud Pro')
-        ->assertSee('Self-Hosted')
-        ->assertSee('Start your 14-day trial')
+        ->assertSee('Prefer to self-host? It’s free.')
+        ->assertSee('Start for free')
+        ->assertSee('14-day trial. No card required.')
         ->assertDontSee('One workspace price as your team grows')
         ->assertDontSee('300 AI credits')
         ->assertDontSee('Generous free tier');
 });
 
-it('advertises all MCP tools in the feature metrics', function (): void {
+it('keeps self-hosting separate from the two paid plan choices', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $response = $this->get('/pricing');
+    $crawler = new Crawler((string) $response->getContent());
+
+    expect($crawler->filter('#pricing-plans h2')->each(fn (Crawler $heading): string => trim($heading->text())))
+        ->toBe(['Cloud Pro', 'Enterprise'])
+        ->and($crawler->filter('#self-hosting a')->attr('href'))->toBe(route('selfHosted'));
+});
+
+it('links to the complete MCP tool offering', function (): void {
     $response = $this->get('/pricing')->assertOk();
     $crawler = new Crawler((string) $response->getContent());
-    $toolCount = $crawler
-        ->filterXPath('//*[normalize-space(text())="MCP Tools"]/preceding-sibling::div[1]')
-        ->text();
+    $toolLink = $crawler->filter('main a[href="'.route('ai').'"]')->text();
 
-    expect($toolCount)->toBe('37');
+    expect($toolLink)->toContain('37 MCP tools');
 });
 
 it('emits product json-ld on the pricing page', function (): void {
@@ -100,14 +113,14 @@ it('scopes the hosted-plan faq to the free tier when billing is off', function (
         ->assertDontSee('2,000-credit');
 });
 
-it('shows the comparison list with the pro-tier hosted price and updates when billing is on', function (): void {
+it('compares hosted product access with scoped Enterprise services when billing is on', function (): void {
     Feature::define(BillingFeature::class, true);
 
     $this->get('/pricing')
         ->assertOk()
-        ->assertSee(__('Self-hosted or hosted: how to choose'))
+        ->assertSee(__('Choose how you get started'))
         ->assertSee('$19/mo per workspace ($228 billed yearly, or $24/mo billed monthly)')
-        ->assertSee(__('Managed by Relaticle. No self-hosted maintenance required'))
+        ->assertSee(__('Scoped implementation project'))
         ->assertDontSee(__('$0/mo per workspace'))
         ->assertDontSee(__('Zero-downtime updates and automatic daily backups, handled for you'));
 });
@@ -131,6 +144,22 @@ it('emits accurate product json-ld offers when billing is on', function (): void
         ->assertSee('"name":"Self-hosted","price":"0"', false)
         ->assertSee('"name":"Cloud Pro","price":"19"', false)
         ->assertDontSee('"name":"Cloud","price":"0"', false);
+});
+
+it('keeps the Enterprise starting price consistent with its annual structured offer', function (): void {
+    Feature::define(BillingFeature::class, true);
+    config(['relaticle.enterprise.starting_price_yearly' => 25_000]);
+
+    $response = $this->get('/pricing')->assertSee('From $25,000 / year');
+    $crawler = new Crawler((string) $response->getContent());
+    $graph = json_decode($crawler->filter('script[type="application/ld+json"]')->text(), true, 512, JSON_THROW_ON_ERROR);
+    $product = collect($graph['@graph'])->firstWhere('@type', 'Product');
+    $offer = collect($product['offers'])->firstWhere('name', 'Enterprise');
+
+    expect($offer)->not->toBeNull()
+        ->and($offer['priceSpecification']['minPrice'])->toBe(25_000)
+        ->and($offer['priceSpecification']['unitText'])->toBe('year')
+        ->and($offer['url'])->toBe(route('contact', ['plan' => 'enterprise']));
 });
 
 it('emits accurate product json-ld offers when billing is off', function (): void {
@@ -256,14 +285,18 @@ it('names the models a plan includes even when this install holds no provider ke
         ->assertDontSee('Gemini');
 });
 
-it('does not claim an unconfirmed Enterprise tier is a purchasable offering when billing is on', function (): void {
-    // No Enterprise plan card or checkout path exists in the codebase, so the page must
-    // not name it as a contactable/sellable tier anywhere in its visible copy.
+it('offers Enterprise through a scoped sales inquiry with an annual starting price', function (): void {
     Feature::define(BillingFeature::class, true);
 
-    $this->get('/pricing')
-        ->assertOk()
-        ->assertDontSee('Enterprise');
+    $response = $this->get('/pricing')
+        ->assertSee('From $20,000 / year')
+        ->assertSee('Scope, usage, support, and delivery milestones agreed before signing.')
+        ->assertSee('What does Enterprise include?');
+
+    $card = (new Crawler((string) $response->getContent()))->filter('#enterprise-plan');
+
+    expect($card->filter('a')->attr('href'))->toBe(route('contact', ['plan' => 'enterprise']))
+        ->and($card->text())->toContain('Implementation scoped to your workflow');
 });
 
 it('does not claim an unconfirmed Enterprise tier is a purchasable offering when billing is off', function (): void {

--- a/tests/Feature/Public/PricingPageTest.php
+++ b/tests/Feature/Public/PricingPageTest.php
@@ -30,7 +30,7 @@ it('shows the pro tier when billing is on', function (): void {
         ->assertSee('$19')
         ->assertSee('$24')
         ->assertSee('$228 billed yearly')
-        ->assertSee('Save $60 a year')
+        ->assertSee('Save 21%')
         ->assertSee('2,000 AI credits')
         ->assertSee('Cloud Pro')
         ->assertSee('Prefer to self-host? It’s free.')
@@ -50,6 +50,45 @@ it('keeps self-hosting separate from the two paid plan choices', function (): vo
     expect($crawler->filter('#pricing-plans h2')->each(fn (Crawler $heading): string => trim($heading->text())))
         ->toBe(['Cloud Pro', 'Enterprise'])
         ->and($crawler->filter('#self-hosting a')->attr('href'))->toBe(route('selfHosted'));
+});
+
+it('closes with a trial start and a sales contact when billing is on', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $response = $this->get('/pricing')->assertOk();
+    $crawler = new Crawler((string) $response->getContent());
+    $cta = $crawler->filter('#pricing-cta');
+
+    expect($cta->filter('h2')->text())->toBe(__('Start with a 14-day trial'))
+        ->and($cta->filter('a[href="'.route('login').'"]')->text())->toContain(__('Start for free'))
+        ->and($cta->filter('a[href="'.route('contact').'"]')->text())->toContain(__('Talk to us'))
+        ->and($crawler->filter('#pricing-plans #self-hosting'))->toHaveCount(0)
+        ->and($crawler->filter('#self-hosting a[href="'.route('selfHosted').'"]'))->toHaveCount(1);
+});
+
+it('closes with a free start and a self-hosting link when billing is off', function (): void {
+    Feature::define(BillingFeature::class, false);
+
+    $response = $this->get('/pricing')->assertOk();
+    $cta = (new Crawler((string) $response->getContent()))->filter('#pricing-cta');
+
+    expect($cta->filter('a[href="'.route('login').'"]')->text())->toContain(__('Start for free'))
+        ->and($cta->filter('a[href="'.route('selfHosted').'"]')->text())->toContain(__('Explore self-hosting'))
+        ->and(trim($cta->filter('a[href="'.route('contact').'"]')->text()))->toBe(__('Questions? Talk to us.'));
+});
+
+it('answers the trial question right after the hosted plan question when billing is on', function (): void {
+    Feature::define(BillingFeature::class, true);
+
+    $response = $this->get('/pricing')->assertOk();
+    $questions = (new Crawler((string) $response->getContent()))
+        ->filter('#pricing-faq button')
+        ->each(fn (Crawler $button): string => trim($button->text()));
+
+    $hostedIndex = array_search(__("What's included in the hosted plan?"), $questions, true);
+
+    expect($hostedIndex)->not->toBeFalse()
+        ->and($questions[$hostedIndex + 1])->toBe(__('What happens after my trial ends?'));
 });
 
 it('links to the complete MCP tool offering', function (): void {


### PR DESCRIPTION
Introduce Enterprise from $20,000/year for scoped implementation, integrations, and ongoing support, while keeping Cloud Pro at $24/month or $228/year.

Refine pricing with two paid plans, secondary self-hosting, “Start for free,” and a prefilled Enterprise inquiry form.

Keep the existing billing layout, clarify credit usage, and preserve managed Enterprise access and allowances when older Pro subscriptions change.

Validation from #653: 4,299 passing tests (two skipped), formatting, static analysis, 100% type coverage, production build, and light, dark, and mobile browser checks.
