### PR TITLE
fix(billing): point the enterprise contact links at the primary host

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -11,3 +11,4 @@ Before planning or editing, find the row whose globs match the file's path and r
 | packages/Chat/** | .ai/rules/chat.md |
 | app/Jobs/Email/**, app/Support/Email/** | .ai/rules/email.md |
 | app/Models/**, app/Casts/** | .ai/rules/models.md |
+| resources/views/filament/**, app/Filament/**, packages/*/src/Filament/**, packages/*/resources/views/** | .ai/rules/panel-links.md |

--- a/.ai/rules/panel-links.md
+++ b/.ai/rules/panel-links.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - 'resources/views/filament/**'
+  - 'app/Filament/**'
+  - 'packages/*/src/Filament/**'
+  - 'packages/*/resources/views/**'
+---
+
+# Linking out of a Filament panel
+
+A panel link to a public marketing or docs route must be built against the
+primary host, not with a bare `route()`:
+
+```blade
+<x-filament::button tag="a" :href="url()->getPublicUrl(route('contact', absolute: false))">
+```
+
+`route()` resolves against the *request* host. Public routes carry no domain
+constraint, so from the app-panel host (`APP_PANEL_DOMAIN`) it yields
+`https://app.<domain>/contact`. `AppPanelProvider` calls `->spa()`, Filament's
+`is_app_url()` sees a matching host and adds `wire:navigate`, then
+`RedirectToPrimaryHost` 301s the fetch to `APP_URL`. That crossing is
+cross-origin, the marketing host sends no `Access-Control-Allow-Origin`, and
+Livewire's `performFetch` swallows the CORS error in a bare `.catch(() => {})`.
+The button goes dead with nothing in the console. This shipped in PR #654 and
+reached production.
+
+`getPublicUrl` puts the primary host in the href, `is_app_url()` returns false,
+Filament omits `wire:navigate`, and the browser navigates natively.
+
+Plain `<a>` tags and `target="_blank"` links are unaffected: they never get
+`wire:navigate` and follow the 301 normally.
+
+A test only catches this when the two hosts differ. Set
+`config()->set('app.url', 'https://marketing.test')` before rendering and
+assert the absolute href, as `tests/Feature/Billing/BillingPageTest.php` does.

--- a/resources/views/filament/pages/billing.blade.php
+++ b/resources/views/filament/pages/billing.blade.php
@@ -227,7 +227,7 @@
                 <h3 class="font-display text-lg font-semibold text-gray-900 dark:text-white">{{ $isEnterprise ? __('billing.enterprise.title') : __('billing.managed.title') }}</h3>
                 <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.body') }}</p>
                 <div class="mt-5 flex flex-wrap gap-3">
-                    <x-filament::button tag="a" color="gray" :href="route('contact')">{{ __('billing.enterprise.manage') }}</x-filament::button>
+                    <x-filament::button tag="a" color="gray" :href="url()->getPublicUrl(route('contact', absolute: false))">{{ __('billing.enterprise.manage') }}</x-filament::button>
                     @if($canManageSubscription && ! $pastDue)
                         <x-filament::button color="gray" wire:click="managePortal">{{ __('billing.manage.button') }}</x-filament::button>
                     @endif
@@ -356,7 +356,7 @@
                         <h3 class="text-base font-semibold text-gray-900 dark:text-white">{{ __('billing.plans.enterprise') }}</h3>
                         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.starting_price', ['price' => number_format(config('relaticle.enterprise.starting_price_yearly'))]) }}</p>
                     </div>
-                    <x-filament::button tag="a" color="gray" :href="route('contact', ['plan' => 'enterprise'])">{{ __('billing.enterprise.contact') }}</x-filament::button>
+                    <x-filament::button tag="a" color="gray" :href="url()->getPublicUrl(route('contact', ['plan' => 'enterprise'], absolute: false))">{{ __('billing.enterprise.contact') }}</x-filament::button>
                 </div>
                 <p class="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-400">{{ __('billing.enterprise.tagline') }} {{ __('billing.enterprise.terms') }}</p>
             </section>

--- a/tests/Feature/Billing/BillingPageTest.php
+++ b/tests/Feature/Billing/BillingPageTest.php
@@ -358,11 +358,12 @@ it('names the workspace in the upgrade confirmation step', function (): void {
 });
 
 it('offers owners an Enterprise conversation without changing their plan', function (): void {
+    config()->set('app.url', 'https://marketing.test');
     [, $team] = billingPageOwner();
 
     livewire(Billing::class)
         ->assertSee('From $20,000 / year')
-        ->assertSeeHtml('href="'.e(route('contact', ['plan' => 'enterprise'])).'"');
+        ->assertSeeHtml('href="https://marketing.test/contact?plan=enterprise"');
 
     expect($team->refresh()->plan)->toBe(Plan::Free);
 });
@@ -379,6 +380,7 @@ it('does not offer Enterprise purchases to workspace members', function (): void
 });
 
 it('keeps an Enterprise grant managed after an older subscription ended', function (): void {
+    config()->set('app.url', 'https://marketing.test');
     [, $team] = billingPageOwner();
     $team->forceFill(['plan' => Plan::Enterprise])->save();
     $team->subscriptions()->create([
@@ -393,6 +395,7 @@ it('keeps an Enterprise grant managed after an older subscription ended', functi
     livewire(Billing::class)
         ->assertSee(__('billing.enterprise.body'))
         ->assertSee('Contact your Relaticle team')
+        ->assertSeeHtml('href="https://marketing.test/contact"')
         ->assertDontSee(__('billing.upgrade.button'))
         ->assertDontSee('From $20,000 / year');
 });


### PR DESCRIPTION
Both "Talk to us" and "Contact your Relaticle team" on the billing page were dead when the app panel runs on its own host (`app.relaticle.com`): `route('contact')` has no domain constraint, so it generated an app-host URL, Filament's `spa()` added `wire:navigate`, `RedirectToPrimaryHost` 301'd the fetch cross-origin, and the marketing host's missing CORS header made Livewire's `performFetch` swallow the failure in a bare `.catch(() => {})`.

Both buttons now build their href with `url()->getPublicUrl(route('contact', absolute: false))`, so the primary host is in the href, `is_app_url()` returns false, Filament omits `wire:navigate`, and the browser navigates natively. `BillingPageTest` sets a distinct `app.url` so the two hosts differ, which is the only way a test can catch this; both assertions fail on the old code.

Verified in a browser with `APP_PANEL_DOMAIN` set: before, the click left the page on `/billing`; after, both buttons land on the contact page. `.ai/rules/panel-links.md` records the trap for any future panel link to a public route.