### PR TITLE
Add meeting RSVP from the meeting card

### DIFF
--- a/app/Policies/MeetingPolicy.php
+++ b/app/Policies/MeetingPolicy.php
@@ -9,15 +9,18 @@ use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
-use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 final readonly class MeetingPolicy
 {
     use HandlesAuthorization;
 
-    public function __construct(private EmailVisibilityService $visibility) {}
+    public function __construct(
+        private EmailVisibilityService $visibility,
+        private MeetingRespondentResolver $respondentResolver,
+    ) {}
 
     public function viewAny(User $user): bool
     {
@@ -47,19 +50,10 @@ final readonly class MeetingPolicy
             return false;
         }
 
-        $account = ConnectedAccount::query()
-            ->whereKey($meeting->connected_account_id)
-            ->where('user_id', $user->getKey())
-            ->first();
-
-        if (! $account instanceof ConnectedAccount) {
+        if ($meeting->status === CalendarEventStatus::CANCELLED) {
             return false;
         }
 
-        if (! $account->isActive() || ! $account->hasCalendar()) {
-            return false;
-        }
-
-        return $meeting->status !== CalendarEventStatus::CANCELLED;
+        return $this->respondentResolver->canRespond($user, $meeting);
     }
 }

--- a/app/Policies/MeetingPolicy.php
+++ b/app/Policies/MeetingPolicy.php
@@ -8,7 +8,10 @@ use App\Features\EmailIntegration;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Laravel\Pennant\Feature;
+use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
 final readonly class MeetingPolicy
@@ -33,5 +36,41 @@ final readonly class MeetingPolicy
         }
 
         return ! $this->visibility->isMeetingHiddenFromViewer($meeting, $user);
+    }
+
+    public function respond(User $user, Meeting $meeting): bool
+    {
+        if (! Feature::active(EmailIntegration::class)) {
+            return false;
+        }
+
+        if (! $this->view($user, $meeting)) {
+            return false;
+        }
+
+        $account = $meeting->connectedAccount;
+
+        if (! $account instanceof ConnectedAccount) {
+            return false;
+        }
+
+        if ($account->user_id !== $user->getKey()) {
+            return false;
+        }
+
+        if (! $account->isActive() || ! $account->hasCalendar()) {
+            return false;
+        }
+
+        if ($meeting->status === CalendarEventStatus::CANCELLED) {
+            return false;
+        }
+
+        $self = $meeting->attendees->first(
+            fn (MeetingAttendee $attendee): bool => $attendee->is_self
+                || $attendee->email_address === strtolower($account->email_address),
+        );
+
+        return $self instanceof MeetingAttendee;
     }
 }

--- a/app/Policies/MeetingPolicy.php
+++ b/app/Policies/MeetingPolicy.php
@@ -11,7 +11,6 @@ use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
-use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
 
 final readonly class MeetingPolicy
@@ -48,13 +47,12 @@ final readonly class MeetingPolicy
             return false;
         }
 
-        $account = $meeting->connectedAccount;
+        $account = ConnectedAccount::query()
+            ->whereKey($meeting->connected_account_id)
+            ->where('user_id', $user->getKey())
+            ->first();
 
         if (! $account instanceof ConnectedAccount) {
-            return false;
-        }
-
-        if ($account->user_id !== $user->getKey()) {
             return false;
         }
 
@@ -62,15 +60,6 @@ final readonly class MeetingPolicy
             return false;
         }
 
-        if ($meeting->status === CalendarEventStatus::CANCELLED) {
-            return false;
-        }
-
-        $self = $meeting->attendees->first(
-            fn (MeetingAttendee $attendee): bool => $attendee->is_self
-                || $attendee->email_address === strtolower($account->email_address),
-        );
-
-        return $self instanceof MeetingAttendee;
+        return $meeting->status !== CalendarEventStatus::CANCELLED;
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -177,6 +177,12 @@ return Application::configure(basePath: dirname(__DIR__))
                 ->withoutOverlapping()
                 ->onOneServer();
 
+            $schedule->command('calendar:renew-push-channels')
+                ->daily()
+                ->name('calendar:renew-push-channels')
+                ->withoutOverlapping()
+                ->onOneServer();
+
             $schedule->command('email:dispatch-outbox')
                 ->everyMinute()
                 ->name('email:dispatch-outbox')

--- a/database/migrations/2026_09_08_070021_add_calendar_push_fields_to_connected_accounts_table.php
+++ b/database/migrations/2026_09_08_070021_add_calendar_push_fields_to_connected_accounts_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('connected_accounts', function (Blueprint $table): void {
+            $table->string('calendar_push_channel_id')->nullable()->after('last_calendar_synced_at');
+            $table->string('calendar_push_resource_id')->nullable()->after('calendar_push_channel_id');
+            $table->text('calendar_push_verification_token')->nullable()->after('calendar_push_resource_id');
+            $table->timestamp('calendar_push_expires_at')->nullable()->after('calendar_push_verification_token');
+        });
+    }
+};

--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -53,8 +53,8 @@ return [
     ],
     'notifications' => [
         'calendar_sync_queued' => [
-            'title' => 'Calendar sync queued.',
-            'body' => 'New events should appear within a minute.',
+            'title' => 'Calendar sync started.',
+            'body' => 'Your meetings will update on this page as the sync finishes.',
         ],
         'disconnected' => [
             'title' => 'Account disconnected.',
@@ -80,6 +80,9 @@ return [
     'in_sync' => 'In Sync',
     'send_missing_tooltip' => 'Send access was not granted. Grant it to send mail from Relaticle.',
     'importing' => 'Syncing',
+    'importing_calendar' => 'Syncing calendar',
+    'importing_email' => 'Syncing email',
+    'importing_email_and_calendar' => 'Syncing email and calendar',
     'importing_percent' => ':percent%',
     'sync_status' => [
         'title_syncing' => 'Syncing',

--- a/lang/en/filament/resources/meeting.php
+++ b/lang/en/filament/resources/meeting.php
@@ -106,6 +106,10 @@ return [
                 'title' => 'Could not update your RSVP.',
                 'body' => 'Reconnect the mailbox and try again.',
             ],
+            'not_synced' => [
+                'title' => 'Could not update your RSVP.',
+                'body' => 'This meeting has not appeared on your calendar yet. Try again in a moment.',
+            ],
         ],
     ],
 

--- a/lang/en/filament/resources/meeting.php
+++ b/lang/en/filament/resources/meeting.php
@@ -29,6 +29,20 @@ return [
         'link_records' => [
             'label' => 'Link records',
         ],
+        'rsvp' => [
+            'label' => 'RSVP',
+            'accepted' => [
+                'label' => 'Accept',
+            ],
+            'tentative' => [
+                'label' => 'Maybe',
+            ],
+            'declined' => [
+                'label' => 'Decline',
+                'heading' => 'Decline this meeting?',
+                'description' => 'Your calendar is updated to declined. The meeting stays on the calendar for other guests.',
+            ],
+        ],
     ],
     'linked_record_types' => [
         'people' => 'Person',
@@ -74,6 +88,24 @@ return [
     'filters' => [
         'response_status' => [
             'label' => 'My RSVP',
+        ],
+    ],
+
+    'notifications' => [
+        'rsvp' => [
+            'accepted' => [
+                'title' => 'Invitation accepted. Your calendar is updated.',
+            ],
+            'tentative' => [
+                'title' => 'Marked as maybe. Your calendar is updated.',
+            ],
+            'declined' => [
+                'title' => 'Invitation declined. Your calendar is updated.',
+            ],
+            'failed' => [
+                'title' => 'Could not update your RSVP.',
+                'body' => 'Reconnect the mailbox and try again.',
+            ],
         ],
     ],
 

--- a/packages/EmailIntegration/resources/views/components/importing-badge.blade.php
+++ b/packages/EmailIntegration/resources/views/components/importing-badge.blade.php
@@ -3,19 +3,40 @@
     'icon',
 ])
 
-<x-filament::badge
-    color="info"
-    size="sm"
-    :icon="$icon"
-    class="whitespace-nowrap"
-    role="progressbar"
-    aria-busy="true"
-    aria-valuemin="0"
-    aria-valuemax="100"
-    aria-valuenow="{{ $account->initialSyncProgressPercent() }}"
-    aria-valuetext="{{ __('filament/pages/email-accounts.importing_percent', ['percent' => $account->initialSyncProgressPercent()]) }}"
-    aria-label="{{ __('filament/pages/email-accounts.importing') }}"
->
-    {{ __('filament/pages/email-accounts.importing') }}
-    {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $account->initialSyncProgressPercent()]) }}
-</x-filament::badge>
+@php
+    $incrementalLabel = $account->incrementalSyncStatusLabel();
+    $percent = $incrementalLabel === null ? $account->initialSyncProgressPercent() : null;
+@endphp
+
+@if ($incrementalLabel !== null)
+    <x-filament::badge
+        color="info"
+        size="sm"
+        :icon="$icon"
+        class="whitespace-nowrap"
+        role="progressbar"
+        aria-busy="true"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        :aria-label="$incrementalLabel"
+    >
+        {{ $incrementalLabel }}
+    </x-filament::badge>
+@else
+    <x-filament::badge
+        color="info"
+        size="sm"
+        :icon="$icon"
+        class="whitespace-nowrap"
+        role="progressbar"
+        aria-busy="true"
+        aria-valuemin="0"
+        aria-valuemax="100"
+        :aria-valuenow="$percent"
+        :aria-valuetext="__('filament/pages/email-accounts.importing_percent', ['percent' => $percent])"
+        :aria-label="__('filament/pages/email-accounts.importing')"
+    >
+        {{ __('filament/pages/email-accounts.importing') }}
+        {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $percent]) }}
+    </x-filament::badge>
+@endif

--- a/packages/EmailIntegration/resources/views/filament/infolists/meeting-header.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/infolists/meeting-header.blade.php
@@ -10,7 +10,7 @@
 
     <h2 class="flex-1 text-xl font-semibold">{{ $state['title'] }}</h2>
 
-    @if ($state['response_status'] !== null)
+    @if ($state['response_status'] !== null && ! $state['can_respond'])
         @include('email-integration::filament.infolists.partials.rsvp-pill', ['status' => $state['response_status']])
     @endif
 </div>

--- a/packages/EmailIntegration/resources/views/filament/infolists/partials/rsvp-pill.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/infolists/partials/rsvp-pill.blade.php
@@ -1,13 +1,3 @@
-@php
-    $dotColor = match ($status->getColor()) {
-        'success' => 'bg-emerald-500',
-        'danger' => 'bg-red-500',
-        'warning' => 'bg-amber-500',
-        default => 'bg-gray-400',
-    };
-@endphp
-
-<span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--surface-block-border)] bg-[var(--surface-block-bg)] px-2.5 py-1 text-xs">
-    <span class="size-1.5 rounded-full {{ $dotColor }}"></span>
+<x-filament::badge :color="$status->getColor()" size="sm">
     {{ $status->getLabel() }}
-</span>
+</x-filament::badge>

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -39,7 +39,7 @@
                     </div>
 
                     <div class="flex shrink-0 items-center gap-3">
-                        @if ($account->isImportingHistory())
+                        @if ($account->showsSyncProgress())
                             <x-email-integration::importing-badge :account="$account" :icon="$this->syncingIcon()" />
                         @else
                             <x-filament::badge

--- a/packages/EmailIntegration/resources/views/livewire/mailbox-import-status.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/mailbox-import-status.blade.php
@@ -117,9 +117,15 @@
                         >
                             <div class="flex items-center justify-between gap-3">
                                 <p class="truncate text-sm text-gray-700 dark:text-gray-300">{{ $mailbox['email'] }}</p>
-                                <span class="shrink-0 rounded-full bg-primary-50 px-2 py-0.5 text-xs font-semibold tabular-nums text-primary-700 dark:bg-primary-400/10 dark:text-primary-300">
-                                    {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $mailbox['percent']]) }}
-                                </span>
+                                @if ($mailbox['incrementalLabel'] !== null)
+                                    <span class="shrink-0 rounded-full bg-primary-50 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:bg-primary-400/10 dark:text-primary-300">
+                                        {{ $mailbox['incrementalLabel'] }}
+                                    </span>
+                                @else
+                                    <span class="shrink-0 rounded-full bg-primary-50 px-2 py-0.5 text-xs font-semibold tabular-nums text-primary-700 dark:bg-primary-400/10 dark:text-primary-300">
+                                        {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $mailbox['percent']]) }}
+                                    </span>
+                                @endif
                             </div>
                             @if ($mailbox['hasCalendar'])
                                 <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
@@ -132,15 +138,22 @@
                             <div
                                 class="mt-2 h-2 overflow-hidden rounded-full bg-primary-100 dark:bg-primary-400/15"
                                 role="progressbar"
-                                aria-valuenow="{{ $mailbox['percent'] }}"
+                                @if ($mailbox['percent'] !== null)
+                                    aria-valuenow="{{ $mailbox['percent'] }}"
+                                @endif
                                 aria-valuemin="0"
                                 aria-valuemax="100"
-                                aria-label="{{ __('filament/pages/email-accounts.importing') }}"
+                                aria-label="{{ $mailbox['incrementalLabel'] ?? __('filament/pages/email-accounts.importing') }}"
+                                aria-busy="{{ $mailbox['importing'] ? 'true' : 'false' }}"
                             >
-                                <div
-                                    class="h-full rounded-full bg-primary-600 transition-[width] duration-500 ease-out"
-                                    style="width: {{ $mailbox['percent'] }}%"
-                                ></div>
+                                @if ($mailbox['incrementalOnly'])
+                                    <div class="h-full w-full animate-pulse rounded-full bg-primary-600/70"></div>
+                                @else
+                                    <div
+                                        class="h-full rounded-full bg-primary-600 transition-[width] duration-500 ease-out"
+                                        style="width: {{ $mailbox['percent'] }}%"
+                                    ></div>
+                                @endif
                             </div>
                         </a>
                     </div>

--- a/packages/EmailIntegration/routes/web.php
+++ b/packages/EmailIntegration/routes/web.php
@@ -3,8 +3,16 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Relaticle\EmailIntegration\Controllers\CalendarPushWebhookController;
 use Relaticle\EmailIntegration\Controllers\CallbackController as EmailCallbackController;
 use Relaticle\EmailIntegration\Controllers\RedirectController as EmailRedirectController;
+
+Route::middleware(['web'])->group(function (): void {
+    Route::post('webhooks/calendar/{provider}', CalendarPushWebhookController::class)
+        ->name('calendar-push.webhook')
+        ->whereIn('provider', ['gmail', 'azure'])
+        ->middleware('throttle:120,1');
+});
 
 Route::middleware(['web', 'auth', 'verified'])->group(function (): void {
     Route::get('/email-accounts/redirect/{provider}', EmailRedirectController::class)

--- a/packages/EmailIntegration/src/Actions/DisconnectConnectedAccountAction.php
+++ b/packages/EmailIntegration/src/Actions/DisconnectConnectedAccountAction.php
@@ -9,9 +9,14 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 final readonly class DisconnectConnectedAccountAction
 {
+    public function __construct(
+        private StopCalendarPushChannelAction $stopCalendarPushChannel,
+    ) {}
+
     public function execute(ConnectedAccount $account): void
     {
         DB::transaction(function () use ($account): void {
+            $this->stopCalendarPushChannel->execute($account);
             // Account is soft-deleted, so the DB-level cascade on email_signatures never
             // fires. Remove dependent signatures and blocklist entries explicitly to avoid
             // orphaned rows whose connectedAccount relation resolves to null.

--- a/packages/EmailIntegration/src/Actions/ReconcileCalendarMeetingsAction.php
+++ b/packages/EmailIntegration/src/Actions/ReconcileCalendarMeetingsAction.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Exceptions\ReconcileCalendarMeetingsFailed;
+use Throwable;
+
+final readonly class ReconcileCalendarMeetingsAction
+{
+    public function __construct(
+        private CalendarServiceFactoryInterface $calendarFactory,
+    ) {}
+
+    public function execute(ConnectedAccount $account): int
+    {
+        if (! $account->hasCalendar()) {
+            return 0;
+        }
+
+        try {
+            $activeIds = $this->calendarFactory->make($account)->listActiveProviderEventIds();
+        } catch (Throwable $exception) {
+            throw ReconcileCalendarMeetingsFailed::fromProvider($exception);
+        }
+
+        if ($activeIds === []) {
+            return Meeting::query()
+                ->where('connected_account_id', $account->getKey())
+                ->delete();
+        }
+
+        return Meeting::query()
+            ->where('connected_account_id', $account->getKey())
+            ->whereNotIn('provider_event_id', $activeIds)
+            ->delete();
+    }
+}

--- a/packages/EmailIntegration/src/Actions/ReconcileCalendarMeetingsAction.php
+++ b/packages/EmailIntegration/src/Actions/ReconcileCalendarMeetingsAction.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use Relaticle\EmailIntegration\Exceptions\ReconcileCalendarMeetingsFailed;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\ReconcileCalendarMeetingsFailed;
 use Throwable;
 
 final readonly class ReconcileCalendarMeetingsAction

--- a/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
@@ -12,6 +12,7 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 final readonly class RespondToMeetingAction
@@ -30,11 +31,19 @@ final readonly class RespondToMeetingAction
         $account = $this->respondentResolver->resolveAccount($user, $meeting);
         abort_unless($account instanceof ConnectedAccount, 403);
 
+        $calendar = $this->calendarFactory->make($account);
         $providerEventId = $this->respondentResolver->resolveProviderEventId($account, $meeting);
+        $iCalUid = $meeting->ical_uid;
 
-        $this->calendarFactory
-            ->make($account)
-            ->respondToEvent($providerEventId, $status);
+        if ($providerEventId === null && is_string($iCalUid) && $iCalUid !== '') {
+            $providerEventId = $calendar->findEventIdByICalUid($iCalUid);
+        }
+
+        if ($providerEventId === null || $providerEventId === '') {
+            throw MeetingResponseFailed::missingMailboxCopy();
+        }
+
+        $calendar->respondToEvent($providerEventId, $status);
 
         if ($this->respondentResolver->ownsMeetingMailbox($account, $meeting)) {
             $this->updateMailboxOwnerResponse($meeting, $account, $status);

--- a/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
@@ -8,11 +8,11 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use InvalidArgumentException;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 final readonly class RespondToMeetingAction

--- a/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
@@ -12,11 +12,13 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 final readonly class RespondToMeetingAction
 {
     public function __construct(
         private CalendarServiceFactoryInterface $calendarFactory,
+        private MeetingRespondentResolver $respondentResolver,
     ) {}
 
     public function execute(User $user, Meeting $meeting, AttendeeResponseStatus $status): Meeting
@@ -25,13 +27,29 @@ final readonly class RespondToMeetingAction
 
         throw_if($status === AttendeeResponseStatus::NEEDS_ACTION, InvalidArgumentException::class, 'Cannot reset an RSVP to needsAction.');
 
-        $account = $meeting->connectedAccount;
+        $account = $this->respondentResolver->resolveAccount($user, $meeting);
         abort_unless($account instanceof ConnectedAccount, 403);
+
+        $providerEventId = $this->respondentResolver->resolveProviderEventId($account, $meeting);
 
         $this->calendarFactory
             ->make($account)
-            ->respondToEvent($meeting->provider_event_id, $status);
+            ->respondToEvent($providerEventId, $status);
 
+        if ($this->respondentResolver->ownsMeetingMailbox($account, $meeting)) {
+            $this->updateMailboxOwnerResponse($meeting, $account, $status);
+        } else {
+            $this->updateListedAttendeeResponse($meeting, $user, $status);
+        }
+
+        return $meeting->refresh()->load(['attendees.contact', 'connectedAccount']);
+    }
+
+    private function updateMailboxOwnerResponse(
+        Meeting $meeting,
+        ConnectedAccount $account,
+        AttendeeResponseStatus $status,
+    ): void {
         $meeting->update(['response_status' => $status]);
 
         $self = $meeting->attendees()
@@ -43,17 +61,37 @@ final readonly class RespondToMeetingAction
 
         if ($self instanceof MeetingAttendee) {
             $self->update(['response_status' => $status]);
-        } else {
-            $meeting->attendees()->create([
-                'email_address' => strtolower($account->email_address),
-                'name' => $account->display_name,
-                'response_status' => $status,
-                'is_organizer' => $meeting->organizer_email !== null
-                    && strtolower($meeting->organizer_email) === strtolower($account->email_address),
-                'is_self' => true,
-            ]);
+
+            return;
         }
 
-        return $meeting->refresh()->load(['attendees.contact', 'connectedAccount']);
+        $meeting->attendees()->create([
+            'email_address' => strtolower($account->email_address),
+            'name' => $account->display_name,
+            'response_status' => $status,
+            'is_organizer' => $meeting->organizer_email !== null
+                && strtolower($meeting->organizer_email) === strtolower($account->email_address),
+            'is_self' => true,
+        ]);
+    }
+
+    private function updateListedAttendeeResponse(
+        Meeting $meeting,
+        User $user,
+        AttendeeResponseStatus $status,
+    ): void {
+        $listedAttendeeEmail = $this->respondentResolver->listedAttendeeEmailForUser($user, $meeting);
+
+        if ($listedAttendeeEmail === null) {
+            return;
+        }
+
+        $attendee = $meeting->attendees()
+            ->whereRaw('lower(email_address) = ?', [$listedAttendeeEmail])
+            ->first();
+
+        if ($attendee instanceof MeetingAttendee) {
+            $attendee->update(['response_status' => $status]);
+        }
     }
 }

--- a/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use InvalidArgumentException;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+
+final readonly class RespondToMeetingAction
+{
+    public function __construct(
+        private CalendarServiceFactoryInterface $calendarFactory,
+    ) {}
+
+    public function execute(User $user, Meeting $meeting, AttendeeResponseStatus $status): Meeting
+    {
+        abort_unless($user->can('respond', $meeting), 403);
+
+        if ($status === AttendeeResponseStatus::NEEDS_ACTION) {
+            throw new InvalidArgumentException('Cannot reset an RSVP to needsAction.');
+        }
+
+        $account = $meeting->connectedAccount;
+        abort_unless($account instanceof ConnectedAccount, 403);
+
+        $this->calendarFactory
+            ->make($account)
+            ->respondToEvent($meeting->provider_event_id, $status);
+
+        $meeting->update(['response_status' => $status]);
+
+        $meeting->attendees()
+            ->where(function (Builder $query) use ($account): void {
+                $query->where('is_self', true)
+                    ->orWhere('email_address', strtolower($account->email_address));
+            })
+            ->update(['response_status' => $status]);
+
+        return $meeting->refresh()->load(['attendees', 'connectedAccount']);
+    }
+}

--- a/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/RespondToMeetingAction.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 
 final readonly class RespondToMeetingAction
@@ -22,9 +23,7 @@ final readonly class RespondToMeetingAction
     {
         abort_unless($user->can('respond', $meeting), 403);
 
-        if ($status === AttendeeResponseStatus::NEEDS_ACTION) {
-            throw new InvalidArgumentException('Cannot reset an RSVP to needsAction.');
-        }
+        throw_if($status === AttendeeResponseStatus::NEEDS_ACTION, InvalidArgumentException::class, 'Cannot reset an RSVP to needsAction.');
 
         $account = $meeting->connectedAccount;
         abort_unless($account instanceof ConnectedAccount, 403);
@@ -35,13 +34,26 @@ final readonly class RespondToMeetingAction
 
         $meeting->update(['response_status' => $status]);
 
-        $meeting->attendees()
+        $self = $meeting->attendees()
             ->where(function (Builder $query) use ($account): void {
                 $query->where('is_self', true)
                     ->orWhere('email_address', strtolower($account->email_address));
             })
-            ->update(['response_status' => $status]);
+            ->first();
 
-        return $meeting->refresh()->load(['attendees', 'connectedAccount']);
+        if ($self instanceof MeetingAttendee) {
+            $self->update(['response_status' => $status]);
+        } else {
+            $meeting->attendees()->create([
+                'email_address' => strtolower($account->email_address),
+                'name' => $account->display_name,
+                'response_status' => $status,
+                'is_organizer' => $meeting->organizer_email !== null
+                    && strtolower($meeting->organizer_email) === strtolower($account->email_address),
+                'is_self' => true,
+            ]);
+        }
+
+        return $meeting->refresh()->load(['attendees.contact', 'connectedAccount']);
     }
 }

--- a/packages/EmailIntegration/src/Actions/StartMailboxHistoryImportAction.php
+++ b/packages/EmailIntegration/src/Actions/StartMailboxHistoryImportAction.php
@@ -4,20 +4,38 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
+use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\RelinkMailboxHistoryJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 final readonly class StartMailboxHistoryImportAction
 {
     public function execute(ConnectedAccount $connectedAccount): void
     {
         dispatch(new RelinkMailboxHistoryJob($connectedAccount))->afterCommit();
-        dispatch(new InitialEmailSyncJob($connectedAccount))->afterCommit();
 
-        if ($connectedAccount->hasCalendar()) {
-            dispatch(new InitialCalendarSyncJob($connectedAccount))->afterCommit();
+        if ($connectedAccount->sync_cursor !== null) {
+            MailboxSyncTracker::markEmailStarted($connectedAccount);
+            dispatch(new IncrementalEmailSyncJob($connectedAccount))->afterCommit();
+        } else {
+            dispatch(new InitialEmailSyncJob($connectedAccount))->afterCommit();
         }
+
+        if (! $connectedAccount->hasCalendar()) {
+            return;
+        }
+
+        if ($connectedAccount->calendar_sync_cursor !== null) {
+            MailboxSyncTracker::markCalendarStarted($connectedAccount);
+            dispatch(new IncrementalCalendarSyncJob($connectedAccount, reconcileAfter: true))->afterCommit();
+
+            return;
+        }
+
+        dispatch(new InitialCalendarSyncJob($connectedAccount))->afterCommit();
     }
 }

--- a/packages/EmailIntegration/src/Actions/StopCalendarPushChannelAction.php
+++ b/packages/EmailIntegration/src/Actions/StopCalendarPushChannelAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Throwable;
+
+final readonly class StopCalendarPushChannelAction
+{
+    public function __construct(
+        private CalendarServiceFactoryInterface $calendarFactory,
+    ) {}
+
+    public function execute(ConnectedAccount $account): void
+    {
+        $channelId = $account->calendar_push_channel_id;
+
+        if ($channelId === null || $channelId === '') {
+            $this->clearPushFields($account);
+
+            return;
+        }
+
+        if ($account->hasCalendar() && $account->status === EmailAccountStatus::ACTIVE) {
+            try {
+                $this->calendarFactory->make($account)->stopPushChannel(
+                    $channelId,
+                    $account->calendar_push_resource_id,
+                );
+            } catch (Throwable) {
+                // Best-effort remote unsubscribe. Local state is cleared below.
+            }
+        }
+
+        $this->clearPushFields($account);
+    }
+
+    private function clearPushFields(ConnectedAccount $account): void
+    {
+        $account->update([
+            'calendar_push_channel_id' => null,
+            'calendar_push_resource_id' => null,
+            'calendar_push_verification_token' => null,
+            'calendar_push_expires_at' => null,
+        ]);
+    }
+}

--- a/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Actions;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Data\NormalizedMeetingPayload;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
@@ -20,7 +21,7 @@ final readonly class StoreMeetingAction
     public function execute(NormalizedMeetingPayload $payload, ConnectedAccount $account): ?Meeting
     {
         if ($this->shouldSkip($payload)) {
-            $this->softDeleteExisting($account, $payload->providerEventId);
+            $this->softDeleteCancelledMeetings($account, $payload);
 
             return null;
         }
@@ -136,12 +137,23 @@ final readonly class StoreMeetingAction
         return $payload->status === CalendarEventStatus::CANCELLED;
     }
 
-    private function softDeleteExisting(ConnectedAccount $account, string $providerEventId): void
+    private function softDeleteCancelledMeetings(ConnectedAccount $account, NormalizedMeetingPayload $payload): void
     {
         Meeting::query()
             ->where('connected_account_id', $account->getKey())
-            ->where('provider_event_id', $providerEventId)
+            ->where(function (Builder $query) use ($payload): void {
+                $query->where('provider_event_id', $payload->providerEventId);
+
+                if ($this->isSeriesMasterPayload($payload)) {
+                    $query->orWhere('provider_recurring_event_id', $payload->providerEventId);
+                }
+            })
             ->delete();
+    }
+
+    private function isSeriesMasterPayload(NormalizedMeetingPayload $payload): bool
+    {
+        return $payload->providerRecurringEventId === null || $payload->providerRecurringEventId === '';
     }
 
     private function bumpInitialCalendarImportProgress(ConnectedAccount $connectedAccount): void

--- a/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
@@ -6,6 +6,7 @@ namespace Relaticle\EmailIntegration\Actions;
 
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Data\NormalizedMeetingPayload;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
@@ -32,6 +33,8 @@ final readonly class StoreMeetingAction
                 ->where('provider_event_id', $payload->providerEventId)
                 ->first();
 
+            $responseStatus = $this->resolveSelfResponseStatus($payload, $account, $meeting);
+
             $attributes = [
                 'team_id' => $account->team_id,
                 'connected_account_id' => $account->getKey(),
@@ -48,7 +51,7 @@ final readonly class StoreMeetingAction
                 'organizer_name' => $payload->organizerName,
                 'status' => $payload->status,
                 'visibility' => $payload->visibility,
-                'response_status' => $payload->selfResponseStatus,
+                'response_status' => $responseStatus,
                 'html_link' => $payload->htmlLink,
                 'deleted_at' => null,
             ];
@@ -67,7 +70,9 @@ final readonly class StoreMeetingAction
                 $meeting->attendees()->create([
                     'email_address' => $attendee->emailAddress,
                     'name' => $attendee->name,
-                    'response_status' => $attendee->responseStatus,
+                    'response_status' => $attendee->isSelf
+                        ? ($attendee->responseStatus ?? $responseStatus)
+                        : $attendee->responseStatus,
                     'is_organizer' => $attendee->isOrganizer,
                     'is_self' => $attendee->isSelf,
                 ]);
@@ -98,6 +103,28 @@ final readonly class StoreMeetingAction
         }
 
         return $meeting;
+    }
+
+    private function resolveSelfResponseStatus(
+        NormalizedMeetingPayload $payload,
+        ConnectedAccount $account,
+        ?Meeting $meeting,
+    ): ?AttendeeResponseStatus {
+        if ($payload->selfResponseStatus instanceof AttendeeResponseStatus) {
+            return $payload->selfResponseStatus;
+        }
+
+        if ($meeting instanceof Meeting && $meeting->response_status instanceof AttendeeResponseStatus) {
+            return $meeting->response_status;
+        }
+
+        $organizerEmail = $payload->organizerEmail;
+
+        if ($organizerEmail !== null && strtolower($organizerEmail) === strtolower($account->email_address)) {
+            return AttendeeResponseStatus::ACCEPTED;
+        }
+
+        return null;
     }
 
     private function shouldSkip(NormalizedMeetingPayload $payload): bool

--- a/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
@@ -6,7 +6,6 @@ namespace Relaticle\EmailIntegration\Actions;
 
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Data\NormalizedMeetingPayload;
-use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
@@ -106,11 +105,8 @@ final readonly class StoreMeetingAction
         if ($payload->visibility->isPrivate()) {
             return true;
         }
-        if ($payload->status === CalendarEventStatus::CANCELLED) {
-            return true;
-        }
 
-        return $payload->selfResponseStatus === AttendeeResponseStatus::DECLINED;
+        return $payload->status === CalendarEventStatus::CANCELLED;
     }
 
     private function softDeleteExisting(ConnectedAccount $account, string $providerEventId): void

--- a/packages/EmailIntegration/src/Console/Commands/IncrementalEmailSyncCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/IncrementalEmailSyncCommand.php
@@ -10,6 +10,7 @@ use Illuminate\Console\Command;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 #[Description('Dispatch incremental mailbox sync jobs for active accounts.')]
 #[Signature('email:incremental-sync')]
@@ -21,6 +22,7 @@ final class IncrementalEmailSyncCommand extends Command
             ->where('status', EmailAccountStatus::ACTIVE)
             ->whereNotNull('sync_cursor')
             ->each(function (ConnectedAccount $account): void {
+                MailboxSyncTracker::markEmailStarted($account);
                 dispatch(new IncrementalEmailSyncJob($account));
             });
 

--- a/packages/EmailIntegration/src/Console/Commands/RenewCalendarPushChannelsCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/RenewCalendarPushChannelsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Jobs\EnsureCalendarPushChannelJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Support\CalendarPushWebhookUrl;
+
+#[Description('Renew calendar push notification channels before they expire.')]
+#[Signature('calendar:renew-push-channels')]
+final class RenewCalendarPushChannelsCommand extends Command
+{
+    public function handle(): int
+    {
+        if (! CalendarPushWebhookUrl::isPubliclyReachable()) {
+            return self::SUCCESS;
+        }
+
+        ConnectedAccount::query()
+            ->where('status', EmailAccountStatus::ACTIVE)
+            ->whereJsonContains('capabilities->calendar', true)
+            ->whereNotNull('calendar_sync_cursor')
+            ->where(function ($query): void {
+                $query
+                    ->whereNull('calendar_push_expires_at')
+                    ->orWhere('calendar_push_expires_at', '<=', now()->addDay());
+            })
+            ->each(function (ConnectedAccount $account): void {
+                dispatch(new EnsureCalendarPushChannelJob($account));
+            });
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/EmailIntegration/src/Console/Commands/RenewCalendarPushChannelsCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/RenewCalendarPushChannelsCommand.php
@@ -7,6 +7,7 @@ namespace Relaticle\EmailIntegration\Console\Commands;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\EnsureCalendarPushChannelJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -26,7 +27,7 @@ final class RenewCalendarPushChannelsCommand extends Command
             ->where('status', EmailAccountStatus::ACTIVE)
             ->whereJsonContains('capabilities->calendar', true)
             ->whereNotNull('calendar_sync_cursor')
-            ->where(function ($query): void {
+            ->where(function (Builder $query): void {
                 $query
                     ->whereNull('calendar_push_expires_at')
                     ->orWhere('calendar_push_expires_at', '<=', now()->addDay());

--- a/packages/EmailIntegration/src/Controllers/CalendarPushWebhookController.php
+++ b/packages/EmailIntegration/src/Controllers/CalendarPushWebhookController.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+final readonly class CalendarPushWebhookController
+{
+    public function __invoke(Request $request, string $provider): Response
+    {
+        if ($provider === EmailProvider::AZURE->value) {
+            return $this->handleMicrosoft($request);
+        }
+
+        if ($provider === EmailProvider::GMAIL->value) {
+            return $this->handleGoogle($request);
+        }
+
+        return response('', Response::HTTP_NOT_FOUND);
+    }
+
+    private function handleMicrosoft(Request $request): Response
+    {
+        $validationToken = $request->query('validationToken');
+
+        if (is_string($validationToken) && $validationToken !== '') {
+            return response($validationToken, Response::HTTP_OK)
+                ->header('Content-Type', 'text/plain');
+        }
+
+        $notifications = $request->input('value');
+
+        if (! is_array($notifications)) {
+            return response('', Response::HTTP_ACCEPTED);
+        }
+
+        foreach ($notifications as $notification) {
+            if (! is_array($notification)) {
+                continue;
+            }
+
+            $subscriptionId = $notification['subscriptionId'] ?? null;
+            $clientState = $notification['clientState'] ?? null;
+
+            if (! is_string($subscriptionId) || $subscriptionId === '') {
+                continue;
+            }
+
+            $account = ConnectedAccount::query()
+                ->where('provider', EmailProvider::AZURE)
+                ->where('calendar_push_channel_id', $subscriptionId)
+                ->where('status', EmailAccountStatus::ACTIVE)
+                ->first();
+
+            if (! $account instanceof ConnectedAccount) {
+                continue;
+            }
+
+            if (! $this->verificationTokenMatches($account, $clientState)) {
+                continue;
+            }
+
+            dispatch(new IncrementalCalendarSyncJob($account));
+        }
+
+        return response('', Response::HTTP_ACCEPTED);
+    }
+
+    private function handleGoogle(Request $request): Response
+    {
+        $channelId = $request->header('X-Goog-Channel-ID');
+        $resourceState = $request->header('X-Goog-Resource-State');
+        $token = $request->header('X-Goog-Channel-Token');
+
+        if (! is_string($channelId) || $channelId === '') {
+            return response('', Response::HTTP_BAD_REQUEST);
+        }
+
+        $account = ConnectedAccount::query()
+            ->where('provider', EmailProvider::GMAIL)
+            ->where('calendar_push_channel_id', $channelId)
+            ->where('status', EmailAccountStatus::ACTIVE)
+            ->first();
+
+        if (! $account instanceof ConnectedAccount) {
+            return response('', Response::HTTP_NOT_FOUND);
+        }
+
+        if (! $this->verificationTokenMatches($account, $token)) {
+            return response('', Response::HTTP_FORBIDDEN);
+        }
+
+        if ($resourceState === 'sync') {
+            return response('', Response::HTTP_OK);
+        }
+
+        if (in_array($resourceState, ['exists', 'not_exists'], true)) {
+            dispatch(new IncrementalCalendarSyncJob($account));
+        }
+
+        return response('', Response::HTTP_OK);
+    }
+
+    private function verificationTokenMatches(ConnectedAccount $account, mixed $token): bool
+    {
+        if (! is_string($token) || $token === '') {
+            return false;
+        }
+
+        return hash_equals((string) $account->calendar_push_verification_token, $token);
+    }
+}

--- a/packages/EmailIntegration/src/Data/CalendarPushChannelData.php
+++ b/packages/EmailIntegration/src/Data/CalendarPushChannelData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Data;
+
+use Illuminate\Support\Carbon;
+
+final readonly class CalendarPushChannelData
+{
+    public function __construct(
+        public string $channelId,
+        public ?string $resourceId,
+        public string $verificationToken,
+        public Carbon $expiresAt,
+    ) {}
+}

--- a/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
+++ b/packages/EmailIntegration/src/EmailIntegrationServiceProvider.php
@@ -21,6 +21,7 @@ use Relaticle\EmailIntegration\Console\Commands\BackfillEmailThreadsCommand;
 use Relaticle\EmailIntegration\Console\Commands\DispatchOutboxCommand;
 use Relaticle\EmailIntegration\Console\Commands\IncrementalCalendarSyncCommand;
 use Relaticle\EmailIntegration\Console\Commands\IncrementalEmailSyncCommand;
+use Relaticle\EmailIntegration\Console\Commands\RenewCalendarPushChannelsCommand;
 use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource\Pages\ManageEmailTemplates;
 use Relaticle\EmailIntegration\Livewire\AccessRequestsTable;
 use Relaticle\EmailIntegration\Livewire\DraftsTable;
@@ -116,6 +117,7 @@ final class EmailIntegrationServiceProvider extends ServiceProvider
                 DispatchOutboxCommand::class,
                 IncrementalCalendarSyncCommand::class,
                 IncrementalEmailSyncCommand::class,
+                RenewCalendarPushChannelsCommand::class,
             ]);
         }
     }

--- a/packages/EmailIntegration/src/Enums/AttendeeResponseStatus.php
+++ b/packages/EmailIntegration/src/Enums/AttendeeResponseStatus.php
@@ -20,7 +20,7 @@ enum AttendeeResponseStatus: string implements HasColor, HasLabel
             self::ACCEPTED => 'Accepted',
             self::DECLINED => 'Declined',
             self::TENTATIVE => 'Maybe',
-            self::NEEDS_ACTION => 'No Response',
+            self::NEEDS_ACTION => 'Pending',
         };
     }
 

--- a/packages/EmailIntegration/src/Exceptions/CalendarPushChannelFailed.php
+++ b/packages/EmailIntegration/src/Exceptions/CalendarPushChannelFailed.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Relaticle\EmailIntegration\Services\Exceptions;
+namespace Relaticle\EmailIntegration\Exceptions;
 
 use RuntimeException;
 use Throwable;

--- a/packages/EmailIntegration/src/Exceptions/CalendarSyncTokenExpired.php
+++ b/packages/EmailIntegration/src/Exceptions/CalendarSyncTokenExpired.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Relaticle\EmailIntegration\Services\Exceptions;
+namespace Relaticle\EmailIntegration\Exceptions;
 
 use RuntimeException;
 

--- a/packages/EmailIntegration/src/Exceptions/MailHistoryExpired.php
+++ b/packages/EmailIntegration/src/Exceptions/MailHistoryExpired.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Relaticle\EmailIntegration\Services\Exceptions;
+namespace Relaticle\EmailIntegration\Exceptions;
 
 use RuntimeException;
 

--- a/packages/EmailIntegration/src/Exceptions/MeetingResponseFailed.php
+++ b/packages/EmailIntegration/src/Exceptions/MeetingResponseFailed.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Relaticle\EmailIntegration\Services\Exceptions;
+namespace Relaticle\EmailIntegration\Exceptions;
 
 use RuntimeException;
 use Throwable;

--- a/packages/EmailIntegration/src/Exceptions/ReconcileCalendarMeetingsFailed.php
+++ b/packages/EmailIntegration/src/Exceptions/ReconcileCalendarMeetingsFailed.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Relaticle\EmailIntegration\Services\Exceptions;
+namespace Relaticle\EmailIntegration\Exceptions;
 
 use RuntimeException;
 use Throwable;

--- a/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Actions;
+
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Notifications\Notification;
+use Filament\Support\Enums\IconPosition;
+use Filament\Support\Enums\Size;
+use Filament\Support\Icons\Heroicon;
+use Relaticle\EmailIntegration\Actions\RespondToMeetingAction;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
+
+final class MeetingRsvpActions
+{
+    /**
+     * @return array<int, Action>
+     */
+    public static function make(): array
+    {
+        return [
+            self::respondAction(
+                name: 'acceptMeeting',
+                status: AttendeeResponseStatus::ACCEPTED,
+                icon: Heroicon::Check,
+                color: 'success',
+            ),
+            self::respondAction(
+                name: 'maybeMeeting',
+                status: AttendeeResponseStatus::TENTATIVE,
+                icon: Heroicon::QuestionMarkCircle,
+                color: 'warning',
+            ),
+            self::respondAction(
+                name: 'declineMeeting',
+                status: AttendeeResponseStatus::DECLINED,
+                icon: Heroicon::XMark,
+                color: 'danger',
+                confirm: true,
+            ),
+        ];
+    }
+
+    public static function group(): ActionGroup
+    {
+        return ActionGroup::make(self::make())
+            ->label(fn (?Meeting $record): string => self::groupLabel($record))
+            ->icon(Heroicon::OutlinedChevronDown)
+            ->iconPosition(IconPosition::After)
+            ->color(fn (?Meeting $record): string => self::currentStatus($record)->getColor())
+            ->button()
+            ->outlined()
+            ->size(Size::ExtraSmall)
+            ->dropdownPlacement('bottom-end');
+    }
+
+    private static function groupLabel(?Meeting $record): string
+    {
+        $status = self::currentStatus($record);
+
+        if ($status === AttendeeResponseStatus::NEEDS_ACTION) {
+            return __('filament/resources/meeting.actions.rsvp.label');
+        }
+
+        return $status->getLabel();
+    }
+
+    private static function currentStatus(?Meeting $record): AttendeeResponseStatus
+    {
+        if (! $record instanceof Meeting) {
+            return AttendeeResponseStatus::NEEDS_ACTION;
+        }
+
+        return $record->response_status ?? AttendeeResponseStatus::NEEDS_ACTION;
+    }
+
+    private static function respondAction(
+        string $name,
+        AttendeeResponseStatus $status,
+        Heroicon $icon,
+        string $color,
+        bool $confirm = false,
+    ): Action {
+        $action = Action::make($name)
+            ->label(__('filament/resources/meeting.actions.rsvp.'.$status->value.'.label'))
+            ->icon($icon)
+            ->color($color)
+            ->authorize('respond')
+            ->disabled(fn (Meeting $record): bool => $record->response_status === $status)
+            ->action(function (Meeting $record) use ($status): void {
+                $user = auth()->user();
+                abort_unless($user instanceof User, 403);
+
+                try {
+                    resolve(RespondToMeetingAction::class)->execute($user, $record, $status);
+                } catch (MeetingResponseFailed $e) {
+                    report($e);
+
+                    Notification::make()
+                        ->danger()
+                        ->title(__('filament/resources/meeting.notifications.rsvp.failed.title'))
+                        ->body(__('filament/resources/meeting.notifications.rsvp.failed.body'))
+                        ->send();
+
+                    return;
+                }
+
+                Notification::make()
+                    ->success()
+                    ->title(__('filament/resources/meeting.notifications.rsvp.'.$status->value.'.title'))
+                    ->send();
+            });
+
+        if ($confirm) {
+            $action
+                ->requiresConfirmation()
+                ->modalHeading(__('filament/resources/meeting.actions.rsvp.declined.heading'))
+                ->modalDescription(__('filament/resources/meeting.actions.rsvp.declined.description'));
+        }
+
+        return $action;
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
@@ -15,6 +15,7 @@ use Relaticle\EmailIntegration\Actions\RespondToMeetingAction;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
+use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 final class MeetingRsvpActions
 {
@@ -61,19 +62,19 @@ final class MeetingRsvpActions
 
     private static function groupLabel(?Meeting $record): string
     {
-        $status = self::currentStatus($record);
-
-        if ($status === AttendeeResponseStatus::NEEDS_ACTION) {
-            return __('filament/resources/meeting.actions.rsvp.label');
-        }
-
-        return $status->getLabel();
+        return self::currentStatus($record)->getLabel();
     }
 
     private static function currentStatus(?Meeting $record): AttendeeResponseStatus
     {
         if (! $record instanceof Meeting) {
             return AttendeeResponseStatus::NEEDS_ACTION;
+        }
+
+        $user = auth()->user();
+
+        if ($user instanceof User) {
+            return resolve(MeetingRespondentResolver::class)->viewerResponseStatus($user, $record);
         }
 
         return $record->response_status ?? AttendeeResponseStatus::NEEDS_ACTION;
@@ -91,7 +92,7 @@ final class MeetingRsvpActions
             ->icon($icon)
             ->color($color)
             ->authorize('respond')
-            ->disabled(fn (Meeting $record): bool => $record->response_status === $status)
+            ->disabled(fn (Meeting $record): bool => self::currentStatus($record) === $status)
             ->action(function (Meeting $record) use ($status): void {
                 $user = auth()->user();
                 abort_unless($user instanceof User, 403);

--- a/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
@@ -13,8 +13,8 @@ use Filament\Support\Enums\Size;
 use Filament\Support\Icons\Heroicon;
 use Relaticle\EmailIntegration\Actions\RespondToMeetingAction;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Models\Meeting;
-use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 final class MeetingRsvpActions

--- a/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MeetingRsvpActions.php
@@ -100,12 +100,14 @@ final class MeetingRsvpActions
                 try {
                     resolve(RespondToMeetingAction::class)->execute($user, $record, $status);
                 } catch (MeetingResponseFailed $e) {
-                    report($e);
+                    report_unless($e->missingMailboxCopy, $e);
+
+                    $notificationKey = $e->missingMailboxCopy ? 'not_synced' : 'failed';
 
                     Notification::make()
                         ->danger()
-                        ->title(__('filament/resources/meeting.notifications.rsvp.failed.title'))
-                        ->body(__('filament/resources/meeting.notifications.rsvp.failed.body'))
+                        ->title(__('filament/resources/meeting.notifications.rsvp.'.$notificationKey.'.title'))
+                        ->body(__('filament/resources/meeting.notifications.rsvp.'.$notificationKey.'.body'))
                         ->send();
 
                     return;

--- a/packages/EmailIntegration/src/Filament/Concerns/HasConnectedAccountActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasConnectedAccountActions.php
@@ -19,9 +19,11 @@ use Illuminate\Support\HtmlString;
 use Relaticle\EmailIntegration\Actions\DisconnectConnectedAccountAction;
 use Relaticle\EmailIntegration\Actions\SetDefaultConnectedAccountAction;
 use Relaticle\EmailIntegration\Actions\StartMailboxHistoryImportAction;
+use Relaticle\EmailIntegration\Actions\StopCalendarPushChannelAction;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountSettingsPage;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 use function Filament\Support\generate_icon_html;
 
@@ -130,6 +132,7 @@ trait HasConnectedAccountActions
                 $account = $this->findOwnedAccountOrFail($arguments);
 
                 if ($account->hasCalendar()) {
+                    resolve(StopCalendarPushChannelAction::class)->execute($account);
                     $account->disableCalendar();
                     $this->afterAccountChanged();
 
@@ -152,7 +155,8 @@ trait HasConnectedAccountActions
             ->action(function (array $arguments): void {
                 $account = $this->findOwnedAccountOrFail($arguments);
 
-                dispatch(new IncrementalCalendarSyncJob($account));
+                MailboxSyncTracker::markCalendarStarted($account);
+                dispatch(new IncrementalCalendarSyncJob($account, reconcileAfter: true));
 
                 Notification::make()
                     ->success()

--- a/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingAttendeeEntry.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingAttendeeEntry.php
@@ -32,7 +32,7 @@ final class MeetingAttendeeEntry extends Entry
         }
 
         $name = $record->name ?: $record->email_address;
-        $contact = $record->getRelationValue('contact');
+        $contact = $record->relationLoaded('contact') ? $record->getRelation('contact') : null;
 
         return [
             'name' => $name,

--- a/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Filament\Infolists\Components\Entry;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 final class MeetingHeaderEntry extends Entry
 {
@@ -31,12 +32,15 @@ final class MeetingHeaderEntry extends Entry
         }
 
         $user = auth()->user();
+        $responseStatus = $user instanceof User
+            ? resolve(MeetingRespondentResolver::class)->viewerResponseStatus($user, $record)
+            : ($record->response_status ?? AttendeeResponseStatus::NEEDS_ACTION);
 
         return [
             'title' => $record->title,
             'month' => strtoupper($record->starts_at->format('M')),
             'day' => $record->starts_at->format('j'),
-            'response_status' => $record->response_status,
+            'response_status' => $responseStatus,
             'can_respond' => $user instanceof User && $user->can('respond', $record),
         ];
     }

--- a/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Infolists\Entries;
 
+use App\Models\User;
 use Filament\Infolists\Components\Entry;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\Meeting;
@@ -13,7 +14,7 @@ final class MeetingHeaderEntry extends Entry
     protected string $view = 'email-integration::filament.infolists.meeting-header';
 
     /**
-     * @return array{title: string, month: string, day: string, response_status: AttendeeResponseStatus|null}
+     * @return array{title: string, month: string, day: string, response_status: AttendeeResponseStatus|null, can_respond: bool}
      */
     public function getState(): array
     {
@@ -25,14 +26,18 @@ final class MeetingHeaderEntry extends Entry
                 'month' => '',
                 'day' => '',
                 'response_status' => null,
+                'can_respond' => false,
             ];
         }
+
+        $user = auth()->user();
 
         return [
             'title' => $record->title,
             'month' => strtoupper($record->starts_at->format('M')),
             'day' => $record->starts_at->format('j'),
             'response_status' => $record->response_status,
+            'can_respond' => $user instanceof User && $user->can('respond', $record),
         ];
     }
 }

--- a/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
@@ -13,6 +13,7 @@ use Filament\Forms\Components\Select;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Flex;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
@@ -21,6 +22,7 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
 use Relaticle\EmailIntegration\Actions\LinkMeetingToRecordAction;
+use Relaticle\EmailIntegration\Filament\Actions\MeetingRsvpActions;
 use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingAttendeeEntry;
 use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingHeaderEntry;
 use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingLinkedRecordsEntry;
@@ -36,6 +38,7 @@ final class MeetingDetailInfolist
             ->schema(fn (Schema $schema): Schema => self::configure($schema))
             ->registerModalActions([
                 self::linkRecordsAction('linkRecordsEmpty'),
+                ...MeetingRsvpActions::make(),
             ]);
     }
 
@@ -45,11 +48,22 @@ final class MeetingDetailInfolist
             $record = $schema->getRecord();
 
             if ($record instanceof Meeting) {
-                $record->loadMissing(['attendees.contact', 'people', 'companies', 'opportunities']);
+                $record->loadMissing(['attendees.contact', 'people', 'companies', 'opportunities', 'connectedAccount']);
+            }
+
+            $rsvpGroup = MeetingRsvpActions::group();
+
+            if ($record instanceof Meeting) {
+                $rsvpGroup->record($record);
             }
 
             return [
-                MeetingHeaderEntry::make('header')->hiddenLabel(),
+                Flex::make([
+                    MeetingHeaderEntry::make('header')
+                        ->hiddenLabel()
+                        ->grow(),
+                    $rsvpGroup,
+                ])->verticallyAlignCenter(),
                 TextEntry::make('time_row')
                     ->hiddenLabel()
                     ->icon(Heroicon::OutlinedClock)

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -112,7 +112,7 @@ final class EmailAccountsPage extends Page
     public function isImportingAnyAccount(): bool
     {
         return $this->connectedAccounts->contains(
-            fn (ConnectedAccount $account): bool => $account->isImportingHistory(),
+            fn (ConnectedAccount $account): bool => $account->showsSyncProgress(),
         );
     }
 

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -49,7 +49,7 @@ abstract class BaseMeetingsRelationManager extends RelationManager
                     $query->whereRaw('0 = 1');
                 }
 
-                return $query->with(['team', 'attendees', 'connectedAccount']);
+                return $query->with(['team', 'attendees.contact', 'connectedAccount']);
             })
             ->columns([
                 TextColumn::make('title')

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -49,7 +49,7 @@ abstract class BaseMeetingsRelationManager extends RelationManager
                     $query->whereRaw('0 = 1');
                 }
 
-                return $query->with('team');
+                return $query->with(['team', 'attendees', 'connectedAccount']);
             })
             ->columns([
                 TextColumn::make('title')

--- a/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
@@ -139,7 +139,7 @@ final class MeetingResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         $query = parent::getEloquentQuery()
-            ->with(['connectedAccount', 'team', 'attendees']);
+            ->with(['connectedAccount', 'team', 'attendees.contact']);
 
         $user = auth()->user();
 

--- a/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
+++ b/packages/EmailIntegration/src/Filament/Resources/MeetingResource.php
@@ -139,7 +139,7 @@ final class MeetingResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         $query = parent::getEloquentQuery()
-            ->with(['connectedAccount', 'team']);
+            ->with(['connectedAccount', 'team', 'attendees']);
 
         $user = auth()->user();
 

--- a/packages/EmailIntegration/src/Jobs/EnsureCalendarPushChannelJob.php
+++ b/packages/EmailIntegration/src/Jobs/EnsureCalendarPushChannelJob.php
@@ -14,12 +14,13 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Data\CalendarPushChannelData;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Exceptions\CalendarPushChannelFailed;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\CalendarPushChannelFailed;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
 use Relaticle\EmailIntegration\Support\CalendarPushWebhookUrl;
 use Throwable;
@@ -137,7 +138,7 @@ final class EnsureCalendarPushChannelJob implements ShouldBeUnique, ShouldQueue
 
         $channel = $service->ensurePushChannel($webhookUrl, $verificationToken);
 
-        if ($channel === null) {
+        if (! $channel instanceof CalendarPushChannelData) {
             throw CalendarPushChannelFailed::unableToCreate();
         }
 

--- a/packages/EmailIntegration/src/Jobs/EnsureCalendarPushChannelJob.php
+++ b/packages/EmailIntegration/src/Jobs/EnsureCalendarPushChannelJob.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Exceptions\CalendarPushChannelFailed;
+use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
+use Relaticle\EmailIntegration\Support\CalendarPushWebhookUrl;
+use Throwable;
+
+#[DeleteWhenMissingModels]
+final class EnsureCalendarPushChannelJob implements ShouldBeUnique, ShouldQueue
+{
+    use DetectsAuthErrors, Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    /** @var array<int, int> */
+    public array $backoff = [60, 300, 900];
+
+    public function __construct(
+        public readonly ConnectedAccount $connectedAccount,
+    ) {
+        $this->onQueue('emails-sync');
+    }
+
+    public function handle(CalendarServiceFactoryInterface $calendarFactory): void
+    {
+        $account = $this->connectedAccount->fresh();
+
+        if (! $account instanceof ConnectedAccount) {
+            return;
+        }
+
+        if (! $this->shouldEnsurePushChannel($account)) {
+            return;
+        }
+
+        if ($this->renewMicrosoftSubscriptionIfNeeded($account)) {
+            return;
+        }
+
+        $this->replacePushChannel($account, $calendarFactory);
+    }
+
+    public function uniqueId(): string
+    {
+        return 'ensure-calendar-push-'.$this->connectedAccount->getKey();
+    }
+
+    private function shouldEnsurePushChannel(ConnectedAccount $account): bool
+    {
+        if (! CalendarPushWebhookUrl::isPubliclyReachable()) {
+            return false;
+        }
+
+        if (! $account->hasCalendar()
+            || $account->status !== EmailAccountStatus::ACTIVE
+            || $account->calendar_sync_cursor === null) {
+            return false;
+        }
+
+        if ($account->calendar_push_expires_at !== null
+            && $account->calendar_push_expires_at->isAfter(now()->addDay())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function renewMicrosoftSubscriptionIfNeeded(ConnectedAccount $account): bool
+    {
+        if ($account->provider !== EmailProvider::AZURE) {
+            return false;
+        }
+
+        $subscriptionId = $account->calendar_push_channel_id;
+
+        if ($subscriptionId === null || $subscriptionId === '') {
+            return false;
+        }
+
+        $expiresAt = now()->addDays(2);
+
+        try {
+            $response = resolve(MicrosoftGraphClientFactory::class)
+                ->make($account)
+                ->patch('/subscriptions/'.rawurlencode($subscriptionId), [
+                    'expirationDateTime' => $expiresAt->utc()->format('Y-m-d\TH:i:s\Z'),
+                ])
+                ->throw()
+                ->json();
+        } catch (Throwable $exception) {
+            if ($exception instanceof RequestException && $exception->response->status() === 404) {
+                return false;
+            }
+
+            throw CalendarPushChannelFailed::fromProvider($exception);
+        }
+
+        $expiration = $response['expirationDateTime'] ?? null;
+
+        $account->update([
+            'calendar_push_expires_at' => is_string($expiration) && $expiration !== ''
+                ? Date::parse($expiration)
+                : $expiresAt,
+        ]);
+
+        return true;
+    }
+
+    private function replacePushChannel(
+        ConnectedAccount $account,
+        CalendarServiceFactoryInterface $calendarFactory,
+    ): void {
+        $service = $calendarFactory->make($account);
+        $verificationToken = Str::random(40);
+        $webhookUrl = CalendarPushWebhookUrl::forProvider($account->provider->value);
+        $oldChannelId = $account->calendar_push_channel_id;
+        $oldResourceId = $account->calendar_push_resource_id;
+
+        $channel = $service->ensurePushChannel($webhookUrl, $verificationToken);
+
+        if ($channel === null) {
+            throw CalendarPushChannelFailed::unableToCreate();
+        }
+
+        $account->update([
+            'calendar_push_channel_id' => $channel->channelId,
+            'calendar_push_resource_id' => $channel->resourceId,
+            'calendar_push_verification_token' => $channel->verificationToken,
+            'calendar_push_expires_at' => $channel->expiresAt,
+        ]);
+
+        if ($oldChannelId !== null && $oldChannelId !== $channel->channelId) {
+            $service->stopPushChannel($oldChannelId, $oldResourceId);
+        }
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $account = $this->connectedAccount->fresh();
+
+        if (! $account instanceof ConnectedAccount) {
+            return;
+        }
+
+        $account->update([
+            'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : $account->status,
+            'last_error' => 'Calendar push notifications could not be renewed: '.$exception->getMessage(),
+        ]);
+    }
+}

--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -16,11 +16,11 @@ use Illuminate\Support\Facades\Bus;
 use Relaticle\EmailIntegration\Actions\ReconcileCalendarMeetingsAction;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Exceptions\ReconcileCalendarMeetingsFailed;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
-use Relaticle\EmailIntegration\Services\Exceptions\ReconcileCalendarMeetingsFailed;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Throwable;
 

--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -100,7 +100,7 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
                 }
 
                 if ($batch->failedJobs > 0) {
-                    self::recordBatchFailure($account, $nextSyncToken, $batch->failedJobs);
+                    self::recordBatchFailure($account, $batch->failedJobs);
 
                     return;
                 }
@@ -140,22 +140,13 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         dispatch(new EnsureCalendarPushChannelJob($account));
     }
 
-    private static function recordBatchFailure(
-        ConnectedAccount $account,
-        ?string $nextSyncToken,
-        int $failedJobs,
-    ): void {
-        $update = [
+    private static function recordBatchFailure(ConnectedAccount $account, int $failedJobs): void
+    {
+        $account->update([
             'last_calendar_synced_at' => now(),
             'status' => EmailAccountStatus::ERROR,
             'last_error' => "{$failedJobs} calendar event(s) could not be stored during sync.",
-        ];
-
-        if ($nextSyncToken !== null) {
-            $update['calendar_sync_cursor'] = $nextSyncToken;
-        }
-
-        $account->update($update);
+        ]);
 
         MailboxSyncTracker::markCalendarFinished($account);
     }

--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Jobs;
 
+use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -12,12 +13,15 @@ use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
+use Relaticle\EmailIntegration\Actions\ReconcileCalendarMeetingsAction;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Services\Exceptions\ReconcileCalendarMeetingsFailed;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Throwable;
 
 #[DeleteWhenMissingModels]
@@ -32,6 +36,7 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
+        public readonly bool $reconcileAfter = false,
     ) {
         $this->onQueue('emails-sync');
     }
@@ -50,11 +55,14 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
+        MailboxSyncTracker::markCalendarStarted($account);
+
         $service = $serviceFactory->make($account);
 
         try {
             $result = $service->fetchDelta($account->calendar_sync_cursor);
         } catch (CalendarSyncTokenExpired) {
+            MailboxSyncTracker::markCalendarFinished($account);
             $account->update(['calendar_sync_cursor' => null]);
             dispatch(new InitialCalendarSyncJob($account));
 
@@ -66,13 +74,14 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         // it is never retried. So advance the cursor only once the batch has fully stored.
         // With no events the delta is a read-only window, so advance inline.
         if ($result->events === []) {
-            self::advanceCursor($account, $result->nextSyncToken);
+            self::finish($account, $result->nextSyncToken, $this->reconcileAfter);
 
             return;
         }
 
         $accountId = (string) $account->getKey();
         $nextSyncToken = $result->nextSyncToken;
+        $reconcileAfter = $this->reconcileAfter;
 
         $jobs = array_map(
             fn (CalendarEventData $event): StoreMeetingJob => new StoreMeetingJob($account, $event),
@@ -83,19 +92,25 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             ->name("Incremental calendar sync: {$account->email_address}")
             ->onQueue('emails-sync')
             ->allowFailures()
-            ->then(static function () use ($accountId, $nextSyncToken): void {
+            ->finally(static function (Batch $batch) use ($accountId, $nextSyncToken, $reconcileAfter): void {
                 $account = ConnectedAccount::query()->whereKey($accountId)->first();
 
                 if (! $account instanceof ConnectedAccount) {
                     return;
                 }
 
-                self::advanceCursor($account, $nextSyncToken);
+                if ($batch->failedJobs > 0) {
+                    self::recordBatchFailure($account, $nextSyncToken, $batch->failedJobs);
+
+                    return;
+                }
+
+                self::finish($account, $nextSyncToken, $reconcileAfter);
             })
             ->dispatch();
     }
 
-    private static function advanceCursor(ConnectedAccount $account, ?string $nextSyncToken): void
+    private static function finish(ConnectedAccount $account, ?string $nextSyncToken, bool $reconcileAfter): void
     {
         $update = [
             'last_calendar_synced_at' => now(),
@@ -103,16 +118,52 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             'last_error' => null,
         ];
 
-        // Never overwrite a good cursor with null (see InitialCalendarSyncJob).
         if ($nextSyncToken !== null) {
             $update['calendar_sync_cursor'] = $nextSyncToken;
         }
 
         $account->update($update);
+
+        if ($reconcileAfter) {
+            try {
+                resolve(ReconcileCalendarMeetingsAction::class)->execute($account);
+            } catch (ReconcileCalendarMeetingsFailed $exception) {
+                $account->update([
+                    'status' => EmailAccountStatus::ERROR,
+                    'last_error' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        MailboxSyncTracker::markCalendarFinished($account);
+
+        dispatch(new EnsureCalendarPushChannelJob($account));
+    }
+
+    private static function recordBatchFailure(
+        ConnectedAccount $account,
+        ?string $nextSyncToken,
+        int $failedJobs,
+    ): void {
+        $update = [
+            'last_calendar_synced_at' => now(),
+            'status' => EmailAccountStatus::ERROR,
+            'last_error' => "{$failedJobs} calendar event(s) could not be stored during sync.",
+        ];
+
+        if ($nextSyncToken !== null) {
+            $update['calendar_sync_cursor'] = $nextSyncToken;
+        }
+
+        $account->update($update);
+
+        MailboxSyncTracker::markCalendarFinished($account);
     }
 
     public function failed(Throwable $exception): void
     {
+        MailboxSyncTracker::markCalendarFinished($this->connectedAccount);
+
         $this->connectedAccount->update([
             'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
             'last_error' => $exception->getMessage(),

--- a/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Jobs;
 
+use Illuminate\Bus\Batch;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -19,6 +20,7 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailRead;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Throwable;
 
 #[DeleteWhenMissingModels]
@@ -45,11 +47,14 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
+        MailboxSyncTracker::markEmailStarted($account);
+
         $service = $mailFactory->make($account);
 
         try {
             $delta = $service->fetchDelta($account->sync_cursor);
         } catch (MailHistoryExpired) {
+            MailboxSyncTracker::markEmailFinished($account);
             $account->update(['sync_cursor' => null]);
             dispatch(new InitialEmailSyncJob($account));
 
@@ -123,18 +128,35 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
             ->name("Incremental sync: {$account->email_address}")
             ->onQueue('emails-sync')
             ->allowFailures()
-            ->then(static function () use ($accountId, $newCursor): void {
+            ->finally(static function (Batch $batch) use ($accountId, $newCursor): void {
                 $account = ConnectedAccount::query()->whereKey($accountId)->first();
-                $account?->update([
+
+                if (! $account instanceof ConnectedAccount) {
+                    return;
+                }
+
+                if ($batch->failedJobs > 0) {
+                    $account->update([
+                        'sync_cursor' => $newCursor,
+                        'last_synced_at' => now(),
+                        'status' => EmailAccountStatus::ERROR,
+                        'last_error' => "{$batch->failedJobs} email(s) could not be stored during sync.",
+                    ]);
+
+                    MailboxSyncTracker::markEmailFinished($account);
+
+                    return;
+                }
+
+                $account->update([
                     'sync_cursor' => $newCursor,
                     'last_synced_at' => now(),
                     'status' => EmailAccountStatus::ACTIVE,
                     'last_error' => null,
                 ]);
+
+                MailboxSyncTracker::markEmailFinished($account);
             })
-            // ponytail: a single failed StoreEmailJob in the batch holds back the cursor
-            // for the WHOLE batch, so its already-stored siblings get re-fetched (deduped,
-            // cheap) next sync. Per-message cursors would avoid that re-fetch; not worth it.
             ->dispatch();
     }
 
@@ -146,10 +168,14 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
             'status' => EmailAccountStatus::ACTIVE,
             'last_error' => null,
         ]);
+
+        MailboxSyncTracker::markEmailFinished($account);
     }
 
     public function failed(Throwable $exception): void
     {
+        MailboxSyncTracker::markEmailFinished($this->connectedAccount);
+
         $this->connectedAccount->update([
             'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
             'last_error' => $exception->getMessage(),

--- a/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
@@ -14,12 +14,12 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailRead;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Throwable;
 

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -16,6 +16,7 @@ use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Throwable;
 
 #[DeleteWhenMissingModels]
@@ -40,7 +41,13 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         $account = $this->connectedAccount;
 
         if (! $account->hasCalendar() || $account->status !== EmailAccountStatus::ACTIVE) {
+            MailboxSyncTracker::markCalendarFinished($account);
+
             return;
+        }
+
+        if ($account->calendar_sync_cursor === null) {
+            MailboxSyncTracker::markCalendarStarted($account);
         }
 
         $service = $serviceFactory->make($account);
@@ -69,6 +76,8 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
     public function failed(Throwable $exception): void
     {
+        MailboxSyncTracker::markCalendarFinished($this->connectedAccount);
+
         $this->connectedAccount->update([
             'status' => $this->isAuthError($exception) ? EmailAccountStatus::REAUTH_REQUIRED : EmailAccountStatus::ERROR,
             'last_error' => $exception->getMessage(),
@@ -108,5 +117,9 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         }
 
         $account->update($update);
+
+        MailboxSyncTracker::markCalendarFinished($account);
+
+        dispatch(new EnsureCalendarPushChannelJob($account));
     }
 }

--- a/packages/EmailIntegration/src/Jobs/InitialSyncPageStoreBatch.php
+++ b/packages/EmailIntegration/src/Jobs/InitialSyncPageStoreBatch.php
@@ -14,6 +14,7 @@ use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 final class InitialSyncPageStoreBatch
 {
@@ -82,7 +83,7 @@ final class InitialSyncPageStoreBatch
                         return;
                     }
 
-                    self::markImportStoreFailed($account, count($missingIds), 'message(s)');
+                    self::markImportStoreFailed($account, count($missingIds), 'message(s)', 'email');
 
                     return;
                 }
@@ -146,7 +147,7 @@ final class InitialSyncPageStoreBatch
                         return;
                     }
 
-                    self::markImportStoreFailed($account, count($missingEvents), 'event(s)');
+                    self::markImportStoreFailed($account, count($missingEvents), 'event(s)', 'calendar');
 
                     return;
                 }
@@ -207,12 +208,24 @@ final class InitialSyncPageStoreBatch
         return max(1, Config::integer('email-integration.sync.initial_store_attempts', 3));
     }
 
-    private static function markImportStoreFailed(ConnectedAccount $account, int $missingCount, string $resourceLabel): void
-    {
+    private static function markImportStoreFailed(
+        ConnectedAccount $account,
+        int $missingCount,
+        string $resourceLabel,
+        string $syncKind,
+    ): void {
         $account->update([
             'status' => EmailAccountStatus::ERROR,
             'last_error' => "Initial import paused: {$missingCount} {$resourceLabel} could not be stored after "
                 .self::maxStoreAttempts().' attempts.',
         ]);
+
+        if ($syncKind === 'calendar') {
+            MailboxSyncTracker::markCalendarFinished($account);
+        }
+
+        if ($syncKind === 'email') {
+            MailboxSyncTracker::markEmailFinished($account);
+        }
     }
 }

--- a/packages/EmailIntegration/src/Livewire/MailboxImportStatus.php
+++ b/packages/EmailIntegration/src/Livewire/MailboxImportStatus.php
@@ -39,7 +39,7 @@ final class MailboxImportStatus extends Component
     {
         $this->ownedAccountsCache = null;
 
-        foreach ($this->importingOwnedAccounts() as $account) {
+        foreach ($this->syncingOwnedAccounts() as $account) {
             $id = (string) $account->getKey();
 
             if (! in_array($id, $this->seenImportingIds, true)) {
@@ -66,7 +66,7 @@ final class MailboxImportStatus extends Component
     }
 
     /**
-     * @return list<array{id: string, email: string, imported: int, meetingsImported: int, hasCalendar: bool, percent: int, importing: bool, settings_url: string}>
+     * @return list<array{id: string, email: string, imported: int, meetingsImported: int, hasCalendar: bool, percent: ?int, importing: bool, incrementalOnly: bool, incrementalLabel: ?string, settings_url: string}>
      */
     public function visibleMailboxes(): array
     {
@@ -83,9 +83,13 @@ final class MailboxImportStatus extends Component
                 continue;
             }
 
-            if (! $account->isImportingHistory() && ! in_array($id, $this->seenImportingIds, true)) {
+            if (! $account->showsSyncProgress() && ! in_array($id, $this->seenImportingIds, true)) {
                 continue;
             }
+
+            $incrementalOnly = $account->isIncrementalSyncing();
+            $percent = $incrementalOnly ? null : $account->initialSyncProgressPercent();
+            $incrementalLabel = $account->incrementalSyncStatusLabel();
 
             $rows[] = [
                 'id' => $id,
@@ -93,8 +97,10 @@ final class MailboxImportStatus extends Component
                 'imported' => $account->initial_sync_imported,
                 'meetingsImported' => $account->initial_calendar_sync_imported,
                 'hasCalendar' => $account->hasCalendar(),
-                'percent' => $account->initialSyncProgressPercent(),
-                'importing' => $account->isImportingHistory(),
+                'percent' => $percent,
+                'importing' => $account->showsSyncProgress(),
+                'incrementalOnly' => $incrementalOnly,
+                'incrementalLabel' => $incrementalLabel,
                 'settings_url' => EmailAccountSettingsPage::getUrl(['account' => $id]),
             ];
         }
@@ -116,10 +122,10 @@ final class MailboxImportStatus extends Component
     /**
      * @return Collection<int, ConnectedAccount>
      */
-    private function importingOwnedAccounts(): Collection
+    private function syncingOwnedAccounts(): Collection
     {
         return $this->ownedAccounts()
-            ->filter(fn (ConnectedAccount $account): bool => $account->isImportingHistory());
+            ->filter(fn (ConnectedAccount $account): bool => $account->showsSyncProgress());
     }
 
     /**

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Carbon;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 /**
  * @property string $id
@@ -46,6 +47,10 @@ use Relaticle\EmailIntegration\Enums\EmailProvider;
  * @property int $initial_calendar_sync_imported
  * @property string|null $calendar_sync_cursor
  * @property Carbon|null $last_calendar_synced_at
+ * @property string|null $calendar_push_channel_id
+ * @property string|null $calendar_push_resource_id
+ * @property string|null $calendar_push_verification_token
+ * @property Carbon|null $calendar_push_expires_at
  */
 final class ConnectedAccount extends Model
 {
@@ -78,6 +83,10 @@ final class ConnectedAccount extends Model
         'initial_calendar_sync_imported',
         'calendar_sync_cursor',
         'last_calendar_synced_at',
+        'calendar_push_channel_id',
+        'calendar_push_resource_id',
+        'calendar_push_verification_token',
+        'calendar_push_expires_at',
         'status',
         'last_error',
         'sync_inbox',
@@ -92,6 +101,7 @@ final class ConnectedAccount extends Model
         'token_expires_at' => 'datetime',
         'last_synced_at' => 'datetime',
         'last_calendar_synced_at' => 'datetime',
+        'calendar_push_expires_at' => 'datetime',
         'initial_sync_imported' => 'integer',
         'initial_sync_estimated' => 'integer',
         'initial_calendar_sync_imported' => 'integer',
@@ -101,6 +111,7 @@ final class ConnectedAccount extends Model
         'capabilities' => 'array',
         'access_token' => 'encrypted',
         'refresh_token' => 'encrypted',
+        'calendar_push_verification_token' => 'encrypted',
         'daily_send_limit' => 'integer',
         'hourly_send_limit' => 'integer',
     ];
@@ -286,6 +297,50 @@ final class ConnectedAccount extends Model
         }
 
         return $this->hasCalendar() && $this->calendar_sync_cursor === null;
+    }
+
+    public function isCalendarSyncing(): bool
+    {
+        return MailboxSyncTracker::isCalendarSyncing($this);
+    }
+
+    public function isEmailSyncing(): bool
+    {
+        return MailboxSyncTracker::isEmailSyncing($this);
+    }
+
+    public function showsSyncProgress(): bool
+    {
+        return $this->isImportingHistory() || $this->isCalendarSyncing() || $this->isEmailSyncing();
+    }
+
+    public function isIncrementalSyncing(): bool
+    {
+        return ! $this->isImportingHistory() && ($this->isCalendarSyncing() || $this->isEmailSyncing());
+    }
+
+    public function incrementalSyncStatusLabel(): ?string
+    {
+        if ($this->isImportingHistory()) {
+            return null;
+        }
+
+        $emailSyncing = $this->isEmailSyncing();
+        $calendarSyncing = $this->isCalendarSyncing();
+
+        if ($emailSyncing && $calendarSyncing) {
+            return __('filament/pages/email-accounts.importing_email_and_calendar');
+        }
+
+        if ($calendarSyncing) {
+            return __('filament/pages/email-accounts.importing_calendar');
+        }
+
+        if ($emailSyncing) {
+            return __('filament/pages/email-accounts.importing_email');
+        }
+
+        return null;
     }
 
     /**

--- a/packages/EmailIntegration/src/Models/Meeting.php
+++ b/packages/EmailIntegration/src/Models/Meeting.php
@@ -96,7 +96,7 @@ final class Meeting extends Model
     /** @return HasMany<MeetingAttendee, $this> */
     public function attendees(): HasMany
     {
-        return $this->hasMany(MeetingAttendee::class);
+        return $this->hasMany(MeetingAttendee::class)->with('contact');
     }
 
     /** @return MorphToMany<People, $this> */

--- a/packages/EmailIntegration/src/Models/Scopes/VisibleMeetingScope.php
+++ b/packages/EmailIntegration/src/Models/Scopes/VisibleMeetingScope.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
 use Relaticle\EmailIntegration\Enums\EmailVisibilityEnforcement;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 /**
  * Hides calendar events that workspace or mailbox visibility rules exclude.
@@ -33,10 +34,13 @@ final readonly class VisibleMeetingScope implements Scope
     {
         $viewerId = $this->viewer->getKey();
         $teamId = $this->viewer->current_team_id;
+        $identityEmails = $teamId !== null
+            ? resolve(MeetingRespondentResolver::class)->identityEmailsForUser($this->viewer, $teamId)
+            : [];
 
         $builder
             ->where('team_id', $teamId)
-            ->where(function (Builder $visibilityQuery) use ($viewerId, $teamId): void {
+            ->where(function (Builder $visibilityQuery) use ($viewerId, $teamId, $identityEmails): void {
                 $this->excludeMeetingsMatchingMailboxBlocklist($visibilityQuery);
                 $this->excludeMeetingsWithBlockedOrganizerMatchingMailboxBlocklist($visibilityQuery);
 
@@ -45,15 +49,26 @@ final readonly class VisibleMeetingScope implements Scope
                     $this->excludeMeetingsWithBlockedOrganizer($visibilityQuery, $teamId);
                 }
 
-                $visibilityQuery->where(function (Builder $ownerOrShared) use ($viewerId, $teamId): void {
+                $visibilityQuery->where(function (Builder $ownerOrShared) use ($viewerId, $teamId, $identityEmails): void {
                     $ownerOrShared
                         ->whereHas(
                             'connectedAccount',
                             fn (Builder $accountQuery): Builder => $accountQuery->where('user_id', $viewerId),
-                        )
-                        ->orWhere(function (Builder $teammateQuery) use ($teamId): void {
-                            $this->excludeTeammateHiddenMeetings($teammateQuery, $teamId);
-                        });
+                        );
+
+                    if ($identityEmails !== []) {
+                        $ownerOrShared->orWhereHas(
+                            'attendees',
+                            fn (Builder $attendeeQuery): Builder => $attendeeQuery->whereIn(
+                                DB::raw('lower(meeting_attendees.email_address)'),
+                                $identityEmails,
+                            ),
+                        );
+                    }
+
+                    $ownerOrShared->orWhere(function (Builder $teammateQuery) use ($teamId): void {
+                        $this->excludeTeammateHiddenMeetings($teammateQuery, $teamId);
+                    });
                 });
             });
     }

--- a/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services\Contracts;
 
+use Relaticle\EmailIntegration\Data\CalendarPushChannelData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
@@ -24,4 +25,13 @@ interface CalendarServiceInterface
      * @throws MeetingResponseFailed when the provider rejects the update
      */
     public function respondToEvent(string $eventId, AttendeeResponseStatus $status): void;
+
+    public function ensurePushChannel(string $webhookUrl, string $verificationToken): ?CalendarPushChannelData;
+
+    public function stopPushChannel(string $channelId, ?string $resourceId): void;
+
+    /**
+     * @return list<string>
+     */
+    public function listActiveProviderEventIds(): array;
 }

--- a/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
@@ -26,6 +26,11 @@ interface CalendarServiceInterface
      */
     public function respondToEvent(string $eventId, AttendeeResponseStatus $status): void;
 
+    /**
+     * This mailbox's provider event id for a shared iCalendar UID, if the event exists.
+     */
+    public function findEventIdByICalUid(string $iCalUid): ?string;
+
     public function ensurePushChannel(string $webhookUrl, string $verificationToken): ?CalendarPushChannelData;
 
     public function stopPushChannel(string $channelId, ?string $resourceId): void;

--- a/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
@@ -7,8 +7,8 @@ namespace Relaticle\EmailIntegration\Services\Contracts;
 use Relaticle\EmailIntegration\Data\CalendarPushChannelData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
-use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
-use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
+use Relaticle\EmailIntegration\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Exceptions\MeetingResponseFailed;
 
 interface CalendarServiceInterface
 {

--- a/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/CalendarServiceInterface.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Services\Contracts;
 
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 
 interface CalendarServiceInterface
 {
@@ -15,4 +17,11 @@ interface CalendarServiceInterface
      * @throws CalendarSyncTokenExpired when Google invalidates the syncToken (HTTP 410)
      */
     public function fetchDelta(string $syncToken): CalendarSyncResult;
+
+    /**
+     * Write the connected account's RSVP to the provider event.
+     *
+     * @throws MeetingResponseFailed when the provider rejects the update
+     */
+    public function respondToEvent(string $eventId, AttendeeResponseStatus $status): void;
 }

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -81,7 +81,7 @@ final class EmailVisibilityService
 
     public function isMeetingHiddenFromViewer(Meeting $meeting, User $viewer): bool
     {
-        $meeting->loadMissing(['attendees', 'connectedAccount']);
+        $meeting->loadMissing(['attendees.contact', 'connectedAccount']);
 
         $attendeeAddresses = $meeting->attendees
             ->pluck('email_address')
@@ -269,7 +269,7 @@ final class EmailVisibilityService
 
     public function meetingCountsTowardCommunicationIntelligence(Meeting $meeting): bool
     {
-        $meeting->loadMissing(['attendees', 'connectedAccount']);
+        $meeting->loadMissing(['attendees.contact', 'connectedAccount']);
 
         $addresses = $meeting->attendees
             ->pluck('email_address')

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -81,9 +81,9 @@ final class EmailVisibilityService
 
     public function isMeetingHiddenFromViewer(Meeting $meeting, User $viewer): bool
     {
-        $meeting->loadMissing(['attendees.contact', 'connectedAccount']);
+        $meeting->loadMissing(['connectedAccount']);
 
-        $attendeeAddresses = $meeting->attendees
+        $attendeeAddresses = $meeting->attendees()
             ->pluck('email_address')
             ->filter()
             ->values()
@@ -106,6 +106,10 @@ final class EmailVisibilityService
         }
 
         if ($isOwner) {
+            return false;
+        }
+
+        if (resolve(MeetingRespondentResolver::class)->userIdentityIsListedAttendee($viewer, $meeting)) {
             return false;
         }
 

--- a/packages/EmailIntegration/src/Services/Exceptions/CalendarPushChannelFailed.php
+++ b/packages/EmailIntegration/src/Services/Exceptions/CalendarPushChannelFailed.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class CalendarPushChannelFailed extends RuntimeException
+{
+    public static function fromProvider(Throwable $previous): self
+    {
+        return new self('Failed to renew the calendar push channel.', 0, $previous);
+    }
+
+    public static function unableToCreate(): self
+    {
+        return new self('Failed to create the calendar push channel.');
+    }
+}

--- a/packages/EmailIntegration/src/Services/Exceptions/MeetingResponseFailed.php
+++ b/packages/EmailIntegration/src/Services/Exceptions/MeetingResponseFailed.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class MeetingResponseFailed extends RuntimeException
+{
+    public static function fromProvider(Throwable $previous): self
+    {
+        return new self('The calendar provider rejected the RSVP update.', previous: $previous);
+    }
+}

--- a/packages/EmailIntegration/src/Services/Exceptions/MeetingResponseFailed.php
+++ b/packages/EmailIntegration/src/Services/Exceptions/MeetingResponseFailed.php
@@ -9,8 +9,25 @@ use Throwable;
 
 final class MeetingResponseFailed extends RuntimeException
 {
+    public function __construct(
+        string $message,
+        int $code = 0,
+        ?Throwable $previous = null,
+        public readonly bool $missingMailboxCopy = false,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
     public static function fromProvider(Throwable $previous): self
     {
         return new self('The calendar provider rejected the RSVP update.', previous: $previous);
+    }
+
+    public static function missingMailboxCopy(): self
+    {
+        return new self(
+            message: 'This mailbox does not have a provider event for the meeting.',
+            missingMailboxCopy: true,
+        );
     }
 }

--- a/packages/EmailIntegration/src/Services/Exceptions/ReconcileCalendarMeetingsFailed.php
+++ b/packages/EmailIntegration/src/Services/Exceptions/ReconcileCalendarMeetingsFailed.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class ReconcileCalendarMeetingsFailed extends RuntimeException
+{
+    public static function fromProvider(Throwable $previous): self
+    {
+        return new self('Calendar reconciliation failed: '.$previous->getMessage(), 0, $previous);
+    }
+}

--- a/packages/EmailIntegration/src/Services/Factories/NormalizedMeetingPayloadFactory.php
+++ b/packages/EmailIntegration/src/Services/Factories/NormalizedMeetingPayloadFactory.php
@@ -18,6 +18,9 @@ final readonly class NormalizedMeetingPayloadFactory
         $attendees = [];
         $selfResponse = null;
         $normalizedAccountEmail = strtolower($accountEmail);
+        $hasSelf = false;
+        $hasOrganizer = false;
+        $organizerEmail = $event->organizerEmail !== null ? strtolower($event->organizerEmail) : null;
 
         foreach ($event->attendees as $att) {
             $email = $att['email'];
@@ -26,6 +29,11 @@ final readonly class NormalizedMeetingPayloadFactory
 
             if ($isSelf) {
                 $selfResponse = $response;
+                $hasSelf = true;
+            }
+
+            if ($att['is_organizer'] || ($organizerEmail !== null && $email === $organizerEmail)) {
+                $hasOrganizer = true;
             }
 
             $attendees[] = new NormalizedAttendee(
@@ -34,6 +42,26 @@ final readonly class NormalizedMeetingPayloadFactory
                 responseStatus: $response,
                 isOrganizer: $att['is_organizer'],
                 isSelf: $isSelf,
+            );
+        }
+
+        $isSelfOrganizer = $organizerEmail === $normalizedAccountEmail;
+
+        if (! $hasSelf && $isSelfOrganizer) {
+            $attendees[] = new NormalizedAttendee(
+                emailAddress: $normalizedAccountEmail,
+                name: $event->organizerName,
+                responseStatus: $selfResponse,
+                isOrganizer: true,
+                isSelf: true,
+            );
+        } elseif ($organizerEmail !== null && ! $hasOrganizer && ! $isSelfOrganizer) {
+            $attendees[] = new NormalizedAttendee(
+                emailAddress: $organizerEmail,
+                name: $event->organizerName,
+                responseStatus: null,
+                isOrganizer: true,
+                isSelf: false,
             );
         }
 

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -16,9 +16,9 @@ use Relaticle\EmailIntegration\Data\MailDeltaResult;
 use Relaticle\EmailIntegration\Enums\EmailCategory;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired;
 
 final readonly class GmailService implements MailServiceInterface
 {

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -118,28 +118,84 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
     {
         $this->assertRespondable($status);
 
-        $self = new EventAttendee;
-        $self->setEmail($this->account->email_address);
-        $self->setResponseStatus($status->value);
-
-        $patch = new GoogleEvent;
-        $patch->setAttendees([$self]);
-        $patch->setAttendeesOmitted(true);
-
         try {
+            $event = $this->client->events->get('primary', $eventId);
+            $attendee = $this->selfAttendeeFrom($event);
+            $patch = new GoogleEvent;
+            $sendUpdates = 'all';
+
+            if ($attendee instanceof EventAttendee) {
+                $attendee->setResponseStatus($status->value);
+                $patch->setAttendees([$attendee]);
+                $patch->setAttendeesOmitted(true);
+            } elseif ($this->accountIsOrganizer($event)) {
+                $attendee = $this->newSelfAttendee($event->getOrganizer()?->getEmail());
+                $attendee->setOrganizer(true);
+                $attendee->setResponseStatus($status->value);
+                $patch->setAttendees([...$this->attendeesFrom($event), $attendee]);
+                $sendUpdates = 'none';
+            } else {
+                $attendee = $this->newSelfAttendee();
+                $attendee->setResponseStatus($status->value);
+                $patch->setAttendees([$attendee]);
+                $patch->setAttendeesOmitted(true);
+            }
+
             $this->client->events->patch('primary', $eventId, $patch, [
-                'sendUpdates' => 'all',
+                'sendUpdates' => $sendUpdates,
             ]);
         } catch (Throwable $e) {
             throw Exceptions\MeetingResponseFailed::fromProvider($e);
         }
     }
 
+    private function selfAttendeeFrom(GoogleEvent $event): ?EventAttendee
+    {
+        $attendees = $this->attendeesFrom($event);
+        $emailMatch = null;
+        $accountEmail = strtolower($this->account->email_address);
+
+        foreach ($attendees as $attendee) {
+            if ($attendee->getSelf()) {
+                return $attendee;
+            }
+
+            if ($emailMatch === null && strtolower((string) $attendee->getEmail()) === $accountEmail) {
+                $emailMatch = $attendee;
+            }
+        }
+
+        return $emailMatch;
+    }
+
+    /**
+     * @return list<EventAttendee>
+     */
+    private function attendeesFrom(GoogleEvent $event): array
+    {
+        return array_values($event->getAttendees() ?: []);
+    }
+
+    private function accountIsOrganizer(GoogleEvent $event): bool
+    {
+        $email = $event->getOrganizer()?->getEmail();
+
+        return is_string($email)
+            && $email !== ''
+            && strtolower($email) === strtolower($this->account->email_address);
+    }
+
+    private function newSelfAttendee(?string $email = null): EventAttendee
+    {
+        $attendee = new EventAttendee;
+        $attendee->setEmail($email ?? $this->account->email_address);
+
+        return $attendee;
+    }
+
     private function assertRespondable(AttendeeResponseStatus $status): void
     {
-        if ($status === AttendeeResponseStatus::NEEDS_ACTION) {
-            throw new InvalidArgumentException('Cannot reset an RSVP to needsAction.');
-        }
+        throw_if($status === AttendeeResponseStatus::NEEDS_ACTION, InvalidArgumentException::class, 'Cannot reset an RSVP to needsAction.');
     }
 
     private function normalizeGoogleEvent(GoogleEvent $event): CalendarEventData

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -15,6 +15,8 @@ use InvalidArgumentException;
 use Relaticle\EmailIntegration\Data;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 use Relaticle\EmailIntegration\Services\Factories\GoogleClientFactory;
@@ -76,7 +78,7 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
     }
 
     /**
-     * @throws Exceptions\CalendarSyncTokenExpired when Google invalidates the syncToken (HTTP 410)
+     * @throws CalendarSyncTokenExpired when Google invalidates the syncToken (HTTP 410)
      */
     public function fetchDelta(string $syncToken): Data\CalendarSyncResult
     {
@@ -101,7 +103,7 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
                 $response = $this->client->events->listEvents('primary', $params);
             } catch (Exception $e) {
                 if ($e->getCode() === 410) {
-                    throw Exceptions\CalendarSyncTokenExpired::forAccount($this->account->getKey());
+                    throw CalendarSyncTokenExpired::forAccount($this->account->getKey());
                 }
                 throw $e;
             }
@@ -180,7 +182,7 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
                 'sendUpdates' => $sendUpdates,
             ]);
         } catch (Throwable $e) {
-            throw Exceptions\MeetingResponseFailed::fromProvider($e);
+            throw MeetingResponseFailed::fromProvider($e);
         }
     }
 

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -129,7 +129,7 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
                 'maxResults' => 250,
             ];
 
-            if ($pageToken !== null && $pageToken !== '') {
+            if ($pageToken !== null) {
                 $params['pageToken'] = $pageToken;
             }
 
@@ -144,7 +144,7 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
             }
 
             $pageToken = $response->getNextPageToken();
-        } while ($pageToken !== null && $pageToken !== '');
+        } while ($pageToken !== null);
 
         return $ids;
     }
@@ -182,6 +182,29 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
         } catch (Throwable $e) {
             throw Exceptions\MeetingResponseFailed::fromProvider($e);
         }
+    }
+
+    public function findEventIdByICalUid(string $iCalUid): ?string
+    {
+        try {
+            $page = $this->client->events->listEvents('primary', [
+                'iCalUID' => $iCalUid,
+                'maxResults' => 1,
+                'showDeleted' => false,
+            ]);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $items = $page->getItems();
+
+        if (! is_array($items) || $items === []) {
+            return null;
+        }
+
+        $id = $items[0]->getId();
+
+        return is_string($id) && $id !== '' ? $id : null;
     }
 
     public function ensurePushChannel(string $webhookUrl, string $verificationToken): ?Data\CalendarPushChannelData

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -6,17 +6,21 @@ namespace Relaticle\EmailIntegration\Services;
 
 use Google\Service\Calendar;
 use Google\Service\Calendar\Event as GoogleEvent;
+use Google\Service\Calendar\EventAttendee;
 use Google\Service\Exception;
 use Illuminate\Support\Facades\Date;
+use InvalidArgumentException;
 use Relaticle\EmailIntegration\Data;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 use Relaticle\EmailIntegration\Services\Factories\GoogleClientFactory;
+use Throwable;
 
 final readonly class GoogleCalendarService implements CalendarServiceInterface
 {
-    private function __construct(
+    public function __construct(
         private ConnectedAccount $account,
         private Calendar $client,
     ) {}
@@ -108,6 +112,34 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
         } while ($pageToken !== null);
 
         return new Data\CalendarSyncResult(events: $events, nextSyncToken: $nextSyncToken);
+    }
+
+    public function respondToEvent(string $eventId, AttendeeResponseStatus $status): void
+    {
+        $this->assertRespondable($status);
+
+        $self = new EventAttendee;
+        $self->setEmail($this->account->email_address);
+        $self->setResponseStatus($status->value);
+
+        $patch = new GoogleEvent;
+        $patch->setAttendees([$self]);
+        $patch->setAttendeesOmitted(true);
+
+        try {
+            $this->client->events->patch('primary', $eventId, $patch, [
+                'sendUpdates' => 'all',
+            ]);
+        } catch (Throwable $e) {
+            throw Exceptions\MeetingResponseFailed::fromProvider($e);
+        }
+    }
+
+    private function assertRespondable(AttendeeResponseStatus $status): void
+    {
+        if ($status === AttendeeResponseStatus::NEEDS_ACTION) {
+            throw new InvalidArgumentException('Cannot reset an RSVP to needsAction.');
+        }
     }
 
     private function normalizeGoogleEvent(GoogleEvent $event): CalendarEventData

--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Services;
 
 use Google\Service\Calendar;
+use Google\Service\Calendar\Channel;
 use Google\Service\Calendar\Event as GoogleEvent;
 use Google\Service\Calendar\EventAttendee;
 use Google\Service\Exception;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Relaticle\EmailIntegration\Data;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
@@ -86,6 +88,7 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
             $params = [
                 'syncToken' => $syncToken,
                 'singleEvents' => true,
+                'showDeleted' => true,
                 'maxResults' => 250,
             ];
 
@@ -112,6 +115,38 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
         } while ($pageToken !== null);
 
         return new Data\CalendarSyncResult(events: $events, nextSyncToken: $nextSyncToken);
+    }
+
+    public function listActiveProviderEventIds(): array
+    {
+        $ids = [];
+        $pageToken = null;
+
+        do {
+            $params = [
+                'singleEvents' => true,
+                'showDeleted' => false,
+                'maxResults' => 250,
+            ];
+
+            if ($pageToken !== null && $pageToken !== '') {
+                $params['pageToken'] = $pageToken;
+            }
+
+            $response = $this->client->events->listEvents('primary', $params);
+
+            foreach ($response->getItems() as $event) {
+                if ($event->getStatus() === 'cancelled') {
+                    continue;
+                }
+
+                $ids[] = (string) $event->getId();
+            }
+
+            $pageToken = $response->getNextPageToken();
+        } while ($pageToken !== null && $pageToken !== '');
+
+        return $ids;
     }
 
     public function respondToEvent(string $eventId, AttendeeResponseStatus $status): void
@@ -146,6 +181,50 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
             ]);
         } catch (Throwable $e) {
             throw Exceptions\MeetingResponseFailed::fromProvider($e);
+        }
+    }
+
+    public function ensurePushChannel(string $webhookUrl, string $verificationToken): ?Data\CalendarPushChannelData
+    {
+        $channel = new Channel;
+        $channel->setId(Str::uuid()->toString());
+        $channel->setType('web_hook');
+        $channel->setAddress($webhookUrl);
+        $channel->setToken($verificationToken);
+
+        try {
+            $response = $this->client->events->watch('primary', $channel);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $expiration = $response->getExpiration();
+        $expiresAt = $expiration !== null
+            ? Date::createFromTimestampMs((int) $expiration)
+            : now()->addDays(6);
+
+        return new Data\CalendarPushChannelData(
+            channelId: (string) $response->getId(),
+            resourceId: $response->getResourceId(),
+            verificationToken: $verificationToken,
+            expiresAt: $expiresAt,
+        );
+    }
+
+    public function stopPushChannel(string $channelId, ?string $resourceId): void
+    {
+        if ($resourceId === null || $resourceId === '') {
+            return;
+        }
+
+        try {
+            $channel = new Channel;
+            $channel->setId($channelId);
+            $channel->setResourceId($resourceId);
+
+            $this->client->channels->stop($channel);
+        } catch (Throwable) {
+            // The channel may already be expired or stopped.
         }
     }
 
@@ -200,6 +279,10 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
 
     private function normalizeGoogleEvent(GoogleEvent $event): CalendarEventData
     {
+        if ($event->getStatus() === 'cancelled') {
+            return $this->tombstone($event);
+        }
+
         $start = $event->getStart();
         $end = $event->getEnd();
 
@@ -248,6 +331,29 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
             organizerEmail: $organizer?->getEmail(),
             organizerName: $organizer?->getDisplayName(),
             attendees: $attendees,
+        );
+    }
+
+    private function tombstone(GoogleEvent $event): CalendarEventData
+    {
+        $now = Date::now();
+
+        return new CalendarEventData(
+            providerEventId: (string) $event->getId(),
+            providerRecurringEventId: $event->getRecurringEventId(),
+            iCalUid: $event->getICalUID(),
+            title: null,
+            description: null,
+            startsAt: $now,
+            endsAt: $now,
+            isAllDay: false,
+            location: null,
+            htmlLink: null,
+            status: 'cancelled',
+            visibility: null,
+            organizerEmail: null,
+            organizerName: null,
+            attendees: [],
         );
     }
 }

--- a/packages/EmailIntegration/src/Services/MailboxSyncTracker.php
+++ b/packages/EmailIntegration/src/Services/MailboxSyncTracker.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+final class MailboxSyncTracker
+{
+    private const int TTL_MINUTES = 30;
+
+    public static function markCalendarStarted(ConnectedAccount $account): void
+    {
+        Cache::put(self::calendarKey($account), true, now()->addMinutes(self::TTL_MINUTES));
+    }
+
+    public static function markCalendarFinished(ConnectedAccount $account): void
+    {
+        Cache::forget(self::calendarKey($account));
+    }
+
+    public static function isCalendarSyncing(ConnectedAccount $account): bool
+    {
+        return Cache::has(self::calendarKey($account));
+    }
+
+    public static function markEmailStarted(ConnectedAccount $account): void
+    {
+        Cache::put(self::emailKey($account), true, now()->addMinutes(self::TTL_MINUTES));
+    }
+
+    public static function markEmailFinished(ConnectedAccount $account): void
+    {
+        Cache::forget(self::emailKey($account));
+    }
+
+    public static function isEmailSyncing(ConnectedAccount $account): bool
+    {
+        return Cache::has(self::emailKey($account));
+    }
+
+    private static function calendarKey(ConnectedAccount $account): string
+    {
+        return 'mailbox-sync:calendar:'.$account->getKey();
+    }
+
+    private static function emailKey(ConnectedAccount $account): string
+    {
+        return 'mailbox-sync:email:'.$account->getKey();
+    }
+}

--- a/packages/EmailIntegration/src/Services/MailboxSyncTracker.php
+++ b/packages/EmailIntegration/src/Services/MailboxSyncTracker.php
@@ -7,7 +7,7 @@ namespace Relaticle\EmailIntegration\Services;
 use Illuminate\Support\Facades\Cache;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
-final class MailboxSyncTracker
+final readonly class MailboxSyncTracker
 {
     private const int TTL_MINUTES = 30;
 

--- a/packages/EmailIntegration/src/Services/MeetingRespondentResolver.php
+++ b/packages/EmailIntegration/src/Services/MeetingRespondentResolver.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final readonly class MeetingRespondentResolver
+{
+    public function canRespond(User $user, Meeting $meeting): bool
+    {
+        return $this->resolveAccount($user, $meeting) instanceof ConnectedAccount;
+    }
+
+    public function resolveAccount(User $user, Meeting $meeting): ?ConnectedAccount
+    {
+        $accounts = ConnectedAccount::query()
+            ->where('team_id', $meeting->team_id)
+            ->where('user_id', $user->getKey())
+            ->get();
+
+        $ownerAccount = $accounts->first(
+            fn (ConnectedAccount $account): bool => $account->getKey() === $meeting->connected_account_id
+                && $account->isActive()
+                && $account->hasCalendar(),
+        );
+
+        if ($ownerAccount instanceof ConnectedAccount) {
+            return $ownerAccount;
+        }
+
+        $listedAttendeeEmails = $this->listedAttendeeEmailsForUser($user, $meeting);
+
+        if ($listedAttendeeEmails === []) {
+            return null;
+        }
+
+        $matchingAccount = $accounts->first(
+            fn (ConnectedAccount $account): bool => $account->isActive()
+                && $account->hasCalendar()
+                && in_array(strtolower($account->email_address), $listedAttendeeEmails, true),
+        );
+
+        if ($matchingAccount instanceof ConnectedAccount) {
+            return $matchingAccount;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, lowercase-string>
+     */
+    public function identityEmailsForUser(User $user, string $teamId): array
+    {
+        $emails = collect([strtolower($user->email)]);
+
+        ConnectedAccount::query()
+            ->where('team_id', $teamId)
+            ->where('user_id', $user->getKey())
+            ->pluck('email_address')
+            ->each(function (mixed $emailAddress) use ($emails): void {
+                $normalized = strtolower(trim((string) $emailAddress));
+
+                if ($normalized !== '') {
+                    $emails->push($normalized);
+                }
+            });
+
+        return $emails->unique()->values()->all();
+    }
+
+    /**
+     * @return array<int, lowercase-string>
+     */
+    public function listedAttendeeEmailsForUser(User $user, Meeting $meeting): array
+    {
+        $identityEmails = $this->identityEmailsForUser($user, (string) $meeting->team_id);
+
+        if ($identityEmails === []) {
+            return [];
+        }
+
+        return $meeting->attendees()
+            ->whereIn(DB::raw('lower(email_address)'), $identityEmails)
+            ->pluck('email_address')
+            ->map(fn (mixed $emailAddress): string => strtolower((string) $emailAddress))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    public function listedAttendeeEmailForUser(User $user, Meeting $meeting): ?string
+    {
+        $listedAttendeeEmails = $this->listedAttendeeEmailsForUser($user, $meeting);
+
+        if ($listedAttendeeEmails === []) {
+            return null;
+        }
+
+        $workspaceEmail = strtolower($user->email);
+
+        if (in_array($workspaceEmail, $listedAttendeeEmails, true)) {
+            return $workspaceEmail;
+        }
+
+        return $listedAttendeeEmails[0];
+    }
+
+    public function userWorkspaceEmailIsListedAttendee(User $user, Meeting $meeting): bool
+    {
+        return $meeting->attendees()
+            ->whereRaw('lower(email_address) = ?', [strtolower($user->email)])
+            ->exists();
+    }
+
+    public function userIdentityIsListedAttendee(User $user, Meeting $meeting): bool
+    {
+        return $this->listedAttendeeEmailsForUser($user, $meeting) !== [];
+    }
+
+    public function viewerResponseStatus(User $user, Meeting $meeting): AttendeeResponseStatus
+    {
+        $meeting->loadMissing('connectedAccount');
+
+        if ($meeting->connectedAccount?->user_id === $user->getKey()) {
+            return $meeting->response_status ?? AttendeeResponseStatus::NEEDS_ACTION;
+        }
+
+        $userEmail = strtolower($user->email);
+
+        $attendeeStatus = $meeting->attendees()
+            ->whereRaw('lower(email_address) = ?', [$userEmail])
+            ->value('response_status');
+
+        if ($attendeeStatus instanceof AttendeeResponseStatus) {
+            return $attendeeStatus;
+        }
+
+        if (is_string($attendeeStatus)) {
+            return AttendeeResponseStatus::tryFrom($attendeeStatus) ?? AttendeeResponseStatus::NEEDS_ACTION;
+        }
+
+        $identityEmails = $this->identityEmailsForUser($user, (string) $meeting->team_id);
+
+        if ($identityEmails === []) {
+            return AttendeeResponseStatus::NEEDS_ACTION;
+        }
+
+        $identityStatus = $meeting->attendees()
+            ->whereIn(DB::raw('lower(email_address)'), $identityEmails)
+            ->value('response_status');
+
+        if (is_string($identityStatus)) {
+            return AttendeeResponseStatus::tryFrom($identityStatus) ?? AttendeeResponseStatus::NEEDS_ACTION;
+        }
+
+        if ($identityStatus instanceof AttendeeResponseStatus) {
+            return $identityStatus;
+        }
+
+        return AttendeeResponseStatus::NEEDS_ACTION;
+    }
+
+    public function resolveProviderEventId(ConnectedAccount $account, Meeting $meeting): string
+    {
+        if ($this->ownsMeetingMailbox($account, $meeting)) {
+            return $meeting->provider_event_id;
+        }
+
+        if (filled($meeting->ical_uid)) {
+            $ownCopyEventId = Meeting::query()
+                ->where('connected_account_id', $account->getKey())
+                ->where('ical_uid', $meeting->ical_uid)
+                ->value('provider_event_id');
+
+            if (is_string($ownCopyEventId) && $ownCopyEventId !== '') {
+                return $ownCopyEventId;
+            }
+        }
+
+        return $meeting->provider_event_id;
+    }
+
+    public function ownsMeetingMailbox(ConnectedAccount $account, Meeting $meeting): bool
+    {
+        return $account->getKey() === $meeting->connected_account_id;
+    }
+}

--- a/packages/EmailIntegration/src/Services/MeetingRespondentResolver.php
+++ b/packages/EmailIntegration/src/Services/MeetingRespondentResolver.php
@@ -40,17 +40,11 @@ final readonly class MeetingRespondentResolver
             return null;
         }
 
-        $matchingAccount = $accounts->first(
+        return $accounts->first(
             fn (ConnectedAccount $account): bool => $account->isActive()
                 && $account->hasCalendar()
                 && in_array(strtolower($account->email_address), $listedAttendeeEmails, true),
         );
-
-        if ($matchingAccount instanceof ConnectedAccount) {
-            return $matchingAccount;
-        }
-
-        return null;
     }
 
     /**
@@ -167,24 +161,26 @@ final readonly class MeetingRespondentResolver
         return AttendeeResponseStatus::NEEDS_ACTION;
     }
 
-    public function resolveProviderEventId(ConnectedAccount $account, Meeting $meeting): string
+    public function resolveProviderEventId(ConnectedAccount $account, Meeting $meeting): ?string
     {
         if ($this->ownsMeetingMailbox($account, $meeting)) {
             return $meeting->provider_event_id;
         }
 
-        if (filled($meeting->ical_uid)) {
-            $ownCopyEventId = Meeting::query()
-                ->where('connected_account_id', $account->getKey())
-                ->where('ical_uid', $meeting->ical_uid)
-                ->value('provider_event_id');
-
-            if (is_string($ownCopyEventId) && $ownCopyEventId !== '') {
-                return $ownCopyEventId;
-            }
+        if (blank($meeting->ical_uid)) {
+            return null;
         }
 
-        return $meeting->provider_event_id;
+        $ownCopyEventId = Meeting::query()
+            ->where('connected_account_id', $account->getKey())
+            ->where('ical_uid', $meeting->ical_uid)
+            ->value('provider_event_id');
+
+        if (is_string($ownCopyEventId) && $ownCopyEventId !== '') {
+            return $ownCopyEventId;
+        }
+
+        return null;
     }
 
     public function ownsMeetingMailbox(ConnectedAccount $account, Meeting $meeting): bool

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -12,10 +12,10 @@ use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Data\CalendarPushChannelData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
-use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
 use Throwable;
 

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -57,6 +57,10 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
                 ])
                 ->throw();
         } catch (Throwable $e) {
+            if ($this->organizerCannotRespond($e)) {
+                return;
+            }
+
             throw MeetingResponseFailed::fromProvider($e);
         }
     }
@@ -274,11 +278,24 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
             'accepted' => 'accepted',
             'declined' => 'declined',
             'tentativelyAccepted' => 'tentative',
-            // The organizer implicitly accepts their own meeting.
-            'organizer' => 'accepted',
+            // Graph marks the host as "organizer", not accepted/declined.
+            // Leave it empty so a host RSVP chosen in Relaticle is not reset on sync.
+            'organizer' => null,
             'none', 'notResponded' => 'needsAction',
             default => null,
         };
+    }
+
+    private function organizerCannotRespond(Throwable $e): bool
+    {
+        if (! $e instanceof RequestException || $e->response->status() !== 400) {
+            return false;
+        }
+
+        return str_contains(
+            strtolower($e->getMessage().' '.$e->response->body()),
+            'organizer',
+        );
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -7,12 +7,16 @@ namespace Relaticle\EmailIntegration\Services;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
+use InvalidArgumentException;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
+use Throwable;
 
 final readonly class MicrosoftCalendarService implements CalendarServiceInterface
 {
@@ -35,6 +39,26 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
     public function fetchDelta(string $syncToken): CalendarSyncResult
     {
         return $this->drainOnePage($syncToken, isInitial: false);
+    }
+
+    public function respondToEvent(string $eventId, AttendeeResponseStatus $status): void
+    {
+        $action = match ($status) {
+            AttendeeResponseStatus::ACCEPTED => 'accept',
+            AttendeeResponseStatus::DECLINED => 'decline',
+            AttendeeResponseStatus::TENTATIVE => 'tentativelyAccept',
+            AttendeeResponseStatus::NEEDS_ACTION => throw new InvalidArgumentException('Cannot reset an RSVP to needsAction.'),
+        };
+
+        try {
+            $this->clientFactory->make($this->account)
+                ->post('/me/events/'.rawurlencode($eventId).'/'.$action, [
+                    'sendResponse' => true,
+                ])
+                ->throw();
+        } catch (Throwable $e) {
+            throw MeetingResponseFailed::fromProvider($e);
+        }
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -66,6 +66,26 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
         }
     }
 
+    public function findEventIdByICalUid(string $iCalUid): ?string
+    {
+        $escaped = str_replace("'", "''", $iCalUid);
+
+        try {
+            $id = $this->clientFactory->make($this->account)
+                ->get('/me/events', [
+                    '$filter' => "iCalUId eq '{$escaped}'",
+                    '$select' => 'id',
+                    '$top' => 1,
+                ])
+                ->throw()
+                ->json('value.0.id');
+        } catch (Throwable) {
+            return null;
+        }
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
     public function listActiveProviderEventIds(): array
     {
         $ids = [];

--- a/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftCalendarService.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use InvalidArgumentException;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
+use Relaticle\EmailIntegration\Data\CalendarPushChannelData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -62,6 +63,104 @@ final readonly class MicrosoftCalendarService implements CalendarServiceInterfac
             }
 
             throw MeetingResponseFailed::fromProvider($e);
+        }
+    }
+
+    public function listActiveProviderEventIds(): array
+    {
+        $ids = [];
+        $windowStart = $this->historyStart();
+        $horizon = $this->horizon();
+
+        while ($windowStart->lt($horizon)) {
+            $url = $this->calendarWindowUrl($windowStart);
+
+            do {
+                $response = $this->clientFactory->make($this->account)
+                    ->get($url)
+                    ->throw()
+                    ->json();
+
+                foreach ($response['value'] ?? [] as $event) {
+                    if (isset($event['@removed']) || ($event['isCancelled'] ?? false)) {
+                        continue;
+                    }
+
+                    $id = $event['id'] ?? null;
+
+                    if (is_string($id) && $id !== '') {
+                        $ids[] = $id;
+                    }
+                }
+
+                $nextLink = $response['@odata.nextLink'] ?? null;
+
+                if (is_string($nextLink) && $nextLink !== '') {
+                    $url = $nextLink;
+
+                    continue;
+                }
+
+                break;
+            } while (true);
+
+            $windowEnd = $windowStart->copy()->addYears(self::WINDOW_YEARS);
+
+            if ($windowEnd->gte($horizon)) {
+                break;
+            }
+
+            $windowStart = $windowEnd;
+        }
+
+        return $ids;
+    }
+
+    public function ensurePushChannel(string $webhookUrl, string $verificationToken): ?CalendarPushChannelData
+    {
+        $expiresAt = now()->addDays(2);
+
+        try {
+            $response = $this->clientFactory->make($this->account)
+                ->post('/subscriptions', [
+                    'changeType' => 'created,updated,deleted',
+                    'notificationUrl' => $webhookUrl,
+                    'resource' => 'me/events',
+                    'expirationDateTime' => $expiresAt->utc()->format('Y-m-d\TH:i:s\Z'),
+                    'clientState' => $verificationToken,
+                ])
+                ->throw()
+                ->json();
+        } catch (Throwable) {
+            return null;
+        }
+
+        $subscriptionId = (string) ($response['id'] ?? '');
+
+        if ($subscriptionId === '') {
+            return null;
+        }
+
+        $expiration = $response['expirationDateTime'] ?? null;
+
+        return new CalendarPushChannelData(
+            channelId: $subscriptionId,
+            resourceId: null,
+            verificationToken: $verificationToken,
+            expiresAt: is_string($expiration) && $expiration !== ''
+                ? Date::parse($expiration)
+                : $expiresAt,
+        );
+    }
+
+    public function stopPushChannel(string $channelId, ?string $resourceId): void
+    {
+        try {
+            $this->clientFactory->make($this->account)
+                ->delete('/subscriptions/'.rawurlencode($channelId))
+                ->throw();
+        } catch (Throwable) {
+            // The subscription may already be gone.
         }
     }
 

--- a/packages/EmailIntegration/src/Support/CalendarPushWebhookUrl.php
+++ b/packages/EmailIntegration/src/Support/CalendarPushWebhookUrl.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Support;
+
+use Illuminate\Support\Str;
+
+final class CalendarPushWebhookUrl
+{
+    public static function forProvider(string $provider): string
+    {
+        return route('calendar-push.webhook', ['provider' => $provider]);
+    }
+
+    public static function isPubliclyReachable(): bool
+    {
+        $url = config('app.url');
+
+        if (! is_string($url) || $url === '') {
+            return false;
+        }
+
+        if (! Str::startsWith($url, 'https://')) {
+            return false;
+        }
+
+        return ! Str::contains($url, ['localhost', '.test', '127.0.0.1']);
+    }
+}

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -229,6 +229,7 @@ arch('package service layers avoid mutation')
         // Exceptions necessarily extend a base throwable:
         'Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired',
         'Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired',
+        'Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed',
         'Relaticle\ImportWizard\Support\DataTypeInferencer',
         'Relaticle\ImportWizard\Support\EntityLinkResolver',
         'Relaticle\ImportWizard\Support\EntityLinkStorage\CustomFieldValueStorage',
@@ -250,6 +251,7 @@ arch('package service layers avoid inheritance')
         // Exceptions necessarily extend a base throwable:
         'Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired',
         'Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired',
+        'Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed',
     ]);
 
 arch('main app must not depend on SystemAdmin module')

--- a/tests/Arch/ArchTest.php
+++ b/tests/Arch/ArchTest.php
@@ -226,10 +226,6 @@ arch('package service layers avoid mutation')
         'Relaticle\EmailIntegration\Services\EmailVisibilityService',
         'Relaticle\EmailIntegration\Services\MicrosoftGraphMailService',
         'Relaticle\EmailIntegration\Services\PrivacyService',
-        // Exceptions necessarily extend a base throwable:
-        'Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired',
-        'Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired',
-        'Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed',
         'Relaticle\ImportWizard\Support\DataTypeInferencer',
         'Relaticle\ImportWizard\Support\EntityLinkResolver',
         'Relaticle\ImportWizard\Support\EntityLinkStorage\CustomFieldValueStorage',
@@ -246,13 +242,7 @@ arch('package service layers avoid mutation')
 arch('package service layers avoid inheritance')
     ->expect($packageServiceLayers)
     ->classes()
-    ->toExtendNothing()
-    ->ignoring([
-        // Exceptions necessarily extend a base throwable:
-        'Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired',
-        'Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired',
-        'Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed',
-    ]);
+    ->toExtendNothing();
 
 arch('main app must not depend on SystemAdmin module')
     ->expect('App')

--- a/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
+++ b/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Relaticle\EmailIntegration\Controllers\CalendarPushWebhookController;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Jobs\EnsureCalendarPushChannelJob;
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
+use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
+use Relaticle\EmailIntegration\Livewire\MailboxImportStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Exceptions\CalendarPushChannelFailed;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
+
+mutates(
+    CalendarPushWebhookController::class,
+    EnsureCalendarPushChannelJob::class,
+    MailboxImportStatus::class,
+);
+
+it('accepts microsoft subscription validation tokens', function (): void {
+    $this->post(route('calendar-push.webhook', ['provider' => EmailProvider::AZURE->value]).'?validationToken=abc123')
+        ->assertOk()
+        ->assertSee('abc123');
+});
+
+it('dispatches calendar sync when google sends a change notification', function (): void {
+    Bus::fake([IncrementalCalendarSyncJob::class]);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'provider' => EmailProvider::GMAIL,
+        'calendar_push_channel_id' => 'channel-123',
+        'calendar_push_verification_token' => 'secret-token',
+    ]));
+
+    $this->post(route('calendar-push.webhook', ['provider' => EmailProvider::GMAIL->value]), [], [
+        'X-Goog-Channel-ID' => 'channel-123',
+        'X-Goog-Channel-Token' => 'secret-token',
+        'X-Goog-Resource-State' => 'exists',
+    ])->assertOk();
+
+    Bus::assertDispatched(fn (IncrementalCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
+});
+
+it('rejects google notifications with the wrong verification token', function (): void {
+    Bus::fake([IncrementalCalendarSyncJob::class]);
+
+    ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'provider' => EmailProvider::GMAIL,
+        'calendar_push_channel_id' => 'channel-123',
+        'calendar_push_verification_token' => 'secret-token',
+    ]));
+
+    $this->post(route('calendar-push.webhook', ['provider' => EmailProvider::GMAIL->value]), [], [
+        'X-Goog-Channel-ID' => 'channel-123',
+        'X-Goog-Channel-Token' => 'wrong-token',
+        'X-Goog-Resource-State' => 'exists',
+    ])->assertForbidden();
+
+    Bus::assertNothingDispatched();
+});
+
+it('shows calendar-only sync progress on the dashboard', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+    Filament::setTenant($user->currentTeam);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $user->currentTeam->getKey(),
+        'user_id' => $user->getKey(),
+        'sync_cursor' => 'done',
+        'calendar_sync_cursor' => 'done',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MailboxSyncTracker::markCalendarStarted($account);
+
+    Livewire::test(MailboxImportStatus::class, ['placement' => 'home'])
+        ->assertSee(__('filament/pages/email-accounts.importing_calendar'))
+        ->assertSee(__('filament/pages/email-accounts.sync_status.title_syncing'));
+});
+
+it('dispatches calendar sync when microsoft sends a valid notification', function (): void {
+    Bus::fake([IncrementalCalendarSyncJob::class]);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->azure()->create([
+        'calendar_push_channel_id' => 'sub-123',
+        'calendar_push_verification_token' => 'secret-token',
+    ]));
+
+    $this->postJson(route('calendar-push.webhook', ['provider' => EmailProvider::AZURE->value]), [
+        'value' => [[
+            'subscriptionId' => 'sub-123',
+            'clientState' => 'secret-token',
+        ]],
+    ])->assertAccepted();
+
+    Bus::assertDispatched(fn (IncrementalCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
+});
+
+it('ignores microsoft notifications with a forged client state', function (): void {
+    Bus::fake([IncrementalCalendarSyncJob::class]);
+
+    ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->azure()->create([
+        'calendar_push_channel_id' => 'sub-123',
+        'calendar_push_verification_token' => 'secret-token',
+    ]));
+
+    $this->postJson(route('calendar-push.webhook', ['provider' => EmailProvider::AZURE->value]), [
+        'value' => [[
+            'subscriptionId' => 'sub-123',
+            'clientState' => 'forged-token',
+        ]],
+    ])->assertAccepted();
+
+    Bus::assertNothingDispatched();
+});
+
+it('marks email sync as started when the scheduled command dispatches incremental sync', function (): void {
+    Bus::fake([IncrementalEmailSyncJob::class]);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'sync_cursor' => 'cursor-1',
+    ]));
+
+    $this->artisan('email:incremental-sync')->assertSuccessful();
+
+    expect(MailboxSyncTracker::isEmailSyncing($account))->toBeTrue();
+});
+
+it('retries microsoft push renewal failures instead of replacing the subscription', function (): void {
+    config()->set('app.url', 'https://app.relaticle.com');
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->azure()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => 'cursor',
+        'calendar_push_channel_id' => 'sub-123',
+        'calendar_push_expires_at' => now()->addHours(6),
+    ]));
+
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/subscriptions/sub-123' => Http::response('', 503),
+    ]);
+
+    $job = new EnsureCalendarPushChannelJob($account);
+
+    expect(fn () => $job->handle(app(CalendarServiceFactoryInterface::class)))
+        ->toThrow(CalendarPushChannelFailed::class);
+
+    expect($account->fresh()?->calendar_push_channel_id)->toBe('sub-123');
+});
+
+it('records push channel renewal failures on the connected account', function (): void {
+    config()->set('app.url', 'https://app.relaticle.com');
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->azure()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => 'cursor',
+        'calendar_push_channel_id' => 'sub-123',
+        'calendar_push_expires_at' => now()->addHours(6),
+        'status' => EmailAccountStatus::ACTIVE,
+    ]));
+
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/subscriptions/sub-123' => Http::response('', 503),
+    ]);
+
+    $job = new EnsureCalendarPushChannelJob($account);
+
+    try {
+        $job->handle(app(CalendarServiceFactoryInterface::class));
+    } catch (CalendarPushChannelFailed) {
+        // expected during handle when retries are exhausted in production
+    }
+
+    $job->failed(new CalendarPushChannelFailed('renewal failed'));
+
+    expect($account->fresh()?->last_error)->toContain('Calendar push notifications could not be renewed');
+});
+
+it('accepts malformed microsoft webhook payloads without dispatching sync', function (): void {
+    Bus::fake([IncrementalCalendarSyncJob::class]);
+
+    ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->azure()->create([
+        'calendar_push_channel_id' => 'sub-123',
+        'calendar_push_verification_token' => 'secret-token',
+    ]));
+
+    $this->postJson(route('calendar-push.webhook', ['provider' => EmailProvider::AZURE->value]), [
+        'value' => 'not-an-array',
+    ])->assertAccepted();
+
+    $this->postJson(route('calendar-push.webhook', ['provider' => EmailProvider::AZURE->value]), [
+        'value' => [
+            'subscriptionId' => 'sub-123',
+            'clientState' => 'secret-token',
+        ],
+    ])->assertAccepted();
+
+    $this->postJson(route('calendar-push.webhook', ['provider' => EmailProvider::AZURE->value]), [
+        'value' => [
+            ['subscriptionId' => 123, 'clientState' => 'secret-token'],
+        ],
+    ])->assertAccepted();
+
+    Bus::assertNothingDispatched();
+});

--- a/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
+++ b/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
@@ -10,13 +10,13 @@ use Livewire\Livewire;
 use Relaticle\EmailIntegration\Controllers\CalendarPushWebhookController;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Exceptions\CalendarPushChannelFailed;
 use Relaticle\EmailIntegration\Jobs\EnsureCalendarPushChannelJob;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Livewire\MailboxImportStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\CalendarPushChannelFailed;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 mutates(

--- a/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
+++ b/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
@@ -7,6 +7,7 @@ use Google\Service\Calendar;
 use Google\Service\Calendar\Event;
 use Google\Service\Calendar\EventAttendee;
 use Google\Service\Calendar\EventOrganizer;
+use Google\Service\Calendar\Events as EventsResource;
 use Google\Service\Calendar\Resource\Events;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -220,4 +221,40 @@ it('adds the host when Google omits the attendees list', function (): void {
 
     (new GoogleCalendarService($account, $calendar))
         ->respondToEvent('evt-1', AttendeeResponseStatus::TENTATIVE);
+});
+
+it('requests deleted events during incremental sync and maps cancellations to tombstones', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $cancelled = new Event;
+    $cancelled->setId('evt-deleted');
+    $cancelled->setStatus('cancelled');
+
+    $eventsList = new EventsResource;
+    $eventsList->setItems([$cancelled]);
+    $eventsList->setNextSyncToken('next-token');
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('listEvents')
+        ->once()
+        ->with('primary', [
+            'syncToken' => 'sync-token',
+            'singleEvents' => true,
+            'showDeleted' => true,
+            'maxResults' => 250,
+        ])
+        ->andReturn($eventsList);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    $result = (new GoogleCalendarService($account, $calendar))->fetchDelta('sync-token');
+
+    expect($result->nextSyncToken)->toBe('next-token')
+        ->and($result->events)->toHaveCount(1)
+        ->and($result->events[0]->providerEventId)->toBe('evt-deleted')
+        ->and($result->events[0]->status)->toBe('cancelled');
 });

--- a/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
+++ b/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Google\Client;
 use Google\Service\Calendar;
 use Google\Service\Calendar\Event;
+use Google\Service\Calendar\EventAttendee;
+use Google\Service\Calendar\EventOrganizer;
 use Google\Service\Calendar\Resource\Events;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -42,14 +44,71 @@ it('paginates initialSync and returns nextSyncToken', function (): void {
     expect(method_exists(GoogleCalendarService::class, 'initialSync'))->toBeTrue();
 });
 
-it('patches the connected account RSVP without replacing other attendees', function (): void {
+it('patches the calendar self attendee RSVP from a fetched event', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'email_address' => 'me@example.com',
         'refresh_token' => 'refresh',
         'token_expires_at' => now()->addHour(),
     ]));
 
+    $self = new EventAttendee;
+    $self->setEmail('alias@example.com');
+    $self->setSelf(true);
+    $self->setResponseStatus('accepted');
+
+    $host = new EventAttendee;
+    $host->setEmail('host@example.com');
+    $host->setResponseStatus('accepted');
+
+    $existing = new Event;
+    $existing->setAttendees([$host, $self]);
+
     $events = Mockery::mock(Events::class);
+    $events->shouldReceive('get')
+        ->once()
+        ->with('primary', 'evt-1')
+        ->andReturn($existing);
+    $events->shouldReceive('patch')
+        ->once()
+        ->withArgs(function (string $calendarId, string $eventId, Event $body, array $opts): bool {
+            $attendees = $body->getAttendees();
+
+            return $calendarId === 'primary'
+                && $eventId === 'evt-1'
+                && $body->getAttendeesOmitted() === true
+                && isset($attendees[0])
+                && $attendees[0]->getEmail() === 'alias@example.com'
+                && $attendees[0]->getResponseStatus() === 'declined'
+                && $opts === ['sendUpdates' => 'all'];
+        })
+        ->andReturn(new Event);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    (new GoogleCalendarService($account, $calendar))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::DECLINED);
+});
+
+it('patches the mailbox email when Google omits the self flag', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'me@example.com',
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $guest = new EventAttendee;
+    $guest->setEmail('me@example.com');
+    $guest->setResponseStatus('accepted');
+
+    $existing = new Event;
+    $existing->setAttendees([$guest]);
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('get')
+        ->once()
+        ->with('primary', 'evt-1')
+        ->andReturn($existing);
     $events->shouldReceive('patch')
         ->once()
         ->withArgs(function (string $calendarId, string $eventId, Event $body, array $opts): bool {
@@ -60,7 +119,7 @@ it('patches the connected account RSVP without replacing other attendees', funct
                 && $body->getAttendeesOmitted() === true
                 && isset($attendees[0])
                 && $attendees[0]->getEmail() === 'me@example.com'
-                && $attendees[0]->getResponseStatus() === 'accepted'
+                && $attendees[0]->getResponseStatus() === 'tentative'
                 && $opts === ['sendUpdates' => 'all'];
         })
         ->andReturn(new Event);
@@ -69,5 +128,96 @@ it('patches the connected account RSVP without replacing other attendees', funct
     $calendar->events = $events;
 
     (new GoogleCalendarService($account, $calendar))
-        ->respondToEvent('evt-1', AttendeeResponseStatus::ACCEPTED);
+        ->respondToEvent('evt-1', AttendeeResponseStatus::TENTATIVE);
+});
+
+it('adds the omitted host to Google attendees so the RSVP can persist', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'me@example.com',
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $guest = new EventAttendee;
+    $guest->setEmail('guest@example.com');
+    $guest->setResponseStatus('accepted');
+
+    $organizer = new EventOrganizer;
+    $organizer->setEmail('me@example.com');
+
+    $existing = new Event;
+    $existing->setOrganizer($organizer);
+    $existing->setAttendees([$guest]);
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('get')
+        ->once()
+        ->with('primary', 'evt-1')
+        ->andReturn($existing);
+    $events->shouldReceive('patch')
+        ->once()
+        ->withArgs(function (string $calendarId, string $eventId, Event $body, array $opts): bool {
+            $byEmail = [];
+
+            foreach ($body->getAttendees() as $attendee) {
+                $byEmail[strtolower((string) $attendee->getEmail())] = $attendee;
+            }
+
+            return $calendarId === 'primary'
+                && $eventId === 'evt-1'
+                && $body->getAttendeesOmitted() !== true
+                && isset($byEmail['me@example.com'], $byEmail['guest@example.com'])
+                && $byEmail['me@example.com']->getOrganizer() === true
+                && $byEmail['me@example.com']->getResponseStatus() === 'declined'
+                && $byEmail['guest@example.com']->getResponseStatus() === 'accepted'
+                && $opts === ['sendUpdates' => 'none'];
+        })
+        ->andReturn(new Event);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    (new GoogleCalendarService($account, $calendar))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::DECLINED);
+});
+
+it('adds the host when Google omits the attendees list', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'me@example.com',
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $organizer = new EventOrganizer;
+    $organizer->setEmail('me@example.com');
+
+    $existing = new Event;
+    $existing->setOrganizer($organizer);
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('get')
+        ->once()
+        ->with('primary', 'evt-1')
+        ->andReturn($existing);
+    $events->shouldReceive('patch')
+        ->once()
+        ->withArgs(function (string $calendarId, string $eventId, Event $body, array $opts): bool {
+            $attendees = $body->getAttendees();
+
+            return $calendarId === 'primary'
+                && $eventId === 'evt-1'
+                && isset($attendees[0])
+                && $attendees[0]->getEmail() === 'me@example.com'
+                && $attendees[0]->getOrganizer() === true
+                && $attendees[0]->getResponseStatus() === 'tentative'
+                && $body->getAttendeesOmitted() !== true
+                && $opts === ['sendUpdates' => 'none'];
+        })
+        ->andReturn(new Event);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    (new GoogleCalendarService($account, $calendar))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::TENTATIVE);
 });

--- a/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
+++ b/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+use Google\Client;
+use Google\Service\Calendar;
+use Google\Service\Calendar\Event;
+use Google\Service\Calendar\Resource\Events;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\GoogleCalendarService;
 
@@ -35,4 +40,34 @@ it('paginates initialSync and returns nextSyncToken', function (): void {
     // The real client call is hard to fake here without a test double — this test is a type-shape smoke test.
 
     expect(method_exists(GoogleCalendarService::class, 'initialSync'))->toBeTrue();
+});
+
+it('patches the connected account RSVP without replacing other attendees', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'me@example.com',
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('patch')
+        ->once()
+        ->withArgs(function (string $calendarId, string $eventId, Event $body, array $opts): bool {
+            $attendees = $body->getAttendees();
+
+            return $calendarId === 'primary'
+                && $eventId === 'evt-1'
+                && $body->getAttendeesOmitted() === true
+                && isset($attendees[0])
+                && $attendees[0]->getEmail() === 'me@example.com'
+                && $attendees[0]->getResponseStatus() === 'accepted'
+                && $opts === ['sendUpdates' => 'all'];
+        })
+        ->andReturn(new Event);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    (new GoogleCalendarService($account, $calendar))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::ACCEPTED);
 });

--- a/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
+++ b/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
@@ -223,6 +223,56 @@ it('adds the host when Google omits the attendees list', function (): void {
         ->respondToEvent('evt-1', AttendeeResponseStatus::TENTATIVE);
 });
 
+it('resolves this mailbox event id from a shared iCalendar UID', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'me@example.com',
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $match = new Event;
+    $match->setId('evt-teammate-mailbox');
+
+    $page = new EventsResource;
+    $page->setItems([$match]);
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('listEvents')
+        ->once()
+        ->with('primary', [
+            'iCalUID' => 'ical-shared',
+            'maxResults' => 1,
+            'showDeleted' => false,
+        ])
+        ->andReturn($page);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    $eventId = (new GoogleCalendarService($account, $calendar))->findEventIdByICalUid('ical-shared');
+
+    expect($eventId)->toBe('evt-teammate-mailbox');
+});
+
+it('returns null when Google has no event for the iCalendar UID', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $page = new EventsResource;
+    $page->setItems([]);
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('listEvents')->once()->andReturn($page);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    expect((new GoogleCalendarService($account, $calendar))->findEventIdByICalUid('missing'))
+        ->toBeNull();
+});
+
 it('requests deleted events during incremental sync and maps cancellations to tombstones', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
         'refresh_token' => 'refresh',

--- a/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
@@ -218,7 +218,7 @@ it('clears the calendar sync badge when delegating to initial sync without start
     expect(MailboxSyncTracker::isCalendarSyncing($account))->toBeFalse();
 });
 
-it('records a batch failure, advances the cursor, and clears the calendar sync badge', function (): void {
+it('records a batch failure, holds the cursor, and clears the calendar sync badge', function (): void {
     Bus::fake();
 
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
@@ -271,7 +271,7 @@ it('records a batch failure, advances the cursor, and clears the calendar sync b
         return true;
     });
 
-    expect($account->fresh()?->calendar_sync_cursor)->toBe('new-token')
+    expect($account->fresh()?->calendar_sync_cursor)->toBe('valid-token')
         ->and($account->fresh()?->status)->toBe(EmailAccountStatus::ERROR)
         ->and($account->fresh()?->last_error)->toContain('1 calendar event(s)')
         ->and(MailboxSyncTracker::isCalendarSyncing($account))->toBeFalse();

--- a/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
@@ -10,13 +10,13 @@ use Laravel\SerializableClosure\SerializableClosure;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Exceptions\CalendarSyncTokenExpired;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreMeetingJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 mutates(IncrementalCalendarSyncJob::class);

--- a/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Testing\Fakes\BatchFake;
+use Laravel\SerializableClosure\SerializableClosure;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
+use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreMeetingJob;
@@ -14,6 +17,7 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 mutates(IncrementalCalendarSyncJob::class);
 
@@ -118,8 +122,18 @@ it('advances the cursor after the store batch completes', function (): void {
     (new IncrementalCalendarSyncJob($account))->handle($factory);
 
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        foreach ($batch->thenCallbacks() as $callback) {
-            $callback();
+        foreach ($batch->finallyCallbacks() as $callback) {
+            $closure = $callback instanceof SerializableClosure ? $callback->getClosure() : $callback;
+            $closure(new BatchFake(
+                id: 'batch-1',
+                name: 'Incremental calendar sync',
+                totalJobs: $batch->jobs->count(),
+                pendingJobs: 0,
+                failedJobs: 0,
+                failedJobIds: [],
+                options: [],
+                createdAt: now()->toImmutable(),
+            ));
         }
 
         return true;
@@ -186,4 +200,79 @@ it('dispatches initial sync when no cursor exists', function (): void {
     (new IncrementalCalendarSyncJob($account))->handle($factory);
 
     Bus::assertDispatched(InitialCalendarSyncJob::class);
+});
+
+it('clears the calendar sync badge when delegating to initial sync without starting incremental sync', function (): void {
+    Bus::fake([InitialCalendarSyncJob::class]);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => null,
+    ]));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldNotReceive('make');
+
+    (new IncrementalCalendarSyncJob($account))->handle($factory);
+
+    expect(MailboxSyncTracker::isCalendarSyncing($account))->toBeFalse();
+});
+
+it('records a batch failure, advances the cursor, and clears the calendar sync badge', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => 'valid-token',
+    ]));
+
+    $event = new CalendarEventData(
+        providerEventId: 'evt-delta',
+        providerRecurringEventId: null,
+        iCalUid: null,
+        title: 'Delta event',
+        description: null,
+        startsAt: Carbon::now()->addDay(),
+        endsAt: Carbon::now()->addDay()->addHour(),
+        isAllDay: false,
+        location: null,
+        htmlLink: null,
+        status: 'confirmed',
+        visibility: 'default',
+        organizerEmail: null,
+        organizerName: null,
+        attendees: [],
+    );
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('fetchDelta')->once()->with('valid-token')
+        ->andReturn(new CalendarSyncResult(events: [$event], nextSyncToken: 'new-token'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new IncrementalCalendarSyncJob($account))->handle($factory);
+
+    Bus::assertBatched(function (PendingBatch $batch): bool {
+        foreach ($batch->finallyCallbacks() as $callback) {
+            $closure = $callback instanceof SerializableClosure ? $callback->getClosure() : $callback;
+            $closure(new BatchFake(
+                id: 'batch-1',
+                name: 'Incremental calendar sync',
+                totalJobs: $batch->jobs->count(),
+                pendingJobs: 0,
+                failedJobs: 1,
+                failedJobIds: ['job-1'],
+                options: [],
+                createdAt: now()->toImmutable(),
+            ));
+        }
+
+        return true;
+    });
+
+    expect($account->fresh()?->calendar_sync_cursor)->toBe('new-token')
+        ->and($account->fresh()?->status)->toBe(EmailAccountStatus::ERROR)
+        ->and($account->fresh()?->last_error)->toContain('1 calendar event(s)')
+        ->and(MailboxSyncTracker::isCalendarSyncing($account))->toBeFalse();
 });

--- a/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
@@ -16,6 +16,7 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 mutates(InitialCalendarSyncJob::class);
 
@@ -378,5 +379,6 @@ it('does not advance the initial calendar import while page events are still mis
     Bus::assertDispatchedTimes(InitialCalendarSyncJob::class, 0);
     expect($account->fresh()?->calendar_sync_cursor)->toBeNull()
         ->and($account->fresh()?->status)->toBe(EmailAccountStatus::ERROR)
-        ->and($account->fresh()?->last_error)->toContain('2 event(s)');
+        ->and($account->fresh()?->last_error)->toContain('2 event(s)')
+        ->and(MailboxSyncTracker::isCalendarSyncing($account))->toBeFalse();
 });

--- a/tests/Feature/CalendarIntegration/MeetingRsvpActionsTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingRsvpActionsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Filament\Actions\MeetingRsvpActions;
+use Relaticle\EmailIntegration\Filament\Infolists\Entries\MeetingHeaderEntry;
+use Relaticle\EmailIntegration\Filament\Infolists\MeetingDetailInfolist;
+use Relaticle\EmailIntegration\Filament\Resources\MeetingResource\Pages\ListMeetings;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\MeetingAttendee;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
+
+mutates(MeetingRsvpActions::class, MeetingDetailInfolist::class, MeetingHeaderEntry::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    $this->team = $this->user->currentTeam;
+    Filament::setTenant($this->team);
+
+    $this->account = ConnectedAccount::withoutEvents(
+        fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->user->id,
+            'email_address' => 'me@example.com',
+            'capabilities' => ['email' => true, 'calendar' => true],
+        ])
+    );
+});
+
+function meetingRsvpInvitation(ConnectedAccount $account, array $overrides = []): Meeting
+{
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_event_id' => 'evt-list-1',
+        'response_status' => $overrides['response_status'] ?? AttendeeResponseStatus::NEEDS_ACTION,
+        'organizer_email' => 'host@example.com',
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => strtolower($account->email_address),
+        'is_self' => $overrides['is_self'] ?? true,
+        'is_organizer' => $overrides['is_organizer'] ?? false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    return $meeting;
+}
+
+it('renders the RSVP dropdown as RSVP when the mailbox has not answered', function (): void {
+    $meeting = meetingRsvpInvitation($this->account);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertSee(__('filament/resources/meeting.actions.rsvp.label'));
+});
+
+it('labels the RSVP dropdown with the current response after the mailbox answers', function (): void {
+    $meeting = meetingRsvpInvitation($this->account, [
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+    ]);
+
+    livewire(ListMeetings::class)
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertSee(AttendeeResponseStatus::ACCEPTED->getLabel());
+});
+
+it('shows RSVP actions on the meeting card for invitations the mailbox owner can answer', function (): void {
+    $meeting = meetingRsvpInvitation($this->account);
+
+    livewire(ListMeetings::class)
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ])
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('maybeMeeting'),
+        ])
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('declineMeeting'),
+        ]);
+});
+
+it('shows RSVP actions when the signed-in user is the host', function (): void {
+    $meeting = meetingRsvpInvitation($this->account, ['is_organizer' => true]);
+
+    livewire(ListMeetings::class)
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ])
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('maybeMeeting'),
+        ])
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('declineMeeting'),
+        ]);
+});
+
+it('hides RSVP actions for a teammate viewing someone else\'s meeting', function (): void {
+    $meeting = meetingRsvpInvitation($this->account);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'buyer@acme-buyer.test',
+        'is_self' => false,
+        'is_organizer' => false,
+    ]);
+
+    $teammate = User::factory()->create();
+    $this->team->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($this->team);
+    $this->actingAs($teammate);
+    Filament::setTenant($this->team);
+
+    livewire(ListMeetings::class)
+        ->assertCanSeeTableRecords([$meeting])
+        ->assertActionHidden([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ]);
+});
+
+it('accepts an invitation from the meeting card and updates the calendar', function (): void {
+    $meeting = meetingRsvpInvitation($this->account);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-list-1', AttendeeResponseStatus::ACCEPTED);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    livewire(ListMeetings::class)
+        ->callAction([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ])
+        ->assertNotified();
+
+    expect($meeting->fresh()?->response_status)->toBe(AttendeeResponseStatus::ACCEPTED);
+});

--- a/tests/Feature/CalendarIntegration/MeetingRsvpActionsTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingRsvpActionsTest.php
@@ -16,8 +16,9 @@ use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
+use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
-mutates(MeetingRsvpActions::class, MeetingDetailInfolist::class, MeetingHeaderEntry::class, MeetingPolicy::class);
+mutates(MeetingRsvpActions::class, MeetingDetailInfolist::class, MeetingHeaderEntry::class, MeetingPolicy::class, MeetingRespondentResolver::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -56,12 +57,12 @@ function meetingRsvpInvitation(ConnectedAccount $account, array $overrides = [])
     return $meeting;
 }
 
-it('renders the RSVP dropdown as RSVP when the mailbox has not answered', function (): void {
+it('renders the RSVP dropdown as Pending when the mailbox has not answered', function (): void {
     $meeting = meetingRsvpInvitation($this->account);
 
     livewire(ListMeetings::class)
         ->mountAction(TestAction::make('view')->table($meeting))
-        ->assertSee(__('filament/resources/meeting.actions.rsvp.label'));
+        ->assertSee(AttendeeResponseStatus::NEEDS_ACTION->getLabel());
 });
 
 it('labels the RSVP dropdown with the current response after the mailbox answers', function (): void {
@@ -134,7 +135,7 @@ it('shows RSVP actions when the signed-in user is the host', function (): void {
         ]);
 });
 
-it('hides RSVP actions for a teammate viewing someone else\'s meeting', function (): void {
+it('hides RSVP actions for a teammate who is not listed on the guest list', function (): void {
     $meeting = meetingRsvpInvitation($this->account);
 
     MeetingAttendee::factory()->create([
@@ -153,6 +154,118 @@ it('hides RSVP actions for a teammate viewing someone else\'s meeting', function
     livewire(ListMeetings::class)
         ->assertCanSeeTableRecords([$meeting])
         ->assertActionHidden([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ]);
+});
+
+it('hides RSVP actions when only the workspace email is invited but no matching calendar account is connected', function (): void {
+    $meeting = meetingRsvpInvitation($this->account);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'buyer@acme-buyer.test',
+        'is_self' => false,
+        'is_organizer' => false,
+    ]);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $this->team->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($this->team);
+
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $this->actingAs($teammate);
+    Filament::setTenant($this->team);
+
+    livewire(ListMeetings::class)
+        ->assertCanSeeTableRecords([$meeting])
+        ->assertActionHidden([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ]);
+});
+
+it('shows RSVP actions when the workspace email is invited and the matching calendar account is connected', function (): void {
+    $meeting = meetingRsvpInvitation($this->account);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $this->team->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($this->team);
+
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $this->actingAs($teammate);
+    Filament::setTenant($this->team);
+
+    livewire(ListMeetings::class)
+        ->assertCanSeeTableRecords([$meeting])
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ]);
+});
+
+it('shows RSVP actions when only the connected mailbox email is on the guest list', function (): void {
+    $meeting = meetingRsvpInvitation($this->account);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'buyer@acme-buyer.test',
+        'is_self' => false,
+        'is_organizer' => false,
+    ]);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $this->team->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($this->team);
+
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+    ]);
+
+    $this->actingAs($teammate);
+    Filament::setTenant($this->team);
+
+    livewire(ListMeetings::class)
+        ->assertCanSeeTableRecords([$meeting])
+        ->assertActionVisible([
             TestAction::make('view')->table($meeting),
             TestAction::make('acceptMeeting'),
         ]);

--- a/tests/Feature/CalendarIntegration/MeetingRsvpActionsTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingRsvpActionsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use App\Policies\MeetingPolicy;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
@@ -16,7 +17,7 @@ use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 
-mutates(MeetingRsvpActions::class, MeetingDetailInfolist::class, MeetingHeaderEntry::class);
+mutates(MeetingRsvpActions::class, MeetingDetailInfolist::class, MeetingHeaderEntry::class, MeetingPolicy::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -75,6 +76,30 @@ it('labels the RSVP dropdown with the current response after the mailbox answers
 
 it('shows RSVP actions on the meeting card for invitations the mailbox owner can answer', function (): void {
     $meeting = meetingRsvpInvitation($this->account);
+
+    livewire(ListMeetings::class)
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('acceptMeeting'),
+        ])
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('maybeMeeting'),
+        ])
+        ->assertActionVisible([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('declineMeeting'),
+        ]);
+});
+
+it('shows RSVP actions when the signed-in user is the host even without a self attendee', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->account->team_id,
+        'connected_account_id' => $this->account->getKey(),
+        'provider_event_id' => 'evt-host-1',
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+        'organizer_email' => $this->account->email_address,
+    ]);
 
     livewire(ListMeetings::class)
         ->assertActionVisible([

--- a/tests/Feature/CalendarIntegration/ReconcileCalendarMeetingsActionTest.php
+++ b/tests/Feature/CalendarIntegration/ReconcileCalendarMeetingsActionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Relaticle\EmailIntegration\Actions\ReconcileCalendarMeetingsAction;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
+use Relaticle\EmailIntegration\Services\Exceptions\ReconcileCalendarMeetingsFailed;
+
+mutates(ReconcileCalendarMeetingsAction::class);
+
+it('reports reconciliation failures on the connected account', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('listActiveProviderEventIds')
+        ->once()
+        ->andThrow(new RuntimeException('Graph unavailable'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->with($account)->andReturn($service);
+
+    expect(fn () => resolve(ReconcileCalendarMeetingsAction::class, ['calendarFactory' => $factory])->execute($account))
+        ->toThrow(ReconcileCalendarMeetingsFailed::class);
+});
+
+it('removes meetings that no longer exist on the provider calendar', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $stale = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'stale-event',
+    ]);
+    $current = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'live-event',
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('listActiveProviderEventIds')
+        ->once()
+        ->andReturn(['live-event']);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->with($account)->andReturn($service);
+
+    resolve(ReconcileCalendarMeetingsAction::class, ['calendarFactory' => $factory])->execute($account);
+
+    expect($stale->fresh()?->trashed())->toBeTrue()
+        ->and($current->fresh()?->trashed())->toBeFalse();
+});

--- a/tests/Feature/CalendarIntegration/ReconcileCalendarMeetingsActionTest.php
+++ b/tests/Feature/CalendarIntegration/ReconcileCalendarMeetingsActionTest.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 use Relaticle\EmailIntegration\Actions\ReconcileCalendarMeetingsAction;
+use Relaticle\EmailIntegration\Exceptions\ReconcileCalendarMeetingsFailed;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\ReconcileCalendarMeetingsFailed;
 
 mutates(ReconcileCalendarMeetingsAction::class);
 

--- a/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
+++ b/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
@@ -14,9 +14,10 @@ use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
+use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-mutates(RespondToMeetingAction::class, MeetingPolicy::class);
+mutates(RespondToMeetingAction::class, MeetingPolicy::class, MeetingRespondentResolver::class);
 
 /**
  * @param  array<string, mixed>  $overrides
@@ -180,7 +181,7 @@ it('lets the mailbox owner change RSVP when they are the host even without an at
         ->and($updated->attendees->first()?->response_status)->toBe(AttendeeResponseStatus::TENTATIVE);
 });
 
-it('forbids a teammate from changing someone else\'s RSVP', function (): void {
+it('forbids a teammate from changing someone else\'s RSVP when they are not on the guest list', function (): void {
     $owner = User::factory()->withTeam()->create();
     $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
     $meeting = respondToMeetingInvitation($account);
@@ -199,6 +200,201 @@ it('forbids a teammate from changing someone else\'s RSVP', function (): void {
 
     expect(fn () => app(RespondToMeetingAction::class)->execute($teammate, $meeting, AttendeeResponseStatus::ACCEPTED))
         ->toThrow(HttpException::class);
+});
+
+it('lets a teammate respond when only their connected mailbox email is on the guest list', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'buyer@acme-buyer.test',
+        'is_self' => false,
+        'is_organizer' => false,
+    ]);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    $teammateAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-rsvp-1', AttendeeResponseStatus::TENTATIVE);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')
+        ->once()
+        ->with(Mockery::on(fn (ConnectedAccount $passed): bool => $passed->is($teammateAccount)))
+        ->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    $updated = app(RespondToMeetingAction::class)->execute(
+        $teammate,
+        $meeting->fresh(['attendees', 'connectedAccount']),
+        AttendeeResponseStatus::TENTATIVE,
+    );
+
+    expect($updated->attendees->firstWhere('email_address', 'mail2asmitnepali99@gmail.com')?->response_status)
+        ->toBe(AttendeeResponseStatus::TENTATIVE);
+});
+
+it('forbids a teammate from responding when only the workspace email is invited without a matching calendar account', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldNotReceive('respondToEvent');
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldNotReceive('make');
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    expect(fn () => app(RespondToMeetingAction::class)->execute(
+        $teammate,
+        $meeting->fresh(['attendees', 'connectedAccount']),
+        AttendeeResponseStatus::TENTATIVE,
+    ))->toThrow(HttpException::class);
+});
+
+it('lets a teammate respond when their workspace email is on the guest list and the matching calendar account is connected', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'buyer@acme-buyer.test',
+        'is_self' => false,
+        'is_organizer' => false,
+    ]);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    $teammateAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-rsvp-1', AttendeeResponseStatus::TENTATIVE);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')
+        ->once()
+        ->with(Mockery::on(fn (ConnectedAccount $passed): bool => $passed->is($teammateAccount)))
+        ->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    $updated = app(RespondToMeetingAction::class)->execute($teammate, $meeting->fresh(['attendees', 'connectedAccount']), AttendeeResponseStatus::TENTATIVE);
+
+    expect($updated->response_status)->toBe(AttendeeResponseStatus::NEEDS_ACTION)
+        ->and($updated->attendees->firstWhere('email_address', 'mail2asmitnepali@gmail.com')?->response_status)
+        ->toBe(AttendeeResponseStatus::TENTATIVE);
+});
+
+it('uses the connected calendar account that matches the listed mailbox identity', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $teammate = User::factory()->create(['email' => 'personal@gmail.com']);
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'personal@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $workAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'work@company.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'work@company.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-rsvp-1', AttendeeResponseStatus::ACCEPTED);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')
+        ->once()
+        ->with(Mockery::on(fn (ConnectedAccount $passed): bool => $passed->is($workAccount)))
+        ->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    app(RespondToMeetingAction::class)->execute(
+        $teammate,
+        $meeting->fresh(['attendees', 'connectedAccount']),
+        AttendeeResponseStatus::ACCEPTED,
+    );
 });
 
 it('forbids RSVP on a meeting from another team', function (): void {

--- a/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
+++ b/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
@@ -8,12 +8,12 @@ use App\Policies\MeetingPolicy;
 use Relaticle\EmailIntegration\Actions\RespondToMeetingAction;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
+use Relaticle\EmailIntegration\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 

--- a/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
+++ b/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
@@ -54,6 +54,19 @@ function respondToMeetingCalendarAccount(User $user, Team $team): ConnectedAccou
     ]));
 }
 
+function teammateMailboxCopy(ConnectedAccount $account, Meeting $source, string $providerEventId = 'evt-teammate-copy'): Meeting
+{
+    return Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_event_id' => $providerEventId,
+        'ical_uid' => $source->ical_uid,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+        'status' => CalendarEventStatus::CONFIRMED,
+        'organizer_email' => $source->organizer_email,
+    ]);
+}
+
 it('writes the RSVP to the provider and updates the local meeting', function (): void {
     $user = User::factory()->withTeam()->create();
     $account = respondToMeetingCalendarAccount($user, $user->currentTeam);
@@ -233,10 +246,12 @@ it('lets a teammate respond when only their connected mailbox email is on the gu
         'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
     ]);
 
+    teammateMailboxCopy($teammateAccount, $meeting);
+
     $service = Mockery::mock(CalendarServiceInterface::class);
     $service->shouldReceive('respondToEvent')
         ->once()
-        ->with('evt-rsvp-1', AttendeeResponseStatus::TENTATIVE);
+        ->with('evt-teammate-copy', AttendeeResponseStatus::TENTATIVE);
 
     $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
     $factory->shouldReceive('make')
@@ -326,10 +341,12 @@ it('lets a teammate respond when their workspace email is on the guest list and 
         'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
     ]);
 
+    teammateMailboxCopy($teammateAccount, $meeting);
+
     $service = Mockery::mock(CalendarServiceInterface::class);
     $service->shouldReceive('respondToEvent')
         ->once()
-        ->with('evt-rsvp-1', AttendeeResponseStatus::TENTATIVE);
+        ->with('evt-teammate-copy', AttendeeResponseStatus::TENTATIVE);
 
     $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
     $factory->shouldReceive('make')
@@ -377,10 +394,12 @@ it('uses the connected calendar account that matches the listed mailbox identity
         'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
     ]);
 
+    teammateMailboxCopy($workAccount, $meeting);
+
     $service = Mockery::mock(CalendarServiceInterface::class);
     $service->shouldReceive('respondToEvent')
         ->once()
-        ->with('evt-rsvp-1', AttendeeResponseStatus::ACCEPTED);
+        ->with('evt-teammate-copy', AttendeeResponseStatus::ACCEPTED);
 
     $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
     $factory->shouldReceive('make')
@@ -395,6 +414,141 @@ it('uses the connected calendar account that matches the listed mailbox identity
         $meeting->fresh(['attendees', 'connectedAccount']),
         AttendeeResponseStatus::ACCEPTED,
     );
+});
+
+it('writes the teammate RSVP to their own mailbox event, not the source mailbox id', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    $teammateAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    teammateMailboxCopy($teammateAccount, $meeting);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldNotReceive('findEventIdByICalUid');
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-teammate-copy', AttendeeResponseStatus::TENTATIVE);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')
+        ->once()
+        ->with(Mockery::on(fn (ConnectedAccount $passed): bool => $passed->is($teammateAccount)))
+        ->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    app(RespondToMeetingAction::class)->execute(
+        $teammate,
+        $meeting->fresh(['attendees', 'connectedAccount']),
+        AttendeeResponseStatus::TENTATIVE,
+    );
+});
+
+it('looks up the teammate mailbox event by iCal UID when their local copy has not synced', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    $teammateAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('findEventIdByICalUid')
+        ->once()
+        ->with($meeting->ical_uid)
+        ->andReturn('evt-teammate-mailbox');
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-teammate-mailbox', AttendeeResponseStatus::TENTATIVE);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')
+        ->once()
+        ->with(Mockery::on(fn (ConnectedAccount $passed): bool => $passed->is($teammateAccount)))
+        ->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    app(RespondToMeetingAction::class)->execute(
+        $teammate,
+        $meeting->fresh(['attendees', 'connectedAccount']),
+        AttendeeResponseStatus::TENTATIVE,
+    );
+});
+
+it('does not RSVP with another mailbox event ID when the teammate copy cannot be resolved', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $teammate = User::factory()->create(['email' => 'mail2asmitnepali@gmail.com']);
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $owner->currentTeam->getKey(),
+        'user_id' => $teammate->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => 'mail2asmitnepali@gmail.com',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('findEventIdByICalUid')->once()->andReturnNull();
+    $service->shouldNotReceive('respondToEvent');
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    expect(fn () => app(RespondToMeetingAction::class)->execute(
+        $teammate,
+        $meeting->fresh(['attendees', 'connectedAccount']),
+        AttendeeResponseStatus::TENTATIVE,
+    ))->toThrow(MeetingResponseFailed::class);
 });
 
 it('forbids RSVP on a meeting from another team', function (): void {

--- a/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
+++ b/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Actions\RespondToMeetingAction;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\MeetingAttendee;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
+use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+mutates(RespondToMeetingAction::class);
+
+/**
+ * @param  array<string, mixed>  $overrides
+ */
+function respondToMeetingInvitation(ConnectedAccount $account, array $overrides = []): Meeting
+{
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_event_id' => $overrides['provider_event_id'] ?? 'evt-rsvp-1',
+        'response_status' => $overrides['response_status'] ?? AttendeeResponseStatus::NEEDS_ACTION,
+        'status' => $overrides['status'] ?? CalendarEventStatus::CONFIRMED,
+        'organizer_email' => $overrides['organizer_email'] ?? 'host@example.com',
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->getKey(),
+        'email_address' => strtolower($account->email_address),
+        'is_self' => $overrides['is_self'] ?? true,
+        'is_organizer' => $overrides['is_organizer'] ?? false,
+        'response_status' => $overrides['attendee_response_status'] ?? AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    return $meeting->load(['attendees', 'connectedAccount', 'team']);
+}
+
+function respondToMeetingCalendarAccount(User $user, Team $team): ConnectedAccount
+{
+    return ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $team->getKey(),
+        'user_id' => $user->getKey(),
+        'email_address' => 'me@example.com',
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+}
+
+it('writes the RSVP to the provider and updates the local meeting', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($user, $user->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-rsvp-1', AttendeeResponseStatus::ACCEPTED);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->with(Mockery::on(
+        fn (ConnectedAccount $passed): bool => $passed->is($account),
+    ))->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    $updated = app(RespondToMeetingAction::class)->execute($user, $meeting, AttendeeResponseStatus::ACCEPTED);
+
+    expect($updated->response_status)->toBe(AttendeeResponseStatus::ACCEPTED)
+        ->and($updated->attendees->first()?->response_status)->toBe(AttendeeResponseStatus::ACCEPTED)
+        ->and($updated->trashed())->toBeFalse();
+});
+
+it('keeps a declined invitation so the RSVP can be changed again', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($user, $user->currentTeam);
+    $meeting = respondToMeetingInvitation($account, [
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+        'attendee_response_status' => AttendeeResponseStatus::ACCEPTED,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-rsvp-1', AttendeeResponseStatus::DECLINED);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    $updated = app(RespondToMeetingAction::class)->execute($user, $meeting, AttendeeResponseStatus::DECLINED);
+
+    expect($updated->response_status)->toBe(AttendeeResponseStatus::DECLINED)
+        ->and($updated->trashed())->toBeFalse();
+});
+
+it('does not update local state when the provider rejects the RSVP', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($user, $user->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->andThrow(MeetingResponseFailed::fromProvider(new RuntimeException('denied')));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    expect(fn () => app(RespondToMeetingAction::class)->execute($user, $meeting, AttendeeResponseStatus::ACCEPTED))
+        ->toThrow(MeetingResponseFailed::class);
+
+    expect($meeting->fresh()?->response_status)->toBe(AttendeeResponseStatus::NEEDS_ACTION);
+});
+
+it('lets the mailbox owner change RSVP when they are the host', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($user, $user->currentTeam);
+    $meeting = respondToMeetingInvitation($account, [
+        'organizer_email' => $account->email_address,
+        'is_organizer' => true,
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+        'attendee_response_status' => AttendeeResponseStatus::ACCEPTED,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-rsvp-1', AttendeeResponseStatus::TENTATIVE);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    $updated = app(RespondToMeetingAction::class)->execute($user, $meeting, AttendeeResponseStatus::TENTATIVE);
+
+    expect($updated->response_status)->toBe(AttendeeResponseStatus::TENTATIVE)
+        ->and($updated->attendees->first()?->response_status)->toBe(AttendeeResponseStatus::TENTATIVE)
+        ->and($updated->trashed())->toBeFalse();
+});
+
+it('forbids a teammate from changing someone else\'s RSVP', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($owner, $owner->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    $teammate = User::factory()->create();
+    $owner->currentTeam->users()->attach($teammate, ['role' => 'admin']);
+    $teammate->switchTeam($owner->currentTeam);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldNotReceive('respondToEvent');
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldNotReceive('make');
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    expect(fn () => app(RespondToMeetingAction::class)->execute($teammate, $meeting, AttendeeResponseStatus::ACCEPTED))
+        ->toThrow(HttpException::class);
+});
+
+it('forbids RSVP on a meeting from another team', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $foreign = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($foreign, $foreign->currentTeam);
+    $meeting = respondToMeetingInvitation($account);
+
+    expect(fn () => app(RespondToMeetingAction::class)->execute($user, $meeting, AttendeeResponseStatus::ACCEPTED))
+        ->toThrow(HttpException::class);
+});

--- a/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
+++ b/tests/Feature/CalendarIntegration/RespondToMeetingActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\Team;
 use App\Models\User;
+use App\Policies\MeetingPolicy;
 use Relaticle\EmailIntegration\Actions\RespondToMeetingAction;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
@@ -15,7 +16,7 @@ use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
 use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-mutates(RespondToMeetingAction::class);
+mutates(RespondToMeetingAction::class, MeetingPolicy::class);
 
 /**
  * @param  array<string, mixed>  $overrides
@@ -146,6 +147,37 @@ it('lets the mailbox owner change RSVP when they are the host', function (): voi
     expect($updated->response_status)->toBe(AttendeeResponseStatus::TENTATIVE)
         ->and($updated->attendees->first()?->response_status)->toBe(AttendeeResponseStatus::TENTATIVE)
         ->and($updated->trashed())->toBeFalse();
+});
+
+it('lets the mailbox owner change RSVP when they are the host even without an attendee row', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $account = respondToMeetingCalendarAccount($user, $user->currentTeam);
+    $meeting = Meeting::factory()->create([
+        'team_id' => $account->team_id,
+        'connected_account_id' => $account->getKey(),
+        'provider_event_id' => 'evt-rsvp-1',
+        'response_status' => AttendeeResponseStatus::ACCEPTED,
+        'status' => CalendarEventStatus::CONFIRMED,
+        'organizer_email' => $account->email_address,
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('respondToEvent')
+        ->once()
+        ->with('evt-rsvp-1', AttendeeResponseStatus::TENTATIVE);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    $updated = app(RespondToMeetingAction::class)->execute($user, $meeting, AttendeeResponseStatus::TENTATIVE);
+
+    expect($updated->response_status)->toBe(AttendeeResponseStatus::TENTATIVE)
+        ->and($updated->attendees)->toHaveCount(1)
+        ->and($updated->attendees->first()?->is_self)->toBeTrue()
+        ->and($updated->attendees->first()?->is_organizer)->toBeTrue()
+        ->and($updated->attendees->first()?->response_status)->toBe(AttendeeResponseStatus::TENTATIVE);
 });
 
 it('forbids a teammate from changing someone else\'s RSVP', function (): void {

--- a/tests/Feature/CalendarIntegration/StopCalendarPushChannelActionTest.php
+++ b/tests/Feature/CalendarIntegration/StopCalendarPushChannelActionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Relaticle\EmailIntegration\Actions\DisconnectConnectedAccountAction;
+use Relaticle\EmailIntegration\Actions\StopCalendarPushChannelAction;
+use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\CalendarServiceInterface;
+
+mutates(DisconnectConnectedAccountAction::class, StopCalendarPushChannelAction::class);
+
+it('stops and clears calendar push fields when disconnecting an account', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/subscriptions/sub-123' => Http::response(null, 204),
+    ]);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->azure()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_push_channel_id' => 'sub-123',
+        'calendar_push_resource_id' => null,
+        'calendar_push_verification_token' => 'secret',
+        'calendar_push_expires_at' => now()->addDay(),
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('stopPushChannel')
+        ->once()
+        ->with('sub-123', null);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->with($account)->andReturn($service);
+
+    resolve(DisconnectConnectedAccountAction::class, [
+        'stopCalendarPushChannel' => new StopCalendarPushChannelAction($factory),
+    ])->execute($account);
+
+    expect($account->fresh()?->trashed())->toBeTrue()
+        ->and($account->fresh()?->calendar_push_channel_id)->toBeNull()
+        ->and($account->fresh()?->calendar_push_verification_token)->toBeNull();
+});
+
+it('stops and clears calendar push fields when disabling calendar sync', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'provider' => EmailProvider::GMAIL,
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_push_channel_id' => 'channel-123',
+        'calendar_push_resource_id' => 'resource-123',
+        'calendar_push_verification_token' => 'secret',
+        'calendar_push_expires_at' => now()->addDay(),
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('stopPushChannel')
+        ->once()
+        ->with('channel-123', 'resource-123');
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->with($account)->andReturn($service);
+
+    resolve(StopCalendarPushChannelAction::class, ['calendarFactory' => $factory])->execute($account);
+
+    $account->refresh();
+
+    expect($account->calendar_push_channel_id)->toBeNull()
+        ->and($account->calendar_push_resource_id)->toBeNull()
+        ->and($account->calendar_push_verification_token)->toBeNull()
+        ->and($account->calendar_push_expires_at)->toBeNull();
+});
+
+it('clears local push fields when the provider client cannot be created', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_push_channel_id' => 'channel-123',
+        'calendar_push_resource_id' => 'resource-123',
+        'calendar_push_verification_token' => 'secret',
+        'calendar_push_expires_at' => now()->addDay(),
+        'refresh_token' => null,
+        'token_expires_at' => now()->subHour(),
+    ]));
+
+    resolve(StopCalendarPushChannelAction::class)->execute($account);
+
+    $account->refresh();
+
+    expect($account->calendar_push_channel_id)->toBeNull()
+        ->and($account->calendar_push_verification_token)->toBeNull();
+});

--- a/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
+++ b/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
@@ -57,6 +57,82 @@ it('stores events declined by self so RSVP can still be changed', function (): v
         ->and(Meeting::query()->first()?->response_status)->toBe(AttendeeResponseStatus::DECLINED);
 });
 
+it('defaults a host meeting with no self response to accepted', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'host@example.com',
+    ]));
+
+    (app(StoreMeetingAction::class))->execute(new NormalizedMeetingPayload(
+        providerEventId: 'evt-host-default',
+        providerRecurringEventId: null,
+        icalUid: null,
+        title: 'Call',
+        description: null,
+        location: null,
+        startsAt: Carbon::now()->addDay(),
+        endsAt: Carbon::now()->addDay()->addHour(),
+        allDay: false,
+        organizerEmail: 'host@example.com',
+        organizerName: 'Host',
+        status: CalendarEventStatus::CONFIRMED,
+        visibility: CalendarVisibility::DEFAULT,
+        selfResponseStatus: null,
+        htmlLink: null,
+        attendees: [],
+    ), $account);
+
+    expect(Meeting::query()->first()?->response_status)->toBe(AttendeeResponseStatus::ACCEPTED);
+});
+
+it('keeps a host RSVP when the next sync has no self response', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'host@example.com',
+    ]));
+
+    $first = new NormalizedMeetingPayload(
+        providerEventId: 'evt-host-keep',
+        providerRecurringEventId: null,
+        icalUid: null,
+        title: 'Call',
+        description: null,
+        location: null,
+        startsAt: Carbon::now()->addDay(),
+        endsAt: Carbon::now()->addDay()->addHour(),
+        allDay: false,
+        organizerEmail: 'host@example.com',
+        organizerName: 'Host',
+        status: CalendarEventStatus::CONFIRMED,
+        visibility: CalendarVisibility::DEFAULT,
+        selfResponseStatus: AttendeeResponseStatus::TENTATIVE,
+        htmlLink: null,
+        attendees: [],
+    );
+
+    (app(StoreMeetingAction::class))->execute($first, $account);
+
+    (app(StoreMeetingAction::class))->execute(new NormalizedMeetingPayload(
+        providerEventId: 'evt-host-keep',
+        providerRecurringEventId: null,
+        icalUid: null,
+        title: 'Call',
+        description: null,
+        location: null,
+        startsAt: $first->startsAt,
+        endsAt: $first->endsAt,
+        allDay: false,
+        organizerEmail: 'host@example.com',
+        organizerName: 'Host',
+        status: CalendarEventStatus::CONFIRMED,
+        visibility: CalendarVisibility::DEFAULT,
+        selfResponseStatus: null,
+        htmlLink: null,
+        attendees: [],
+    ), $account);
+
+    expect(Meeting::query()->where('provider_event_id', 'evt-host-keep')->first()?->response_status)
+        ->toBe(AttendeeResponseStatus::TENTATIVE);
+});
+
 it('stores events older than 90 days', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
     (app(StoreMeetingAction::class))->execute(payload([

--- a/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
+++ b/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
@@ -17,7 +17,7 @@ function payload(array $overrides = []): NormalizedMeetingPayload
 {
     return new NormalizedMeetingPayload(
         providerEventId: $overrides['providerEventId'] ?? 'evt-'.fake()->uuid(),
-        providerRecurringEventId: null,
+        providerRecurringEventId: $overrides['providerRecurringEventId'] ?? null,
         icalUid: null,
         title: 'Quarterly Sync',
         description: null,
@@ -47,6 +47,97 @@ it('skips cancelled events', function (): void {
     (app(StoreMeetingAction::class))->execute(payload(['status' => CalendarEventStatus::CANCELLED]), $account);
 
     expect(Meeting::query()->count())->toBe(0);
+});
+
+it('soft-deletes existing meeting when it is cancelled in the provider calendar', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
+    $existing = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'evt-cancelled',
+    ]);
+
+    (app(StoreMeetingAction::class))->execute(payload([
+        'providerEventId' => 'evt-cancelled',
+        'status' => CalendarEventStatus::CANCELLED,
+    ]), $account);
+
+    expect($existing->fresh()?->trashed())->toBeTrue();
+});
+
+it('soft-deletes only one occurrence when a single recurring instance is cancelled', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
+    $first = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'series_20250908',
+        'provider_recurring_event_id' => 'series-master',
+    ]);
+    $second = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'series_20250909',
+        'provider_recurring_event_id' => 'series-master',
+    ]);
+
+    (app(StoreMeetingAction::class))->execute(payload([
+        'providerEventId' => 'series_20250908',
+        'providerRecurringEventId' => 'series-master',
+        'status' => CalendarEventStatus::CANCELLED,
+    ]), $account);
+
+    expect($first->fresh()?->trashed())->toBeTrue()
+        ->and($second->fresh()?->trashed())->toBeFalse();
+});
+
+it('soft-deletes only one occurrence when a single recurring instance becomes private', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
+    $first = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'series_20250908',
+        'provider_recurring_event_id' => 'series-master',
+    ]);
+    $second = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'series_20250909',
+        'provider_recurring_event_id' => 'series-master',
+    ]);
+
+    (app(StoreMeetingAction::class))->execute(payload([
+        'providerEventId' => 'series_20250908',
+        'providerRecurringEventId' => 'series-master',
+        'visibility' => CalendarVisibility::PRIVATE,
+    ]), $account);
+
+    expect($first->fresh()?->trashed())->toBeTrue()
+        ->and($second->fresh()?->trashed())->toBeFalse();
+});
+
+it('soft-deletes all meetings in a recurring series when the series master is cancelled', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
+    $first = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'series_20250908',
+        'provider_recurring_event_id' => 'series-master',
+    ]);
+    $second = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'series_20250909',
+        'provider_recurring_event_id' => 'series-master',
+    ]);
+
+    (app(StoreMeetingAction::class))->execute(payload([
+        'providerEventId' => 'series-master',
+        'providerRecurringEventId' => null,
+        'status' => CalendarEventStatus::CANCELLED,
+    ]), $account);
+
+    expect($first->fresh()?->trashed())->toBeTrue()
+        ->and($second->fresh()?->trashed())->toBeTrue();
 });
 
 it('stores events declined by self so RSVP can still be changed', function (): void {

--- a/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
+++ b/tests/Feature/CalendarIntegration/StoreMeetingActionFilterTest.php
@@ -49,11 +49,12 @@ it('skips cancelled events', function (): void {
     expect(Meeting::query()->count())->toBe(0);
 });
 
-it('skips events declined by self', function (): void {
+it('stores events declined by self so RSVP can still be changed', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create());
     (app(StoreMeetingAction::class))->execute(payload(['selfResponseStatus' => AttendeeResponseStatus::DECLINED]), $account);
 
-    expect(Meeting::query()->count())->toBe(0);
+    expect(Meeting::query()->count())->toBe(1)
+        ->and(Meeting::query()->first()?->response_status)->toBe(AttendeeResponseStatus::DECLINED);
 });
 
 it('stores events older than 90 days', function (): void {

--- a/tests/Feature/CalendarIntegration/StoreMeetingJobTest.php
+++ b/tests/Feature/CalendarIntegration/StoreMeetingJobTest.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 use Illuminate\Support\Carbon;
 use Relaticle\EmailIntegration\Actions\StoreMeetingAction;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Jobs\StoreMeetingJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\Factories\NormalizedMeetingPayloadFactory;
 
-mutates(StoreMeetingJob::class);
+mutates(StoreMeetingJob::class, NormalizedMeetingPayloadFactory::class);
 
 it('stores a calendar event via StoreMeetingJob', function (): void {
     $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create(['email_address' => 'me@example.com']));
@@ -41,4 +42,76 @@ it('stores a calendar event via StoreMeetingJob', function (): void {
     );
 
     expect(Meeting::query()->where('provider_event_id', 'evt-123')->exists())->toBeTrue();
+});
+
+it('stores the mailbox owner as host when the provider omits them from attendees', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'me@example.com',
+    ]));
+
+    $event = new CalendarEventData(
+        providerEventId: 'evt-host',
+        providerRecurringEventId: null,
+        iCalUid: null,
+        title: 'Call Asmit',
+        description: null,
+        startsAt: Carbon::now()->addDay(),
+        endsAt: Carbon::now()->addDay()->addHour(),
+        isAllDay: false,
+        location: null,
+        htmlLink: null,
+        status: 'confirmed',
+        visibility: 'default',
+        organizerEmail: 'me@example.com',
+        organizerName: 'Asmit Magan',
+        attendees: [
+            ['email' => 'guest@example.com', 'name' => 'Guest', 'response_status' => 'needsAction', 'is_organizer' => false],
+        ],
+    );
+
+    (new StoreMeetingJob($account, $event))->handle(
+        app(StoreMeetingAction::class),
+        app(NormalizedMeetingPayloadFactory::class),
+    );
+
+    $meeting = Meeting::query()->where('provider_event_id', 'evt-host')->firstOrFail();
+
+    expect($meeting->response_status)->toBe(AttendeeResponseStatus::ACCEPTED)
+        ->and($meeting->attendees()->where('is_self', true)->first()?->is_organizer)->toBeTrue();
+});
+
+it('does not duplicate a host who is already in attendees without the organizer flag', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'email_address' => 'guest@example.com',
+    ]));
+
+    $event = new CalendarEventData(
+        providerEventId: 'evt-listed-host',
+        providerRecurringEventId: null,
+        iCalUid: null,
+        title: 'Listed host',
+        description: null,
+        startsAt: Carbon::now()->addDay(),
+        endsAt: Carbon::now()->addDay()->addHour(),
+        isAllDay: false,
+        location: null,
+        htmlLink: null,
+        status: 'confirmed',
+        visibility: 'default',
+        organizerEmail: 'host@example.com',
+        organizerName: 'Host',
+        attendees: [
+            ['email' => 'host@example.com', 'name' => 'Host', 'response_status' => 'accepted', 'is_organizer' => false],
+            ['email' => 'guest@example.com', 'name' => 'Guest', 'response_status' => 'accepted', 'is_organizer' => false],
+        ],
+    );
+
+    (new StoreMeetingJob($account, $event))->handle(
+        app(StoreMeetingAction::class),
+        app(NormalizedMeetingPayloadFactory::class),
+    );
+
+    $meeting = Meeting::query()->where('provider_event_id', 'evt-listed-host')->firstOrFail();
+
+    expect($meeting->attendees()->where('email_address', 'host@example.com')->count())->toBe(1);
 });

--- a/tests/Feature/Commands/EmailIntegrationScheduleTest.php
+++ b/tests/Feature/Commands/EmailIntegrationScheduleTest.php
@@ -10,12 +10,14 @@ use Illuminate\Support\Facades\Bus;
 use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Console\Commands\IncrementalCalendarSyncCommand;
 use Relaticle\EmailIntegration\Console\Commands\IncrementalEmailSyncCommand;
+use Relaticle\EmailIntegration\Console\Commands\RenewCalendarPushChannelsCommand;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 mutates(IncrementalEmailSyncCommand::class);
 mutates(IncrementalCalendarSyncCommand::class);
+mutates(RenewCalendarPushChannelsCommand::class);
 
 it('registers outbox and sync schedules when email integration is active', function (): void {
     Feature::activate(EmailIntegration::class);
@@ -25,6 +27,7 @@ it('registers outbox and sync schedules when email integration is active', funct
         ->expectsOutputToContain('email:dispatch-outbox')
         ->expectsOutputToContain('email:incremental-sync')
         ->expectsOutputToContain('calendar:incremental-sync')
+        ->expectsOutputToContain('calendar:renew-push-channels')
         ->assertSuccessful();
 });
 
@@ -40,10 +43,11 @@ it('runs email sync and outbox schedules on a single server without overlapping'
 
             return str_contains($haystack, 'email:incremental-sync')
                 || str_contains($haystack, 'calendar:incremental-sync')
+                || str_contains($haystack, 'calendar:renew-push-channels')
                 || str_contains($haystack, 'email:dispatch-outbox');
         });
 
-    expect($events)->toHaveCount(3)
+    expect($events)->toHaveCount(4)
         ->and($events->every(fn (Event $event): bool => $event->onOneServer && $event->withoutOverlapping))->toBeTrue();
 });
 
@@ -57,6 +61,7 @@ it('does not register outbox or sync schedules when email integration is inactiv
         ->doesntExpectOutputToContain('email:dispatch-outbox')
         ->doesntExpectOutputToContain('email:incremental-sync')
         ->doesntExpectOutputToContain('calendar:incremental-sync')
+        ->doesntExpectOutputToContain('calendar:renew-push-channels')
         ->assertSuccessful();
 });
 

--- a/tests/Feature/EmailIntegration/GmailMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/GmailMailServiceTest.php
@@ -13,8 +13,8 @@ use Google\Service\Gmail\Message;
 use Google\Service\Gmail\MessagePart;
 use Google\Service\Gmail\MessagePartBody;
 use Google\Service\Gmail\MessagePartHeader;
+use Relaticle\EmailIntegration\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
-use Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Services\GmailService;
 
 mutates(GmailService::class);

--- a/tests/Feature/EmailIntegration/IncrementalEmailSyncJobMicrosoftTest.php
+++ b/tests/Feature/EmailIntegration/IncrementalEmailSyncJobMicrosoftTest.php
@@ -6,8 +6,11 @@ use App\Models\User;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Testing\Fakes\BatchFake;
+use Laravel\SerializableClosure\SerializableClosure;
 use Relaticle\EmailIntegration\Data\MailDeltaResult;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
@@ -16,7 +19,6 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailRead;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
-use Relaticle\EmailIntegration\Services\Exceptions\MailHistoryExpired;
 
 mutates(IncrementalEmailSyncJob::class);
 
@@ -117,8 +119,18 @@ it('advances the cursor after the store batch completes', function (): void {
     (new IncrementalEmailSyncJob($account))->handle($factory);
 
     Bus::assertBatched(function (PendingBatch $batch): bool {
-        foreach ($batch->thenCallbacks() as $callback) {
-            $callback();
+        foreach ($batch->finallyCallbacks() as $callback) {
+            $closure = $callback instanceof SerializableClosure ? $callback->getClosure() : $callback;
+            $closure(new BatchFake(
+                id: 'batch-1',
+                name: 'Incremental sync',
+                totalJobs: $batch->jobs->count(),
+                pendingJobs: 0,
+                failedJobs: 0,
+                failedJobIds: [],
+                options: [],
+                createdAt: now()->toImmutable(),
+            ));
         }
 
         return true;

--- a/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
-use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
-use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
 use Relaticle\EmailIntegration\Services\MicrosoftCalendarService;
 

--- a/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
@@ -255,3 +255,43 @@ it('still fails when Graph returns a server error that mentions organizer', func
         ->respondToEvent('evt-1', AttendeeResponseStatus::DECLINED))
         ->toThrow(MeetingResponseFailed::class);
 });
+
+it('paginates listActiveProviderEventIds across nextLink pages and time windows', function (): void {
+    $this->travelTo('2020-01-01 00:00:00');
+
+    Http::fake(function (Request $request) {
+        $url = urldecode($request->url());
+
+        if (str_contains($url, 'startDateTime=1990-01-01') && ! str_contains($url, '$skiptoken=')) {
+            return Http::response([
+                'value' => [
+                    ['id' => 'evt-window-1', 'isCancelled' => false],
+                ],
+                '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=PAGE2',
+            ]);
+        }
+
+        if (str_contains($url, '$skiptoken=PAGE2')) {
+            return Http::response([
+                'value' => [
+                    ['id' => 'evt-window-1-page-2', 'isCancelled' => false],
+                ],
+            ]);
+        }
+
+        if (str_contains($url, 'startDateTime=1995-01-01')) {
+            return Http::response([
+                'value' => [
+                    ['id' => 'evt-window-2', 'isCancelled' => false],
+                ],
+            ]);
+        }
+
+        return Http::response(['value' => []]);
+    });
+
+    $ids = (new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class)))
+        ->listActiveProviderEventIds();
+
+    expect($ids)->toContain('evt-window-1', 'evt-window-1-page-2', 'evt-window-2');
+});

--- a/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
@@ -256,6 +256,45 @@ it('still fails when Graph returns a server error that mentions organizer', func
         ->toThrow(MeetingResponseFailed::class);
 });
 
+it('resolves this mailbox event id from a shared iCalendar UID', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/events*' => Http::response([
+            'value' => [
+                ['id' => 'evt-teammate-mailbox'],
+            ],
+        ]),
+    ]);
+
+    $eventId = (new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class)))
+        ->findEventIdByICalUid("uid-with'-quote");
+
+    expect($eventId)->toBe('evt-teammate-mailbox');
+
+    Http::assertSent(function (Request $request): bool {
+        $url = urldecode($request->url());
+
+        return $request->method() === 'GET'
+            && str_contains($url, '/me/events')
+            && str_contains($url, "iCalUId eq 'uid-with''-quote'")
+            && str_contains($url, '$select=id')
+            && str_contains($url, '$top=1');
+    });
+});
+
+it('returns null when Graph has no event for the iCalendar UID', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/events*' => Http::response([
+            'value' => [],
+        ]),
+    ]);
+
+    expect((new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class)))
+        ->findEventIdByICalUid('missing'))
+        ->toBeNull();
+});
+
 it('paginates listActiveProviderEventIds across nextLink pages and time windows', function (): void {
     $this->travelTo('2020-01-01 00:00:00');
 

--- a/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
@@ -10,6 +10,7 @@ use Relaticle\EmailIntegration\Data\CalendarSyncResult;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
+use Relaticle\EmailIntegration\Services\Exceptions\MeetingResponseFailed;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
 use Relaticle\EmailIntegration\Services\MicrosoftCalendarService;
 
@@ -90,6 +91,7 @@ it('maps Graph attendee response codes to the canonical vocabulary', function ()
                     'attendees' => [
                         ['emailAddress' => ['address' => 'tent@example.com'], 'status' => ['response' => 'tentativelyAccepted']],
                         ['emailAddress' => ['address' => 'none@example.com'], 'status' => ['response' => 'notResponded']],
+                        ['emailAddress' => ['address' => 'org@example.com'], 'status' => ['response' => 'organizer']],
                     ],
                 ],
             ],
@@ -101,8 +103,10 @@ it('maps Graph attendee response codes to the canonical vocabulary', function ()
         ->fetchDelta('https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=OLD');
 
     // tentativelyAccepted -> tentative, notResponded -> needsAction (Google's vocab).
+    // organizer is not an RSVP. Leave it empty so a host status chosen in Relaticle is kept.
     expect($result->events[0]->attendees[0]['response_status'])->toBe('tentative')
-        ->and($result->events[0]->attendees[1]['response_status'])->toBe('needsAction');
+        ->and($result->events[0]->attendees[1]['response_status'])->toBe('needsAction')
+        ->and($result->events[0]->attendees[2]['response_status'])->toBeNull();
 });
 
 it('maps Graph "personal" sensitivity to private so the event is treated as private', function (): void {
@@ -217,4 +221,37 @@ it('posts tentativelyAccept for maybe', function (): void {
         ->respondToEvent('evt-1', AttendeeResponseStatus::TENTATIVE);
 
     Http::assertSent(fn (Request $request): bool => str_ends_with($request->url(), '/me/events/evt-1/tentativelyAccept'));
+});
+
+it('does not fail when Graph rejects the host responding to their own meeting', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/events/evt-1/tentativelyAccept' => Http::response([
+            'error' => [
+                'code' => 'ErrorInvalidRequest',
+                'message' => 'Your request can\'t be completed. You can\'t respond to this meeting because you\'re the organizer.',
+            ],
+        ], 400),
+    ]);
+
+    (new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class)))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::TENTATIVE);
+
+    Http::assertSent(fn (Request $request): bool => str_ends_with($request->url(), '/me/events/evt-1/tentativelyAccept'));
+});
+
+it('still fails when Graph returns a server error that mentions organizer', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/events/evt-1/decline' => Http::response([
+            'error' => [
+                'code' => 'UnknownError',
+                'message' => 'The organizer service is unavailable.',
+            ],
+        ], 500),
+    ]);
+
+    expect(fn () => (new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class)))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::DECLINED))
+        ->toThrow(MeetingResponseFailed::class);
 });

--- a/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftCalendarServiceTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Relaticle\EmailIntegration\Data\CalendarSyncResult;
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Exceptions\CalendarSyncTokenExpired;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
@@ -190,4 +191,30 @@ it('throws CalendarSyncTokenExpired on Graph 410', function (): void {
     expect(fn (): CalendarSyncResult => new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class))
         ->fetchDelta('https://graph.microsoft.com/v1.0/me/calendarView/delta?$deltatoken=EXPIRED'))
         ->toThrow(CalendarSyncTokenExpired::class);
+});
+
+it('posts accept to Graph so the organizer is notified', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/events/evt-1/accept' => Http::response(null, 202),
+    ]);
+
+    new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::ACCEPTED);
+
+    Http::assertSent(fn (Request $request): bool => $request->method() === 'POST'
+        && str_ends_with($request->url(), '/me/events/evt-1/accept')
+        && $request['sendResponse'] === true);
+});
+
+it('posts tentativelyAccept for maybe', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/events/evt-1/tentativelyAccept' => Http::response(null, 202),
+    ]);
+
+    new MicrosoftCalendarService(makeAzureCalendarAccount(), resolve(MicrosoftGraphClientFactory::class))
+        ->respondToEvent('evt-1', AttendeeResponseStatus::TENTATIVE);
+
+    Http::assertSent(fn (Request $request): bool => str_ends_with($request->url(), '/me/events/evt-1/tentativelyAccept'));
 });

--- a/tests/Feature/EmailIntegration/StartMailboxHistoryImportActionTest.php
+++ b/tests/Feature/EmailIntegration/StartMailboxHistoryImportActionTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Bus;
 use Relaticle\EmailIntegration\Actions\StartMailboxHistoryImportAction;
+use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
+use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\RelinkMailboxHistoryJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 mutates(StartMailboxHistoryImportAction::class);
 
@@ -36,4 +39,26 @@ it('also queues initial calendar sync when the account has calendar', function (
     resolve(StartMailboxHistoryImportAction::class)->execute($account);
 
     Bus::assertDispatched(InitialCalendarSyncJob::class, fn (InitialCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
+});
+
+it('queues incremental sync when calendar and mailbox cursors already exist', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'sync_cursor' => 'mail-cursor',
+        'calendar_sync_cursor' => 'calendar-cursor',
+        'capabilities' => [
+            'email' => true,
+            'calendar' => true,
+        ],
+    ]));
+
+    resolve(StartMailboxHistoryImportAction::class)->execute($account);
+
+    Bus::assertDispatched(IncrementalEmailSyncJob::class, fn (IncrementalEmailSyncJob $job): bool => $job->connectedAccount->is($account));
+    Bus::assertDispatched(fn (IncrementalCalendarSyncJob $job): bool => $job->connectedAccount->is($account) && $job->reconcileAfter);
+    Bus::assertNotDispatched(InitialEmailSyncJob::class);
+    Bus::assertNotDispatched(InitialCalendarSyncJob::class);
+
+    expect(MailboxSyncTracker::isCalendarSyncing($account))->toBeTrue();
 });

--- a/tests/Feature/EmailIntegration/VisibleMeetingScopeTest.php
+++ b/tests/Feature/EmailIntegration/VisibleMeetingScopeTest.php
@@ -56,6 +56,26 @@ function visibleMeetingsTo(User $viewer): Collection
         ->get();
 }
 
+it('shows a coworker meeting to a workspace member listed on the guest list even when all attendees are protected', function (): void {
+    $coworkerEmail = strtolower((string) $this->coworker->email);
+
+    $internal = ($this->makeCoworkerMeeting)([$coworkerEmail, 'mail2asmitnepali99@gmail.com']);
+
+    expect(visibleMeetingsTo($this->coworker)->modelKeys())->toContain($internal->id);
+});
+
+it('shows a coworker meeting when only the connected mailbox identity is on the guest list', function (): void {
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->coworker->id,
+        'email_address' => 'mail2asmitnepali99@gmail.com',
+    ]));
+
+    $internal = ($this->makeCoworkerMeeting)(['mail2asmitnepali99@gmail.com']);
+
+    expect(visibleMeetingsTo($this->coworker)->modelKeys())->toContain($internal->id);
+});
+
 it('hides a coworker meeting when all attendees are protected', function (): void {
     TeamEmailBlocklist::factory()->protected()->email('vip@contact.com')->create([
         'team_id' => $this->team->id,


### PR DESCRIPTION
## Summary
- Let mailbox owners accept, maybe, or decline invitations from the meeting card.
- Write the response back to Google Calendar or Microsoft Graph.
- Keep declined meetings in Relaticle, and color participant badges by status.

## Test plan
- [x] Open a meeting you host or were invited to and confirm the RSVP dropdown sits next to the title, extra-small like Close.
- [x] Unanswered invitations show RSVP. After answering, the trigger shows Accepted, Maybe, or Declined.
- [x] Accept, Maybe, and Decline update the provider calendar and the local meeting plus self attendee. Decline asks for confirmation and leaves the meeting in Relaticle.
- [x] A teammate viewing someone else's mailbox sees a static status pill, not the dropdown.
- [x] Participant badges use success, warning, danger, and gray for Accepted, Maybe, Declined, and No Response.
- [x] Organizers can still change their RSVP. Cancelled meetings and disconnected mailboxes cannot.