### PR TITLE
Fix four app panel UI issues: row action menus, stale opportunity card, panel overscroll, sidebar search

### DIFF
--- a/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
+++ b/app/Filament/Resources/OpportunityResource/Pages/ViewOpportunity.php
@@ -17,6 +17,7 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Flex;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Filament\Support\Livewire\Partials\PartialsComponentHook;
 use Illuminate\Support\Js;
 use Relaticle\CustomFields\Facades\CustomFields;
 
@@ -27,7 +28,16 @@ final class ViewOpportunity extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
-            EditAction::make()->icon('heroicon-o-pencil-square')->label(__('filament/resources/opportunity.pages.view.actions.edit.label')),
+            EditAction::make()
+                ->icon('heroicon-o-pencil-square')
+                ->label(__('filament/resources/opportunity.pages.view.actions.edit.label'))
+                ->after(function (): void {
+                    $this->getRecord()
+                        ->refresh()
+                        ->load(['company', 'contact', 'customFieldValues.customField.options']);
+
+                    resolve(PartialsComponentHook::class)->forceRender($this);
+                }),
             ActionGroup::make([
                 ActionGroup::make([
                     Action::make('copyPageUrl')

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -27,18 +27,42 @@
    Pure Tailwind CSS Classes Only
    =================================== */
 
-/* App Panel Custom Layout */
+/* App Panel Custom Layout
+
+   Profile (and any tall page) was scrolling the document. Overflow past
+   <body> paints on <html>. html.fi is only min-h-dvh; Filament also sets
+   .fi-main-ctn to min-h-[calc(100dvh-4rem)]. The app shell used h-screen
+   (100vh), which can be taller than 100dvh. Lock html/body and keep the
+   only scroller on .fi-layout. */
+html.fi:has(body.fi-panel-app) {
+    height: 100dvh;
+    overflow: hidden;
+}
+
+.fi-body.fi-panel-app {
+    height: 100dvh;
+    overflow: hidden;
+}
+
 .fi-app-layout {
-    @apply flex h-screen;
+    @apply flex h-full overflow-hidden;
 }
 
 .fi-app-main-wrapper {
-    @apply flex-1 flex flex-col min-w-0;
+    @apply flex min-h-0 min-w-0 flex-1 flex-col;
 
-    /* Only the content area scrolls, not the topbar */
     > .fi-layout {
-        @apply flex-1 overflow-y-auto;
+        @apply min-h-0 flex-1 overflow-y-auto;
+        height: auto;
     }
+}
+
+.fi-body.fi-panel-app .fi-app-layout .fi-main-ctn {
+    min-height: 0;
+}
+
+.fi-app-layout .fi-main {
+    height: auto;
 }
 
 .fi-header-heading {

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -122,6 +122,13 @@ html.fi:has(body.fi-panel-app) {
        above the prefix icon instead of centred on it. */
     .fi-input {
         @apply h-full py-0 text-sm placeholder:text-gray-500 dark:placeholder:text-gray-400;
+
+        /* Global search renders `type="search"`, so WebKit paints its own blue
+           cancel glyph next to the key cap. Escape already clears the field. */
+        &::-webkit-search-cancel-button,
+        &::-webkit-search-decoration {
+            @apply appearance-none;
+        }
     }
 
     /* Keyboard hint reads as a key cap rather than trailing text */
@@ -283,8 +290,15 @@ html.fi:has(body.fi-panel-app) {
 
     .fi-sidebar-item-btn,
     .fi-sidebar-group-btn,
-    .fi-sidebar-search,
     .fi-tenant-menu-trigger-text {
+        @apply overflow-hidden;
+    }
+
+    /* The search field clips only while the rail is collapsed, so its label
+       slides out behind the narrowing edge like every other one. An open
+       sidebar must not clip it: the results panel is absolutely positioned and
+       wider than the column, so a clip here hides every result on desktop. */
+    .fi-sidebar:not(.fi-sidebar-open) .fi-sidebar-search {
         @apply overflow-hidden;
     }
 

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -427,8 +427,19 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     @apply border-r border-gray-100 dark:border-gray-800;
 }
 
+/* Rounded corners only. overflow-hidden made this box Floating UI's flip
+   clipping ancestor. Row action menus teleport out so they stay visible, then
+   flip to the top of a short relation-manager table and cover + New / Attach. */
 .fi-ta-content {
-    @apply rounded-xl overflow-hidden;
+    @apply rounded-xl;
+}
+
+/* asmit/resized-column sets overflow-x: auto on the same node Filament marks
+   as the fixed positioning context. CSS then computes overflow-y to auto as
+   well, which is the same clipping ancestor as above. Keep horizontal scroll
+   on .fi-ta-table-wrapper only. */
+.fi-ta-content-ctn.fi-fixed-positioning-context {
+    overflow: visible;
 }
 
 .fi-ta-table thead {
@@ -493,22 +504,42 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
 }
 
 /* Dropdowns */
-.fi-dropdown-panel {
-    @apply rounded-xl;
-}
 
 /* asmit/resized-column lifts the table toolbar (`.fi-ta-header-ctn`) to
    z-index 21 so its own dropdowns clear the sticky table head at 19. That also
    puts it above a page-header action dropdown, whose panel is Filament's
    default z-index 20, so the panel renders *behind* the search field and
-   filter/column triggers. Lift those panels over the toolbar; 22 keeps them
-   under Filament chrome (topbar/sidebar, z-index 30). */
-.fi-header-actions-ctn .fi-dropdown-panel {
-    @apply z-[22];
+   filter/column triggers. Row ⋮ menus teleport to body at the same default,
+   so they paint under + New / Attach and the column-reorder grip sits on
+   Detach. 22 clears the toolbar and stays under Filament chrome (30). */
+.fi-dropdown-panel {
+    @apply z-[22] rounded-xl p-1;
+}
+
+.fi-dropdown-list {
+    @apply flex flex-col gap-0.5 p-0;
+}
+
+.fi-dropdown-list + .fi-dropdown-list {
+    @apply mt-1 border-t border-gray-100 pt-1 dark:border-white/10;
 }
 
 .fi-dropdown-list-item {
-    @apply rounded-lg;
+    @apply flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm;
+}
+
+.fi-dropdown-list-item .fi-icon {
+    @apply size-5 shrink-0;
+}
+
+.fi-dropdown-list-item-label {
+    @apply min-w-0 flex-1 text-start;
+}
+
+/* Livewire shows this on click. Idle, it must not occupy layout or it reads
+   as a grip on Detach. */
+.fi-dropdown-panel .fi-loading-indicator {
+    display: none;
 }
 
 /* Panels */
@@ -537,7 +568,7 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
 
 /* Actions */
 .fi-ac-action:hover,
-.fi-ta-actions button:hover {
+.fi-ta-actions button:hover:not(.fi-dropdown-list-item) {
     @apply transition-opacity duration-200 opacity-80;
 }
 

--- a/resources/views/vendor/filament-panels/components/layout/index.blade.php
+++ b/resources/views/vendor/filament-panels/components/layout/index.blade.php
@@ -85,7 +85,6 @@
                             x-bind:style="'display: flex; opacity:1;'" {{-- Mimics `x-cloak`, as using `x-cloak` causes visual issues with chart widgets --}}
                         @endif
                         class="fi-main-ctn"
-                        style="min-height: 100%;"
                     >
                         {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::CONTENT_BEFORE, scopes: $renderHookScopes) }}
 


### PR DESCRIPTION
## Summary

Four UI fixes in the app panel, all found while using the CRM.

- **Row action menus stay put.** The `⋮` menu on table rows flipped upward on short relation-manager tables and covered `+ New` and `Attach`. `.fi-ta-content` carried `overflow-hidden` for its rounded corners, which made it Floating UI's clipping ancestor, so the teleported panel had nowhere to go but up. Corners now come from `rounded-xl` alone, and `.fi-ta-content-ctn.fi-fixed-positioning-context` gets `overflow: visible`, because `asmit/resized-column` sets `overflow-x: auto` on the same node Filament marks as the fixed positioning context. Horizontal scroll stays on `.fi-ta-table-wrapper`. The panel also moves to `z-[22]` so it clears that package's toolbar at 21 while staying under Filament chrome at 30, and the idle loading indicator no longer reserves layout, where it read as a drag grip on `Detach`.
- **The opportunity card refreshes after an edit.** Saving the header Edit form updated the name but left Amount, Stage, and Close Date stale until a full page reload. Those are custom fields, loaded once through the `customFieldValues` relation, so the in-memory snapshot survived the save. The `EditAction` now reloads `company`, `contact`, and `customFieldValues.customField.options`, then forces a re-render.
- **The app panel no longer scrolls past its content.** Profile, and any tall page, scrolled the document itself and revealed empty space below the layout. Overflow past `<body>` paints on `<html>`, and the app shell used `h-screen` (100vh), which can exceed 100dvh. `<html>` and `<body>` are now locked to `100dvh` with `overflow: hidden`, leaving `.fi-layout` as the only scroller. The vendor layout's `min-height: 100%` on `.fi-main-ctn` was fighting that, so it is gone.
- **Sidebar global search shows results on desktop.** `.fi-sidebar-search` was clipped at all times so its label could slide behind the collapsing rail. The results panel is absolutely positioned and wider than the column, so that clip hid every result. The clip now applies only while the rail is collapsed. WebKit's own blue cancel glyph on the `type="search"` input is also hidden, since Escape already clears the field.

## Test plan

- [ ] Open a relation manager with one or two rows, click a row `⋮`, and confirm the menu opens below the trigger and does not cover `+ New` or `Attach`.
- [ ] Confirm wide tables still scroll horizontally and the sticky table head still works.
- [ ] Open an opportunity, click Edit, change Amount and Stage, save, and confirm the card updates with no page refresh.
- [ ] Scroll `/settings/profile` to the bottom and confirm there is no extra scroll into empty space, and that the topbar and sidebar stay fixed.
- [ ] Type in the sidebar global search on a desktop viewport and confirm results appear, then confirm the label still slides behind the rail when the sidebar is collapsed.
- [ ] Check the table menus and profile page in light and dark mode, and on a mobile viewport.
