### PR TITLE
Fix email and calendar sync retries

### DIFF
--- a/packages/EmailIntegration/src/Controllers/RedirectController.php
+++ b/packages/EmailIntegration/src/Controllers/RedirectController.php
@@ -44,6 +44,7 @@ final readonly class RedirectController
     {
         return [
             'https://graph.microsoft.com/Mail.Read',
+            'https://graph.microsoft.com/Mail.ReadWrite',
             'https://graph.microsoft.com/Mail.Send',
             'https://graph.microsoft.com/User.Read',
             'offline_access',

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -11,6 +11,9 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Relaticle\EmailIntegration\Data\CalendarEventData;
+use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
+use Relaticle\EmailIntegration\Enums\CalendarVisibility;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -53,21 +56,27 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         $service = $serviceFactory->make($account);
         $result = $service->initialSync($this->pageToken);
 
-        if ($result->events === []) {
+        $eventsToStore = array_values($result->events);
+
+        if ($eventsToStore === []) {
             self::continueOrFinish($account, $result->nextPageToken, $result->nextSyncToken);
 
             return;
         }
 
+        $pageEvents = array_values(array_filter(
+            $eventsToStore,
+            static fn (CalendarEventData $event): bool => ! CalendarVisibility::tryFrom($event->visibility ?? '')?->isPrivate()
+                && $event->status !== CalendarEventStatus::CANCELLED->value,
+        ));
+
         $nextPageToken = $result->nextPageToken;
         $nextSyncToken = $result->nextSyncToken;
-
-        $pageEvents = array_values($result->events);
 
         InitialSyncPageStoreBatch::dispatchMeetings(
             account: $account,
             pageEvents: $pageEvents,
-            eventsToStore: $pageEvents,
+            eventsToStore: $eventsToStore,
             onPageStored: static function (ConnectedAccount $account) use ($nextPageToken, $nextSyncToken): void {
                 self::continueOrFinish($account, $nextPageToken, $nextSyncToken);
             },

--- a/packages/EmailIntegration/src/Jobs/InitialSyncPageStoreBatch.php
+++ b/packages/EmailIntegration/src/Jobs/InitialSyncPageStoreBatch.php
@@ -65,6 +65,12 @@ final class InitialSyncPageStoreBatch
                     return;
                 }
 
+                if ($batch->failedJobs === 0) {
+                    $onPageStored($account);
+
+                    return;
+                }
+
                 $missingIds = self::missingMessageIds($account, $pageMessageIds);
 
                 if ($missingIds !== []) {

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -23,6 +23,8 @@ final class MicrosoftGraphMailService implements MailServiceInterface
     // Folder/direction is derived per message from parentFolderId in fetchMessage().
     private const string MESSAGES_DELTA = '/me/messages/delta';
 
+    private const string RECONCILIATION_PROPERTY_ID = 'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId';
+
     /**
      * @var array<string, string>|null Cached folder id => lowercase displayName map per instance.
      */
@@ -203,13 +205,6 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             'bccRecipients' => $this->formatRecipients($data['bcc'] ?? []),
         ];
 
-        // Best-effort: ask Graph to use our Message-ID so a retry can reconcile via
-        // findSentMessage(). Graph may override it on /me/sendMail, in which case
-        // retry de-duplication degrades to the synthetic id below.
-        if (isset($data['rfc_message_id'])) {
-            $message['internetMessageId'] = $data['rfc_message_id'];
-        }
-
         if (($data['attachments'] ?? []) !== []) {
             $message['attachments'] = array_map(fn (array $attachment): array => [
                 '@odata.type' => '#microsoft.graph.fileAttachment',
@@ -217,6 +212,13 @@ final class MicrosoftGraphMailService implements MailServiceInterface
                 'contentType' => $attachment['mime_type'],
                 'contentBytes' => base64_encode($attachment['content']),
             ], $data['attachments']);
+        }
+
+        if (isset($data['rfc_message_id'])) {
+            $message['singleValueExtendedProperties'] = [[
+                'id' => self::RECONCILIATION_PROPERTY_ID,
+                'value' => $data['rfc_message_id'],
+            ]];
         }
 
         $this->clientFactory->make($this->account)
@@ -240,7 +242,7 @@ final class MicrosoftGraphMailService implements MailServiceInterface
 
         $message = $this->clientFactory->make($this->account)
             ->get('/me/messages', [
-                '$filter' => "internetMessageId eq '{$escaped}'",
+                '$filter' => "singleValueExtendedProperties/Any(ep: ep/id eq '".self::RECONCILIATION_PROPERTY_ID."' and ep/value eq '{$escaped}')",
                 '$select' => 'id,conversationId,internetMessageId',
                 '$top' => 1,
             ])

--- a/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
@@ -212,6 +212,51 @@ it('stores the sync token immediately when the last page has no events', functio
         ->and($account->fresh()?->initial_calendar_sync_imported)->toBe(0);
 });
 
+it('batches skipped events for cleanup without waiting for them to persist', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $events = [
+        new CalendarEventData(
+            providerEventId: 'private-event', providerRecurringEventId: null, iCalUid: null,
+            title: 'Private', description: null, startsAt: Date::now()->addDay(), endsAt: Date::now()->addDay()->addHour(),
+            isAllDay: false, location: null, htmlLink: null, status: 'confirmed', visibility: 'private',
+            organizerEmail: null, organizerName: null, attendees: [],
+        ),
+        new CalendarEventData(
+            providerEventId: 'cancelled-event', providerRecurringEventId: null, iCalUid: null,
+            title: 'Cancelled', description: null, startsAt: Date::now()->addDays(2), endsAt: Date::now()->addDays(2)->addHour(),
+            isAllDay: false, location: null, htmlLink: null, status: 'cancelled', visibility: 'default',
+            organizerEmail: null, organizerName: null, attendees: [],
+        ),
+        new CalendarEventData(
+            providerEventId: 'confidential-event', providerRecurringEventId: null, iCalUid: null,
+            title: 'Confidential', description: null, startsAt: Date::now()->addDays(3), endsAt: Date::now()->addDays(3)->addHour(),
+            isAllDay: false, location: null, htmlLink: null, status: 'confirmed', visibility: 'confidential',
+            organizerEmail: null, organizerName: null, attendees: [],
+        ),
+    ];
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: $events, nextSyncToken: 'token-xyz'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new InitialCalendarSyncJob($account))->handle($factory);
+
+    Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->jobs->count() === 3
+        && $batch->jobs->every(fn (object $job): bool => $job instanceof StoreMeetingJob));
+
+    invokeInitialCalendarSyncBatchFinallyCallbacks();
+
+    expect($account->fresh()?->calendar_sync_cursor)->toBe('token-xyz');
+});
+
 it('writes the stored meeting count when the initial calendar backfill finishes', function (): void {
     Bus::fake();
 

--- a/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
+++ b/tests/Feature/EmailIntegration/InitialEmailSyncJobTest.php
@@ -6,8 +6,12 @@ use Illuminate\Bus\PendingBatch;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Testing\Fakes\BatchFake;
+use Relaticle\EmailIntegration\Actions\StoreEmailAction;
+use Relaticle\EmailIntegration\Data\FetchedEmailData;
 use Relaticle\EmailIntegration\Data\MailBackfillPage;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -18,17 +22,17 @@ use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 
 mutates(InitialEmailSyncJob::class);
 
-function invokeInitialEmailSyncBatchFinallyCallbacks(): void
+function invokeInitialEmailSyncBatchFinallyCallbacks(int $failedJobs = 0): void
 {
-    Bus::assertBatched(function (PendingBatch $batch): bool {
+    Bus::assertBatched(function (PendingBatch $batch) use ($failedJobs): bool {
         foreach ($batch->finallyCallbacks() as $callback) {
             $callback(new BatchFake(
                 id: 'batch-1',
                 name: 'Initial sync',
                 totalJobs: $batch->jobs->count(),
                 pendingJobs: 0,
-                failedJobs: 0,
-                failedJobIds: [],
+                failedJobs: $failedJobs,
+                failedJobIds: array_fill(0, $failedJobs, 'failed-job'),
                 options: [],
                 createdAt: now()->toImmutable(),
             ));
@@ -281,6 +285,54 @@ it('sets the cursor after the last page store batch finishes', function (): void
     );
 });
 
+it('advances after a disabled direction skips every message in a page', function (): void {
+    Bus::fake();
+    Notification::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'sync_inbox' => false,
+    ]));
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('initialBackfill')->andReturn(new MailBackfillPage(
+        messageIds: collect(['M1']),
+        nextPageToken: 'page-2',
+        cursor: 'history-1',
+    ));
+    $service->shouldReceive('fetchMessage')->once()->with('M1')->andReturn(new FetchedEmailData(
+        providerMessageId: 'M1',
+        threadId: 'thread-1',
+        rfcMessageId: '<m1@example.com>',
+        inReplyTo: null,
+        subject: 'Skipped inbox email',
+        snippet: 'Skipped inbox email',
+        bodyText: 'Skipped inbox email',
+        bodyHtml: '<p>Skipped inbox email</p>',
+        direction: EmailDirection::INBOUND,
+        folder: EmailFolder::Inbox,
+        sentAt: now(),
+        isRead: true,
+        hasAttachments: false,
+        participants: [],
+        attachments: [],
+    ));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+
+    (new InitialEmailSyncJob($account))->handle($factory);
+
+    (new StoreEmailJob($account, 'M1'))->handle($factory, resolve(StoreEmailAction::class));
+
+    invokeInitialEmailSyncBatchFinallyCallbacks();
+
+    Bus::assertDispatched(
+        InitialEmailSyncJob::class,
+        fn (InitialEmailSyncJob $job): bool => $job->pageToken === 'page-2',
+    );
+    expect(Email::query()->where('provider_message_id', 'M1')->exists())->toBeFalse();
+});
+
 it('does not advance the initial import while page messages are still missing', function (): void {
     Bus::fake();
     Notification::fake();
@@ -300,7 +352,7 @@ it('does not advance the initial import while page messages are still missing', 
 
     (new InitialEmailSyncJob($account))->handle($factory);
 
-    invokeInitialEmailSyncBatchFinallyCallbacks();
+    invokeInitialEmailSyncBatchFinallyCallbacks(1);
 
     Bus::assertDispatchedTimes(InitialEmailSyncJob::class, 0);
     expect($account->fresh()?->sync_cursor)->toBeNull()
@@ -335,7 +387,7 @@ it('re-dispatches store jobs for missing messages before advancing the page', fu
         'provider_message_id' => 'M1',
     ]);
 
-    invokeInitialEmailSyncBatchFinallyCallbacks();
+    invokeInitialEmailSyncBatchFinallyCallbacks(1);
 
     Bus::assertBatchCount(2);
     Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->jobs->count() === 1

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -177,11 +177,45 @@ it('POSTs to /me/sendMail and returns provider ids', function (): void {
         'body_html' => '<p>Hi</p>',
         'body_text' => 'Hi',
         'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'rfc_message_id' => '<local-id@example.com>',
     ]);
 
     expect($result['provider_message_id'])->not->toBeEmpty();
 
-    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/sendMail'));
+    Http::assertSent(function (Request $r): bool {
+        $message = $r->data()['message'];
+
+        return str_contains((string) $r->url(), '/me/sendMail')
+            && ! array_key_exists('internetMessageId', $message)
+            && $message['singleValueExtendedProperties'] === [[
+                'id' => 'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId',
+                'value' => '<local-id@example.com>',
+            ]];
+    });
+});
+
+it('finds a sent message by its reconciliation property', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/messages*' => Http::response([
+            'value' => [[
+                'id' => 'AAA1',
+                'conversationId' => 'thread-1',
+                'internetMessageId' => '<provider-id@example.com>',
+            ]],
+        ]),
+    ]);
+
+    $result = resolve(MicrosoftGraphServiceFactory::class)
+        ->make(makeAzureAccount())
+        ->findSentMessage('<local-id@example.com>');
+
+    expect($result)->toBe([
+        'provider_message_id' => 'AAA1',
+        'thread_id' => 'thread-1',
+        'rfc_message_id' => '<provider-id@example.com>',
+    ]);
+
+    Http::assertSent(fn (Request $r): bool => str_contains(urldecode((string) $r->url()), "singleValueExtendedProperties/Any(ep: ep/id eq 'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId' and ep/value eq '<local-id@example.com>')"));
 });
 
 it('includes file attachments in the /me/sendMail payload', function (): void {

--- a/tests/Feature/EmailIntegration/MicrosoftOAuthRedirectTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftOAuthRedirectTest.php
@@ -25,6 +25,7 @@ it('redirects to Microsoft with mail Graph scopes and prompt=consent', function 
     expect($location)->toContain('login.microsoftonline.com')
         ->toContain('prompt=consent')
         ->toContain(urlencode('https://graph.microsoft.com/Mail.Read'))
+        ->toContain(urlencode('https://graph.microsoft.com/Mail.ReadWrite'))
         ->toContain(urlencode('https://graph.microsoft.com/Mail.Send'))
         ->toContain(urlencode('https://graph.microsoft.com/User.Read'))
         ->toContain(urlencode('offline_access'))


### PR DESCRIPTION
## Summary
- Use a provider-supported reconciliation marker for send retries.
- Advance initial email imports when disabled directions are intentionally skipped.
- Preserve calendar cleanup while excluding skipped events from completion checks.
- Request the mail permission required for retry reconciliation.

## Verification
- Focused email and calendar integration tests
- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/rector --dry-run`
- `vendor/bin/phpstan analyse`
- 100% type coverage