### PR TITLE
fix(calendar): convert Google timed events to UTC before persistence

### DIFF
--- a/packages/EmailIntegration/src/Services/GoogleCalendarService.php
+++ b/packages/EmailIntegration/src/Services/GoogleCalendarService.php
@@ -317,12 +317,16 @@ final readonly class GoogleCalendarService implements CalendarServiceInterface
 
         // All-day events carry a bare Y-m-d with no zone; parse as UTC so a server in a
         // timezone behind UTC doesn't roll the stored date back a day.
-        $startsAt = $isAllDay ? Date::parse($startDate, 'UTC') : Date::parse((string) $start->getDateTime());
+        // Timed events include an offset in dateTime; convert to UTC before persistence
+        // because meetings.starts_at is timestamp without time zone.
+        $startsAt = $isAllDay
+            ? Date::parse($startDate, 'UTC')
+            : Date::parse((string) $start->getDateTime())->utc();
         // Google's all-day end.date is EXCLUSIVE (the day after the last day), so a 1-day
         // event spans start..start+1. Subtract a day to store the inclusive last day.
         $endsAt = $isAllDay
             ? Date::parse($endDate, 'UTC')->subDay()
-            : Date::parse((string) $end->getDateTime());
+            : Date::parse((string) $end->getDateTime())->utc();
 
         $attendees = [];
         foreach ($event->getAttendees() as $attendee) {

--- a/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
+++ b/tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php
@@ -6,6 +6,7 @@ use Google\Client;
 use Google\Service\Calendar;
 use Google\Service\Calendar\Event;
 use Google\Service\Calendar\EventAttendee;
+use Google\Service\Calendar\EventDateTime;
 use Google\Service\Calendar\EventOrganizer;
 use Google\Service\Calendar\Events as EventsResource;
 use Google\Service\Calendar\Resource\Events;
@@ -271,6 +272,45 @@ it('returns null when Google has no event for the iCalendar UID', function (): v
 
     expect((new GoogleCalendarService($account, $calendar))->findEventIdByICalUid('missing'))
         ->toBeNull();
+});
+
+it('converts timed Google events to UTC before persistence', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'refresh_token' => 'refresh',
+        'token_expires_at' => now()->addHour(),
+    ]));
+
+    $start = new EventDateTime;
+    $start->setDateTime('2024-01-01T09:00:00+05:45');
+
+    $end = new EventDateTime;
+    $end->setDateTime('2024-01-01T10:00:00+05:45');
+
+    $event = new Event;
+    $event->setId('evt-timed');
+    $event->setStatus('confirmed');
+    $event->setSummary('Morning sync');
+    $event->setStart($start);
+    $event->setEnd($end);
+
+    $eventsList = new EventsResource;
+    $eventsList->setItems([$event]);
+    $eventsList->setNextSyncToken('next-token');
+
+    $events = Mockery::mock(Events::class);
+    $events->shouldReceive('listEvents')
+        ->once()
+        ->andReturn($eventsList);
+
+    $calendar = new Calendar(Mockery::mock(Client::class));
+    $calendar->events = $events;
+
+    $result = (new GoogleCalendarService($account, $calendar))->initialSync();
+
+    expect($result->events)->toHaveCount(1)
+        ->and($result->events[0]->startsAt->timezone->getName())->toBe('UTC')
+        ->and($result->events[0]->startsAt->toDateTimeString())->toBe('2024-01-01 03:15:00')
+        ->and($result->events[0]->endsAt->toDateTimeString())->toBe('2024-01-01 04:15:00');
 });
 
 it('requests deleted events during incremental sync and maps cancellations to tombstones', function (): void {


### PR DESCRIPTION
## Summary

- Google Calendar `dateTime` values include timezone offsets, but `meetings.starts_at` is stored as UTC wall clock in PostgreSQL.
- Normalize timed events with `->utc()` in `GoogleCalendarService` so a 09:00 +05:45 meeting persists as 03:15 UTC instead of 09:00.
- Fixes shifted meeting times in Relaticle when syncing Google Calendar events.

## Test plan

- [x] `php artisan test tests/Feature/CalendarIntegration/GoogleCalendarServiceTest.php --filter='converts timed Google events to UTC'`
- [x] Full `GoogleCalendarServiceTest` suite passes (11 tests)