### PR TITLE
Stamp synced email privacy from the mailbox workspace

### DIFF
--- a/packages/EmailIntegration/src/Observers/EmailObserver.php
+++ b/packages/EmailIntegration/src/Observers/EmailObserver.php
@@ -21,7 +21,7 @@ final readonly class EmailObserver
         $owner = User::query()->find($email->user_id);
 
         if ($owner && ! $email->isDirty('privacy_tier')) {
-            $email->privacy_tier = $this->privacyService->defaultTierForUser($owner);
+            $email->privacy_tier = $this->privacyService->defaultTierForUser($owner, $email->team);
         }
     }
 

--- a/packages/EmailIntegration/src/Services/PrivacyService.php
+++ b/packages/EmailIntegration/src/Services/PrivacyService.php
@@ -59,10 +59,14 @@ final readonly class PrivacyService
     }
 
     /**
-     * Resolve the default tier to stamp on a newly synced email.
+     * Resolve the default tier to stamp on a newly created email.
      * User preference wins over workspace default.
+     *
+     * Pass the mailbox's workspace for background sync. `$user->current_team_id` is
+     * only the owner's currently selected workspace, so using it for imports would
+     * stamp another team's default onto this mailbox.
      */
-    public function defaultTierForUser(User $user): EmailPrivacyTier
+    public function defaultTierForUser(User $user, ?Team $workspace = null): EmailPrivacyTier
     {
         if ($user->default_email_sharing_tier) {
             return $user->default_email_sharing_tier;
@@ -71,7 +75,7 @@ final readonly class PrivacyService
         // Resolve the team explicitly (instead of $user->currentTeam, whose accessor
         // larastan types as never-null and which can auto-switch teams as a side
         // effect) so the null case, a user without a current team, is handled.
-        $team = $user->current_team_id !== null ? Team::query()->find($user->current_team_id) : null;
+        $team = $workspace ?? ($user->current_team_id !== null ? Team::query()->find($user->current_team_id) : null);
 
         if ($team === null) {
             return EmailPrivacyTier::METADATA_ONLY;

--- a/tests/Feature/EmailIntegration/PrivacyServiceTest.php
+++ b/tests/Feature/EmailIntegration/PrivacyServiceTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
@@ -258,6 +259,31 @@ it('defaultTierForUser falls back to team default when user has no preference', 
     $tier = $this->service->defaultTierForUser($this->owner->fresh());
 
     expect($tier)->toBe(EmailPrivacyTier::FULL);
+});
+
+it('defaultTierForUser prefers the user setting over the mailbox workspace default', function (): void {
+    $this->owner->update(['default_email_sharing_tier' => EmailPrivacyTier::SUBJECT]);
+    $this->team->update(['default_email_sharing_tier' => EmailPrivacyTier::FULL]);
+
+    $tier = $this->service->defaultTierForUser($this->owner->fresh(), $this->team);
+
+    expect($tier)->toBe(EmailPrivacyTier::SUBJECT);
+});
+
+it('defaultTierForUser uses the mailbox workspace default instead of the owner current team', function (): void {
+    $this->owner->update(['default_email_sharing_tier' => null]);
+    $this->team->update(['default_email_sharing_tier' => EmailPrivacyTier::PRIVATE]);
+
+    $otherTeam = Team::factory()->create([
+        'user_id' => $this->owner->getKey(),
+        'default_email_sharing_tier' => EmailPrivacyTier::FULL,
+    ]);
+    $this->owner->teams()->attach($otherTeam, ['role' => 'admin']);
+    $this->owner->forceFill(['current_team_id' => $otherTeam->getKey()])->save();
+
+    $tier = $this->service->defaultTierForUser($this->owner->fresh(), $this->team);
+
+    expect($tier)->toBe(EmailPrivacyTier::PRIVATE);
 });
 
 it('defaultTierForUser returns metadata-only when the user has no current team', function (): void {

--- a/tests/Feature/EmailIntegration/StoreEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\CustomField;
 use App\Models\People;
+use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Storage;
@@ -12,6 +13,7 @@ use Relaticle\EmailIntegration\Data\FetchedEmailData;
 use Relaticle\EmailIntegration\Enums\EmailCategory;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -363,6 +365,22 @@ it('marks email as internal when all participants are team members', function ()
     $email = resolve(StoreEmailAction::class)->execute($this->account, $data);
 
     expect($email->is_internal)->toBeTrue();
+});
+
+it('stamps the mailbox workspace privacy default when the owner has switched current team', function (): void {
+    $this->user->update(['default_email_sharing_tier' => null]);
+    $this->team->update(['default_email_sharing_tier' => EmailPrivacyTier::PRIVATE]);
+
+    $otherTeam = Team::factory()->create([
+        'user_id' => $this->user->getKey(),
+        'default_email_sharing_tier' => EmailPrivacyTier::FULL,
+    ]);
+    $this->user->teams()->attach($otherTeam, ['role' => 'admin']);
+    $this->user->forceFill(['current_team_id' => $otherTeam->getKey()])->save();
+
+    $email = resolve(StoreEmailAction::class)->execute($this->account->fresh(), makeFetchedEmailData());
+
+    expect($email->privacy_tier)->toBe(EmailPrivacyTier::PRIVATE);
 });
 
 it('treats a member as internal even when their active team is a different team', function (): void {


### PR DESCRIPTION
## Summary
- Background imports stamped privacy from the owner's currently selected workspace, not the mailbox's workspace.
- Switching to a full-sharing workspace then leaked that default onto later imports into a private mailbox.
- Sync now resolves the default from the mailbox team. A user-level preference still wins.

## Test plan
- [x] Import into a mailbox whose workspace defaults to private after switching to a full-sharing workspace.
- [x] Confirm new emails stay private.
- [x] Confirm a user-level privacy preference still overrides the workspace default.