### PR TITLE
Hide metadata-only email subjects on the activity timeline

### DIFF
--- a/.ai/rules/models.md
+++ b/.ai/rules/models.md
@@ -6,6 +6,10 @@ paths:
 
 # Models
 
+## Activity timeline email titles
+
+`VisibleEmailScope` admits metadata-only emails (participants and timestamp). Field masking is a view/policy concern. Timeline titles must go through `$viewer->can('viewSubject', $email)` and render `(subject hidden)` when that is false. Never copy `$email->subject` onto a teammate-facing surface.
+
 ## Email canonicalization
 
 - Emails are stored canonical: trimmed, lowercase. The `AsCanonicalEmail`

--- a/app/Models/Concerns/HasActivityTimeline.php
+++ b/app/Models/Concerns/HasActivityTimeline.php
@@ -41,8 +41,16 @@ trait HasActivityTimeline
                         'email_received',
                         when: fn (Email $email): bool => $email->direction === EmailDirection::INBOUND && $email->sent_at === null,
                     )
-                    ->with(['from', 'labels', 'participants'])
-                    ->title(fn (Email $email): string => $email->subject ?? 'Email')
+                    ->with(['from', 'labels', 'participants', 'shares'])
+                    ->title(function (Email $email) use ($viewer): string {
+                        // VisibleEmailScope admits metadata-only mail. Subjects are masked
+                        // here the same way the inbox does: viewSubject, not a raw column read.
+                        if (! $viewer instanceof User || ! $viewer->can('viewSubject', $email)) {
+                            return '(subject hidden)';
+                        }
+
+                        return $email->subject ?? 'Email';
+                    })
                     ->description(fn (Email $email): ?string => $email->from->first()?->email_address)
                     ->causer(fn (Email $email) => $email->from->first());
 

--- a/tests/Feature/ActivityLog/PeopleTimelineActivityTest.php
+++ b/tests/Feature/ActivityLog/PeopleTimelineActivityTest.php
@@ -206,6 +206,136 @@ it('labels inbound mailbox mail as received and outbound mail as sent', function
         ->and($emailEvents->has($unsentOutbound->getKey()))->toBeFalse();
 });
 
+it('hides metadata-only subjects from teammates on the activity timeline', function (): void {
+    $teammate = User::factory()->create();
+    $teammate->teams()->attach($this->team);
+    $teammate->forceFill(['current_team_id' => $this->team->id])->save();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+    ]));
+
+    $person = People::factory()->create([
+        'name' => 'Jordan Hale',
+        'team_id' => $this->team->getKey(),
+        'creator_id' => $this->user->getKey(),
+    ]);
+
+    $email = Email::factory()->inbound()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'connected_account_id' => $account->getKey(),
+        'subject' => 'Confidential acquisition terms',
+        'sent_at' => now()->subHour(),
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+    ]);
+
+    $person->emails()->attach($email->getKey());
+
+    $this->actingAs($teammate);
+    Filament::setTenant($this->team);
+
+    $title = $person->timeline()
+        ->get()
+        ->firstWhere('event', 'email_received')
+        ?->title;
+
+    expect($title)->toBe('(subject hidden)');
+
+    livewire(ActivityLogLivewire::class, [
+        'subjectClass' => $person::class,
+        'subjectKey' => $person->getKey(),
+        'perPage' => 20,
+    ])
+        ->assertDontSee('Confidential acquisition terms')
+        ->assertSee('(subject hidden)');
+});
+
+it('shows metadata-only subjects to the owner on the activity timeline', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+    ]));
+
+    $person = People::factory()->create([
+        'name' => 'Jordan Hale',
+        'team_id' => $this->team->getKey(),
+        'creator_id' => $this->user->getKey(),
+    ]);
+
+    $email = Email::factory()->inbound()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'connected_account_id' => $account->getKey(),
+        'subject' => 'Confidential acquisition terms',
+        'sent_at' => now()->subHour(),
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+    ]);
+
+    $person->emails()->attach($email->getKey());
+
+    $title = $person->timeline()
+        ->get()
+        ->firstWhere('event', 'email_received')
+        ?->title;
+
+    expect($title)->toBe('Confidential acquisition terms');
+
+    livewire(ActivityLogLivewire::class, [
+        'subjectClass' => $person::class,
+        'subjectKey' => $person->getKey(),
+        'perPage' => 20,
+    ])->assertSee('Confidential acquisition terms');
+});
+
+it('shows the email subject on the activity timeline when a teammate can view it', function (EmailPrivacyTier $tier): void {
+    $teammate = User::factory()->create();
+    $teammate->teams()->attach($this->team);
+    $teammate->forceFill(['current_team_id' => $this->team->id])->save();
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+    ]));
+
+    $person = People::factory()->create([
+        'name' => 'Jordan Hale',
+        'team_id' => $this->team->getKey(),
+        'creator_id' => $this->user->getKey(),
+    ]);
+
+    $email = Email::factory()->inbound()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->user->getKey(),
+        'connected_account_id' => $account->getKey(),
+        'subject' => 'Q3 pricing proposal',
+        'sent_at' => now()->subHour(),
+        'privacy_tier' => $tier,
+    ]);
+
+    $person->emails()->attach($email->getKey());
+
+    $this->actingAs($teammate);
+    Filament::setTenant($this->team);
+
+    $title = $person->timeline()
+        ->get()
+        ->firstWhere('event', 'email_received')
+        ?->title;
+
+    expect($title)->toBe('Q3 pricing proposal');
+
+    livewire(ActivityLogLivewire::class, [
+        'subjectClass' => $person::class,
+        'subjectKey' => $person->getKey(),
+        'perPage' => 20,
+    ])->assertSee('Q3 pricing proposal');
+})->with([
+    'subject tier' => EmailPrivacyTier::SUBJECT,
+    'full tier' => EmailPrivacyTier::FULL,
+]);
+
 describe('ActivityLogSummary::from()', function (): void {
     it('builds a one-field sentence', function (): void {
         $summary = ActivityLogSummary::from(sampleUpdatedEntry(['name' => 'New']));


### PR DESCRIPTION
## Summary
- Mask restricted email subjects on the activity timeline so teammates cannot read subjects the inbox already hides.
- `VisibleEmailScope` still admits metadata-only mail. Timeline titles now go through `viewSubject`, matching the inbox.

## Test plan
- [x] Open a record timeline as a teammate on a metadata-only email and confirm the title is `(subject hidden)`
- [x] Confirm the mailbox owner still sees the real subject
- [x] Confirm Subject and Full privacy tiers still show the subject to teammates