### PR TITLE
Recreate ai_summaries so upgraded installs can store thread summaries

### DIFF
--- a/app/Models/AiSummary.php
+++ b/app/Models/AiSummary.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
     'summarizable_type',
     'summarizable_id',
     'summary',
+    'input_hash',
     'model_used',
     'prompt_tokens',
     'completion_tokens',

--- a/database/migrations/2026_07_30_120000_drop_ai_summaries_table.php
+++ b/database/migrations/2026_07_30_120000_drop_ai_summaries_table.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::dropIfExists('ai_summaries');
+    }
+};

--- a/database/migrations/2026_09_09_015446_recreate_ai_summaries_table.php
+++ b/database/migrations/2026_09_09_015446_recreate_ai_summaries_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Recreate ai_summaries after 2026_07_30_120000 dropped it.
+ *
+ * That drop has already run on existing installations. Removing it from
+ * the repo does not restore the table. Thread summary generation and
+ * SubscriberProfileDeriver::hasAiUsage() query this table after upgrade.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ai_summaries', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('team_id')->constrained()->cascadeOnDelete();
+            $table->ulidMorphs('summarizable');
+            $table->text('summary');
+            $table->string('input_hash', 64)->nullable();
+            $table->string('model_used');
+            $table->unsignedInteger('prompt_tokens')->nullable();
+            $table->unsignedInteger('completion_tokens')->nullable();
+            $table->timestamps();
+
+            $table->unique(['summarizable_type', 'summarizable_id', 'team_id']);
+        });
+    }
+};

--- a/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
+++ b/packages/EmailIntegration/src/Services/EmailThreadSummaryService.php
@@ -26,17 +26,20 @@ final readonly class EmailThreadSummaryService
      */
     public function getSummary(EmailThread $thread, User $viewer, bool $regenerate = false): AiSummary
     {
+        $prompt = $this->buildPrompt($thread, $viewer);
+        $inputHash = hash('sha256', $viewer->getKey()."\n".$prompt);
+
         if (! $regenerate) {
-            $cached = $thread->aiSummary;
+            $cached = $thread->aiSummary()->where('input_hash', $inputHash)->first();
             if ($cached !== null) {
                 return $cached;
             }
         }
 
-        return $this->generateAndCache($thread, $viewer);
+        return $this->generateAndCache($thread, $prompt, $inputHash);
     }
 
-    private function generateAndCache(EmailThread $thread, User $viewer): AiSummary
+    private function buildPrompt(EmailThread $thread, User $viewer): string
     {
         $emails = $thread->emails()
             ->with(['from', 'participants', 'body', 'labels', 'shares'])
@@ -90,11 +93,16 @@ final readonly class EmailThreadSummaryService
             $lines[] = '';
         }
 
+        return implode("\n", $lines);
+    }
+
+    private function generateAndCache(EmailThread $thread, string $prompt, string $inputHash): AiSummary
+    {
         $provider = (string) config('services.email_summary.provider');
         $model = (string) config('services.email_summary.model');
 
         $response = (new ThreadSummarizer)->prompt(
-            implode("\n", $lines),
+            $prompt,
             provider: $provider,
             model: $model,
         );
@@ -109,6 +117,7 @@ final readonly class EmailThreadSummaryService
             'summarizable_type' => $thread->getMorphClass(),
             'summarizable_id' => $thread->getKey(),
             'summary' => $response->text,
+            'input_hash' => $inputHash,
             'model_used' => $model,
             'prompt_tokens' => $response->usage->promptTokens,
             'completion_tokens' => $response->usage->completionTokens,

--- a/tests/Feature/Email/SubscriberTaggingTest.php
+++ b/tests/Feature/Email/SubscriberTaggingTest.php
@@ -3,9 +3,11 @@
 declare(strict_types=1);
 
 use App\Jobs\Email\SyncSubscriberJob;
+use App\Models\AiSummary;
 use App\Models\Company;
 use App\Models\User;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
 
 beforeEach(function (): void {
     Queue::fake([SyncSubscriberJob::class]);
@@ -94,3 +96,40 @@ test('creating a second personal access token does not dispatch again', function
 
     Queue::assertNotPushed(SyncSubscriberJob::class);
 });
+
+test('creating the first ai summary dispatches a profile sync', function (): void {
+    $user = User::factory()->withTeam()->create();
+
+    $this->actingAs($user);
+
+    createAiSummaryForTeam($user->currentTeam->id);
+
+    Queue::assertPushed(SyncSubscriberJob::class, fn (SyncSubscriberJob $job): bool => invade($job)->userId === (string) $user->id);
+});
+
+test('creating a second ai summary does not dispatch a sync again', function (): void {
+    $user = User::factory()->withTeam()->create();
+
+    $this->actingAs($user);
+
+    createAiSummaryForTeam($user->currentTeam->id);
+
+    Queue::fake([SyncSubscriberJob::class]);
+
+    createAiSummaryForTeam($user->currentTeam->id);
+
+    Queue::assertNotPushed(SyncSubscriberJob::class);
+});
+
+function createAiSummaryForTeam(string $teamId): AiSummary
+{
+    return AiSummary::query()->create([
+        'team_id' => $teamId,
+        'summarizable_type' => 'email_thread',
+        'summarizable_id' => (string) Str::ulid(),
+        'summary' => 'Follow up next week.',
+        'model_used' => 'gpt-4o-mini',
+        'prompt_tokens' => 10,
+        'completion_tokens' => 5,
+    ]);
+}

--- a/tests/Feature/EmailIntegration/EmailThreadSummaryServiceTest.php
+++ b/tests/Feature/EmailIntegration/EmailThreadSummaryServiceTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Filament\Resources\PeopleResource\Pages\PeopleEmailsPage;
 use App\Models\AiSummary;
+use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Laravel\Ai\Responses\Data\Meta;
@@ -14,6 +16,7 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Models\EmailThread;
 use Relaticle\EmailIntegration\Services\EmailThreadSummaryService;
 
@@ -59,7 +62,10 @@ function makeThreadWithEmail(): EmailThread
         'privacy_tier' => EmailPrivacyTier::FULL,
     ]);
 
-    EmailParticipant::factory()->from()->create(['email_id' => $email->getKey()]);
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $email->getKey(),
+        'email_address' => 'prospect@customer.test',
+    ]);
     EmailBody::factory()->create(['email_id' => $email->getKey()]);
 
     return $thread;
@@ -91,15 +97,9 @@ it('generates and caches a summary for an email thread', function (): void {
 it('returns the cached summary without calling the model again', function (): void {
     $thread = makeThreadWithEmail();
 
-    $cached = AiSummary::query()->create([
-        'team_id' => $this->team->getKey(),
-        'summarizable_type' => $thread->getMorphClass(),
-        'summarizable_id' => $thread->getKey(),
-        'summary' => 'Cached thread summary',
-        'model_used' => 'gpt-4o-mini',
-        'prompt_tokens' => 10,
-        'completion_tokens' => 5,
-    ]);
+    ThreadSummarizer::fake(['Cached thread summary']);
+    $cached = resolve(EmailThreadSummaryService::class)->getSummary($thread, $this->owner);
+    ThreadSummarizer::fake()->preventStrayPrompts();
 
     $summary = resolve(EmailThreadSummaryService::class)->getSummary($thread->fresh(), $this->owner);
 
@@ -133,4 +133,78 @@ it('regenerates the summary when requested', function (): void {
 
     $this->assertDatabaseCount('ai_summaries', 1);
     $this->assertDatabaseHas('ai_summaries', ['summary' => 'Fresh summary']);
+});
+
+it('does not expose cached private content to a viewer of one shared message', function (bool $revokeShare): void {
+    $thread = makeThreadWithEmail();
+    $shared = $thread->emails()->firstOrFail();
+    $shared->update(['privacy_tier' => EmailPrivacyTier::PRIVATE]);
+    $private = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->owner->id,
+        'connected_account_id' => $this->account->getKey(),
+        'thread_id' => $thread->thread_id,
+        'privacy_tier' => EmailPrivacyTier::PRIVATE,
+    ]);
+    EmailBody::factory()->create(['email_id' => $private->getKey(), 'body_text' => 'Confidential acquisition budget']);
+    $person = People::factory()->create(['team_id' => $this->team->id, 'creator_id' => $this->owner->id]);
+    $person->emails()->attach([$shared->getKey(), $private->getKey()]);
+    $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($viewer, ['role' => 'editor']);
+    EmailShare::factory()->create([
+        'team_id' => $this->team->id,
+        'email_id' => $shared->getKey(),
+        'shared_by' => $this->owner->id,
+        'shared_with' => $viewer->id,
+        'tier' => EmailPrivacyTier::FULL->value,
+    ]);
+    if ($revokeShare) {
+        EmailShare::factory()->create([
+            'team_id' => $this->team->id,
+            'email_id' => $private->getKey(),
+            'shared_by' => $this->owner->id,
+            'shared_with' => $viewer->id,
+            'tier' => EmailPrivacyTier::FULL->value,
+        ]);
+        $this->actingAs($viewer->refresh());
+    }
+
+    ThreadSummarizer::fake(fn (string $prompt): string => str_contains($prompt, 'Confidential acquisition budget')
+        ? 'Confidential acquisition budget summary'
+        : 'Shared message summary');
+
+    livewire(PeopleEmailsPage::class, ['record' => $person->getKey()])
+        ->mountAction('summarizeThread', arguments: ['emailId' => $shared->getKey()])
+        ->assertMountedActionModalSee('Confidential acquisition budget summary');
+
+    $private->shares()->delete();
+    $this->actingAs($viewer->refresh());
+    expect($viewer->can('viewBody', $shared->fresh()))->toBeTrue();
+
+    livewire(PeopleEmailsPage::class, ['record' => $person->getKey()])
+        ->mountAction('summarizeThread', arguments: ['emailId' => $shared->getKey()])
+        ->assertMountedActionModalSee('Shared message summary')
+        ->assertMountedActionModalDontSee('Confidential acquisition budget summary');
+})->with(['another viewer' => false, 'revoked share' => true]);
+
+it('regenerates legacy summaries without a permission fingerprint', function (): void {
+    $thread = makeThreadWithEmail();
+    $email = $thread->emails()->firstOrFail();
+    $person = People::factory()->create(['team_id' => $this->team->id, 'creator_id' => $this->owner->id]);
+    $person->emails()->attach($email->getKey());
+    AiSummary::query()->create([
+        'team_id' => $this->team->id,
+        'summarizable_type' => $thread->getMorphClass(),
+        'summarizable_id' => $thread->getKey(),
+        'summary' => 'Legacy unscoped summary',
+        'model_used' => 'gpt-4o-mini',
+        'prompt_tokens' => 10,
+        'completion_tokens' => 5,
+    ]);
+    ThreadSummarizer::fake(['Verified summary']);
+
+    livewire(PeopleEmailsPage::class, ['record' => $person->getKey()])
+        ->mountAction('summarizeThread', arguments: ['emailId' => $email->getKey()])
+        ->assertMountedActionModalSee('Verified summary')
+        ->assertMountedActionModalDontSee('Legacy unscoped summary');
 });


### PR DESCRIPTION
## Summary
- Main already dropped `ai_summaries`. Deleting that drop does not restore the table on existing installs.
- This adds a later recreate migration, including `input_hash`, so thread summaries and the subscriber has-ai-usage query work after upgrade.
- Thread summaries are cached per viewer permission fingerprint so a shared-message viewer cannot reuse a private summary.

## Test plan
- [x] Fresh migrate still creates `ai_summaries`.
- [x] An install that already ran the drop gets the table back from the new migration.
- [x] Generate an email thread summary and confirm it persists.
- [x] Confirm a viewer of one shared message does not see a cached private-thread summary.