### PR TITLE
Keep provider thread IDs within their sending mailbox

### DIFF
--- a/packages/EmailIntegration/src/Actions/SendEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailAction.php
@@ -97,7 +97,13 @@ final readonly class SendEmailAction
                 // double-sending. See EmailSendingService::send().
                 'rfc_message_id' => $this->generateRfcMessageId($account),
                 'provider_message_id' => null,
-                'thread_id' => $inReplyTo?->thread_id,
+                // Gmail threadId / Graph conversationId exist only inside the
+                // mailbox that received the original. A reply from a shared
+                // inbox or a different connected account must not pass that
+                // foreign id to the sending mailbox.
+                'thread_id' => $inReplyTo !== null && $inReplyTo->connected_account_id === $account->getKey()
+                    ? $inReplyTo->thread_id
+                    : null,
                 'in_reply_to' => $inReplyTo?->rfc_message_id,
                 'subject' => $data['subject'],
                 'snippet' => mb_substr(strip_tags((string) $data['body_html']), 0, 255),

--- a/packages/EmailIntegration/src/Services/EmailSendingService.php
+++ b/packages/EmailIntegration/src/Services/EmailSendingService.php
@@ -101,6 +101,9 @@ final readonly class EmailSendingService
 
         if ($email->in_reply_to !== null) {
             $payload['in_reply_to'] = (string) $email->in_reply_to;
+        }
+
+        if ($email->thread_id !== null) {
             $payload['thread_id'] = (string) $email->thread_id;
         }
 

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -185,7 +185,8 @@ final readonly class GmailService implements MailServiceInterface
 
     /**
      * Send a new email or reply to an existing thread.
-     * Pass `in_reply_to` and `thread_id` in $data to send as a reply.
+     * Pass `in_reply_to` to send as a reply. Pass `thread_id` only when it
+     * belongs to this mailbox; Gmail rejects a thread id from another account.
      *
      * @param array{
      *     subject: string,
@@ -203,15 +204,15 @@ final readonly class GmailService implements MailServiceInterface
      */
     public function sendMessage(array $data): array
     {
-        $isReply = isset($data['in_reply_to']);
         $raw = $this->buildMimeMessage($data, $data['in_reply_to'] ?? null);
 
         $message = new Message;
         $message->setRaw(rtrim(strtr(base64_encode($raw), '+/', '-_'), '='));
 
-        if ($isReply) {
-            assert(isset($data['thread_id']), 'thread_id is required when in_reply_to is set');
-            $message->setThreadId($data['thread_id']);
+        $threadId = $data['thread_id'] ?? null;
+
+        if (is_string($threadId) && $threadId !== '') {
+            $message->setThreadId($threadId);
         }
 
         $sent = $this->gmail->users_messages->send('me', $message);

--- a/tests/Feature/EmailIntegration/GmailMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/GmailMailServiceTest.php
@@ -147,6 +147,52 @@ it('sends a plain multipart/alternative message when there are no attachments', 
         ->and($raw)->not->toContain('multipart/mixed');
 });
 
+it('threads a same-mailbox reply with the provider thread id', function (): void {
+    $account = ConnectedAccount::factory()->make([
+        'email_address' => 'sender@example.com',
+        'display_name' => 'Sender',
+    ]);
+
+    $captured = null;
+    $gmail = fakeGmail(function (Message $message) use (&$captured): void {
+        $captured = $message;
+    });
+
+    new GmailService($account, $gmail)->sendMessage([
+        'subject' => 'Re: Hello',
+        'body_html' => '<p>Reply</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'in_reply_to' => '<original@example.com>',
+        'thread_id' => 'gmail-thread-abc',
+    ]);
+
+    expect($captured->getThreadId())->toBe('gmail-thread-abc');
+});
+
+it('sends a reply without a provider thread id when the thread belongs to another mailbox', function (): void {
+    $account = ConnectedAccount::factory()->make([
+        'email_address' => 'sender@example.com',
+        'display_name' => 'Sender',
+    ]);
+
+    $captured = null;
+    $gmail = fakeGmail(function (Message $message) use (&$captured): void {
+        $captured = $message;
+    });
+
+    new GmailService($account, $gmail)->sendMessage([
+        'subject' => 'Re: Hello',
+        'body_html' => '<p>Reply from another mailbox</p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'in_reply_to' => '<original@example.com>',
+    ]);
+
+    $raw = decodeRaw($captured);
+
+    expect($captured->getThreadId())->toBeNull()
+        ->and($raw)->toContain('In-Reply-To: <original@example.com>');
+});
+
 it('strips quotes and newlines from attachment filenames to prevent header injection', function (): void {
     $account = ConnectedAccount::factory()->make([
         'email_address' => 'sender@example.com',

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -149,6 +149,65 @@ it('ignores an in_reply_to_email_id that belongs to another team', function (): 
         ->and($email->in_reply_to)->toBeNull();
 });
 
+it('does not copy a provider thread id from a different sending mailbox', function (): void {
+    $otherAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'email_address' => 'other@example.com',
+        'display_name' => 'Other Mailbox',
+    ]));
+    $sharedEmail = Email::query()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $otherAccount->getKey(),
+        'rfc_message_id' => '<shared@example.com>',
+        'provider_message_id' => 'provider-shared',
+        'thread_id' => 'gmail-thread-from-other-mailbox',
+        'subject' => 'Shared mail',
+        'snippet' => 'Shared',
+        'sent_at' => now()->subHour(),
+        'direction' => EmailDirection::INBOUND,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'status' => EmailStatus::SENT,
+    ]);
+
+    $reply = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Re: Shared mail',
+        'body_html' => '<p>Reply from my mailbox</p>',
+        'to' => [['email' => 'someone@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => $sharedEmail->getKey(),
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]);
+
+    expect($reply->thread_id)->toBeNull()
+        ->and($reply->in_reply_to)->toBe('<shared@example.com>');
+
+    $captured = null;
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('sendMessage')->once()->andReturnUsing(function (array $payload) use (&$captured): array {
+        $captured = $payload;
+
+        return [
+            'provider_message_id' => 'provider-cross-mailbox',
+            'thread_id' => 'new-thread-in-sender-mailbox',
+            'rfc_message_id' => $payload['rfc_message_id'] ?? '<reply@example.com>',
+        ];
+    });
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    app(EmailSendingService::class)->send($reply);
+
+    expect($captured)->not->toHaveKey('thread_id')
+        ->and($captured['in_reply_to'])->toBe('<shared@example.com>');
+});
+
 it('syncs the email thread aggregate when an outbound reply is sent', function (): void {
     $original = Email::query()->create([
         'team_id' => $this->team->id,


### PR DESCRIPTION
## Summary
- Replies copied the source email's Gmail or Graph thread ID even when sending from another connected mailbox.
- Those IDs are mailbox-scoped, so replying to shared mail or from a second account made Gmail reject the send.
- Same-mailbox replies still attach to the original thread. Cross-mailbox replies omit the provider thread ID and keep the RFC In-Reply-To header.

## Test plan
- [x] Reply from the same connected mailbox and confirm the message stays on the original Gmail thread.
- [x] Reply from another connected mailbox, or to shared mail, and confirm the send succeeds.
- [x] Confirm the recipient still sees the message as a reply.