### PR TITLE
Store Gmail-inlined attachment bytes for ordinary files

### DIFF
--- a/packages/EmailIntegration/src/Actions/StoreEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreEmailAction.php
@@ -162,15 +162,14 @@ final readonly class StoreEmailAction
     }
 
     /**
+     * Persist Gmail-inlined bytes. Small parts (<25 KB) arrive as body data with
+     * no attachment ID, including ordinary files, so downloads 404 unless we store them.
+     *
      * @param  array{filename: string|null, mime_type: string|null, size: int, content_id: string|null, attachment_id: string|null, inline_data: string|null, is_inline?: bool}  $attachment
      * @param  list<string>  $storedInlinePaths
      */
     private function storeInlineData(Email $email, array $attachment, array &$storedInlinePaths): ?string
     {
-        if (($attachment['is_inline'] ?? false) === false) {
-            return null;
-        }
-
         if (blank($attachment['inline_data'])) {
             return null;
         }

--- a/tests/Feature/EmailIntegration/StoreEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailActionTest.php
@@ -268,6 +268,40 @@ it('stores inline attachment metadata', function (): void {
         ->assertExists((string) $attachment->storage_path);
 });
 
+it('stores embedded bytes for ordinary attachments that have no provider id', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $data = makeFetchedEmailData([
+        'hasAttachments' => true,
+        'attachments' => [
+            [
+                'filename' => 'notes.txt',
+                'mime_type' => 'text/plain',
+                'size' => 11,
+                'content_id' => null,
+                'attachment_id' => null,
+                'inline_data' => rtrim(strtr(base64_encode('hello-bytes'), '+/', '-_'), '='),
+                'is_inline' => false,
+            ],
+        ],
+    ]);
+
+    $email = resolve(StoreEmailAction::class)->execute($this->account, $data);
+
+    $attachment = $email->attachments()->sole();
+
+    expect($attachment->filename)->toBe('notes.txt')
+        ->and($attachment->is_inline)->toBeFalse()
+        ->and($attachment->provider_attachment_id)->toBeNull()
+        ->and($attachment->storage_path)->not->toBeNull();
+
+    Storage::disk(EmailAttachment::DISK)
+        ->assertExists((string) $attachment->storage_path);
+
+    expect(Storage::disk(EmailAttachment::DISK)->get((string) $attachment->storage_path))
+        ->toBe('hello-bytes');
+});
+
 it('stores a nameless inline cid image with a generated filename', function (): void {
     $data = makeFetchedEmailData([
         'attachments' => [


### PR DESCRIPTION
## Summary
- Gmail inlines small attachments as body bytes with no attachment ID.
- `StoreEmailAction` previously discarded those bytes unless the file was a CID image.
- Ordinary attachments then had neither a storage path nor a provider ID, so downloads returned 404.

## Test plan
- [x] Import a Gmail message with a small ordinary attachment (no provider attachment ID).
- [x] Confirm the stored row has a `storage_path`.
- [x] Download the attachment and confirm it is not 404.
- [x] CID inline images still store and render.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/StoreEmailActionTest.php`