### PR TITLE
Keep Gmail read state from the last history change in a sync

### DIFF
--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -34,10 +34,12 @@ final readonly class GmailService implements MailServiceInterface
     {
         /** @var array<int, string> $messageIds */
         $messageIds = [];
-        /** @var array<int, string> $readMessageIds */
-        $readMessageIds = [];
-        /** @var array<int, string> $unreadMessageIds */
-        $unreadMessageIds = [];
+        // id => isRead, last-write-wins. UNREAD can be added and removed on the
+        // same message across history records in one sync; keying by id keeps
+        // the LATEST state so a message never lands in both lists (which the
+        // sync job would then apply unread-last, overriding the final state).
+        /** @var array<string, bool> $readState */
+        $readState = [];
 
         $newCursor = $cursor;
         $pageToken = null;
@@ -76,20 +78,14 @@ final readonly class GmailService implements MailServiceInterface
                 // Track messages where the UNREAD label was removed (user read the email)
                 foreach ($item->getLabelsRemoved() ?? [] as $change) {
                     if (in_array('UNREAD', $change->getLabelIds() ?? [], strict: true)) {
-                        $id = $change->getMessage()->getId();
-                        if (! in_array($id, $readMessageIds, strict: true)) {
-                            $readMessageIds[] = $id;
-                        }
+                        $readState[$change->getMessage()->getId()] = true;
                     }
                 }
 
                 // Track messages where the UNREAD label was re-added (marked unread again)
                 foreach ($item->getLabelsAdded() ?? [] as $change) {
                     if (in_array('UNREAD', $change->getLabelIds() ?? [], strict: true)) {
-                        $id = $change->getMessage()->getId();
-                        if (! in_array($id, $unreadMessageIds, strict: true)) {
-                            $unreadMessageIds[] = $id;
-                        }
+                        $readState[$change->getMessage()->getId()] = false;
                     }
                 }
             }
@@ -100,6 +96,19 @@ final readonly class GmailService implements MailServiceInterface
 
             $pageToken = $history->getNextPageToken();
         } while ($pageToken !== null && $pageToken !== '');
+
+        /** @var array<int, string> $readMessageIds */
+        $readMessageIds = [];
+        /** @var array<int, string> $unreadMessageIds */
+        $unreadMessageIds = [];
+
+        foreach ($readState as $id => $isRead) {
+            if ($isRead) {
+                $readMessageIds[] = (string) $id;
+            } else {
+                $unreadMessageIds[] = (string) $id;
+            }
+        }
 
         return new MailDeltaResult(
             messageIds: collect($messageIds),

--- a/tests/Feature/EmailIntegration/GmailMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/GmailMailServiceTest.php
@@ -402,6 +402,76 @@ it('surfaces new, read, and unread message ids from gmail history', function ():
         ->and($delta->newCursor)->toBe('4000');
 });
 
+it('keeps only the last unread-label change when a message is marked unread then read in one sync', function (): void {
+    $account = ConnectedAccount::factory()->make();
+
+    $markedUnread = new History;
+    $markedUnread->setLabelsAdded([gmailHistoryLabelAdded('msg-flip', ['UNREAD'])]);
+
+    $markedRead = new History;
+    $markedRead->setLabelsRemoved([gmailHistoryLabelRemoved('msg-flip', ['UNREAD'])]);
+
+    $response = new ListHistoryResponse;
+    $response->setHistoryId('4000');
+    $response->setHistory([$markedUnread, $markedRead]);
+
+    $gmail = fakeGmailHistory(fn (): ListHistoryResponse => $response);
+
+    $delta = new GmailService($account, $gmail)->fetchDelta('3891');
+
+    expect($delta->readMessageIds->all())->toBe(['msg-flip'])
+        ->and($delta->unreadMessageIds?->all())->toBe([]);
+});
+
+it('keeps only the last unread-label change when a message is marked read then unread in one sync', function (): void {
+    $account = ConnectedAccount::factory()->make();
+
+    $markedRead = new History;
+    $markedRead->setLabelsRemoved([gmailHistoryLabelRemoved('msg-flip', ['UNREAD'])]);
+
+    $markedUnread = new History;
+    $markedUnread->setLabelsAdded([gmailHistoryLabelAdded('msg-flip', ['UNREAD'])]);
+
+    $response = new ListHistoryResponse;
+    $response->setHistoryId('4000');
+    $response->setHistory([$markedRead, $markedUnread]);
+
+    $gmail = fakeGmailHistory(fn (): ListHistoryResponse => $response);
+
+    $delta = new GmailService($account, $gmail)->fetchDelta('3891');
+
+    expect($delta->unreadMessageIds?->all())->toBe(['msg-flip'])
+        ->and($delta->readMessageIds->all())->toBe([]);
+});
+
+it('keeps only the last unread-label change when the flip spans history pages', function (): void {
+    $account = ConnectedAccount::factory()->make();
+
+    $firstHistory = new History;
+    $firstHistory->setLabelsAdded([gmailHistoryLabelAdded('msg-flip', ['UNREAD'])]);
+
+    $firstPage = new ListHistoryResponse;
+    $firstPage->setHistoryId('4100');
+    $firstPage->setNextPageToken('page-2');
+    $firstPage->setHistory([$firstHistory]);
+
+    $secondHistory = new History;
+    $secondHistory->setLabelsRemoved([gmailHistoryLabelRemoved('msg-flip', ['UNREAD'])]);
+
+    $secondPage = new ListHistoryResponse;
+    $secondPage->setHistoryId('4100');
+    $secondPage->setHistory([$secondHistory]);
+
+    $gmail = fakeGmailHistory(function (string $userId, array $params) use ($firstPage, $secondPage): ListHistoryResponse {
+        return isset($params['pageToken']) ? $secondPage : $firstPage;
+    });
+
+    $delta = new GmailService($account, $gmail)->fetchDelta('3891');
+
+    expect($delta->readMessageIds->all())->toBe(['msg-flip'])
+        ->and($delta->unreadMessageIds?->all())->toBe([]);
+});
+
 it('follows gmail history pages until the token is exhausted', function (): void {
     $account = ConnectedAccount::factory()->make();
     $captured = [];


### PR DESCRIPTION
## Summary
- A message marked unread and then read in one Gmail history window entered both delta lists.
- Incremental sync always applied unread last, so the CRM stayed unread even when Gmail's last state was read.
- `fetchDelta` now last-write-wins per message, including across history pages, matching Microsoft Graph.

## Test plan
- [ ] `php artisan test --compact tests/Feature/EmailIntegration/GmailMailServiceTest.php`
- [ ] Mark a synced Gmail message unread, then read, before the next incremental sync. Relaticle should show it as read.
- [ ] Mark a synced Gmail message read, then unread, before the next incremental sync. Relaticle should show it as unread.