### PR TITLE
Remove Product Hunt launch badge from footer

### DIFF
--- a/resources/views/components/layout/footer.blade.php
+++ b/resources/views/components/layout/footer.blade.php
@@ -33,16 +33,6 @@
                         <x-ri-linkedin-box-fill class="h-5 w-5" />
                     </a>
                 </div>
-
-                <a href="https://www.producthunt.com/products/relaticle?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-relaticle"
-                   target="_blank" rel="noopener noreferrer" class="inline-flex w-fit">
-                    <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1238864&amp;theme=light"
-                         alt="Relaticle - Open-source CRM with approval-gated AI writes | Product Hunt"
-                         width="250" height="54" loading="lazy" class="dark:hidden" />
-                    <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1238864&amp;theme=dark"
-                         alt="Relaticle - Open-source CRM with approval-gated AI writes | Product Hunt"
-                         width="250" height="54" loading="lazy" class="hidden dark:block" />
-                </a>
             </div>
 
             @php($columns = app(\App\Support\MarketingNavigation::class)->footer())

--- a/tests/Feature/Public/MarketingNavigationTest.php
+++ b/tests/Feature/Public/MarketingNavigationTest.php
@@ -172,10 +172,8 @@ it('renders the works-with strip on the homepage with a link to the developer do
         ->and($strip)->toContain('21,000+');
 });
 
-it('shows one product hunt badge per theme in the footer', function (): void {
+it('renders the homepage without the product hunt launch badge', function (): void {
     $html = $this->get('/')->assertOk()->getContent();
 
-    expect($html)->toContain('https://www.producthunt.com/products/relaticle?embed=true')
-        ->and($html)->toContain('featured.svg?post_id=1238864&amp;theme=light')
-        ->and($html)->toContain('featured.svg?post_id=1238864&amp;theme=dark');
+    expect($html)->not->toContain('producthunt.com', 'Product Hunt');
 });


### PR DESCRIPTION
The Product Hunt launch has finished, so the site footer no longer displays its badge in either theme.
Update the homepage test to assert that the launch badge is absent.

Verified the footer on desktop and mobile in light and dark themes.
Validation: Pint, Rector, PHPStan, 100% type coverage, marketing navigation tests, and the full non-TIA test suite.
