### PR TITLE
Exclude Gmail drafts from shared email imports

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - 'packages/EmailIntegration/**'
+---
+
+# Email integration
+
+## Never import provider drafts
+
+Gmail drafts carry the `DRAFT` label and not `SENT`, so `fetchMessage()` classifies
+them as inbound. `StoreEmailJob` skips `EmailFolder::Drafts` before the inbox/sent
+toggle, and Gmail backfill lists with `-in:drafts`. Importing a draft would store it
+as `SYNCED` with the account's sharing default, so teammates could read unsent mail
+through linked CRM records. Composer drafts (`EmailStatus::DRAFT`) are a different
+path and stay local.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -9,6 +9,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Models/** | .ai/rules/boost/models.md |
 | tests/** | .ai/rules/boost/tests.md |
 | packages/Chat/** | .ai/rules/chat.md |
+| packages/EmailIntegration/** | .ai/rules/email-integration.md |
 | app/Jobs/Email/**, app/Support/Email/** | .ai/rules/email.md |
 | app/Models/**, app/Casts/** | .ai/rules/models.md |
 | resources/views/filament/**, app/Filament/**, packages/*/src/Filament/**, packages/*/resources/views/** | .ai/rules/panel-links.md |

--- a/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Relaticle\EmailIntegration\Actions\StoreEmailAction;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Jobs\Concerns\ReleasesOnProviderRateLimit;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -74,6 +75,16 @@ final class StoreEmailJob implements ShouldBeUnique, ShouldQueue
             }
 
             throw $exception;
+        }
+
+        // Provider drafts are unsent. Gmail drafts carry DRAFT and not SENT, so
+        // fetchMessage() classifies them as inbound. Skip them here rather than
+        // in a provider service so it covers Gmail and Microsoft, and both the
+        // initial backfill and incremental syncs. Otherwise they store as SYNCED
+        // with the account's sharing default, and teammates can read them
+        // through linked CRM records.
+        if ($fetched->folder === EmailFolder::Drafts) {
+            return;
         }
 
         // Honour the account's inbox/sent toggles. Gated here rather than in a

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -169,10 +169,14 @@ final readonly class GmailService implements MailServiceInterface
 
         $params = [
             'maxResults' => 500,
+            // Gmail's messages.list includes drafts unless we exclude them.
+            // Drafts have no SENT label, so the store job would treat them as
+            // inbound and share unsent mail with the workspace.
+            'q' => '-in:drafts',
         ];
 
         if ($daysBack !== null && $daysBack > 0) {
-            $params['q'] = 'after:'.now()->subDays($daysBack)->timestamp;
+            $params['q'] .= ' after:'.now()->subDays($daysBack)->timestamp;
         }
 
         if ($pageToken !== null && $pageToken !== '') {

--- a/tests/Feature/EmailIntegration/EmailSyncDirectionFilterTest.php
+++ b/tests/Feature/EmailIntegration/EmailSyncDirectionFilterTest.php
@@ -19,7 +19,7 @@ mutates(StoreEmailJob::class);
  * Build a StoreEmailJob whose mailbox returns a message of the given direction,
  * then run it against the account's inbox/sent toggles.
  */
-function runStoreEmailJob(ConnectedAccount $account, EmailDirection $direction): void
+function runStoreEmailJob(ConnectedAccount $account, EmailDirection $direction, ?EmailFolder $folder = null): void
 {
     $fetched = new FetchedEmailData(
         providerMessageId: 'msg-'.$direction->value,
@@ -30,7 +30,7 @@ function runStoreEmailJob(ConnectedAccount $account, EmailDirection $direction):
         snippet: 'Hello',
         sentAt: Date::now(),
         direction: $direction,
-        folder: $direction === EmailDirection::OUTBOUND ? EmailFolder::Sent : EmailFolder::Inbox,
+        folder: $folder ?? ($direction === EmailDirection::OUTBOUND ? EmailFolder::Sent : EmailFolder::Inbox),
         hasAttachments: false,
         isRead: true,
         bodyText: 'Hello',
@@ -72,4 +72,12 @@ it('stores an email whose direction is enabled', function (): void {
     runStoreEmailJob($account, EmailDirection::INBOUND);
 
     expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(1);
+});
+
+it('skips storing a provider draft even when inbox sync is on', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create(['sync_inbox' => true, 'sync_sent' => true]));
+
+    runStoreEmailJob($account, EmailDirection::INBOUND, EmailFolder::Drafts);
+
+    expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(0);
 });

--- a/tests/Feature/EmailIntegration/GmailMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/GmailMailServiceTest.php
@@ -9,10 +9,14 @@ use Google\Service\Gmail\HistoryLabelAdded;
 use Google\Service\Gmail\HistoryLabelRemoved;
 use Google\Service\Gmail\HistoryMessageAdded;
 use Google\Service\Gmail\ListHistoryResponse;
+use Google\Service\Gmail\ListMessagesResponse;
 use Google\Service\Gmail\Message;
 use Google\Service\Gmail\MessagePart;
 use Google\Service\Gmail\MessagePartBody;
 use Google\Service\Gmail\MessagePartHeader;
+use Google\Service\Gmail\Profile;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\GmailService;
@@ -587,4 +591,99 @@ it('does not treat other Gmail history HTTP errors as an expired cursor', functi
 
     expect(fn () => new GmailService($account, $gmail)->fetchDelta('history-1'))
         ->toThrow(GoogleServiceException::class);
+});
+
+it('classifies a DRAFT-labeled message as an inbound draft', function (): void {
+    $account = ConnectedAccount::factory()->make();
+
+    $payload = new MessagePart;
+    $payload->setHeaders([
+        new MessagePartHeader(['name' => 'Message-ID', 'value' => '<draft@example.test>']),
+        new MessagePartHeader(['name' => 'Subject', 'value' => 'Unsent']),
+        new MessagePartHeader(['name' => 'From', 'value' => 'Owner <owner@example.test>']),
+        new MessagePartHeader(['name' => 'To', 'value' => 'Prospect <prospect@example.test>']),
+    ]);
+    $payload->setParts([]);
+
+    $message = new Message([
+        'id' => 'gmail-draft-1',
+        'threadId' => 'gmail-thread-draft',
+        'internalDate' => (string) (now()->timestamp * 1000),
+        'labelIds' => ['DRAFT'],
+        'snippet' => 'Unsent',
+    ]);
+    $message->setPayload($payload);
+
+    $messages = Mockery::mock();
+    $messages->shouldReceive('get')
+        ->once()
+        ->with('me', 'gmail-draft-1', ['format' => 'full'])
+        ->andReturn($message);
+
+    $gmail = Mockery::mock(Gmail::class);
+    $gmail->users_messages = $messages;
+
+    $data = new GmailService($account, $gmail)->fetchMessage('gmail-draft-1');
+
+    expect($data->direction)->toBe(EmailDirection::INBOUND)
+        ->and($data->folder)->toBe(EmailFolder::Drafts);
+});
+
+it('excludes drafts from the initial backfill listing', function (): void {
+    $account = ConnectedAccount::factory()->make();
+    $captured = [];
+
+    $profile = new Profile;
+    $profile->setHistoryId('1000');
+
+    $users = Mockery::mock();
+    $users->shouldReceive('getProfile')->once()->with('me')->andReturn($profile);
+
+    $messages = Mockery::mock();
+    $messages->shouldReceive('listUsersMessages')
+        ->once()
+        ->andReturnUsing(function (string $userId, array $params) use (&$captured): ListMessagesResponse {
+            $captured = ['userId' => $userId, 'params' => $params];
+
+            return new ListMessagesResponse;
+        });
+
+    $gmail = Mockery::mock(Gmail::class);
+    $gmail->users = $users;
+    $gmail->users_messages = $messages;
+
+    new GmailService($account, $gmail)->initialBackfill();
+
+    expect($captured['userId'])->toBe('me')
+        ->and($captured['params']['q'])->toBe('-in:drafts');
+});
+
+it('keeps the draft exclusion when the initial backfill is date-capped', function (): void {
+    $this->travelTo('2026-09-09 12:00:00');
+
+    $account = ConnectedAccount::factory()->make();
+    $captured = [];
+
+    $profile = new Profile;
+    $profile->setHistoryId('1000');
+
+    $users = Mockery::mock();
+    $users->shouldReceive('getProfile')->once()->with('me')->andReturn($profile);
+
+    $messages = Mockery::mock();
+    $messages->shouldReceive('listUsersMessages')
+        ->once()
+        ->andReturnUsing(function (string $userId, array $params) use (&$captured): ListMessagesResponse {
+            $captured = $params;
+
+            return new ListMessagesResponse;
+        });
+
+    $gmail = Mockery::mock(Gmail::class);
+    $gmail->users = $users;
+    $gmail->users_messages = $messages;
+
+    new GmailService($account, $gmail)->initialBackfill(90);
+
+    expect($captured['q'])->toBe('-in:drafts after:1781179200');
 });

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -128,6 +128,35 @@ it('paginates delta with @odata.nextLink and surfaces new + read ids + new curso
         ->and($delta->newCursor)->toContain('$deltatoken=FRESH');
 });
 
+it('maps a Graph drafts-folder message as an inbound draft', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/mailFolders*' => Http::response([
+            'value' => [['id' => 'drafts-folder-id', 'displayName' => 'Drafts']],
+        ]),
+        'https://graph.microsoft.com/v1.0/me/messages/DRAFT1*' => Http::response([
+            'id' => 'DRAFT1',
+            'internetMessageId' => '<draft@example.com>',
+            'conversationId' => 'thread-draft',
+            'subject' => 'Unsent',
+            'bodyPreview' => 'Still writing',
+            'receivedDateTime' => '2026-01-15T10:00:00Z',
+            'isRead' => true,
+            'hasAttachments' => false,
+            'parentFolderId' => 'drafts-folder-id',
+            'from' => ['emailAddress' => ['address' => 'owner@example.com', 'name' => 'Owner']],
+            'toRecipients' => [['emailAddress' => ['address' => 'prospect@example.com', 'name' => 'Prospect']]],
+            'ccRecipients' => [],
+            'bccRecipients' => [],
+            'body' => ['contentType' => 'html', 'content' => '<p>Still writing</p>'],
+        ]),
+    ]);
+
+    $email = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->fetchMessage('DRAFT1');
+
+    expect($email->direction)->toBe(EmailDirection::INBOUND)
+        ->and($email->folder)->toBe(EmailFolder::Drafts);
+});
+
 it('maps a Graph message payload to FetchedEmailData', function (): void {
     Http::fake([
         'https://graph.microsoft.com/v1.0/me/mailFolders*' => Http::response([


### PR DESCRIPTION
## Summary
- Gmail drafts have no SENT label, so the import filter treated them as inbound mail.
- They were stored as SYNCED and stamped with the account sharing default. With full sharing, teammates could read unsent drafts through linked CRM records.
- `StoreEmailJob` now skips the Drafts folder for Gmail and Microsoft. Gmail backfill also lists with `-in:drafts`.

## Test plan
- [x] A DRAFT-labeled Gmail message maps to inbound + Drafts and is not stored even when inbox sync is on.
- [x] Gmail initial backfill always includes `-in:drafts`, including date-capped imports.
- [x] A Microsoft Graph Drafts-folder message maps the same way and is skipped by the store job.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailSyncDirectionFilterTest.php tests/Feature/EmailIntegration/GmailMailServiceTest.php tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php tests/Feature/EmailIntegration/StoreEmailJobTest.php`