### PR TITLE
Include plain-text originals when quoting replies and forwards

### DIFF
--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -146,7 +146,7 @@ trait HasEmailComposeActions
         };
 
         // Only quote the original body when the viewer is entitled to read it.
-        $quotedBody = $user->can('viewBody', $email) ? ($email->body->body_html ?? '') : '';
+        $quotedBody = $user->can('viewBody', $email) ? ($email->quotedBodyHtml() ?? '') : '';
 
         $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
         $originalSubject = $user->can('viewSubject', $email) ? ($email->subject ?? '') : '';

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -452,7 +452,7 @@ final class EmailInboxPage extends Page
         };
 
         // Only quote the original body when the viewer is entitled to read it.
-        $quotedBody = $user->can('viewBody', $email) ? $email->body?->body_html : null;
+        $quotedBody = $user->can('viewBody', $email) ? $email->quotedBodyHtml() : null;
 
         $subjectPrefix = $mode === 'forward' ? 'Fwd: ' : 'Re: ';
         $originalSubject = $user->can('viewSubject', $email) ? ($email->subject ?? '') : '';

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -296,7 +296,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $this->subject = ($this->replyMode === 'forward' ? 'Fwd: ' : 'Re: ').$originalSubject;
 
         // Only quote the original body when the viewer is entitled to read it.
-        $this->quotedBodyHtml = $user->can('viewBody', $email) ? $email->body?->body_html : null;
+        $this->quotedBodyHtml = $user->can('viewBody', $email) ? $email->quotedBodyHtml() : null;
         $this->sourceEmailId = (string) $email->getKey();
         // A forward carries its source for display, but must not thread against it.
         $this->inReplyToEmailId = $this->replyMode === 'forward' ? null : $this->sourceEmailId;
@@ -1450,7 +1450,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             default => 'reply',
         };
         $this->inReplyToEmailId = $this->replyMode === 'forward' ? null : $this->sourceEmailId;
-        $this->quotedBodyHtml = $user->can('viewBody', $original) ? $original->body?->body_html : null;
+        $this->quotedBodyHtml = $user->can('viewBody', $original) ? $original->quotedBodyHtml() : null;
     }
 
     /**

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -324,6 +324,27 @@ final class Email extends Model
     }
 
     /**
+     * HTML to append when this message is replied to or forwarded. Prefers the
+     * stored HTML. A plain-text-only body is escaped so the original is not dropped.
+     */
+    public function quotedBodyHtml(): ?string
+    {
+        $html = $this->body?->body_html;
+
+        if (filled($html)) {
+            return $html;
+        }
+
+        $text = $this->body?->body_text;
+
+        if (blank($text)) {
+            return null;
+        }
+
+        return nl2br(e($text), false);
+    }
+
+    /**
      * Reply-all recipient addresses: the original sender PLUS the to/cc recipients
      * (never bcc), excluding the replying user's own account address. De-duplicated
      * case-insensitively. Operates on the loaded `participants` relation.

--- a/resources/views/components/emails/quoted-message.blade.php
+++ b/resources/views/components/emails/quoted-message.blade.php
@@ -19,7 +19,7 @@
         ->implode('');
 
     $safeHtml = $authUser->can('viewBody', $record)
-        ? EmailHtmlSanitizer::sanitize($record->body?->body_html, $record->attachments->where('is_inline', true))
+        ? EmailHtmlSanitizer::sanitize($record->quotedBodyHtml(), $record->attachments->where('is_inline', true))
         : null;
 @endphp
 

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -24,7 +24,7 @@ use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
-mutates(EmailsRelationManager::class, EmailInboxPage::class, EmailComposer::class, HasEmailComposeActions::class, RedirectsToGrantSend::class, ConnectedAccount::class, QueuedSendNotifier::class);
+mutates(EmailsRelationManager::class, EmailInboxPage::class, EmailComposer::class, Email::class, HasEmailComposeActions::class, RedirectsToGrantSend::class, ConnectedAccount::class, QueuedSendNotifier::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -270,7 +270,8 @@ it('inline composer prefills reply-all and forward from their modes', function (
         ->assertSet('subject', 'Fwd: Original Subject')
         // A forward has no recipient yet, and does not thread against the original.
         ->assertSet('to', [])
-        ->assertSet('inReplyToEmailId', null);
+        ->assertSet('inReplyToEmailId', null)
+        ->assertSet('quotedBodyHtml', '<p>Original body</p>');
 });
 
 it('a reply saved as a draft still threads when it is sent later', function (): void {
@@ -297,6 +298,150 @@ it('a reply saved as a draft still threads when it is sent later', function (): 
 
     expect($reply->in_reply_to)->toBe($this->inboundEmail->rfc_message_id)
         ->and($reply->thread_id)->toBe($this->inboundEmail->thread_id);
+});
+
+it('includes the original plain-text body when quoting a reply or forward', function (string $mode, string $marker): void {
+    $this->inboundEmail->body->update([
+        'body_html' => null,
+        'body_text' => "Please review the invoice by Friday.\nThanks, Acme Billing",
+    ]);
+
+    $composer = livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, $mode)
+        ->set('bodyHtml', '<p>FYI</p>');
+
+    if ($mode === 'forward') {
+        $composer->set('to', ['forward-to@example.com']);
+    }
+
+    $composer->call('send')->assertHasNoErrors();
+
+    $outbound = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->firstOrFail();
+
+    expect($outbound->body->body_html)
+        ->toContain('FYI')
+        ->toContain('Please review the invoice by Friday.')
+        ->toContain('Thanks, Acme Billing')
+        ->toContain($marker);
+})->with([
+    'reply' => ['reply', 'blockquote'],
+    'forward' => ['forward', '---------- Forwarded message ----------'],
+]);
+
+it('escapes html in a plain-text original when quoting a forward', function (): void {
+    $this->inboundEmail->body->update([
+        'body_html' => null,
+        'body_text' => '<script>alert(1)</script>Please pay',
+    ]);
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>FYI</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $html = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->firstOrFail()
+        ->body
+        ->body_html;
+
+    expect($html)
+        ->toContain('Please pay')
+        ->toContain('alert(1)')
+        ->not->toContain('<script>alert(1)</script>');
+});
+
+it('restores the plain-text original when a saved forward is reopened', function (): void {
+    $this->inboundEmail->body->update([
+        'body_html' => null,
+        'body_text' => 'Please review the invoice by Friday.',
+    ]);
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>FYI</p>')
+        ->call('close');
+
+    $draftId = Email::query()->where('status', EmailStatus::DRAFT)->sole()->getKey();
+
+    $composer = livewire(EmailComposer::class)
+        ->call('open', [], $draftId);
+
+    expect($composer->get('quotedBodyHtml'))
+        ->toContain('Please review the invoice by Friday.');
+
+    $composer->assertSee('Please review the invoice by Friday.');
+});
+
+it('includes the original plain-text body when forwarding from the relation manager', function (): void {
+    $this->inboundEmail->body->update([
+        'body_html' => null,
+        'body_text' => 'Please review the invoice by Friday.',
+    ]);
+
+    livewire(EmailsRelationManager::class, [
+        'ownerRecord' => $this->person,
+        'pageClass' => ViewPeople::class,
+    ])
+        ->callAction(
+            'replyForwardEmail',
+            data: [
+                'connected_account_id' => $this->account->id,
+                'to' => ['forward-to@example.com'],
+                'cc' => [],
+                'bcc' => [],
+                'subject' => 'Fwd: Original Subject',
+                'body_html' => '<p>FYI</p>',
+            ],
+            arguments: ['emailId' => $this->inboundEmail->id, 'mode' => 'forward'],
+        );
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->firstOrFail();
+
+    expect($forward->body->body_html)
+        ->toContain('FYI')
+        ->toContain('Please review the invoice by Friday.')
+        ->toContain('---------- Forwarded message ----------');
+});
+
+it('includes the original plain-text body when forwarding from the inbox', function (): void {
+    $this->inboundEmail->body->update([
+        'body_html' => null,
+        'body_text' => 'Please review the invoice by Friday.',
+    ]);
+
+    livewire(EmailInboxPage::class)
+        ->callAction(
+            'replyForwardEmail',
+            data: [
+                'connected_account_id' => $this->account->id,
+                'to' => ['forward-to@example.com'],
+                'cc' => [],
+                'bcc' => [],
+                'subject' => 'Fwd: Original Subject',
+                'body_html' => '<p>FYI</p>',
+            ],
+            arguments: ['emailId' => $this->inboundEmail->id, 'mode' => 'forward'],
+        );
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->firstOrFail();
+
+    expect($forward->body->body_html)
+        ->toContain('FYI')
+        ->toContain('Please review the invoice by Friday.')
+        ->toContain('---------- Forwarded message ----------');
 });
 
 it('a forward saved as a draft keeps its source without threading against it', function (): void {


### PR DESCRIPTION
## Summary
- Quoting only read `body_html`, so forwarding a plain-text email sent only the new commentary (for example `<p>FYI</p>` with the original missing).
- Replies, forwards, draft restore, and the inbox/record compose actions now fall back to escaped `body_text` when there is no HTML body.

## Test plan
- [x] Forward a plain-text-only inbound email with commentary such as FYI. Confirm the queued body includes the original and the forwarded-message marker.
- [x] Save that forward as a draft, reopen it, and send. Confirm the original is still quoted.
- [x] Forward an HTML email and confirm the stored HTML original is still used.
- [x] Confirm a metadata-only email still quotes nothing.