### PR TITLE
Import Gmail attachments when the file is the root payload

### DIFF
--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -404,6 +404,8 @@ final readonly class GmailService implements MailServiceInterface
 
     /**
      * Recursively walk MIME parts and collect attachment metadata.
+     * The current part is inspected, not only its children, because an
+     * attachment-only message puts the file on the root payload.
      * Covers both file attachments (Content-Disposition: attachment) and
      * inline images (Content-Disposition: inline with Content-ID).
      *
@@ -414,47 +416,46 @@ final readonly class GmailService implements MailServiceInterface
     {
         $attachments = [];
 
+        $partHeaders = collect($payload->getHeaders())
+            ->keyBy(fn (MessagePartHeader $header): string => strtolower((string) $header->getName()));
+
+        $disposition = $partHeaders->get('content-disposition')?->getValue() ?? '';
+        $filename = $payload->getFilename();
+
+        $contentId = $partHeaders->get('content-id')?->getValue();
+        if ($contentId !== null) {
+            $contentId = trim($contentId, '<>');
+        }
+
+        $mimeType = (string) $payload->getMimeType();
+        $lowerDisposition = strtolower($disposition);
+        $isInline = $contentId !== null && (
+            str_starts_with($lowerDisposition, 'inline') ||
+            isset($referencedContentIds[mb_strtolower($contentId)])
+        );
+
+        $isMultipart = str_starts_with(mb_strtolower($mimeType), 'multipart/');
+
+        if (! $isMultipart && (filled($filename) || str_starts_with($lowerDisposition, 'attachment') || $isInline)) {
+            $body = $payload->getBody();
+            // getAttachmentId() returns empty string when not present (large attachments have it set)
+            $gmailAttachmentId = $body->getAttachmentId();
+            $attachmentId = filled($gmailAttachmentId) ? $gmailAttachmentId : null;
+
+            $attachments[] = [
+                'filename' => filled($filename) ? $filename : null,
+                'mime_type' => $mimeType,
+                'size' => $body->getSize(),
+                'content_id' => $contentId,
+                'attachment_id' => $attachmentId,
+                // For small attachments (<25 KB) the binary is inlined; large ones have an attachment_id
+                'inline_data' => $attachmentId === null ? ($body->getData() ?: null) : null,
+                'is_inline' => $isInline,
+            ];
+        }
+
         foreach ($payload->getParts() as $part) {
-            $partHeaders = collect($part->getHeaders())
-                ->keyBy(fn (MessagePartHeader $header): string => strtolower((string) $header->getName()));
-
-            $disposition = $partHeaders->get('content-disposition')?->getValue() ?? '';
-            $filename = $part->getFilename();
-
-            $contentId = $partHeaders->get('content-id')?->getValue();
-            if ($contentId !== null) {
-                $contentId = trim($contentId, '<>');
-            }
-
-            $mimeType = (string) $part->getMimeType();
-            $lowerDisposition = strtolower($disposition);
-            $isInline = $contentId !== null && (
-                str_starts_with($lowerDisposition, 'inline') ||
-                isset($referencedContentIds[mb_strtolower($contentId)])
-            );
-
-            if (filled($filename) || str_starts_with($lowerDisposition, 'attachment') || $isInline) {
-                $body = $part->getBody();
-                // getAttachmentId() returns empty string when not present (large attachments have it set)
-                $gmailAttachmentId = $body->getAttachmentId();
-                $attachmentId = filled($gmailAttachmentId) ? $gmailAttachmentId : null;
-
-                $attachments[] = [
-                    'filename' => filled($filename) ? $filename : null,
-                    'mime_type' => $mimeType,
-                    'size' => $body->getSize(),
-                    'content_id' => $contentId,
-                    'attachment_id' => $attachmentId,
-                    // For small attachments (<25 KB) the binary is inlined; large ones have an attachment_id
-                    'inline_data' => $attachmentId === null ? ($body->getData() ?: null) : null,
-                    'is_inline' => $isInline,
-                ];
-            }
-
-            // Recurse into multipart containers (e.g. multipart/mixed, multipart/related)
-            if ($part->getParts()) {
-                $attachments = array_merge($attachments, $this->extractAttachments($part, $referencedContentIds));
-            }
+            $attachments = array_merge($attachments, $this->extractAttachments($part, $referencedContentIds));
         }
 
         return $attachments;

--- a/tests/Feature/EmailIntegration/GmailMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/GmailMailServiceTest.php
@@ -341,6 +341,94 @@ it('marks body-referenced gmail attachment-disposition cid images inline', funct
         ->and($data->attachments[0]['is_inline'])->toBeTrue();
 });
 
+it('imports a file when the gmail payload itself is the attachment', function (): void {
+    $account = ConnectedAccount::factory()->make();
+
+    $payload = new MessagePart;
+    $payload->setMimeType('application/pdf');
+    $payload->setFilename('invoice.pdf');
+    $payload->setHeaders([
+        new MessagePartHeader(['name' => 'Message-ID', 'value' => '<msg@example.test>']),
+        new MessagePartHeader(['name' => 'Subject', 'value' => 'Invoice']),
+        new MessagePartHeader(['name' => 'From', 'value' => 'Sender <sender@example.test>']),
+        new MessagePartHeader(['name' => 'To', 'value' => 'Owner <owner@example.test>']),
+        new MessagePartHeader(['name' => 'Content-Disposition', 'value' => 'attachment; filename="invoice.pdf"']),
+    ]);
+    $payload->setBody(new MessagePartBody([
+        'attachmentId' => 'pdf-attachment-id',
+        'size' => 2048,
+    ]));
+
+    $message = new Message([
+        'id' => 'gmail-msg-root-pdf',
+        'threadId' => 'gmail-thread-root-pdf',
+        'internalDate' => (string) (now()->timestamp * 1000),
+        'labelIds' => ['INBOX'],
+        'snippet' => 'Invoice',
+    ]);
+    $message->setPayload($payload);
+
+    $messages = Mockery::mock();
+    $messages->shouldReceive('get')
+        ->once()
+        ->with('me', 'gmail-msg-root-pdf', ['format' => 'full'])
+        ->andReturn($message);
+
+    $gmail = Mockery::mock(Gmail::class);
+    $gmail->users_messages = $messages;
+
+    $data = new GmailService($account, $gmail)->fetchMessage('gmail-msg-root-pdf');
+
+    expect($data->hasAttachments)->toBeTrue()
+        ->and($data->attachments)->toHaveCount(1)
+        ->and($data->attachments[0]['filename'])->toBe('invoice.pdf')
+        ->and($data->attachments[0]['mime_type'])->toBe('application/pdf')
+        ->and($data->attachments[0]['size'])->toBe(2048)
+        ->and($data->attachments[0]['attachment_id'])->toBe('pdf-attachment-id')
+        ->and($data->attachments[0]['is_inline'])->toBeFalse();
+});
+
+it('does not treat a root text payload as an attachment', function (): void {
+    $account = ConnectedAccount::factory()->make();
+
+    $payload = new MessagePart;
+    $payload->setMimeType('text/plain');
+    $payload->setHeaders([
+        new MessagePartHeader(['name' => 'Message-ID', 'value' => '<msg@example.test>']),
+        new MessagePartHeader(['name' => 'Subject', 'value' => 'Hello']),
+        new MessagePartHeader(['name' => 'From', 'value' => 'Sender <sender@example.test>']),
+        new MessagePartHeader(['name' => 'To', 'value' => 'Owner <owner@example.test>']),
+    ]);
+    $payload->setBody(new MessagePartBody([
+        'data' => rtrim(strtr(base64_encode('Hello'), '+/', '-_'), '='),
+        'size' => 5,
+    ]));
+
+    $message = new Message([
+        'id' => 'gmail-msg-plain',
+        'threadId' => 'gmail-thread-plain',
+        'internalDate' => (string) (now()->timestamp * 1000),
+        'labelIds' => ['INBOX'],
+        'snippet' => 'Hello',
+    ]);
+    $message->setPayload($payload);
+
+    $messages = Mockery::mock();
+    $messages->shouldReceive('get')
+        ->once()
+        ->with('me', 'gmail-msg-plain', ['format' => 'full'])
+        ->andReturn($message);
+
+    $gmail = Mockery::mock(Gmail::class);
+    $gmail->users_messages = $messages;
+
+    $data = new GmailService($account, $gmail)->fetchMessage('gmail-msg-plain');
+
+    expect($data->hasAttachments)->toBeFalse()
+        ->and($data->attachments)->toBe([])
+        ->and($data->bodyText)->toBe('Hello');
+});
+
 it('keeps unreferenced gmail attachment-disposition cid images downloadable', function (): void {
     $account = ConnectedAccount::factory()->make();
 


### PR DESCRIPTION
## Summary
- Gmail attachment extraction walked child MIME parts only, so an attachment-only message whose root payload is the file imported with no attachment.
- The extractor now inspects the current part before recursing, and skips multipart containers so a mixed envelope is not stored as a file.
- A root PDF now imports. A plain-text root is still not treated as an attachment.

## Test plan
- [x] Root PDF payload imports with filename, mime type, size, and attachment id.
- [x] Root `text/plain` payload still has no attachments.
- [x] Nested CID images and downloadable child attachments still extract.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/GmailMailServiceTest.php`