### PR TITLE
Include original attachments when forwarding an email

### DIFF
--- a/lang/en/filament/emails/composer.php
+++ b/lang/en/filament/emails/composer.php
@@ -67,6 +67,10 @@ return [
             'title' => 'Some files were too large',
             'body' => 'Not attached: :files. Each file must be under :max, and all attachments together under :total.',
         ],
+        'attachment_unavailable' => [
+            'title' => 'Some attachments could not be included',
+            'body' => 'Not attached: :files. Download them from the original email and add them here if you still need them.',
+        ],
         'draft_account_disconnected' => [
             'title' => 'Original account no longer connected',
             'body' => 'The account this draft was written from isn\'t connected anymore, so it\'s been switched to your default account. Double-check the sender before sending.',

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -55,10 +55,12 @@ use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
+use Throwable;
 
 /**
  * @property-read Action $createSignatureAction
@@ -301,6 +303,10 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         // A forward carries its source for display, but must not thread against it.
         $this->inReplyToEmailId = $this->replyMode === 'forward' ? null : $this->sourceEmailId;
 
+        if ($this->replyMode === 'forward' && $user->can('viewBody', $email)) {
+            $this->loadForwardedAttachments($email);
+        }
+
         $signature = $this->defaultSignatureFor($this->accountId);
         $this->signatureId = $signature?->getKey();
         $this->setBodyHtml(resolve(EmailTemplateRenderService::class)
@@ -396,7 +402,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $user = $this->authUser();
 
         $email = Email::query()
-            ->with(['participants', 'body', 'shares'])
+            ->with(['participants', 'body', 'shares', 'attachments'])
             ->forTeam($user->current_team_id)
             ->withGlobalScope('visible', new VisibleEmailScope($user))
             ->whereKey($emailId)
@@ -436,9 +442,10 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
         [$pendingPaths, $pendingNames] = $this->storeAttachments();
         [$copiedPaths, $copiedNames] = $this->copySavedAttachments();
+        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
 
-        $attachmentPaths = [...$pendingPaths, ...$copiedPaths];
-        $attachmentNames = [...$pendingNames, ...$copiedNames];
+        $attachmentPaths = [...$pendingPaths, ...$copiedPaths, ...$forwardedPaths];
+        $attachmentNames = [...$pendingNames, ...$copiedNames, ...$forwardedNames];
 
         $linkRecord = $this->linkRecord();
 
@@ -625,6 +632,11 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
     public function removeSavedAttachment(string $attachmentId): void
     {
         if ($this->draftId === null) {
+            $this->savedAttachments = array_values(array_filter(
+                $this->savedAttachments,
+                fn (array $attachment): bool => $attachment['id'] !== $attachmentId,
+            ));
+
             return;
         }
 
@@ -1282,6 +1294,163 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
     }
 
     /**
+     * Put the source email's downloadable files into {@see $savedAttachments} so
+     * they show as chips and are copied on send or save. Inline images stay in
+     * the quoted HTML. Oversized files are dropped with the same cap as uploads.
+     */
+    private function loadForwardedAttachments(Email $email): void
+    {
+        /** @var list<array{id: string, filename: string, size: int}> $kept */
+        $kept = [];
+        $rejected = [];
+        $total = 0;
+
+        foreach ($email->downloadAttachments() as $attachment) {
+            $size = (int) $attachment->size;
+
+            if ($size > self::MAX_ATTACHMENT_BYTES || $total + $size > self::MAX_ATTACHMENTS_TOTAL_BYTES) {
+                $rejected[] = (string) $attachment->filename;
+
+                continue;
+            }
+
+            $total += $size;
+            $kept[] = [
+                'id' => (string) $attachment->getKey(),
+                'filename' => (string) $attachment->filename,
+                'size' => $size,
+            ];
+        }
+
+        $this->savedAttachments = $kept;
+
+        if ($rejected === []) {
+            return;
+        }
+
+        Notification::make()
+            ->warning()
+            ->title(__('filament/emails/composer.notifications.attachment_too_large.title'))
+            ->body(__('filament/emails/composer.notifications.attachment_too_large.body', [
+                'files' => implode(', ', $rejected),
+                'max' => Number::fileSize(self::MAX_ATTACHMENT_BYTES),
+                'total' => Number::fileSize(self::MAX_ATTACHMENTS_TOTAL_BYTES),
+            ]))
+            ->send();
+    }
+
+    /**
+     * Copy remaining source-email files for a forward that has not yet saved
+     * them onto a draft. After persist, {@see $savedAttachments} holds draft
+     * ids and this becomes a no-op. The source files themselves stay put.
+     *
+     * @return array{0: list<string>, 1: array<string, string>}
+     */
+    private function copyForwardedSourceAttachments(): array
+    {
+        if ($this->replyMode !== 'forward' || $this->sourceEmailId === null || $this->savedAttachments === []) {
+            return [[], []];
+        }
+
+        $source = $this->replyableEmail($this->sourceEmailId);
+
+        if (! $source instanceof Email || $this->authUser()->cannot('viewBody', $source)) {
+            return [[], []];
+        }
+
+        $attachments = EmailAttachment::query()
+            ->with('email.connectedAccount')
+            ->where('email_id', $source->getKey())
+            ->where('is_inline', false)
+            ->whereIn('id', array_column($this->savedAttachments, 'id'))
+            ->get();
+
+        $paths = [];
+        $names = [];
+        $unavailable = [];
+
+        foreach ($attachments as $attachment) {
+            $copy = $this->copyAttachmentFile($attachment);
+
+            if ($copy === null) {
+                $unavailable[] = (string) $attachment->filename;
+
+                continue;
+            }
+
+            $paths[] = $copy;
+            $names[$copy] = (string) $attachment->filename;
+        }
+
+        if ($unavailable !== []) {
+            Notification::make()
+                ->warning()
+                ->title(__('filament/emails/composer.notifications.attachment_unavailable.title'))
+                ->body(__('filament/emails/composer.notifications.attachment_unavailable.body', [
+                    'files' => implode(', ', $unavailable),
+                ]))
+                ->send();
+        }
+
+        return [$paths, $names];
+    }
+
+    private function copyAttachmentFile(EmailAttachment $attachment): ?string
+    {
+        $disk = Storage::disk(EmailAttachment::DISK);
+        $extension = pathinfo((string) $attachment->filename, PATHINFO_EXTENSION);
+
+        if ($extension === '' && is_string($attachment->storage_path)) {
+            $extension = pathinfo($attachment->storage_path, PATHINFO_EXTENSION);
+        }
+
+        $copy = 'email-attachments/'.Str::ulid().($extension !== '' ? '.'.$extension : '');
+        $source = $attachment->storage_path;
+
+        if (is_string($source) && $source !== '' && $disk->exists($source)) {
+            $disk->copy($source, $copy);
+
+            return $copy;
+        }
+
+        $bytes = $this->downloadProviderAttachment($attachment);
+
+        if ($bytes === null) {
+            return null;
+        }
+
+        $disk->put($copy, $bytes);
+
+        return $copy;
+    }
+
+    private function downloadProviderAttachment(EmailAttachment $attachment): ?string
+    {
+        $email = $attachment->email;
+        $providerAttachmentId = $attachment->provider_attachment_id;
+
+        if (! $email instanceof Email || blank($email->provider_message_id) || blank($providerAttachmentId)) {
+            return null;
+        }
+
+        $account = $email->connectedAccount;
+
+        if (! $account instanceof ConnectedAccount) {
+            return null;
+        }
+
+        try {
+            return resolve(MailServiceFactoryInterface::class)
+                ->make($account)
+                ->downloadAttachment($email->provider_message_id, $providerAttachmentId);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return null;
+        }
+    }
+
+    /**
      * Persist the in-progress message as a DRAFT unless it is blank. Skipped
      * entirely for a blank compose (nothing to save) or when the account was
      * rejected by {@see self::ownedAccountId()} (nothing safe to save under).
@@ -1303,6 +1472,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         }
 
         [$attachmentPaths, $attachmentNames] = $this->storeAttachments();
+        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
 
         $draft = resolve(SaveEmailDraftAction::class)->execute(
             user: $this->authUser(),
@@ -1317,8 +1487,8 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                 // message: no original to show, and no threading when it is sent.
                 'source_email_id' => $this->sourceEmailId,
                 'creation_source' => $this->creationSource(),
-                'attachments' => $attachmentPaths,
-                'attachment_file_names' => $attachmentNames,
+                'attachments' => [...$attachmentPaths, ...$forwardedPaths],
+                'attachment_file_names' => [...$attachmentNames, ...$forwardedNames],
             ],
             draftId: $this->draftId,
         );

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -16,6 +16,7 @@ use Livewire\Livewire;
 use Relaticle\EmailIntegration\Actions\DeleteEmailDraftAction;
 use Relaticle\EmailIntegration\Actions\SaveEmailDraftAction;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
@@ -31,6 +32,8 @@ use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
+use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
@@ -974,6 +977,119 @@ it('does not copy another user\'s saved draft attachment from client-controlled 
         ->sole();
 
     expect($email->attachments)->toHaveCount(0);
+});
+
+it('does not copy another email\'s attachments from client-controlled forward state', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $otherUser = User::factory()->withTeam()->create();
+    $otherAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'user_id' => $otherUser->id,
+        'team_id' => $otherUser->current_team_id,
+        'status' => 'active',
+    ]));
+    $foreignEmail = Email::factory()->create([
+        'team_id' => $otherUser->current_team_id,
+        'user_id' => $otherUser->id,
+        'connected_account_id' => $otherAccount->id,
+        'status' => EmailStatus::SYNCED,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    Storage::disk(EmailAttachment::DISK)->put('email-attachments/secret.pdf', 'secret');
+
+    $foreignAttachment = EmailAttachment::factory()->create([
+        'email_id' => $foreignEmail->getKey(),
+        'filename' => 'secret.pdf',
+        'storage_path' => 'email-attachments/secret.pdf',
+        'size' => 6,
+    ]);
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['lead@example.com'])
+        ->set('subject', 'Forged forward attachment')
+        ->set('bodyHtml', '<p>Body</p>')
+        ->set('replyMode', 'forward')
+        ->set('sourceEmailId', (string) $foreignEmail->getKey())
+        ->set('savedAttachments', [[
+            'id' => (string) $foreignAttachment->getKey(),
+            'filename' => 'secret.pdf',
+            'size' => 6,
+        ]])
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $email = Email::query()
+        ->where('subject', 'Forged forward attachment')
+        ->where('status', EmailStatus::QUEUED)
+        ->sole();
+
+    expect($email->attachments)->toHaveCount(0);
+});
+
+it('downloads a provider-stored attachment when forwarding', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $this->account->update(['email_address' => 'me@example.com']);
+
+    $inbound = Email::factory()->create([
+        'team_id' => $this->user->current_team_id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'status' => EmailStatus::SYNCED,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'provider_message_id' => 'provider-msg-1',
+        'rfc_message_id' => '<original@example.com>',
+        'subject' => 'Has a contract',
+    ]);
+
+    EmailParticipant::factory()->create([
+        'email_id' => $inbound->id,
+        'email_address' => 'sender@contact.com',
+        'role' => EmailParticipantRole::FROM,
+    ]);
+
+    $attachment = EmailAttachment::factory()->create([
+        'email_id' => $inbound->getKey(),
+        'filename' => 'contract.pdf',
+        'storage_path' => null,
+        'provider_attachment_id' => 'provider-att-1',
+        'size' => 18,
+        'is_inline' => false,
+    ]);
+
+    $mail = Mockery::mock(MailServiceInterface::class);
+    $mail->shouldReceive('downloadAttachment')
+        ->once()
+        ->with('provider-msg-1', 'provider-att-1')
+        ->andReturn('gmail-contract-bytes');
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($mail);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    Livewire::test(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', (string) $inbound->getKey(), 'forward')
+        ->assertSet('savedAttachments', [[
+            'id' => (string) $attachment->getKey(),
+            'filename' => 'contract.pdf',
+            'size' => 18,
+        ]])
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>See attached</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->sole();
+    $sentPath = (string) $forward->attachments->sole()->storage_path;
+
+    expect($forward->attachments->sole()->filename)->toBe('contract.pdf');
+    Storage::disk(EmailAttachment::DISK)->assertExists($sentPath);
+    expect(Storage::disk(EmailAttachment::DISK)->get($sentPath))->toBe('gmail-contract-bytes');
 });
 
 it('deletes a draft\'s attachment files when the draft is deleted', function (): void {

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -8,6 +8,8 @@ use App\Filament\Resources\PeopleResource\RelationManagers\EmailsRelationManager
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -20,6 +22,7 @@ use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
 use Relaticle\EmailIntegration\Livewire\EmailComposer;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
@@ -316,6 +319,185 @@ it('a forward saved as a draft keeps its source without threading against it', f
         ->assertSet('inReplyToEmailId', null);
 });
 
+it('lists and sends the original attachments when forwarding', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $attachment = inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->assertSet('savedAttachments', [[
+            'id' => (string) $attachment->getKey(),
+            'filename' => 'contract.pdf',
+            'size' => 15,
+        ]])
+        ->assertSee('contract.pdf')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>See attached contract</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->sole();
+    $sentAttachment = $forward->attachments->sole();
+
+    expect($sentAttachment->filename)->toBe('contract.pdf')
+        ->and($sentAttachment->storage_path)->not->toBe($attachment->storage_path);
+
+    Storage::disk(EmailAttachment::DISK)->assertExists((string) $attachment->storage_path);
+    Storage::disk(EmailAttachment::DISK)->assertExists((string) $sentAttachment->storage_path);
+    expect(Storage::disk(EmailAttachment::DISK)->get((string) $sentAttachment->storage_path))->toBe('signed-contract');
+});
+
+it('does not attach the original files when replying', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'reply')
+        ->assertSet('savedAttachments', [])
+        ->assertDontSee('contract.pdf')
+        ->set('bodyHtml', '<p>Thanks</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $reply = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::REPLY)
+        ->sole();
+
+    expect($reply->attachments)->toHaveCount(0);
+});
+
+it('omits a forwarded attachment the user removes before sending', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $keep = inboundStoredAttachment($this->inboundEmail, 'keep.pdf', 'keep-bytes');
+    $drop = inboundStoredAttachment($this->inboundEmail, 'drop.pdf', 'drop-bytes');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->assertSee('keep.pdf')
+        ->assertSee('drop.pdf')
+        ->call('removeSavedAttachment', (string) $drop->getKey())
+        ->assertSee('keep.pdf')
+        ->assertDontSee('drop.pdf')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>Only keep.pdf</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->sole();
+
+    expect($forward->attachments->pluck('filename')->all())->toBe(['keep.pdf']);
+
+    Storage::disk(EmailAttachment::DISK)->assertExists((string) $drop->storage_path);
+    expect($this->inboundEmail->refresh()->attachments)->toHaveCount(2)
+        ->and($keep->refresh()->storage_path)->not->toBeNull();
+});
+
+it('saves forwarded attachments onto a draft and sends those copies', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $attachment = inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->set('bodyHtml', '<p>Passing this on</p>')
+        ->call('close');
+
+    $draft = Email::query()->where('status', EmailStatus::DRAFT)->sole();
+    $draftAttachment = $draft->attachments->sole();
+
+    expect($draftAttachment->filename)->toBe('contract.pdf')
+        ->and($draftAttachment->storage_path)->not->toBe($attachment->storage_path);
+
+    livewire(EmailComposer::class)
+        ->call('open', [], (string) $draft->getKey())
+        ->assertSee('contract.pdf')
+        ->set('to', ['forward-to@example.com'])
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->sole();
+
+    expect($forward->attachments->sole()->filename)->toBe('contract.pdf');
+
+    Storage::disk(EmailAttachment::DISK)->assertExists((string) $attachment->storage_path);
+    Storage::disk(EmailAttachment::DISK)->assertMissing((string) $draftAttachment->storage_path);
+});
+
+it('does not list original attachments when the viewer cannot read the body', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
+
+    $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+    $this->team->users()->attach($viewer, ['role' => 'editor']);
+
+    ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $viewer->id,
+        'status' => 'active',
+    ]));
+
+    $this->inboundEmail->update(['privacy_tier' => EmailPrivacyTier::METADATA_ONLY]);
+
+    $this->actingAs($viewer);
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->assertSet('savedAttachments', [])
+        ->assertDontSee('contract.pdf');
+});
+
+it('does not list inline images as forwarded attachments', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    inboundStoredAttachment($this->inboundEmail, 'logo.png', 'png-bytes', inline: true);
+    $file = inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->assertSet('savedAttachments', [[
+            'id' => (string) $file->getKey(),
+            'filename' => 'contract.pdf',
+            'size' => 15,
+        ]])
+        ->assertSee('contract.pdf')
+        ->assertDontSee('logo.png');
+});
+
+it('includes a newly uploaded file alongside the original attachments on a forward', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>Contract plus note</p>')
+        ->set('attachments', [UploadedFile::fake()->create('cover-note.pdf', 12)])
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->sole();
+
+    expect($forward->attachments->pluck('filename')->all())->toEqualCanonicalizing(['contract.pdf', 'cover-note.pdf']);
+});
+
 it('the docked composer closes when the reader moves to another email', function (): void {
     $other = Email::create([
         'team_id' => $this->team->id,
@@ -520,3 +702,19 @@ it('redirects to oauth when grant permission is confirmed for a mailbox that nee
         ->callAction('grantSendPermission')
         ->assertRedirect(route('email-accounts.redirect', ['provider' => 'gmail']));
 });
+
+function inboundStoredAttachment(Email $email, string $filename, string $contents, bool $inline = false): EmailAttachment
+{
+    $path = 'email-attachments/'.$filename;
+
+    Storage::disk(EmailAttachment::DISK)->put($path, $contents);
+
+    return EmailAttachment::factory()->create([
+        'email_id' => $email->getKey(),
+        'filename' => $filename,
+        'storage_path' => $path,
+        'size' => strlen($contents),
+        'is_inline' => $inline,
+        'mime_type' => $inline ? 'image/png' : 'application/pdf',
+    ]);
+}


### PR DESCRIPTION
## Summary
- Opening a forward never copied the source email's attachments into the composer's send collections.
- Forwards now list those files as chips and copy them onto the queued message or draft. Replies still omit them.

## Test plan
- [ ] Forward an inbound email that has a contract PDF. Confirm the chip appears and the queued send includes a copy.
- [ ] Remove one forwarded chip before sending. Confirm that file is omitted and the original stays on the source email.
- [ ] Save the forward as a draft, reopen it, and send. Confirm the attachments still go out.
- [ ] Reply to the same email and confirm the original files are not attached.
- [ ] Confirm a metadata-only viewer does not see or send the original attachments.