### PR TITLE
Stop sending when a forwarded attachment cannot be downloaded

### DIFF
--- a/lang/en/filament/emails/composer.php
+++ b/lang/en/filament/emails/composer.php
@@ -71,6 +71,10 @@ return [
             'title' => 'Some attachments could not be included',
             'body' => 'Not attached: :files. Download them from the original email and add them here if you still need them.',
         ],
+        'send_attachment_unavailable' => [
+            'title' => 'Could not include some attachments',
+            'body' => 'The email was not sent. These files could not be downloaded: :files. Remove them, or try sending again.',
+        ],
         'draft_account_disconnected' => [
             'title' => 'Original account no longer connected',
             'body' => 'The account this draft was written from isn\'t connected anymore, so it\'s been switched to your default account. Double-check the sender before sending.',

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -438,11 +438,19 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             return;
         }
 
+        [$forwardedPaths, $forwardedNames, $unavailable] = $this->copyForwardedSourceAttachments();
+
+        if ($unavailable !== []) {
+            $this->notifyUnavailableForwardedAttachments($unavailable, abortingSend: true);
+            $this->deleteCopiedAttachmentFiles($forwardedPaths);
+
+            return;
+        }
+
         $renderer = resolve(EmailTemplateRenderService::class);
 
         [$pendingPaths, $pendingNames] = $this->storeAttachments();
         [$copiedPaths, $copiedNames] = $this->copySavedAttachments();
-        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
 
         $attachmentPaths = [...$pendingPaths, ...$copiedPaths, ...$forwardedPaths];
         $attachmentNames = [...$pendingNames, ...$copiedNames, ...$forwardedNames];
@@ -1344,18 +1352,18 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * them onto a draft. After persist, {@see $savedAttachments} holds draft
      * ids and this becomes a no-op. The source files themselves stay put.
      *
-     * @return array{0: list<string>, 1: array<string, string>}
+     * @return array{0: list<string>, 1: array<string, string>, 2: list<string>}
      */
     private function copyForwardedSourceAttachments(): array
     {
         if ($this->replyMode !== 'forward' || $this->sourceEmailId === null || $this->savedAttachments === []) {
-            return [[], []];
+            return [[], [], []];
         }
 
         $source = $this->replyableEmail($this->sourceEmailId);
 
         if (! $source instanceof Email || $this->authUser()->cannot('viewBody', $source)) {
-            return [[], []];
+            return [[], [], []];
         }
 
         $attachments = EmailAttachment::query()
@@ -1382,17 +1390,39 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             $names[$copy] = (string) $attachment->filename;
         }
 
-        if ($unavailable !== []) {
-            Notification::make()
-                ->warning()
-                ->title(__('filament/emails/composer.notifications.attachment_unavailable.title'))
-                ->body(__('filament/emails/composer.notifications.attachment_unavailable.body', [
-                    'files' => implode(', ', $unavailable),
-                ]))
-                ->send();
-        }
+        return [$paths, $names, $unavailable];
+    }
 
-        return [$paths, $names];
+    /**
+     * @param  list<string>  $filenames
+     */
+    private function notifyUnavailableForwardedAttachments(array $filenames, bool $abortingSend): void
+    {
+        $key = $abortingSend
+            ? 'filament/emails/composer.notifications.send_attachment_unavailable'
+            : 'filament/emails/composer.notifications.attachment_unavailable';
+
+        $notification = Notification::make()
+            ->title(__($key.'.title'))
+            ->body(__($key.'.body', [
+                'files' => implode(', ', $filenames),
+            ]));
+
+        $abortingSend ? $notification->danger() : $notification->warning();
+
+        $notification->send();
+    }
+
+    /**
+     * @param  list<string>  $paths
+     */
+    private function deleteCopiedAttachmentFiles(array $paths): void
+    {
+        $disk = Storage::disk(EmailAttachment::DISK);
+
+        foreach ($paths as $path) {
+            $disk->delete($path);
+        }
     }
 
     private function copyAttachmentFile(EmailAttachment $attachment): ?string
@@ -1472,7 +1502,11 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         }
 
         [$attachmentPaths, $attachmentNames] = $this->storeAttachments();
-        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
+        [$forwardedPaths, $forwardedNames, $unavailable] = $this->copyForwardedSourceAttachments();
+
+        if ($unavailable !== []) {
+            $this->notifyUnavailableForwardedAttachments($unavailable, abortingSend: false);
+        }
 
         $draft = resolve(SaveEmailDraftAction::class)->execute(
             user: $this->authUser(),

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -1092,6 +1092,66 @@ it('downloads a provider-stored attachment when forwarding', function (): void {
     expect(Storage::disk(EmailAttachment::DISK)->get($sentPath))->toBe('gmail-contract-bytes');
 });
 
+it('does not queue a forward when a provider attachment cannot be downloaded', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $this->account->update(['email_address' => 'me@example.com']);
+
+    $inbound = Email::factory()->create([
+        'team_id' => $this->user->current_team_id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'status' => EmailStatus::SYNCED,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'provider_message_id' => 'provider-msg-1',
+        'rfc_message_id' => '<original@example.com>',
+        'subject' => 'Has a contract',
+    ]);
+
+    EmailParticipant::factory()->create([
+        'email_id' => $inbound->id,
+        'email_address' => 'sender@contact.com',
+        'role' => EmailParticipantRole::FROM,
+    ]);
+
+    $attachment = EmailAttachment::factory()->create([
+        'email_id' => $inbound->getKey(),
+        'filename' => 'contract.pdf',
+        'storage_path' => null,
+        'provider_attachment_id' => 'provider-att-1',
+        'size' => 18,
+        'is_inline' => false,
+    ]);
+
+    $mail = Mockery::mock(MailServiceInterface::class);
+    $mail->shouldReceive('downloadAttachment')
+        ->once()
+        ->with('provider-msg-1', 'provider-att-1')
+        ->andThrow(new RuntimeException('provider unavailable'));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($mail);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    Livewire::test(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', (string) $inbound->getKey(), 'forward')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>See attached</p>')
+        ->call('send')
+        ->assertSet('isOpen', true)
+        ->assertSet('savedAttachments', [[
+            'id' => (string) $attachment->getKey(),
+            'filename' => 'contract.pdf',
+            'size' => 18,
+        ]])
+        ->assertNotified(__('filament/emails/composer.notifications.send_attachment_unavailable.title'));
+
+    expect(Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->exists())->toBeFalse();
+});
+
 it('deletes a draft\'s attachment files when the draft is deleted', function (): void {
     Storage::fake(EmailAttachment::DISK);
 


### PR DESCRIPTION
## Summary
- Abort composer send when a forwarded attachment cannot be copied from the provider, instead of queuing the email without that file.
- Keep the composer open with the attachment chips so the user can remove the file or try again.
- Clean up any partial copies from the failed send attempt.

## Test plan
- [x] Forward an email whose attachment is only on the provider, then fail the download (disconnect or force a provider error) and confirm Send does not queue mail.
- [x] Confirm the danger notification names the file, and the composer stays open with the chip still present.
- [x] Remove the unavailable file and send successfully, or retry after the download works again.
- [x] Forward with a locally stored attachment and confirm send still attaches it as before.