### PR TITLE
Respect restrictive shares in record email search

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -13,3 +13,12 @@ toggle, and Gmail backfill lists with `-in:drafts`. Importing a draft would stor
 as `SYNCED` with the account's sharing default, so teammates could read unsent mail
 through linked CRM records. Composer drafts (`EmailStatus::DRAFT`) are a different
 path and stay local.
+
+## Per-viewer shares override the email default in search
+
+`PrivacyService::effectiveTier()` applies a viewer's share before the email's
+`privacy_tier`. Search must do the same. Do not `OR` `privacy_tier` FULL or
+SUBJECT with a share: a metadata-only share on a FULL email would still match
+subject and snippet. Use the share when one exists (direct first, then another
+copy of the same `rfc_message_id`). Fall back to `privacy_tier` only when the
+viewer has no share.

--- a/packages/EmailIntegration/src/Services/EmailSearchService.php
+++ b/packages/EmailIntegration/src/Services/EmailSearchService.php
@@ -53,20 +53,10 @@ final readonly class EmailSearchService
      */
     private function whereViewerCanSeeSubject(Builder $query, string $viewerId): Builder
     {
-        return $query->where(function (Builder $access) use ($viewerId): void {
-            $access
-                ->where('user_id', $viewerId)
-                ->orWhereIn('privacy_tier', [EmailPrivacyTier::SUBJECT->value, EmailPrivacyTier::FULL->value])
-                ->orWhereHas('shares', fn (Builder $shareQuery): Builder => $shareQuery
-                    ->where('shared_with', $viewerId)
-                    ->whereIn('tier', [EmailPrivacyTier::SUBJECT->value, EmailPrivacyTier::FULL->value]))
-                ->orWhereExists(fn (BaseBuilder $copyQuery): BaseBuilder => $this->syncedCopyExists($copyQuery, $viewerId))
-                ->orWhereExists(fn (BaseBuilder $shareQuery): BaseBuilder => $this->crossMessageShareExists(
-                    $shareQuery,
-                    $viewerId,
-                    [EmailPrivacyTier::SUBJECT->value, EmailPrivacyTier::FULL->value],
-                ));
-        });
+        return $this->whereViewerHasAccessAtTiers($query, $viewerId, [
+            EmailPrivacyTier::SUBJECT->value,
+            EmailPrivacyTier::FULL->value,
+        ]);
     }
 
     /**
@@ -75,19 +65,47 @@ final readonly class EmailSearchService
      */
     private function whereViewerCanSeeBody(Builder $query, string $viewerId): Builder
     {
-        return $query->where(function (Builder $access) use ($viewerId): void {
+        return $this->whereViewerHasAccessAtTiers($query, $viewerId, [
+            EmailPrivacyTier::FULL->value,
+        ]);
+    }
+
+    /**
+     * Match PrivacyService: a per-viewer share overrides the email default.
+     *
+     * @param  Builder<Email>  $query
+     * @param  list<string>  $tiers
+     * @return Builder<Email>
+     */
+    private function whereViewerHasAccessAtTiers(Builder $query, string $viewerId, array $tiers): Builder
+    {
+        return $query->where(function (Builder $access) use ($viewerId, $tiers): void {
             $access
                 ->where('user_id', $viewerId)
-                ->orWhere('privacy_tier', EmailPrivacyTier::FULL->value)
+                ->orWhereExists(fn (BaseBuilder $copyQuery): BaseBuilder => $this->syncedCopyExists($copyQuery, $viewerId))
                 ->orWhereHas('shares', fn (Builder $shareQuery): Builder => $shareQuery
                     ->where('shared_with', $viewerId)
-                    ->where('tier', EmailPrivacyTier::FULL->value))
-                ->orWhereExists(fn (BaseBuilder $copyQuery): BaseBuilder => $this->syncedCopyExists($copyQuery, $viewerId))
-                ->orWhereExists(fn (BaseBuilder $shareQuery): BaseBuilder => $this->crossMessageShareExists(
-                    $shareQuery,
-                    $viewerId,
-                    [EmailPrivacyTier::FULL->value],
-                ));
+                    ->whereIn('tier', $tiers))
+                ->orWhere(function (Builder $crossShare) use ($viewerId, $tiers): void {
+                    $crossShare
+                        ->whereDoesntHave('shares', fn (Builder $shareQuery): Builder => $shareQuery
+                            ->where('shared_with', $viewerId))
+                        ->whereExists(fn (BaseBuilder $shareQuery): BaseBuilder => $this->crossMessageShareExists(
+                            $shareQuery,
+                            $viewerId,
+                            $tiers,
+                        ));
+                })
+                ->orWhere(function (Builder $byDefault) use ($viewerId, $tiers): void {
+                    $byDefault
+                        ->whereIn('privacy_tier', $tiers)
+                        ->whereDoesntHave('shares', fn (Builder $shareQuery): Builder => $shareQuery
+                            ->where('shared_with', $viewerId))
+                        ->whereNotExists(fn (BaseBuilder $shareQuery): BaseBuilder => $this->crossMessageShareExists(
+                            $shareQuery,
+                            $viewerId,
+                        ));
+                });
         });
     }
 
@@ -101,16 +119,22 @@ final readonly class EmailSearchService
     }
 
     /**
-     * @param  list<string>  $tiers
+     * @param  list<string>|null  $tiers
      */
-    private function crossMessageShareExists(BaseBuilder $query, string $viewerId, array $tiers): BaseBuilder
+    private function crossMessageShareExists(BaseBuilder $query, string $viewerId, ?array $tiers = null): BaseBuilder
     {
-        return $query->from('email_shares')
+        $query
+            ->from('email_shares')
             ->join('emails as share_source_emails', 'share_source_emails.id', '=', 'email_shares.email_id')
             ->where('email_shares.shared_with', $viewerId)
-            ->whereIn('email_shares.tier', $tiers)
             ->whereColumn('share_source_emails.team_id', 'emails.team_id')
             ->whereColumn('share_source_emails.rfc_message_id', 'emails.rfc_message_id')
             ->whereNotNull('emails.rfc_message_id');
+
+        if ($tiers !== null) {
+            $query->whereIn('email_shares.tier', $tiers);
+        }
+
+        return $query;
     }
 }

--- a/tests/Feature/EmailIntegration/RecordEmailsEmptyStateTest.php
+++ b/tests/Feature/EmailIntegration/RecordEmailsEmptyStateTest.php
@@ -28,6 +28,7 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
 use Relaticle\EmailIntegration\Services\EmailSearchService;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
@@ -676,6 +677,103 @@ it('does not match hidden subject or snippet text when searching metadata-only e
         ->assertSee(__('filament/pages/email-inbox.list_empty.no_results', ['search' => 'Secret preview text']))
         ->set('search', 'Customer')
         ->assertSee('Customer');
+});
+
+it('does not match hidden subject or snippet text when a metadata-only share overrides a full default', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+    $viewer = User::factory()->create(['current_team_id' => $team->id]);
+    $team->users()->attach($viewer, ['role' => 'editor']);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+    ]));
+
+    $person = People::factory()->create([
+        'team_id' => $team->id,
+        'creator_id' => $owner->id,
+    ]);
+
+    $email = Email::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+        'connected_account_id' => $account->getKey(),
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'subject' => 'Quarterly forecast',
+        'snippet' => 'Secret preview text',
+    ]);
+
+    EmailShare::factory()->tier(EmailPrivacyTier::METADATA_ONLY)->create([
+        'email_id' => $email->getKey(),
+        'team_id' => $team->id,
+        'shared_by' => $owner->id,
+        'shared_with' => $viewer->id,
+    ]);
+
+    EmailParticipant::query()->create([
+        'email_id' => $email->id,
+        'email_address' => 'customer@acme.com',
+        'name' => 'Customer',
+        'role' => EmailParticipantRole::FROM,
+    ]);
+
+    $person->emails()->attach($email->getKey());
+
+    $this->actingAs($viewer);
+    Filament::setTenant($team);
+
+    livewire(PeopleEmailsPage::class, ['record' => $person->getKey()])
+        ->set('search', 'Quarterly forecast')
+        ->assertSee(__('filament/pages/email-inbox.list_empty.no_results', ['search' => 'Quarterly forecast']))
+        ->set('search', 'Secret preview text')
+        ->assertSee(__('filament/pages/email-inbox.list_empty.no_results', ['search' => 'Secret preview text']))
+        ->set('search', 'Customer')
+        ->assertSee('Customer');
+});
+
+it('does not match snippet text when a subject share overrides a full default', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+    $viewer = User::factory()->create(['current_team_id' => $team->id]);
+    $team->users()->attach($viewer, ['role' => 'editor']);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+    ]));
+
+    $person = People::factory()->create([
+        'team_id' => $team->id,
+        'creator_id' => $owner->id,
+    ]);
+
+    $email = Email::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+        'connected_account_id' => $account->getKey(),
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'subject' => 'Quarterly forecast',
+        'snippet' => 'Secret preview text',
+    ]);
+
+    EmailShare::factory()->tier(EmailPrivacyTier::SUBJECT)->create([
+        'email_id' => $email->getKey(),
+        'team_id' => $team->id,
+        'shared_by' => $owner->id,
+        'shared_with' => $viewer->id,
+    ]);
+
+    $person->emails()->attach($email->getKey());
+
+    $this->actingAs($viewer);
+    Filament::setTenant($team);
+
+    livewire(PeopleEmailsPage::class, ['record' => $person->getKey()])
+        ->set('search', 'Quarterly forecast')
+        ->assertSee('Quarterly forecast')
+        ->set('search', 'Secret preview text')
+        ->assertSee(__('filament/pages/email-inbox.list_empty.no_results', ['search' => 'Secret preview text']));
 });
 
 it('shows a request access pill on record mailbox rows without body access', function (): void {


### PR DESCRIPTION
## Summary
- Record email search now follows `PrivacyService`: a per-viewer share overrides the email default instead of OR-ing with it.
- A metadata-only or subject share on a FULL email no longer matches hidden subject or snippet text. Participants stay searchable.
- Adds coverage for both override cases on the record mailbox search path.

## Test plan
- [x] Search a FULL email with a metadata-only share for the viewer: subject and snippet queries return no results; a participant name still matches.
- [x] Search the same setup with a subject share: subject matches, snippet does not.
- [x] Confirm an owner or a teammate with a synced copy can still search subject and snippet.