### PR TITLE
Fix inbox search privacy and blocked forward sends

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -13,3 +13,10 @@ toggle, and Gmail backfill lists with `-in:drafts`. Importing a draft would stor
 as `SYNCED` with the account's sharing default, so teammates could read unsent mail
 through linked CRM records. Composer drafts (`EmailStatus::DRAFT`) are a different
 path and stay local.
+
+## Privacy-aware email search
+
+Mailbox search (inbox and record email pages) must go through
+`EmailSearchService`. Never `ilike` on `subject` or `snippet` alone.
+Metadata-only teammate rows stay in the list, but those columns are hidden.
+A guessed subject must not match. Participants remain searchable.

--- a/lang/en/filament/emails/composer.php
+++ b/lang/en/filament/emails/composer.php
@@ -71,6 +71,10 @@ return [
             'title' => 'Some attachments could not be included',
             'body' => 'Not attached: :files. Download them from the original email and add them here if you still need them.',
         ],
+        'send_attachment_unavailable' => [
+            'title' => 'Could not include some attachments',
+            'body' => 'The email was not sent. These files could not be downloaded: :files. Remove them, or try sending again.',
+        ],
         'draft_account_disconnected' => [
             'title' => 'Original account no longer connected',
             'body' => 'The account this draft was written from isn\'t connected anymore, so it\'s been switched to your default account. Double-check the sender before sending.',

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -43,6 +43,7 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
+use Relaticle\EmailIntegration\Services\EmailSearchService;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
@@ -209,10 +210,7 @@ final class EmailInboxPage extends Page
         $query->where('status', '!=', EmailStatus::DRAFT);
 
         if (filled($this->search)) {
-            $query->where(function (Builder $q): void {
-                $q->where('subject', 'ilike', '%'.$this->search.'%')
-                    ->orWhere('snippet', 'ilike', '%'.$this->search.'%');
-            });
+            resolve(EmailSearchService::class)->applyToQuery($query, $user, $this->search);
         }
 
         return $query->latest('sent_at')->paginate(20);

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -438,11 +438,19 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             return;
         }
 
+        [$forwardedPaths, $forwardedNames, $unavailable] = $this->copyForwardedSourceAttachments();
+
+        if ($unavailable !== []) {
+            $this->notifyUnavailableForwardedAttachments($unavailable, abortingSend: true);
+            $this->deleteCopiedAttachmentFiles($forwardedPaths);
+
+            return;
+        }
+
         $renderer = resolve(EmailTemplateRenderService::class);
 
         [$pendingPaths, $pendingNames] = $this->storeAttachments();
         [$copiedPaths, $copiedNames] = $this->copySavedAttachments();
-        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
 
         $attachmentPaths = [...$pendingPaths, ...$copiedPaths, ...$forwardedPaths];
         $attachmentNames = [...$pendingNames, ...$copiedNames, ...$forwardedNames];
@@ -1344,18 +1352,18 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * them onto a draft. After persist, {@see $savedAttachments} holds draft
      * ids and this becomes a no-op. The source files themselves stay put.
      *
-     * @return array{0: list<string>, 1: array<string, string>}
+     * @return array{0: list<string>, 1: array<string, string>, 2: list<string>}
      */
     private function copyForwardedSourceAttachments(): array
     {
         if ($this->replyMode !== 'forward' || $this->sourceEmailId === null || $this->savedAttachments === []) {
-            return [[], []];
+            return [[], [], []];
         }
 
         $source = $this->replyableEmail($this->sourceEmailId);
 
         if (! $source instanceof Email || $this->authUser()->cannot('viewBody', $source)) {
-            return [[], []];
+            return [[], [], []];
         }
 
         $attachments = EmailAttachment::query()
@@ -1382,17 +1390,39 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             $names[$copy] = (string) $attachment->filename;
         }
 
-        if ($unavailable !== []) {
-            Notification::make()
-                ->warning()
-                ->title(__('filament/emails/composer.notifications.attachment_unavailable.title'))
-                ->body(__('filament/emails/composer.notifications.attachment_unavailable.body', [
-                    'files' => implode(', ', $unavailable),
-                ]))
-                ->send();
-        }
+        return [$paths, $names, $unavailable];
+    }
 
-        return [$paths, $names];
+    /**
+     * @param  list<string>  $filenames
+     */
+    private function notifyUnavailableForwardedAttachments(array $filenames, bool $abortingSend): void
+    {
+        $key = $abortingSend
+            ? 'filament/emails/composer.notifications.send_attachment_unavailable'
+            : 'filament/emails/composer.notifications.attachment_unavailable';
+
+        $notification = Notification::make()
+            ->title(__($key.'.title'))
+            ->body(__($key.'.body', [
+                'files' => implode(', ', $filenames),
+            ]));
+
+        $abortingSend ? $notification->danger() : $notification->warning();
+
+        $notification->send();
+    }
+
+    /**
+     * @param  list<string>  $paths
+     */
+    private function deleteCopiedAttachmentFiles(array $paths): void
+    {
+        $disk = Storage::disk(EmailAttachment::DISK);
+
+        foreach ($paths as $path) {
+            $disk->delete($path);
+        }
     }
 
     private function copyAttachmentFile(EmailAttachment $attachment): ?string
@@ -1472,7 +1502,11 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         }
 
         [$attachmentPaths, $attachmentNames] = $this->storeAttachments();
-        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
+        [$forwardedPaths, $forwardedNames, $unavailable] = $this->copyForwardedSourceAttachments();
+
+        if ($unavailable !== []) {
+            $this->notifyUnavailableForwardedAttachments($unavailable, abortingSend: false);
+        }
 
         $draft = resolve(SaveEmailDraftAction::class)->execute(
             user: $this->authUser(),

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -1092,6 +1092,66 @@ it('downloads a provider-stored attachment when forwarding', function (): void {
     expect(Storage::disk(EmailAttachment::DISK)->get($sentPath))->toBe('gmail-contract-bytes');
 });
 
+it('does not queue a forward when a provider attachment cannot be downloaded', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $this->account->update(['email_address' => 'me@example.com']);
+
+    $inbound = Email::factory()->create([
+        'team_id' => $this->user->current_team_id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'status' => EmailStatus::SYNCED,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'provider_message_id' => 'provider-msg-1',
+        'rfc_message_id' => '<original@example.com>',
+        'subject' => 'Has a contract',
+    ]);
+
+    EmailParticipant::factory()->create([
+        'email_id' => $inbound->id,
+        'email_address' => 'sender@contact.com',
+        'role' => EmailParticipantRole::FROM,
+    ]);
+
+    $attachment = EmailAttachment::factory()->create([
+        'email_id' => $inbound->getKey(),
+        'filename' => 'contract.pdf',
+        'storage_path' => null,
+        'provider_attachment_id' => 'provider-att-1',
+        'size' => 18,
+        'is_inline' => false,
+    ]);
+
+    $mail = Mockery::mock(MailServiceInterface::class);
+    $mail->shouldReceive('downloadAttachment')
+        ->once()
+        ->with('provider-msg-1', 'provider-att-1')
+        ->andThrow(new RuntimeException('provider unavailable'));
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($mail);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    Livewire::test(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', (string) $inbound->getKey(), 'forward')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>See attached</p>')
+        ->call('send')
+        ->assertSet('isOpen', true)
+        ->assertSet('savedAttachments', [[
+            'id' => (string) $attachment->getKey(),
+            'filename' => 'contract.pdf',
+            'size' => 18,
+        ]])
+        ->assertNotified(__('filament/emails/composer.notifications.send_attachment_unavailable.title'));
+
+    expect(Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->exists())->toBeFalse();
+});
+
 it('deletes a draft\'s attachment files when the draft is deleted', function (): void {
     Storage::fake(EmailAttachment::DISK);
 

--- a/tests/Feature/EmailIntegration/EmailInboxSearchTest.php
+++ b/tests/Feature/EmailIntegration/EmailInboxSearchTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Services\EmailSearchService;
+
+mutates(EmailInboxPage::class, EmailSearchService::class);
+
+it('does not match hidden subject or snippet text when searching metadata-only teammate emails', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+    $viewer = User::factory()->create(['current_team_id' => $team->id]);
+    $team->users()->attach($viewer, ['role' => 'editor']);
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+    ]));
+
+    $email = Email::factory()->inbound()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+        'connected_account_id' => $account->getKey(),
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'subject' => 'Quarterly forecast',
+        'snippet' => 'Secret preview text',
+        'is_internal' => false,
+        'sent_at' => now(),
+    ]);
+
+    EmailParticipant::query()->create([
+        'email_id' => $email->id,
+        'email_address' => 'customer@acme.com',
+        'name' => 'Customer',
+        'role' => EmailParticipantRole::FROM,
+    ]);
+
+    $this->actingAs($viewer);
+    Filament::setTenant($team);
+
+    $page = livewire(EmailInboxPage::class)->set('accountId', 'all');
+
+    expect($page->instance()->emails()->pluck('id')->all())->toBe([$email->getKey()]);
+
+    $page->set('search', 'Quarterly forecast');
+
+    expect($page->instance()->emails()->pluck('id')->all())->toBe([]);
+
+    $page->set('search', 'Secret preview text');
+
+    expect($page->instance()->emails()->pluck('id')->all())->toBe([]);
+
+    $page->set('search', 'Customer');
+
+    expect($page->instance()->emails()->pluck('id')->all())->toBe([$email->getKey()]);
+});
+
+it('still matches subject text on emails the viewer owns', function (): void {
+    $owner = User::factory()->withTeam()->create();
+    $team = $owner->currentTeam;
+
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+        'is_default' => true,
+    ]));
+
+    $email = Email::factory()->inbound()->create([
+        'team_id' => $team->id,
+        'user_id' => $owner->id,
+        'connected_account_id' => $account->getKey(),
+        'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+        'subject' => 'Quarterly forecast',
+        'snippet' => 'Secret preview text',
+        'sent_at' => now(),
+    ]);
+
+    EmailParticipant::query()->create([
+        'email_id' => $email->id,
+        'email_address' => 'customer@acme.com',
+        'name' => 'Customer',
+        'role' => EmailParticipantRole::FROM,
+    ]);
+
+    $this->actingAs($owner);
+    Filament::setTenant($team);
+
+    $page = livewire(EmailInboxPage::class)->set('search', 'Quarterly forecast');
+
+    expect($page->instance()->emails()->pluck('id')->all())->toBe([$email->getKey()]);
+});


### PR DESCRIPTION
## Summary
- Inbox search now uses `EmailSearchService`, so guessed subject or snippet text no longer matches teammate emails those fields are hidden on. Participant names still match.
- Forwarding no longer queues a send when a provider attachment cannot be downloaded. The composer stays open so the files can be removed or retried.

## Test plan
- [x] As a teammate, open the shared inbox, search a metadata-only email's hidden subject: no results. Search the sender name: the row still appears.
- [x] Search your own mail by subject: it still matches.
- [x] Forward an email whose attachment fails to download from the provider: the send is blocked, a danger notification names the files, and no outbound email is queued.
- [x] Forward when attachments download normally: the send still queues with the files attached.