### PR TITLE
Preserve inline CID images when forwarding

### DIFF
--- a/packages/EmailIntegration/src/Actions/SaveEmailDraftAction.php
+++ b/packages/EmailIntegration/src/Actions/SaveEmailDraftAction.php
@@ -48,6 +48,7 @@ final readonly class SaveEmailDraftAction
      *     creation_source?: ?EmailCreationSource,
      *     attachments?: list<string>,
      *     attachment_file_names?: array<string, string>,
+     *     attachment_attributes?: array<string, array{is_inline?: bool, content_id?: ?string}>,
      * }  $data
      */
     public function execute(User $user, array $data, ?string $draftId = null): Email
@@ -112,7 +113,7 @@ final readonly class SaveEmailDraftAction
                 'body_text' => strip_tags((string) $data['body_html']),
             ]);
 
-            $this->attachFiles($draft, $data['attachments'] ?? [], $data['attachment_file_names'] ?? []);
+            $this->attachFiles($draft, $data['attachments'] ?? [], $data['attachment_file_names'] ?? [], $data['attachment_attributes'] ?? []);
 
             $draft->participants()->delete();
 
@@ -169,8 +170,9 @@ final readonly class SaveEmailDraftAction
      *
      * @param  list<string>  $paths
      * @param  array<string, string>  $originalNames  storage path => original client filename
+     * @param  array<string, array{is_inline?: bool, content_id?: ?string}>  $attributes
      */
-    private function attachFiles(Email $draft, array $paths, array $originalNames): void
+    private function attachFiles(Email $draft, array $paths, array $originalNames, array $attributes): void
     {
         $disk = Storage::disk(EmailAttachment::DISK);
 
@@ -190,9 +192,11 @@ final readonly class SaveEmailDraftAction
                 'mime_type' => $disk->mimeType($path) ?: 'application/octet-stream',
                 'size' => $disk->size($path),
                 'storage_path' => $path,
+                'is_inline' => $attributes[$path]['is_inline'] ?? false,
+                'content_id' => $attributes[$path]['content_id'] ?? null,
             ]);
         }
 
-        $draft->update(['has_attachments' => $draft->attachments()->exists()]);
+        $draft->update(['has_attachments' => $draft->attachments()->where('is_inline', false)->exists()]);
     }
 }

--- a/packages/EmailIntegration/src/Actions/SendEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailAction.php
@@ -48,6 +48,7 @@ final readonly class SendEmailAction
      *     priority?: EmailPriority,
      *     attachments?: array<int, string>,
      *     attachment_file_names?: array<string, string>,
+     *     attachment_attributes?: array<string, array{is_inline?: bool, content_id?: ?string}>,
      * }  $data
      * @param  class-string|null  $linkToType
      */
@@ -73,7 +74,13 @@ final readonly class SendEmailAction
         /** @var array<int, string> $attachmentPaths */
         $attachmentPaths = array_values($data['attachments'] ?? []);
 
-        return DB::transaction(function () use ($account, $data, $priority, $scheduledFor, $linkToType, $linkToId, $attachmentPaths): Email {
+        /** @var array<string, array{is_inline?: bool, content_id?: ?string}> $attachmentAttributes */
+        $attachmentAttributes = $data['attachment_attributes'] ?? [];
+
+        $hasDownloadableAttachments = collect($attachmentPaths)
+            ->contains(fn (string $path): bool => ($attachmentAttributes[$path]['is_inline'] ?? false) !== true);
+
+        return DB::transaction(function () use ($account, $data, $priority, $scheduledFor, $linkToType, $linkToId, $attachmentPaths, $attachmentAttributes, $hasDownloadableAttachments): Email {
             // Scope the reply lookup to the sender's team. in_reply_to_email_id arrives
             // from a client-controlled hidden field and Email has no team global scope,
             // so an unscoped lookup would let a user thread their outbound mail onto
@@ -114,7 +121,7 @@ final readonly class SendEmailAction
                 'status' => EmailStatus::QUEUED,
                 'priority' => $priority,
                 'privacy_tier' => $data['privacy_tier'],
-                'has_attachments' => $attachmentPaths !== [],
+                'has_attachments' => $hasDownloadableAttachments,
                 'is_internal' => false,
                 'creation_source' => $data['creation_source'],
                 'batch_id' => $data['batch_id'] ?? null,
@@ -145,7 +152,7 @@ final readonly class SendEmailAction
                 }
             }
 
-            $this->storeAttachments($email, $attachmentPaths, $data['attachment_file_names'] ?? []);
+            $this->storeAttachments($email, $attachmentPaths, $data['attachment_file_names'] ?? [], $attachmentAttributes);
 
             if ($linkToType !== null && $linkToId !== null && in_array($linkToType, [Company::class, Opportunity::class, People::class], true)) {
                 $linked = $linkToType::query()->whereKey($linkToId)->first();
@@ -168,8 +175,9 @@ final readonly class SendEmailAction
      *
      * @param  array<int, string>  $paths
      * @param  array<string, string>  $originalNames  storage path => original client filename
+     * @param  array<string, array{is_inline?: bool, content_id?: ?string}>  $attributes
      */
-    private function storeAttachments(Email $email, array $paths, array $originalNames): void
+    private function storeAttachments(Email $email, array $paths, array $originalNames, array $attributes): void
     {
         $disk = Storage::disk(EmailAttachment::DISK);
 
@@ -184,6 +192,8 @@ final readonly class SendEmailAction
                 'mime_type' => $disk->mimeType($path) ?: 'application/octet-stream',
                 'size' => $disk->size($path),
                 'storage_path' => $path,
+                'is_inline' => $attributes[$path]['is_inline'] ?? false,
+                'content_id' => $attributes[$path]['content_id'] ?? null,
             ]);
         }
     }

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -168,14 +168,6 @@ trait HasEmailComposeActions
      */
     private function submitReplyForward(array $data, string $mode): void
     {
-        if (filled($data['quoted_body_html'] ?? '')) {
-            $quotedSection = $mode === 'forward'
-                ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
-                : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
-
-            $data['body_html'] = ($data['body_html'] ?? '').$quotedSection;
-        }
-
         $source = match ($mode) {
             'reply_all' => EmailCreationSource::REPLY_ALL,
             'forward' => EmailCreationSource::FORWARD,
@@ -327,10 +319,18 @@ trait HasEmailComposeActions
         $renderer = resolve(EmailTemplateRenderService::class);
         $record = $this->getCrmRecord();
 
+        $bodyHtml = $renderer->renderForSending((string) $data['body_html'], $record);
+
+        if (filled($data['quoted_body_html'] ?? '')) {
+            $bodyHtml .= $source === EmailCreationSource::FORWARD
+                ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
+                : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
+        }
+
         return [
             'connected_account_id' => $data['connected_account_id'],
             'subject' => $renderer->renderContent((string) $data['subject'], $record),
-            'body_html' => $renderer->renderForSending((string) $data['body_html'], $record),
+            'body_html' => $bodyHtml,
             'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['to'] ?? []),
             'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['cc'] ?? []),
             'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['bcc'] ?? []),

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -474,14 +474,6 @@ final class EmailInboxPage extends Page
      */
     private function submitReplyForward(array $data, string $mode): void
     {
-        if (filled($data['quoted_body_html'] ?? '')) {
-            $quotedSection = $mode === 'forward'
-                ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
-                : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
-
-            $data['body_html'] = ($data['body_html'] ?? '').$quotedSection;
-        }
-
         $source = match ($mode) {
             'reply_all' => EmailCreationSource::REPLY_ALL,
             'forward' => EmailCreationSource::FORWARD,
@@ -644,10 +636,18 @@ final class EmailInboxPage extends Page
     {
         $renderer = resolve(EmailTemplateRenderService::class);
 
+        $bodyHtml = $renderer->renderForSending((string) $data['body_html']);
+
+        if (filled($data['quoted_body_html'] ?? '')) {
+            $bodyHtml .= $source === EmailCreationSource::FORWARD
+                ? '<br><p><strong>---------- Forwarded message ----------</strong></p>'.$data['quoted_body_html']
+                : '<br><blockquote style="border-left:3px solid #ccc;margin-left:0;padding-left:1rem">'.$data['quoted_body_html'].'</blockquote>';
+        }
+
         return [
             'connected_account_id' => $data['connected_account_id'],
             'subject' => $renderer->renderContent((string) $data['subject']),
-            'body_html' => $renderer->renderForSending((string) $data['body_html']),
+            'body_html' => $bodyHtml,
             'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['to'] ?? []),
             'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['cc'] ?? []),
             'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['bcc'] ?? []),

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -440,12 +440,14 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
         $renderer = resolve(EmailTemplateRenderService::class);
 
-        [$pendingPaths, $pendingNames] = $this->storeAttachments();
-        [$copiedPaths, $copiedNames] = $this->copySavedAttachments();
-        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
+        [$pendingPaths, $pendingNames, $pendingAttributes] = $this->storeAttachments();
+        [$copiedPaths, $copiedNames, $copiedAttributes] = $this->copySavedAttachments();
+        [$forwardedPaths, $forwardedNames, $forwardedAttributes] = $this->copyForwardedSourceAttachments();
+        [$inlinePaths, $inlineNames, $inlineAttributes] = $this->copyForwardedInlineAttachments();
 
-        $attachmentPaths = [...$pendingPaths, ...$copiedPaths, ...$forwardedPaths];
-        $attachmentNames = [...$pendingNames, ...$copiedNames, ...$forwardedNames];
+        $attachmentPaths = [...$pendingPaths, ...$copiedPaths, ...$forwardedPaths, ...$inlinePaths];
+        $attachmentNames = [...$pendingNames, ...$copiedNames, ...$forwardedNames, ...$inlineNames];
+        $attachmentAttributes = [...$pendingAttributes, ...$copiedAttributes, ...$forwardedAttributes, ...$inlineAttributes];
 
         $linkRecord = $this->linkRecord();
 
@@ -453,7 +455,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             data: [
                 'connected_account_id' => (string) $this->accountId,
                 'subject' => $renderer->renderContent((string) $this->subject),
-                'body_html' => $renderer->renderForSending($this->withQuotedBody($bodyHtml)),
+                'body_html' => $this->withQuotedBody($renderer->renderForSending($bodyHtml)),
                 'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->to),
                 'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->cc),
                 'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->bcc),
@@ -466,6 +468,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                 'priority' => EmailPriority::PRIORITY,
                 'attachments' => $attachmentPaths,
                 'attachment_file_names' => $attachmentNames,
+                'attachment_attributes' => $attachmentAttributes,
             ],
             linkToType: $linkRecord === null ? null : $linkRecord::class,
             linkToId: $linkRecord?->getKey(),
@@ -1226,7 +1229,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * Persist pending uploads to the same disk/directory the old Filament
      * FileUpload used, in the shape SendEmailAction consumes.
      *
-     * @return array{0: list<string>, 1: array<string, string>}
+     * @return array{0: list<string>, 1: array<string, string>, 2: array<string, array{is_inline: bool, content_id: ?string}>}
      */
     private function storeAttachments(): array
     {
@@ -1243,7 +1246,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             $names[$path] = $file->getClientOriginalName();
         }
 
-        return [$paths, $names];
+        return [$paths, $names, []];
     }
 
     /**
@@ -1252,12 +1255,12 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * or deleting the draft right after send (see {@see self::send()}) would pull
      * the files out from under a message that has not gone out yet.
      *
-     * @return array{0: list<string>, 1: array<string, string>}
+     * @return array{0: list<string>, 1: array<string, string>, 2: array<string, array{is_inline: bool, content_id: ?string}>}
      */
     private function copySavedAttachments(): array
     {
         if ($this->draftId === null || $this->savedAttachments === []) {
-            return [[], []];
+            return [[], [], []];
         }
 
         $disk = Storage::disk(EmailAttachment::DISK);
@@ -1290,13 +1293,15 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             $names[$copy] = (string) $attachment->filename;
         }
 
-        return [$paths, $names];
+        return [$paths, $names, []];
     }
 
     /**
      * Put the source email's downloadable files into {@see $savedAttachments} so
-     * they show as chips and are copied on send or save. Inline images stay in
-     * the quoted HTML. Oversized files are dropped with the same cap as uploads.
+     * they show as chips and are copied on send or save. Inline CID images are
+     * copied separately ({@see self::copyForwardedInlineAttachments()}) so they
+     * do not appear as removable files. Oversized files are dropped with the
+     * same cap as uploads.
      */
     private function loadForwardedAttachments(Email $email): void
     {
@@ -1344,18 +1349,18 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * them onto a draft. After persist, {@see $savedAttachments} holds draft
      * ids and this becomes a no-op. The source files themselves stay put.
      *
-     * @return array{0: list<string>, 1: array<string, string>}
+     * @return array{0: list<string>, 1: array<string, string>, 2: array<string, array{is_inline: bool, content_id: ?string}>}
      */
     private function copyForwardedSourceAttachments(): array
     {
         if ($this->replyMode !== 'forward' || $this->sourceEmailId === null || $this->savedAttachments === []) {
-            return [[], []];
+            return [[], [], []];
         }
 
         $source = $this->replyableEmail($this->sourceEmailId);
 
         if (! $source instanceof Email || $this->authUser()->cannot('viewBody', $source)) {
-            return [[], []];
+            return [[], [], []];
         }
 
         $attachments = EmailAttachment::query()
@@ -1365,8 +1370,79 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             ->whereIn('id', array_column($this->savedAttachments, 'id'))
             ->get();
 
+        return $this->copyAttachmentRecords($attachments);
+    }
+
+    /**
+     * Copy CID images for a forward. Before the first draft save they still live
+     * on the source email. After persist they live on the draft (hidden from
+     * chips) and must be copied from there so send does not share those bytes.
+     *
+     * @return array{0: list<string>, 1: array<string, string>, 2: array<string, array{is_inline: bool, content_id: ?string}>}
+     */
+    private function copyForwardedInlineAttachments(): array
+    {
+        if ($this->draftId !== null) {
+            return $this->copyDraftInlineAttachments();
+        }
+
+        return $this->copySourceInlineAttachments();
+    }
+
+    /**
+     * @return array{0: list<string>, 1: array<string, string>, 2: array<string, array{is_inline: bool, content_id: ?string}>}
+     */
+    private function copySourceInlineAttachments(): array
+    {
+        if ($this->replyMode !== 'forward' || $this->sourceEmailId === null || $this->draftId !== null) {
+            return [[], [], []];
+        }
+
+        $source = $this->replyableEmail($this->sourceEmailId);
+
+        if (! $source instanceof Email || $this->authUser()->cannot('viewBody', $source)) {
+            return [[], [], []];
+        }
+
+        $attachments = EmailAttachment::query()
+            ->with('email.connectedAccount')
+            ->where('email_id', $source->getKey())
+            ->where('is_inline', true)
+            ->get();
+
+        return $this->copyAttachmentRecords($attachments, inline: true);
+    }
+
+    /**
+     * @return array{0: list<string>, 1: array<string, string>, 2: array<string, array{is_inline: bool, content_id: ?string}>}
+     */
+    private function copyDraftInlineAttachments(): array
+    {
+        if ($this->draftId === null) {
+            return [[], [], []];
+        }
+
+        $attachments = EmailAttachment::query()
+            ->where('email_id', $this->draftId)
+            ->where('is_inline', true)
+            ->whereHas('email', fn (Builder $query): Builder => $query
+                ->where('user_id', $this->authUser()->getKey())
+                ->where('team_id', $this->authUser()->current_team_id)
+                ->where('status', EmailStatus::DRAFT))
+            ->get();
+
+        return $this->copyAttachmentRecords($attachments, inline: true);
+    }
+
+    /**
+     * @param  iterable<int, EmailAttachment>  $attachments
+     * @return array{0: list<string>, 1: array<string, string>, 2: array<string, array{is_inline: bool, content_id: ?string}>}
+     */
+    private function copyAttachmentRecords(iterable $attachments, bool $inline = false): array
+    {
         $paths = [];
         $names = [];
+        $attributes = [];
         $unavailable = [];
 
         foreach ($attachments as $attachment) {
@@ -1380,6 +1456,13 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
             $paths[] = $copy;
             $names[$copy] = (string) $attachment->filename;
+
+            if ($inline || $attachment->is_inline) {
+                $attributes[$copy] = [
+                    'is_inline' => true,
+                    'content_id' => $attachment->content_id,
+                ];
+            }
         }
 
         if ($unavailable !== []) {
@@ -1392,7 +1475,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                 ->send();
         }
 
-        return [$paths, $names];
+        return [$paths, $names, $attributes];
     }
 
     private function copyAttachmentFile(EmailAttachment $attachment): ?string
@@ -1471,8 +1554,9 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             return;
         }
 
-        [$attachmentPaths, $attachmentNames] = $this->storeAttachments();
-        [$forwardedPaths, $forwardedNames] = $this->copyForwardedSourceAttachments();
+        [$attachmentPaths, $attachmentNames, $attachmentAttributes] = $this->storeAttachments();
+        [$forwardedPaths, $forwardedNames, $forwardedAttributes] = $this->copyForwardedSourceAttachments();
+        [$inlinePaths, $inlineNames, $inlineAttributes] = $this->copySourceInlineAttachments();
 
         $draft = resolve(SaveEmailDraftAction::class)->execute(
             user: $this->authUser(),
@@ -1487,8 +1571,9 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                 // message: no original to show, and no threading when it is sent.
                 'source_email_id' => $this->sourceEmailId,
                 'creation_source' => $this->creationSource(),
-                'attachments' => [...$attachmentPaths, ...$forwardedPaths],
-                'attachment_file_names' => [...$attachmentNames, ...$forwardedNames],
+                'attachments' => [...$attachmentPaths, ...$forwardedPaths, ...$inlinePaths],
+                'attachment_file_names' => [...$attachmentNames, ...$forwardedNames, ...$inlineNames],
+                'attachment_attributes' => [...$attachmentAttributes, ...$forwardedAttributes, ...$inlineAttributes],
             ],
             draftId: $this->draftId,
         );
@@ -1521,6 +1606,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
     {
         /** @var list<array{id: string, filename: string, size: int}> $rows */
         $rows = $draft->attachments()
+            ->where('is_inline', false)
             ->get()
             ->map(fn (EmailAttachment $attachment): array => [
                 'id' => (string) $attachment->getKey(),

--- a/packages/EmailIntegration/src/Services/Contracts/MailServiceInterface.php
+++ b/packages/EmailIntegration/src/Services/Contracts/MailServiceInterface.php
@@ -33,7 +33,7 @@ interface MailServiceInterface
      *     in_reply_to?: string,
      *     thread_id?: string,
      *     rfc_message_id?: string,
-     *     attachments?: array<int, array{filename: string, mime_type: string, content: string}>,
+     *     attachments?: array<int, array{filename: string, mime_type: string, content: string, is_inline?: bool, content_id?: ?string}>,
      * } $data
      * @return array{provider_message_id: string, thread_id: string, rfc_message_id: string}
      */

--- a/packages/EmailIntegration/src/Services/EmailSendingService.php
+++ b/packages/EmailIntegration/src/Services/EmailSendingService.php
@@ -120,14 +120,10 @@ final readonly class EmailSendingService
      * Read the stored bytes for each attachment so the provider can serialize them
      * into the outgoing message.
      *
-     * @return array<int, array{filename: string, mime_type: string, content: string}>
+     * @return array<int, array{filename: string, mime_type: string, content: string, is_inline: bool, content_id: ?string}>
      */
     private function resolveAttachments(Email $email): array
     {
-        if (! $email->has_attachments) {
-            return [];
-        }
-
         $disk = Storage::disk(EmailAttachment::DISK);
 
         return $email->attachments
@@ -136,6 +132,8 @@ final readonly class EmailSendingService
                 'filename' => (string) $attachment->filename,
                 'mime_type' => (string) $attachment->mime_type,
                 'content' => (string) $disk->get((string) $attachment->storage_path),
+                'is_inline' => (bool) $attachment->is_inline,
+                'content_id' => $attachment->content_id,
             ])
             ->values()
             ->all();

--- a/packages/EmailIntegration/src/Services/GmailService.php
+++ b/packages/EmailIntegration/src/Services/GmailService.php
@@ -212,6 +212,7 @@ final readonly class GmailService implements MailServiceInterface
      *     in_reply_to?: string,
      *     thread_id?: string,
      *     rfc_message_id?: string,
+     *     attachments?: array<int, array{filename: string, mime_type: string, content: string, is_inline?: bool, content_id?: ?string}>,
      * } $data
      * @return array{provider_message_id: string, thread_id: string, rfc_message_id: string}
      */
@@ -293,12 +294,20 @@ final readonly class GmailService implements MailServiceInterface
         }
 
         $attachments = $data['attachments'] ?? [];
+        $inlineAttachments = [];
+        $fileAttachments = [];
+
+        foreach ($attachments as $attachment) {
+            if (($attachment['is_inline'] ?? false) === true && filled($attachment['content_id'] ?? null)) {
+                $inlineAttachments[] = $attachment;
+            } else {
+                $fileAttachments[] = $attachment;
+            }
+        }
 
         $headers[] = 'Subject: =?UTF-8?B?'.base64_encode((string) $data['subject']).'?=';
         $headers[] = 'MIME-Version: 1.0';
-        $headers[] = $attachments === []
-            ? 'Content-Type: multipart/alternative; boundary="boundary_relaticle"'
-            : 'Content-Type: multipart/mixed; boundary="mixed_relaticle"';
+        $headers[] = $this->rootContentTypeHeader($inlineAttachments !== [], $fileAttachments !== []);
         $headers[] = 'Date: '.now()->toRfc2822String();
 
         // Stamp our own Message-ID so a retry can find an already-sent copy via
@@ -322,28 +331,81 @@ final readonly class GmailService implements MailServiceInterface
             .($data['body_html'] ?? '')."\r\n\r\n"
             .'--boundary_relaticle--';
 
-        if ($attachments === []) {
+        if ($inlineAttachments === [] && $fileAttachments === []) {
             return implode("\r\n", $headers)."\r\n\r\n".$alternative;
         }
 
-        // Attachments present: nest the alternative body inside a multipart/mixed
-        // envelope, then append each file as a base64 attachment part.
+        if ($fileAttachments === []) {
+            return implode("\r\n", $headers)."\r\n\r\n".$this->mimeRelatedBody($alternative, $inlineAttachments);
+        }
+
         $raw = implode("\r\n", $headers)."\r\n\r\n";
         $raw .= "--mixed_relaticle\r\n";
-        $raw .= "Content-Type: multipart/alternative; boundary=\"boundary_relaticle\"\r\n\r\n";
-        $raw .= $alternative."\r\n\r\n";
 
-        foreach ($attachments as $attachment) {
-            $filename = $this->sanitizeAttachmentFilename($attachment['filename']);
+        if ($inlineAttachments === []) {
+            $raw .= "Content-Type: multipart/alternative; boundary=\"boundary_relaticle\"\r\n\r\n";
+            $raw .= $alternative."\r\n\r\n";
+        } else {
+            $raw .= "Content-Type: multipart/related; boundary=\"related_relaticle\"\r\n\r\n";
+            $raw .= $this->mimeRelatedBody($alternative, $inlineAttachments)."\r\n\r\n";
+        }
 
-            $raw .= "--mixed_relaticle\r\n";
-            $raw .= 'Content-Type: '.$attachment['mime_type'].'; name="'.$filename."\"\r\n";
-            $raw .= "Content-Transfer-Encoding: base64\r\n";
-            $raw .= 'Content-Disposition: attachment; filename="'.$filename."\"\r\n\r\n";
-            $raw .= chunk_split(base64_encode($attachment['content']))."\r\n";
+        foreach ($fileAttachments as $attachment) {
+            $raw .= $this->mimeAttachmentPart('mixed_relaticle', $attachment, inline: false);
         }
 
         return $raw.'--mixed_relaticle--';
+    }
+
+    private function rootContentTypeHeader(bool $hasInline, bool $hasFiles): string
+    {
+        if ($hasFiles) {
+            return 'Content-Type: multipart/mixed; boundary="mixed_relaticle"';
+        }
+
+        if ($hasInline) {
+            return 'Content-Type: multipart/related; boundary="related_relaticle"';
+        }
+
+        return 'Content-Type: multipart/alternative; boundary="boundary_relaticle"';
+    }
+
+    /**
+     * @param  array<int, array{filename: string, mime_type: string, content: string, is_inline?: bool, content_id?: ?string}>  $inlineAttachments
+     */
+    private function mimeRelatedBody(string $alternative, array $inlineAttachments): string
+    {
+        $raw = "--related_relaticle\r\n";
+        $raw .= "Content-Type: multipart/alternative; boundary=\"boundary_relaticle\"\r\n\r\n";
+        $raw .= $alternative."\r\n\r\n";
+
+        foreach ($inlineAttachments as $attachment) {
+            $raw .= $this->mimeAttachmentPart('related_relaticle', $attachment, inline: true);
+        }
+
+        return $raw.'--related_relaticle--';
+    }
+
+    /**
+     * @param  array{filename: string, mime_type: string, content: string, is_inline?: bool, content_id?: ?string}  $attachment
+     */
+    private function mimeAttachmentPart(string $boundary, array $attachment, bool $inline): string
+    {
+        $filename = $this->sanitizeAttachmentFilename($attachment['filename']);
+
+        $part = "--{$boundary}\r\n";
+        $part .= 'Content-Type: '.$attachment['mime_type'].'; name="'.$filename."\"\r\n";
+        $part .= "Content-Transfer-Encoding: base64\r\n";
+
+        if ($inline) {
+            $contentId = $this->sanitizeContentId((string) ($attachment['content_id'] ?? ''));
+            $part .= 'Content-ID: <'.$contentId.">\r\n";
+            $part .= 'Content-Disposition: inline; filename="'.$filename."\"\r\n\r\n";
+        } else {
+            $part .= 'Content-Disposition: attachment; filename="'.$filename."\"\r\n\r\n";
+        }
+
+        return $part.chunk_split(base64_encode($attachment['content']))."\r\n";
     }
 
     /**
@@ -353,6 +415,11 @@ final readonly class GmailService implements MailServiceInterface
     private function sanitizeAttachmentFilename(string $filename): string
     {
         return str_replace(['"', '\\', "\r", "\n"], '', $filename);
+    }
+
+    private function sanitizeContentId(string $contentId): string
+    {
+        return str_replace(['"', '\\', "\r", "\n", '<', '>'], '', $contentId);
     }
 
     private function formatAddress(string $name, string $email): string

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -206,12 +206,24 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         ];
 
         if (($data['attachments'] ?? []) !== []) {
-            $message['attachments'] = array_map(fn (array $attachment): array => [
-                '@odata.type' => '#microsoft.graph.fileAttachment',
-                'name' => $attachment['filename'],
-                'contentType' => $attachment['mime_type'],
-                'contentBytes' => base64_encode($attachment['content']),
-            ], $data['attachments']);
+            $message['attachments'] = array_map(function (array $attachment): array {
+                $payload = [
+                    '@odata.type' => '#microsoft.graph.fileAttachment',
+                    'name' => $attachment['filename'],
+                    'contentType' => $attachment['mime_type'],
+                    'contentBytes' => base64_encode($attachment['content']),
+                ];
+
+                if (($attachment['is_inline'] ?? false) === true) {
+                    $payload['isInline'] = true;
+
+                    if (filled($attachment['content_id'] ?? null)) {
+                        $payload['contentId'] = $attachment['content_id'];
+                    }
+                }
+
+                return $payload;
+            }, $data['attachments']);
         }
 
         if (isset($data['rfc_message_id'])) {

--- a/tests/Feature/EmailIntegration/GmailMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/GmailMailServiceTest.php
@@ -121,11 +121,44 @@ it('wraps the body and attachment in a multipart/mixed MIME message', function (
 
     $raw = decodeRaw($captured);
 
-    expect($result['provider_message_id'])->toBe('gmail-id')
-        ->and($raw)->toContain('Content-Type: multipart/mixed; boundary="mixed_relaticle"')
+    expect($raw)->toContain('Content-Type: multipart/mixed; boundary="mixed_relaticle"')
         ->and($raw)->toContain('Content-Type: multipart/alternative; boundary="boundary_relaticle"')
         ->and($raw)->toContain('Content-Disposition: attachment; filename="report.pdf"')
         ->and($raw)->toContain(chunk_split(base64_encode('RAW-PDF-BYTES')));
+});
+
+it('embeds inline cid images in a multipart/related MIME part', function (): void {
+    $account = ConnectedAccount::factory()->make([
+        'email_address' => 'sender@example.com',
+        'display_name' => 'Sender',
+    ]);
+
+    $captured = null;
+    $gmail = fakeGmail(function (Message $message) use (&$captured): void {
+        $captured = $message;
+    });
+
+    new GmailService($account, $gmail)->sendMessage([
+        'subject' => 'Forwarded with logo',
+        'body_html' => '<p><img src="cid:logo@example.test"></p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'attachments' => [[
+            'filename' => 'logo.png',
+            'mime_type' => 'image/png',
+            'content' => 'PNG-BYTES',
+            'is_inline' => true,
+            'content_id' => 'logo@example.test',
+        ]],
+    ]);
+
+    $raw = decodeRaw($captured);
+
+    expect($raw)->toContain('Content-Type: multipart/related; boundary="related_relaticle"')
+        ->and($raw)->not->toContain('multipart/mixed')
+        ->and($raw)->toContain('Content-ID: <logo@example.test>')
+        ->and($raw)->toContain('Content-Disposition: inline; filename="logo.png"')
+        ->and($raw)->toContain('cid:logo@example.test')
+        ->and($raw)->toContain(chunk_split(base64_encode('PNG-BYTES')));
 });
 
 it('sends a plain multipart/alternative message when there are no attachments', function (): void {

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -276,6 +276,37 @@ it('includes file attachments in the /me/sendMail payload', function (): void {
     });
 });
 
+it('marks cid images as inline file attachments on sendMail', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/sendMail' => Http::response('', 202),
+    ]);
+
+    $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
+
+    $service->sendMessage([
+        'subject' => 'Hi',
+        'body_html' => '<p><img src="cid:logo@example.test"></p>',
+        'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'attachments' => [[
+            'filename' => 'logo.png',
+            'mime_type' => 'image/png',
+            'content' => 'PNG-BYTES',
+            'is_inline' => true,
+            'content_id' => 'logo@example.test',
+        ]],
+    ]);
+
+    Http::assertSent(function (Request $r): bool {
+        $attachments = $r->data()['message']['attachments'] ?? [];
+
+        return $attachments !== []
+            && $attachments[0]['isInline'] === true
+            && $attachments[0]['contentId'] === 'logo@example.test'
+            && $attachments[0]['name'] === 'logo.png'
+            && $attachments[0]['contentBytes'] === base64_encode('PNG-BYTES');
+    });
+});
+
 it('expands and maps inbound attachment metadata into FetchedEmailData', function (): void {
     Http::fake([
         'https://graph.microsoft.com/v1.0/me/mailFolders*' => Http::response([

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -10,6 +10,8 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Relaticle\EmailIntegration\Actions\SaveEmailDraftAction;
+use Relaticle\EmailIntegration\Actions\SendEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
@@ -27,7 +29,7 @@ use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
-mutates(EmailsRelationManager::class, EmailInboxPage::class, EmailComposer::class, Email::class, HasEmailComposeActions::class, RedirectsToGrantSend::class, ConnectedAccount::class, QueuedSendNotifier::class);
+mutates(EmailsRelationManager::class, EmailInboxPage::class, EmailComposer::class, Email::class, HasEmailComposeActions::class, RedirectsToGrantSend::class, ConnectedAccount::class, QueuedSendNotifier::class, SendEmailAction::class, SaveEmailDraftAction::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -608,7 +610,7 @@ it('does not list original attachments when the viewer cannot read the body', fu
 it('does not list inline images as forwarded attachments', function (): void {
     Storage::fake(EmailAttachment::DISK);
 
-    inboundStoredAttachment($this->inboundEmail, 'logo.png', 'png-bytes', inline: true);
+    inboundStoredAttachment($this->inboundEmail, 'logo.png', 'png-bytes', inline: true, contentId: 'logo@example.test');
     $file = inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
 
     livewire(EmailComposer::class, ['dock' => 'inline'])
@@ -620,6 +622,85 @@ it('does not list inline images as forwarded attachments', function (): void {
         ]])
         ->assertSee('contract.pdf')
         ->assertDontSee('logo.png');
+});
+
+it('sends quoted inline images with the forwarded message', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $this->inboundEmail->body->update([
+        'body_html' => '<p>See logo</p><img src="cid:logo@example.test">',
+    ]);
+
+    $inline = inboundStoredAttachment($this->inboundEmail, 'logo.png', 'png-bytes', inline: true, contentId: 'logo@example.test');
+    inboundStoredAttachment($this->inboundEmail, 'contract.pdf', 'signed-contract');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->assertDontSee('logo.png')
+        ->set('to', ['forward-to@example.com'])
+        ->set('bodyHtml', '<p>Passing this on</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->sole();
+    $sentInline = $forward->attachments->firstWhere('is_inline', true);
+    $sentFile = $forward->attachments->firstWhere('is_inline', false);
+
+    expect($forward->body->body_html)->toContain('cid:logo@example.test')
+        ->and($forward->has_attachments)->toBeTrue()
+        ->and($sentInline)->not->toBeNull()
+        ->and($sentInline->filename)->toBe('logo.png')
+        ->and($sentInline->content_id)->toBe('logo@example.test')
+        ->and($sentInline->storage_path)->not->toBe($inline->storage_path)
+        ->and($sentFile?->filename)->toBe('contract.pdf');
+
+    expect(Storage::disk(EmailAttachment::DISK)->get((string) $sentInline->storage_path))->toBe('png-bytes');
+});
+
+it('saves quoted inline images onto a forward draft and sends those copies', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $this->inboundEmail->body->update([
+        'body_html' => '<p>See logo</p><img src="cid:logo@example.test">',
+    ]);
+
+    $inline = inboundStoredAttachment($this->inboundEmail, 'logo.png', 'png-bytes', inline: true, contentId: 'logo@example.test');
+
+    livewire(EmailComposer::class, ['dock' => 'inline'])
+        ->call('openReply', $this->inboundEmail->id, 'forward')
+        ->set('bodyHtml', '<p>Passing this on</p>')
+        ->call('close');
+
+    $draft = Email::query()->where('status', EmailStatus::DRAFT)->sole();
+    $draftInline = $draft->attachments->sole();
+
+    expect($draftInline->is_inline)->toBeTrue()
+        ->and($draftInline->content_id)->toBe('logo@example.test')
+        ->and($draftInline->storage_path)->not->toBe($inline->storage_path)
+        ->and($draft->has_attachments)->toBeFalse();
+
+    livewire(EmailComposer::class)
+        ->call('open', [], (string) $draft->getKey())
+        ->assertDontSee('logo.png')
+        ->set('to', ['forward-to@example.com'])
+        ->call('send')
+        ->assertHasNoErrors();
+
+    $forward = Email::query()
+        ->where('direction', EmailDirection::OUTBOUND)
+        ->where('creation_source', EmailCreationSource::FORWARD)
+        ->sole();
+    $sentInline = $forward->attachments->sole();
+
+    expect($sentInline->is_inline)->toBeTrue()
+        ->and($sentInline->content_id)->toBe('logo@example.test')
+        ->and($forward->body->body_html)->toContain('cid:logo@example.test');
+
+    Storage::disk(EmailAttachment::DISK)->assertExists((string) $inline->storage_path);
+    Storage::disk(EmailAttachment::DISK)->assertMissing((string) $draftInline->storage_path);
 });
 
 it('includes a newly uploaded file alongside the original attachments on a forward', function (): void {
@@ -848,7 +929,7 @@ it('redirects to oauth when grant permission is confirmed for a mailbox that nee
         ->assertRedirect(route('email-accounts.redirect', ['provider' => 'gmail']));
 });
 
-function inboundStoredAttachment(Email $email, string $filename, string $contents, bool $inline = false): EmailAttachment
+function inboundStoredAttachment(Email $email, string $filename, string $contents, bool $inline = false, ?string $contentId = null): EmailAttachment
 {
     $path = 'email-attachments/'.$filename;
 
@@ -860,6 +941,7 @@ function inboundStoredAttachment(Email $email, string $filename, string $content
         'storage_path' => $path,
         'size' => strlen($contents),
         'is_inline' => $inline,
+        'content_id' => $inline ? ($contentId ?? 'cid-'.$filename) : null,
         'mime_type' => $inline ? 'image/png' : 'application/pdf',
     ]);
 }

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -472,3 +472,58 @@ it('reads attachment bytes into the provider payload when sending', function ():
         ->and($captured['attachments'][0]['mime_type'])->not->toBeEmpty()
         ->and($captured['attachments'][0]['content'])->toBe('attachment body');
 });
+
+it('persists inline cid attachments and includes them in the provider payload', function (): void {
+    Storage::fake('local');
+
+    $path = UploadedFile::fake()
+        ->createWithContent('logo.png', 'png-bytes')
+        ->store('email-attachments', 'local');
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Fwd with logo',
+        'body_html' => '<p><img src="cid:logo@example.test"></p>',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::FORWARD,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+        'attachments' => [$path],
+        'attachment_file_names' => [$path => 'logo.png'],
+        'attachment_attributes' => [$path => [
+            'is_inline' => true,
+            'content_id' => 'logo@example.test',
+        ]],
+    ]);
+
+    $attachment = $email->attachments()->first();
+
+    expect($email->has_attachments)->toBeFalse()
+        ->and($attachment->is_inline)->toBeTrue()
+        ->and($attachment->content_id)->toBe('logo@example.test');
+
+    $captured = null;
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('sendMessage')->once()->andReturnUsing(function (array $payload) use (&$captured): array {
+        $captured = $payload;
+
+        return [
+            'provider_message_id' => 'pm',
+            'thread_id' => 'th',
+            'rfc_message_id' => $payload['rfc_message_id'] ?? '<x@example.com>',
+        ];
+    });
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(MailServiceFactoryInterface::class, $factory);
+
+    app(EmailSendingService::class)->send($email->refresh());
+
+    expect($captured['attachments'])->toHaveCount(1)
+        ->and($captured['attachments'][0]['is_inline'])->toBeTrue()
+        ->and($captured['attachments'][0]['content_id'])->toBe('logo@example.test')
+        ->and($captured['attachments'][0]['content'])->toBe('png-bytes');
+});


### PR DESCRIPTION
## Summary
- Copy quoted CID images with a forward (and onto a saved draft) without listing them as removable attachments.
- Keep `cid:` in the quoted original by appending that HTML after composer rendering, then emit matching inline MIME parts for Gmail and Graph.

## Test plan
- [x] Forward a message that has an inline logo in the body. Confirm the recipient sees the image, not a broken `cid:` placeholder.
- [x] Confirm the composer still lists only downloadable files as chips (no `logo.png` chip).
- [x] Save the forward as a draft, reopen it, and send. Confirm the image still goes out.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/ReplyForwardEmailTest.php tests/Feature/EmailIntegration/GmailMailServiceTest.php tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php tests/Feature/EmailIntegration/SendEmailActionTest.php`