### PR TITLE
fix(auth): make the linked provider the identity modal's only action

### DIFF
--- a/app/Enums/SocialiteProvider.php
+++ b/app/Enums/SocialiteProvider.php
@@ -8,4 +8,12 @@ enum SocialiteProvider: string
 {
     case GOOGLE = 'google';
     case MICROSOFT = 'microsoft';
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::GOOGLE => 'ri-google-fill',
+            self::MICROSOFT => 'ri-microsoft-fill',
+        };
+    }
 }

--- a/app/Filament/Actions/ConfirmIdentityAction.php
+++ b/app/Filament/Actions/ConfirmIdentityAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Actions;
 
+use App\Enums\SocialiteProvider;
 use App\Models\User;
 use App\Models\UserSocialAccount;
 use App\Support\Auth\AuthenticationSession;
@@ -331,7 +332,7 @@ final class ConfirmIdentityAction extends Action
         $user = $this->confirmingUser();
 
         if (! $user->hasPassword()) {
-            return $this->providerOffer();
+            return [];
         }
 
         $hasPasskey = $user->hasPasskey();
@@ -439,22 +440,6 @@ final class ConfirmIdentityAction extends Action
     }
 
     /**
-     * @return array<int, Component>
-     */
-    private function providerOffer(): array
-    {
-        if (! $this->providerProofPending()) {
-            return [];
-        }
-
-        return [
-            Placeholder::make('providerOfferHint')
-                ->hiddenLabel()
-                ->content(__('auth.confirm.description')),
-        ];
-    }
-
-    /**
      * Rendering this marks nothing confirmed; only completing the round trip does.
      */
     private function providerConfirmationAction(): ?Action
@@ -467,6 +452,7 @@ final class ConfirmIdentityAction extends Action
 
         return Action::make('confirmWithProvider')
             ->label(__('auth.confirm.continue_with_provider', ['provider' => ucfirst($account->provider_name)]))
+            ->icon(SocialiteProvider::tryFrom($account->provider_name)?->icon())
             ->url(route('auth.socialite.confirm.redirect', ['provider' => $account->provider_name]));
     }
 

--- a/app/Filament/Actions/ConfirmIdentityAction.php
+++ b/app/Filament/Actions/ConfirmIdentityAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Actions;
 
 use App\Models\User;
+use App\Models\UserSocialAccount;
 use App\Support\Auth\AuthenticationSession;
 use App\Support\Auth\IdentityConfirmation;
 use Closure;
@@ -36,8 +37,9 @@ use LogicException;
  * then re-invokes callMountedAction. On re-entry the gate is satisfied and
  * confirmedUsing() runs. The password path validates and marks confirmed
  * inline, with no ceremony. A user with neither a password nor a passkey has
- * no inline proof to give; if a linked provider offers one, identityFields()
- * renders it as a link the user must actually complete, never as a bypass.
+ * no inline proof to give; if a linked provider offers one, it becomes the
+ * modal's only footer action, a link the user must actually complete, never a
+ * bypass.
  *
  * Irreversible actions opt into alwaysConfirm(): the freshness window is
  * ignored and a fresh proof is demanded on every attempt. Re-entry is scoped to
@@ -126,13 +128,21 @@ final class ConfirmIdentityAction extends Action
             ...$this->identityFields(),
         ]);
 
-        $this->modalSubmitAction(function (Action $action): Action {
+        $this->modalSubmitAction(function (Action $action): Action|false {
+            if ($this->providerProofPending()) {
+                return false;
+            }
+
             if ($this->confirmingUser()->hasPasskey()) {
                 $action->icon(Heroicon::FingerPrint);
             }
 
             return $action;
         });
+
+        $this->modalCancelAction(fn (Action $action): Action|false => $this->providerProofPending() ? false : $action);
+
+        $this->extraModalFooterActions(fn (): array => array_filter([$this->providerConfirmationAction()]));
 
         $this->action(function (array $data, Action $action, ?Schema $schema): mixed {
             $user = $this->confirmingUser();
@@ -321,7 +331,7 @@ final class ConfirmIdentityAction extends Action
         $user = $this->confirmingUser();
 
         if (! $user->hasPassword()) {
-            return $this->providerOffer($user);
+            return $this->providerOffer();
         }
 
         $hasPasskey = $user->hasPasskey();
@@ -429,22 +439,11 @@ final class ConfirmIdentityAction extends Action
     }
 
     /**
-     * A user with no password and no passkey (a provider-only account) has
-     * nothing to prove inline. If a provider is linked, offer it as a real
-     * navigation to a fresh OAuth round trip; merely rendering this link marks
-     * nothing confirmed, only completing it does.
-     *
      * @return array<int, Component>
      */
-    private function providerOffer(User $user): array
+    private function providerOffer(): array
     {
-        if ($user->hasPasskey()) {
-            return [];
-        }
-
-        $account = $user->socialAccounts()->first();
-
-        if (! $account) {
+        if (! $this->providerProofPending()) {
             return [];
         }
 
@@ -452,12 +451,53 @@ final class ConfirmIdentityAction extends Action
             Placeholder::make('providerOfferHint')
                 ->hiddenLabel()
                 ->content(__('auth.confirm.description')),
-            Actions::make([
-                Action::make('confirmWithProvider')
-                    ->label(__('auth.confirm.continue_with_provider', ['provider' => ucfirst($account->provider_name)]))
-                    ->url(fn (): string => route('auth.socialite.confirm.redirect', ['provider' => $account->provider_name])),
-            ]),
         ];
+    }
+
+    /**
+     * Rendering this marks nothing confirmed; only completing the round trip does.
+     */
+    private function providerConfirmationAction(): ?Action
+    {
+        $account = $this->linkedProviderAccount();
+
+        if (! $account instanceof UserSocialAccount || ! $this->providerProofPending()) {
+            return null;
+        }
+
+        return Action::make('confirmWithProvider')
+            ->label(__('auth.confirm.continue_with_provider', ['provider' => ucfirst($account->provider_name)]))
+            ->url(route('auth.socialite.confirm.redirect', ['provider' => $account->provider_name]));
+    }
+
+    /**
+     * False once the round trip returns proven, so the normal submit action
+     * comes back and the operation can actually finish.
+     */
+    private function providerProofPending(): bool
+    {
+        if (! $this->linkedProviderAccount() instanceof UserSocialAccount) {
+            return false;
+        }
+
+        if ($this->operation !== null) {
+            $pending = AuthenticationSession::pendingOperation();
+
+            return $pending === [] || ! $pending['proven'];
+        }
+
+        return ! IdentityConfirmation::confirmedRecently($this->alwaysConfirm ? null : $this->within);
+    }
+
+    private function linkedProviderAccount(): ?UserSocialAccount
+    {
+        $user = $this->confirmingUser();
+
+        if ($user->hasPassword() || $user->hasPasskey()) {
+            return null;
+        }
+
+        return $user->socialAccounts()->first();
     }
 
     private function confirmingUser(): User

--- a/app/Http/Controllers/Auth/IdentityConfirmationController.php
+++ b/app/Http/Controllers/Auth/IdentityConfirmationController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Actions\Auth\ConfirmIdentity;
 use App\Enums\AuthMethod;
+use App\Enums\SocialiteProvider;
 use App\Http\Controllers\Auth\Concerns\ResolvesConfirmingUser;
 use App\Models\User;
 use App\Support\Auth\AuthenticationSession;
@@ -28,11 +29,13 @@ final readonly class IdentityConfirmationController
     public function show(Request $request): View
     {
         $user = $this->user($request);
+        $provider = $user->socialAccounts()->first()?->provider_name;
 
         return view('auth.confirm-identity', [
             'hasPassword' => $user->hasPassword(),
             'hasPasskey' => $user->hasPasskey(),
-            'provider' => $user->socialAccounts()->first()?->provider_name,
+            'provider' => $provider,
+            'providerIcon' => $provider === null ? null : SocialiteProvider::tryFrom($provider)?->icon(),
         ]);
     }
 

--- a/app/Livewire/App/Profile/UpdatePassword.php
+++ b/app/Livewire/App/Profile/UpdatePassword.php
@@ -68,7 +68,9 @@ final class UpdatePassword extends BaseLivewireComponent
     {
         return ConfirmIdentityAction::make('save')
             ->label(__('profile.actions.save'))
-            ->modalHeading(__('auth.confirm.heading'))
+            ->modalHeading($this->authUser()->hasPassword()
+                ? __('profile.sections.update_password.title')
+                : __('profile.sections.set_password.title'))
             ->modalDescription(__('auth.confirm.description'))
             ->alwaysConfirm()
             ->operation('set_password')

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -248,6 +248,13 @@ final class AppPanelProvider extends PanelProvider
             ->discoverClusters(in: app_path('Filament/Clusters'), for: 'App\\Filament\\Clusters')
             ->readOnlyRelationManagersOnResourceViewPagesByDefault(false)
             ->spa()
+            // The socialite entry points answer with a 302 to the provider's own
+            // domain, and wire:navigate cannot follow a cross-origin redirect.
+            ->spaUrlExceptions([
+                '*/auth/redirect/*',
+                '*/auth/link/redirect/*',
+                '*/auth/confirm/redirect/*',
+            ])
             ->routes(function () use ($panel): void {
                 Route::get('/register', fn (): RedirectResponse => redirect()->to(Filament::getLoginUrl()))
                     ->name('auth.register');

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -34,8 +34,8 @@ return [
     ],
     'confirm' => [
         'heading' => 'Confirm your identity',
-        'description' => 'Please confirm your identity before continuing.',
-        'email_change_description' => 'Confirm your identity to change your email to :email.',
+        'description' => 'This is a sensitive change, so we need to check it\'s you.',
+        'email_change_description' => 'We will send a verification link to :email.',
         'continue' => 'Continue',
         'use_passkey' => 'Use your passkey instead',
         'passkey_waiting' => 'Waiting for your passkey…',

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -122,7 +122,7 @@ return [
             'cancel' => 'Cancel',
             'remove' => 'Remove',
             'remove_confirm_title' => 'Remove passkey',
-            'remove_confirm' => 'Remove this passkey? You will no longer be able to use it to sign in.',
+            'remove_confirm' => 'You will no longer be able to use it to sign in.',
         ],
     ],
 
@@ -168,7 +168,7 @@ return [
         ],
         'log_out_other_browsers' => [
             'title' => 'Log Out Other Browser Sessions',
-            'description' => 'Confirm it\'s you to log out of your other browser sessions across all of your devices.',
+            'description' => 'You will be signed out on all of your other devices.',
         ],
     ],
 

--- a/resources/views/auth/confirm-identity.blade.php
+++ b/resources/views/auth/confirm-identity.blade.php
@@ -128,7 +128,7 @@
                         href="{{ route('auth.socialite.confirm.redirect', ['provider' => $provider]) }}"
                         class="mt-5 block"
                     >
-                        <x-filament::button color="gray" class="w-full justify-center" tag="span">
+                        <x-filament::button color="gray" :icon="$providerIcon" class="w-full justify-center" tag="span">
                             {{ __('auth.confirm.continue_with_provider', ['provider' => ucfirst($provider)]) }}
                         </x-filament::button>
                     </a>

--- a/tests/Feature/Profile/ManagePasskeysTest.php
+++ b/tests/Feature/Profile/ManagePasskeysTest.php
@@ -12,6 +12,7 @@ use App\Models\UserSocialAccount;
 use App\Support\Auth\AuthenticationSession;
 use App\Support\Auth\IdentityConfirmation;
 use Database\Factories\UserFactory;
+use Filament\Facades\Filament;
 use Laravel\Fortify\Fortify;
 use Laravel\Passkeys\Passkey;
 use Laravel\Pennant\Feature;
@@ -136,9 +137,28 @@ it('offers a linked provider for fresh proof without setting a confirmation time
 
     livewire(ManagePasskeys::class)
         ->mountAction('registerPasskey')
-        ->assertMountedActionModalSee(__('auth.confirm.continue_with_provider', ['provider' => 'Google']));
+        ->assertMountedActionModalSee(__('auth.confirm.continue_with_provider', ['provider' => 'Google']))
+        ->assertMountedActionModalDontSee(__('profile.sections.passkeys.register'))
+        ->assertMountedActionModalDontSee(__('filament-actions::modal.actions.cancel.label'));
 
     expect(session('auth.password_confirmed_at'))->toBeNull();
+});
+
+it('links the provider offer outside the SPA so the OAuth redirect is followed', function (): void {
+    $user = User::factory()->create(['password' => null]);
+    $this->actingAs($user);
+
+    UserSocialAccount::factory()->create([
+        'user_id' => $user->id,
+        'provider_name' => SocialiteProvider::GOOGLE->value,
+    ]);
+
+    Filament::getPanel('app')->boot();
+
+    livewire(ManagePasskeys::class)
+        ->mountAction('registerPasskey')
+        ->assertMountedActionModalSeeHtml('href="'.e(route('auth.socialite.confirm.redirect', ['provider' => 'google'])).'"')
+        ->assertMountedActionModalDontSeeHtml('wire:navigate');
 });
 
 it('resumes first passkey registration after returning from the linked provider', function (): void {
@@ -162,7 +182,10 @@ it('resumes first passkey registration after returning from the linked provider'
         ->assertRedirect();
 
     livewire(ManagePasskeys::class)
-        ->callAction('registerPasskey')
+        ->mountAction('registerPasskey')
+        ->assertMountedActionModalSee(__('profile.sections.passkeys.register'))
+        ->assertMountedActionModalDontSee(__('auth.confirm.continue_with_provider', ['provider' => 'Google']))
+        ->callMountedAction()
         ->assertHasNoActionErrors()
         ->assertDispatched('passkey-register');
 


### PR DESCRIPTION
Clicking `Continue with Google` in a sensitive-operation modal did nothing. The app panel runs in SPA mode, so Filament rendered the socialite link with `wire:navigate`; Livewire fetched the route, could not follow its cross-origin 302 to Google, and silently aborted. The panel now excludes the socialite redirects from SPA navigation.

A provider-only account (no password, no passkey) also saw `Cancel` and a submit button it could never use next to the provider link. While the proof is outstanding the modal now carries the provider link alone, and once the round trip returns proven the normal submit comes back so the operation can finish. This covers all six `ConfirmIdentityAction` call sites: passkeys, MFA, password, profile, delete account, sessions.

Verified in the browser (the click now reaches `accounts.google.com`) and with two tests that were each checked red against the unfixed code.