### PR TITLE
Label the meeting link picker with the selected record type

### DIFF
--- a/lang/en/filament/resources/meeting.php
+++ b/lang/en/filament/resources/meeting.php
@@ -50,6 +50,12 @@ return [
         'opportunities' => 'Opportunity',
     ],
     'fields' => [
+        'record_type' => [
+            'label' => 'Type',
+        ],
+        'record' => [
+            'label' => 'Record',
+        ],
         'organizer' => [
             'label' => 'Organizer',
         ],

--- a/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
@@ -152,29 +152,7 @@ final class MeetingDetailInfolist
         return Action::make($name)
             ->label(__('filament/resources/meeting.actions.link_records.label'))
             ->icon(Heroicon::Plus)
-            ->schema([
-                Select::make('target_type')
-                    ->options([
-                        'People' => __('filament/resources/meeting.linked_record_types.people'),
-                        'Company' => __('filament/resources/meeting.linked_record_types.companies'),
-                        'Opportunity' => __('filament/resources/meeting.linked_record_types.opportunities'),
-                    ])
-                    ->required()
-                    ->live(),
-                Select::make('target_id')
-                    ->options(function (Get $get): array {
-                        $teamId = filament()->getTenant()?->getKey();
-
-                        return match ((string) $get('target_type')) {
-                            'People' => People::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
-                            'Company' => Company::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
-                            'Opportunity' => Opportunity::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
-                            default => [],
-                        };
-                    })
-                    ->searchable()
-                    ->required(),
-            ])
+            ->schema(self::linkRecordFields())
             ->action(function (array $data, Meeting $record): void {
                 $target = self::resolveLinkTarget(
                     (string) $data['target_type'],
@@ -188,6 +166,61 @@ final class MeetingDetailInfolist
                     ->title(__('filament/relation-managers/meetings.notifications.linked.title'))
                     ->send();
             });
+    }
+
+    /**
+     * @return array<int, Select>
+     */
+    public static function linkRecordFields(): array
+    {
+        return [
+            Select::make('target_type')
+                ->label(__('filament/resources/meeting.fields.record_type.label'))
+                ->options(self::linkTargetTypeOptions())
+                ->required()
+                ->live(),
+            Select::make('target_id')
+                ->label(fn (Get $get): string => self::linkTargetLabel((string) $get('target_type')))
+                ->options(fn (Get $get): array => self::linkTargetOptions((string) $get('target_type')))
+                ->searchable()
+                ->required(),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function linkTargetTypeOptions(): array
+    {
+        return [
+            'People' => __('filament/resources/meeting.linked_record_types.people'),
+            'Company' => __('filament/resources/meeting.linked_record_types.companies'),
+            'Opportunity' => __('filament/resources/meeting.linked_record_types.opportunities'),
+        ];
+    }
+
+    private static function linkTargetLabel(string $type): string
+    {
+        return self::linkTargetTypeOptions()[$type] ?? __('filament/resources/meeting.fields.record.label');
+    }
+
+    /**
+     * CRM models carry no global tenant scope, so every query here must be
+     * constrained to the current tenant. Otherwise the option list (and the
+     * resolveLinkTarget lookup below) would expose and link records from other teams.
+     *
+     * @return array<int|string, string>
+     */
+    private static function linkTargetOptions(string $type): array
+    {
+        $teamId = filament()->getTenant()?->getKey();
+
+        return match ($type) {
+            'People' => People::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+            'Company' => Company::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+            'Opportunity' => Opportunity::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
+            default => [],
+        };
     }
 
     private static function resolveLinkTarget(string $type, string $id): Model

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -9,10 +9,8 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Actions\Action;
-use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
-use Filament\Schemas\Components\Utilities\Get;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
@@ -109,20 +107,7 @@ abstract class BaseMeetingsRelationManager extends RelationManager
                     ->label(__('filament/relation-managers/meetings.actions.link_to_record.label'))
                     ->icon(Heroicon::Link)
                     ->color('gray')
-                    ->schema([
-                        Select::make('target_type')
-                            ->options([
-                                'People' => 'Person',
-                                'Company' => 'Company',
-                                'Opportunity' => 'Opportunity',
-                            ])
-                            ->required()
-                            ->live(),
-                        Select::make('target_id')
-                            ->options(fn (Get $get): array => $this->searchOptions((string) $get('target_type')))
-                            ->searchable()
-                            ->required(),
-                    ])
+                    ->schema(MeetingDetailInfolist::linkRecordFields())
                     ->action(function (array $data, Meeting $record): void {
                         resolve(LinkMeetingToRecordAction::class)
                             ->execute($record, $this->resolveRecord((string) $data['target_type'], (string) $data['target_id']));
@@ -148,22 +133,6 @@ abstract class BaseMeetingsRelationManager extends RelationManager
                             ->send();
                     }),
             ]);
-    }
-
-    /** @return array<string, string> */
-    private function searchOptions(string $type): array
-    {
-        // CRM models carry no global tenant scope, so every query here must be
-        // constrained to the current tenant. Otherwise the option list (and the
-        // resolveRecord lookup below) would expose and link records from other teams.
-        $teamId = filament()->getTenant()?->getKey();
-
-        return match ($type) {
-            'People' => People::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
-            'Company' => Company::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
-            'Opportunity' => Opportunity::query()->where('team_id', $teamId)->pluck('name', 'id')->all(),
-            default => [],
-        };
     }
 
     private function resolveRecord(string $type, string $id): Model

--- a/tests/Feature/CalendarIntegration/MeetingDetailTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingDetailTest.php
@@ -10,6 +10,7 @@ use App\Models\People;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Route;
 use Livewire\Features\SupportTesting\Testable;
@@ -297,6 +298,36 @@ it('links a record from the meeting view modal', function (): void {
 
     expect($meeting->fresh()?->people()->count())->toBe(1);
 });
+
+it('labels the link record picker with the selected type', function (string $type, string $labelKey): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+
+    meetingDetailsOnRecord([$meeting])
+        ->mountAction([
+            TestAction::make('view')->table($meeting),
+            TestAction::make('linkRecords'),
+        ])
+        ->assertFormFieldExists(
+            'target_type',
+            fn (Select $field): bool => $field->getLabel() === __('filament/resources/meeting.fields.record_type.label'),
+        )
+        ->assertFormFieldExists(
+            'target_id',
+            fn (Select $field): bool => $field->getLabel() === __('filament/resources/meeting.fields.record.label'),
+        )
+        ->fillForm(['target_type' => $type])
+        ->assertFormFieldExists(
+            'target_id',
+            fn (Select $field): bool => $field->getLabel() === __($labelKey),
+        );
+})->with([
+    'person' => ['People', 'filament/resources/meeting.linked_record_types.people'],
+    'company' => ['Company', 'filament/resources/meeting.linked_record_types.companies'],
+    'opportunity' => ['Opportunity', 'filament/resources/meeting.linked_record_types.opportunities'],
+]);
 
 it('filters past meetings', function (): void {
     $future = Meeting::factory()->create([


### PR DESCRIPTION
## Summary
- Replace the auto-generated Target ID label in the meeting link record modal.
- The record picker label switches to Person, Company, or Opportunity with the selected type.
- Share the same form fields between the meeting drawer and the meetings table action.

## Test plan
- [x] Open a meeting and click Link records.
- [x] Confirm the second field is labeled Record, not Target ID.
- [x] Select Person, Company, and Opportunity. Confirm the record picker label switches each time.
- [x] Repeat from the meetings table Link to record action.