### PR TITLE
Embed mailbox sync progress in the Home meetings section

### DIFF
--- a/lang/en/filament/pages/dashboard.php
+++ b/lang/en/filament/pages/dashboard.php
@@ -66,6 +66,16 @@ return [
         'happening_now' => 'Now',
         'time_range' => ':start to :end',
         'load_more' => 'Load more',
+        'syncing' => [
+            'title' => 'Syncing',
+            'title_with_percent' => 'Syncing (:percent%)',
+            'description_initial' => 'We are processing your email and calendar events...',
+            'description_update' => 'Checking for new emails and calendar updates...',
+            'emails_processed' => '{1}:count email processed|[2,*]:count emails processed',
+            'meetings_processed' => '{1}:count meeting found|[2,*]:count meetings found',
+            'emails_updated' => '{1}:count new email|[2,*]:count new emails',
+            'meetings_updated' => '{1}:count meeting updated|[2,*]:count meetings updated',
+        ],
     ],
     'tasks' => [
         'heading' => 'Tasks',

--- a/packages/Chat/resources/views/filament/pages/dashboard.blade.php
+++ b/packages/Chat/resources/views/filament/pages/dashboard.blade.php
@@ -60,10 +60,6 @@
         </form>
 
         @if (\Laravel\Pennant\Feature::active(\App\Features\EmailIntegration::class))
-            @island(name: 'mailbox-import')
-                @livewire('email-integration.mailbox-import-status', ['placement' => 'home'])
-            @endisland
-
             @livewire('email-integration.meetings-home-widget')
         @endif
 

--- a/packages/EmailIntegration/resources/views/components/importing-badge.blade.php
+++ b/packages/EmailIntegration/resources/views/components/importing-badge.blade.php
@@ -4,39 +4,22 @@
 ])
 
 @php
-    $incrementalLabel = $account->incrementalSyncStatusLabel();
-    $percent = $incrementalLabel === null ? $account->initialSyncProgressPercent() : null;
+    $percent = $account->syncDisplayPercent();
 @endphp
 
-@if ($incrementalLabel !== null)
-    <x-filament::badge
-        color="info"
-        size="sm"
-        :icon="$icon"
-        class="whitespace-nowrap"
-        role="progressbar"
-        aria-busy="true"
-        aria-valuemin="0"
-        aria-valuemax="100"
-        :aria-label="$incrementalLabel"
-    >
-        {{ $incrementalLabel }}
-    </x-filament::badge>
-@else
-    <x-filament::badge
-        color="info"
-        size="sm"
-        :icon="$icon"
-        class="whitespace-nowrap"
-        role="progressbar"
-        aria-busy="true"
-        aria-valuemin="0"
-        aria-valuemax="100"
-        :aria-valuenow="$percent"
-        :aria-valuetext="__('filament/pages/email-accounts.importing_percent', ['percent' => $percent])"
-        :aria-label="__('filament/pages/email-accounts.importing')"
-    >
-        {{ __('filament/pages/email-accounts.importing') }}
-        {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $percent]) }}
-    </x-filament::badge>
-@endif
+<x-filament::badge
+    color="info"
+    size="sm"
+    :icon="$icon"
+    class="whitespace-nowrap"
+    role="progressbar"
+    aria-busy="true"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    :aria-valuenow="$percent"
+    :aria-valuetext="__('filament/pages/email-accounts.importing_percent', ['percent' => $percent])"
+    :aria-label="__('filament/pages/email-accounts.importing')"
+>
+    {{ __('filament/pages/email-accounts.importing') }}
+    {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $percent]) }}
+</x-filament::badge>

--- a/packages/EmailIntegration/resources/views/livewire/mailbox-import-status.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/mailbox-import-status.blade.php
@@ -117,15 +117,9 @@
                         >
                             <div class="flex items-center justify-between gap-3">
                                 <p class="truncate text-sm text-gray-700 dark:text-gray-300">{{ $mailbox['email'] }}</p>
-                                @if ($mailbox['incrementalLabel'] !== null)
-                                    <span class="shrink-0 rounded-full bg-primary-50 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:bg-primary-400/10 dark:text-primary-300">
-                                        {{ $mailbox['incrementalLabel'] }}
-                                    </span>
-                                @else
-                                    <span class="shrink-0 rounded-full bg-primary-50 px-2 py-0.5 text-xs font-semibold tabular-nums text-primary-700 dark:bg-primary-400/10 dark:text-primary-300">
-                                        {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $mailbox['percent']]) }}
-                                    </span>
-                                @endif
+                                <span class="shrink-0 rounded-full bg-primary-50 px-2 py-0.5 text-xs font-semibold tabular-nums text-primary-700 dark:bg-primary-400/10 dark:text-primary-300">
+                                    {{ __('filament/pages/email-accounts.importing_percent', ['percent' => $mailbox['percent']]) }}
+                                </span>
                             </div>
                             @if ($mailbox['hasCalendar'])
                                 <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
@@ -143,7 +137,7 @@
                                 @endif
                                 aria-valuemin="0"
                                 aria-valuemax="100"
-                                aria-label="{{ $mailbox['incrementalLabel'] ?? __('filament/pages/email-accounts.importing') }}"
+                                aria-label="{{ __('filament/pages/email-accounts.importing') }}"
                                 aria-busy="{{ $mailbox['importing'] ? 'true' : 'false' }}"
                             >
                                 @if ($mailbox['incrementalOnly'])

--- a/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
@@ -1,12 +1,13 @@
 @php
     $mailboxConnected = $this->isMailboxConnected();
+    $mailboxSyncing = $mailboxConnected && $this->isMailboxSyncing();
 @endphp
 
 <div class="mt-14" data-testid="meetings-home">
     <div class="mb-3 flex items-center justify-between gap-3">
         <h2 class="flex items-baseline gap-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
             <span>{{ __('filament/pages/dashboard.meetings.heading') }}</span>
-            @if ($mailboxConnected)
+            @if ($mailboxConnected && ! $mailboxSyncing)
                 <span class="text-gray-400 dark:text-gray-500">{{ $this->meetings->count() }}</span>
             @endif
         </h2>
@@ -66,7 +67,9 @@
         </div>
     </div>
 
-    @if (! $mailboxConnected)
+    @if ($mailboxSyncing)
+        @include('email-integration::livewire.partials.mailbox-sync-status')
+    @elseif (! $mailboxConnected)
         <div class="rounded-xl border border-dashed border-[var(--surface-block-border)] px-6 py-10 text-center" data-testid="meetings-disconnected">
             <p class="text-sm font-medium text-gray-900 dark:text-white">
                 {{ __('filament/pages/dashboard.meetings.disconnected.title') }}

--- a/packages/EmailIntegration/resources/views/livewire/partials/mailbox-sync-status.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/partials/mailbox-sync-status.blade.php
@@ -1,0 +1,81 @@
+@php
+    $percent = $this->syncDisplayPercent();
+    $emailsProcessed = $this->syncEmailsProcessed();
+    $meetingsProcessed = $this->syncMeetingsProcessed();
+    $showsMeetingsProcessed = $this->syncShowsMeetingsProcessed();
+    $isInitialImport = $this->syncIsInitialImport();
+    $showsPercent = $this->syncShowsPercent();
+    $showsProcessedCounts = $this->syncShowsProcessedCounts();
+@endphp
+
+<div
+    @if ($this->shouldPollMailboxSync()) wire:poll.5s="refreshMailboxSync" @endif
+    data-testid="meetings-mailbox-sync"
+    class="rounded-xl border border-dashed border-[var(--surface-block-border)] px-6 py-10 text-center"
+    aria-busy="true"
+    aria-live="polite"
+>
+    <p class="text-sm font-medium text-gray-900 dark:text-white">
+        @if ($showsPercent)
+            {{ __('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => $percent]) }}
+        @else
+            {{ __('filament/pages/dashboard.meetings.syncing.title') }}
+        @endif
+    </p>
+
+    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        @if ($isInitialImport)
+            {{ __('filament/pages/dashboard.meetings.syncing.description_initial') }}
+        @else
+            {{ __('filament/pages/dashboard.meetings.syncing.description_update') }}
+        @endif
+    </p>
+
+    @if ($showsProcessedCounts)
+        <div class="mt-3 space-y-0.5 text-xs text-gray-500 dark:text-gray-400">
+            @if ($emailsProcessed > 0)
+                <p>
+                    @if ($isInitialImport)
+                        {{ trans_choice('filament/pages/dashboard.meetings.syncing.emails_processed', $emailsProcessed, ['count' => $emailsProcessed]) }}
+                    @else
+                        {{ trans_choice('filament/pages/dashboard.meetings.syncing.emails_updated', $emailsProcessed, ['count' => $emailsProcessed]) }}
+                    @endif
+                </p>
+            @endif
+            @if ($showsMeetingsProcessed && $meetingsProcessed > 0)
+                <p>
+                    @if ($isInitialImport)
+                        {{ trans_choice('filament/pages/dashboard.meetings.syncing.meetings_processed', $meetingsProcessed, ['count' => $meetingsProcessed]) }}
+                    @else
+                        {{ trans_choice('filament/pages/dashboard.meetings.syncing.meetings_updated', $meetingsProcessed, ['count' => $meetingsProcessed]) }}
+                    @endif
+                </p>
+            @endif
+        </div>
+    @endif
+
+    <div
+        class="mx-auto mt-6 h-1 max-w-xs overflow-hidden rounded-full bg-gray-200 dark:bg-white/10"
+        role="progressbar"
+        @if ($showsPercent)
+            aria-valuenow="{{ $percent }}"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-label="{{ __('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => $percent]) }}"
+        @else
+            aria-label="{{ __('filament/pages/dashboard.meetings.syncing.title') }}"
+        @endif
+        aria-busy="true"
+    >
+        <div
+            @class([
+                'h-full rounded-full bg-primary-600',
+                'transition-[width] duration-500 ease-out' => $showsPercent,
+                'w-1/3 animate-pulse' => ! $showsPercent,
+            ])
+            @if ($showsPercent)
+                style="width: {{ $percent }}%"
+            @endif
+        ></div>
+    </div>
+</div>

--- a/packages/EmailIntegration/src/Actions/StoreEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreEmailAction.php
@@ -16,6 +16,7 @@ use Relaticle\EmailIntegration\Models\EmailLabel;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailRead;
 use Relaticle\EmailIntegration\Services\EmailClassifier;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Symfony\Component\Mime\MimeTypes;
 use Throwable;
 
@@ -190,9 +191,15 @@ final readonly class StoreEmailAction
 
     private function bumpInitialImportProgress(ConnectedAccount $connectedAccount): void
     {
-        ConnectedAccount::query()
-            ->whereKey($connectedAccount->getKey())
-            ->whereNull('sync_cursor')
-            ->increment('initial_sync_imported');
+        if ($connectedAccount->sync_cursor === null) {
+            ConnectedAccount::query()
+                ->whereKey($connectedAccount->getKey())
+                ->whereNull('sync_cursor')
+                ->increment('initial_sync_imported');
+        }
+
+        if (MailboxSyncTracker::isEmailSyncing($connectedAccount)) {
+            MailboxSyncTracker::bumpEmailProcessed($connectedAccount);
+        }
     }
 }

--- a/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreMeetingAction.php
@@ -11,6 +11,7 @@ use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 final readonly class StoreMeetingAction
 {
@@ -158,9 +159,15 @@ final readonly class StoreMeetingAction
 
     private function bumpInitialCalendarImportProgress(ConnectedAccount $connectedAccount): void
     {
-        ConnectedAccount::query()
-            ->whereKey($connectedAccount->getKey())
-            ->whereNull('calendar_sync_cursor')
-            ->increment('initial_calendar_sync_imported');
+        if ($connectedAccount->calendar_sync_cursor === null) {
+            ConnectedAccount::query()
+                ->whereKey($connectedAccount->getKey())
+                ->whereNull('calendar_sync_cursor')
+                ->increment('initial_calendar_sync_imported');
+        }
+
+        if (MailboxSyncTracker::isCalendarSyncing($connectedAccount)) {
+            MailboxSyncTracker::bumpCalendarProcessed($connectedAccount);
+        }
     }
 }

--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -88,6 +88,8 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             $result->events,
         );
 
+        MailboxSyncTracker::setCalendarRunTotal($account, count($jobs));
+
         Bus::batch($jobs)
             ->name("Incremental calendar sync: {$account->email_address}")
             ->onQueue('emails-sync')

--- a/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalEmailSyncJob.php
@@ -118,6 +118,8 @@ final class IncrementalEmailSyncJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
+        MailboxSyncTracker::setEmailRunTotal($account, count($newIds));
+
         $accountId = (string) $account->getKey();
         $newCursor = $delta->newCursor;
 

--- a/packages/EmailIntegration/src/Livewire/MailboxImportStatus.php
+++ b/packages/EmailIntegration/src/Livewire/MailboxImportStatus.php
@@ -88,19 +88,17 @@ final class MailboxImportStatus extends Component
             }
 
             $incrementalOnly = $account->isIncrementalSyncing();
-            $percent = $incrementalOnly ? null : $account->initialSyncProgressPercent();
-            $incrementalLabel = $account->incrementalSyncStatusLabel();
 
             $rows[] = [
                 'id' => $id,
                 'email' => $account->email_address,
-                'imported' => $account->initial_sync_imported,
-                'meetingsImported' => $account->initial_calendar_sync_imported,
+                'imported' => $account->syncEmailsProcessedCount(),
+                'meetingsImported' => $account->syncMeetingsProcessedCount(),
                 'hasCalendar' => $account->hasCalendar(),
-                'percent' => $percent,
+                'percent' => $account->syncDisplayPercent(),
                 'importing' => $account->showsSyncProgress(),
                 'incrementalOnly' => $incrementalOnly,
-                'incrementalLabel' => $incrementalLabel,
+                'incrementalLabel' => null,
                 'settings_url' => EmailAccountSettingsPage::getUrl(['account' => $id]),
             ];
         }

--- a/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
+++ b/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
@@ -30,11 +30,13 @@ use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
 use Relaticle\EmailIntegration\Services\ListMeetingsForDay;
 use Relaticle\EmailIntegration\Services\MailboxDisplayNameDirectory;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Relaticle\EmailIntegration\Services\MeetingAttendeePresenter;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 /**
  * @property-read Collection<int, Meeting> $meetings
+ * @property-read list<array{id: string, email: string, emailsImported: int, meetingsImported: int, percent: int, hasCalendar: bool, isInitialImport: bool}> $mailboxSyncRows
  * @property-read Action $connectGmailAction
  */
 final class MeetingsHomeWidget extends Component implements HasActions, HasSchemas
@@ -129,6 +131,115 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
         }
 
         return ConnectedAccount::hasActiveFor($user, $team instanceof Team ? $team : null);
+    }
+
+    public function isMailboxSyncing(): bool
+    {
+        return $this->mailboxSyncRows !== [];
+    }
+
+    public function shouldPollMailboxSync(): bool
+    {
+        return $this->isMailboxSyncing();
+    }
+
+    public function syncDisplayPercent(): int
+    {
+        $percents = array_map(
+            fn (array $row): int => $row['percent'],
+            $this->mailboxSyncRows,
+        );
+
+        return $percents === [] ? 0 : max($percents);
+    }
+
+    public function syncEmailsProcessed(): int
+    {
+        return array_sum(array_map(
+            fn (array $row): int => $row['emailsImported'],
+            $this->mailboxSyncRows,
+        ));
+    }
+
+    public function syncMeetingsProcessed(): int
+    {
+        return array_sum(array_map(
+            fn (array $row): int => $row['meetingsImported'],
+            $this->mailboxSyncRows,
+        ));
+    }
+
+    public function syncShowsMeetingsProcessed(): bool
+    {
+        return array_any(
+            $this->mailboxSyncRows,
+            fn (array $row): bool => $row['hasCalendar'],
+        );
+    }
+
+    public function syncIsInitialImport(): bool
+    {
+        return array_any(
+            $this->mailboxSyncRows,
+            fn (array $row): bool => $row['isInitialImport'],
+        );
+    }
+
+    public function syncShowsPercent(): bool
+    {
+        if ($this->syncIsInitialImport()) {
+            return true;
+        }
+
+        return $this->syncDisplayPercent() > 0;
+    }
+
+    public function syncShowsProcessedCounts(): bool
+    {
+        if ($this->syncEmailsProcessed() > 0) {
+            return true;
+        }
+
+        return $this->syncShowsMeetingsProcessed() && $this->syncMeetingsProcessed() > 0;
+    }
+
+    public function refreshMailboxSync(): void
+    {
+        unset($this->mailboxSyncRows);
+        unset($this->meetings);
+    }
+
+    /**
+     * @return list<array{id: string, email: string, emailsImported: int, meetingsImported: int, percent: int, hasCalendar: bool, isInitialImport: bool}>
+     */
+    #[Computed]
+    public function mailboxSyncRows(): array
+    {
+        $rows = [];
+
+        foreach ($this->ownedAccounts() as $account) {
+            if (! $account->showsSyncProgress()) {
+                continue;
+            }
+
+            $isInitialImport = $account->isImportingHistory();
+
+            $rows[] = [
+                'id' => (string) $account->getKey(),
+                'email' => $account->email_address,
+                'emailsImported' => $isInitialImport
+                    ? $account->syncEmailsProcessedCount()
+                    : ($account->isEmailSyncing() ? MailboxSyncTracker::emailProcessedCount($account) : 0),
+                'meetingsImported' => $isInitialImport
+                    ? $account->syncMeetingsProcessedCount()
+                    : ($account->isCalendarSyncing() ? MailboxSyncTracker::calendarProcessedCount($account) : 0),
+                'percent' => $account->syncDisplayPercent(),
+                'hasCalendar' => $account->hasCalendar(),
+                'isInitialImport' => $isInitialImport,
+            ];
+        }
+
+        return $rows;
     }
 
     public function nextDayWithMeetings(): ?CarbonImmutable
@@ -347,6 +458,21 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
         }
 
         return array_values($states);
+    }
+
+    /**
+     * @return Collection<int, ConnectedAccount>
+     */
+    private function ownedAccounts(): Collection
+    {
+        $user = auth()->user();
+        $team = Filament::getTenant();
+
+        if (! $user instanceof User || ! $team instanceof Team) {
+            return new Collection;
+        }
+
+        return ConnectedAccount::query()->ownedBy($user, $team)->get();
     }
 
     private function resolveVisibleMeeting(string $meetingId): ?Meeting

--- a/packages/EmailIntegration/src/Models/ConnectedAccount.php
+++ b/packages/EmailIntegration/src/Models/ConnectedAccount.php
@@ -299,9 +299,22 @@ final class ConnectedAccount extends Model
         return $this->hasCalendar() && $this->calendar_sync_cursor === null;
     }
 
+    public function isImportingCalendarHistory(): bool
+    {
+        return $this->isActive()
+            && $this->hasCalendar()
+            && $this->calendar_sync_cursor === null;
+    }
+
     public function isCalendarSyncing(): bool
     {
         return MailboxSyncTracker::isCalendarSyncing($this);
+    }
+
+    public function showsCalendarSyncProgress(): bool
+    {
+        return $this->isImportingCalendarHistory()
+            || ($this->hasCalendar() && $this->isCalendarSyncing());
     }
 
     public function isEmailSyncing(): bool
@@ -356,6 +369,41 @@ final class ConnectedAccount extends Model
         }
 
         return min(100, (int) round(($this->initial_sync_imported / $estimated) * 100));
+    }
+
+    public function syncEmailsProcessedCount(): int
+    {
+        if ($this->isEmailSyncing()) {
+            return MailboxSyncTracker::emailProcessedCount($this);
+        }
+
+        if ($this->isImportingHistory() && $this->hasEmail() && $this->sync_cursor === null) {
+            return $this->initial_sync_imported;
+        }
+
+        return $this->initial_sync_imported;
+    }
+
+    public function syncMeetingsProcessedCount(): int
+    {
+        if ($this->isCalendarSyncing()) {
+            return MailboxSyncTracker::calendarProcessedCount($this);
+        }
+
+        if ($this->isImportingCalendarHistory()) {
+            return $this->initial_calendar_sync_imported;
+        }
+
+        return $this->initial_calendar_sync_imported;
+    }
+
+    public function syncDisplayPercent(): int
+    {
+        if ($this->isImportingHistory()) {
+            return $this->initialSyncProgressPercent();
+        }
+
+        return MailboxSyncTracker::runProgressPercent($this);
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/MailboxSyncTracker.php
+++ b/packages/EmailIntegration/src/Services/MailboxSyncTracker.php
@@ -14,11 +14,30 @@ final readonly class MailboxSyncTracker
     public static function markCalendarStarted(ConnectedAccount $account): void
     {
         Cache::put(self::calendarKey($account), true, now()->addMinutes(self::TTL_MINUTES));
+        Cache::put(self::calendarProcessedKey($account), 0, now()->addMinutes(self::TTL_MINUTES));
+        Cache::forget(self::calendarTotalKey($account));
     }
 
     public static function markCalendarFinished(ConnectedAccount $account): void
     {
         Cache::forget(self::calendarKey($account));
+        Cache::forget(self::calendarProcessedKey($account));
+        Cache::forget(self::calendarTotalKey($account));
+    }
+
+    public static function setCalendarRunTotal(ConnectedAccount $account, int $total): void
+    {
+        Cache::put(self::calendarTotalKey($account), $total, now()->addMinutes(self::TTL_MINUTES));
+    }
+
+    public static function bumpCalendarProcessed(ConnectedAccount $account): void
+    {
+        Cache::increment(self::calendarProcessedKey($account));
+    }
+
+    public static function calendarProcessedCount(ConnectedAccount $account): int
+    {
+        return (int) Cache::get(self::calendarProcessedKey($account), 0);
     }
 
     public static function isCalendarSyncing(ConnectedAccount $account): bool
@@ -29,11 +48,51 @@ final readonly class MailboxSyncTracker
     public static function markEmailStarted(ConnectedAccount $account): void
     {
         Cache::put(self::emailKey($account), true, now()->addMinutes(self::TTL_MINUTES));
+        Cache::put(self::emailProcessedKey($account), 0, now()->addMinutes(self::TTL_MINUTES));
+        Cache::forget(self::emailTotalKey($account));
     }
 
     public static function markEmailFinished(ConnectedAccount $account): void
     {
         Cache::forget(self::emailKey($account));
+        Cache::forget(self::emailProcessedKey($account));
+        Cache::forget(self::emailTotalKey($account));
+    }
+
+    public static function setEmailRunTotal(ConnectedAccount $account, int $total): void
+    {
+        Cache::put(self::emailTotalKey($account), $total, now()->addMinutes(self::TTL_MINUTES));
+    }
+
+    public static function bumpEmailProcessed(ConnectedAccount $account): void
+    {
+        Cache::increment(self::emailProcessedKey($account));
+    }
+
+    public static function emailProcessedCount(ConnectedAccount $account): int
+    {
+        return (int) Cache::get(self::emailProcessedKey($account), 0);
+    }
+
+    public static function runProgressPercent(ConnectedAccount $account): int
+    {
+        $percents = [];
+
+        if (self::isEmailSyncing($account)) {
+            $percents[] = self::channelProgressPercent(
+                self::emailProcessedCount($account),
+                Cache::get(self::emailTotalKey($account)),
+            );
+        }
+
+        if (self::isCalendarSyncing($account)) {
+            $percents[] = self::channelProgressPercent(
+                self::calendarProcessedCount($account),
+                Cache::get(self::calendarTotalKey($account)),
+            );
+        }
+
+        return $percents === [] ? 0 : max($percents);
     }
 
     public static function isEmailSyncing(ConnectedAccount $account): bool
@@ -49,5 +108,34 @@ final readonly class MailboxSyncTracker
     private static function emailKey(ConnectedAccount $account): string
     {
         return 'mailbox-sync:email:'.$account->getKey();
+    }
+
+    private static function emailProcessedKey(ConnectedAccount $account): string
+    {
+        return 'mailbox-sync:email:'.$account->getKey().':processed';
+    }
+
+    private static function emailTotalKey(ConnectedAccount $account): string
+    {
+        return 'mailbox-sync:email:'.$account->getKey().':total';
+    }
+
+    private static function calendarProcessedKey(ConnectedAccount $account): string
+    {
+        return 'mailbox-sync:calendar:'.$account->getKey().':processed';
+    }
+
+    private static function calendarTotalKey(ConnectedAccount $account): string
+    {
+        return 'mailbox-sync:calendar:'.$account->getKey().':total';
+    }
+
+    private static function channelProgressPercent(int $processed, mixed $total): int
+    {
+        if (! is_int($total) || $total <= 0) {
+            return 0;
+        }
+
+        return min(100, (int) round(($processed / $total) * 100));
     }
 }

--- a/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
+++ b/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
@@ -84,7 +84,7 @@ it('shows calendar-only sync progress on the dashboard', function (): void {
     MailboxSyncTracker::markCalendarStarted($account);
 
     Livewire::test(MailboxImportStatus::class, ['placement' => 'home'])
-        ->assertSee(__('filament/pages/email-accounts.importing_calendar'))
+        ->assertSee(__('filament/pages/email-accounts.importing_percent', ['percent' => 0]))
         ->assertSee(__('filament/pages/email-accounts.sync_status.title_syncing'));
 });
 

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -19,6 +19,7 @@ use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\ListMeetingsForDay;
 use Relaticle\EmailIntegration\Services\MailboxDisplayNameDirectory;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Relaticle\EmailIntegration\Services\MeetingAttendeePresenter;
 use Relaticle\EmailIntegration\Services\TeamMemberDirectory;
 
@@ -37,6 +38,9 @@ beforeEach(function (): void {
         fn (): ConnectedAccount => ConnectedAccount::factory()->create([
             'team_id' => $this->team->id,
             'user_id' => $this->user->id,
+            'sync_cursor' => 'done',
+            'calendar_sync_cursor' => 'done',
+            'last_synced_at' => now(),
         ])
     );
 });
@@ -55,6 +59,167 @@ it('renders the empty day copy on home', function (): void {
         ->assertSee(__('filament/pages/dashboard.meetings.empty.title'))
         ->assertSee(__('filament/pages/dashboard.meetings.empty.description'))
         ->assertSee(__('filament/pages/dashboard.meetings.date.today'));
+});
+
+it('shows mailbox sync progress inside the meetings section', function (): void {
+    $this->account->update([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'sync_cursor' => null,
+        'calendar_sync_cursor' => null,
+        'initial_sync_imported' => 12,
+        'initial_sync_estimated' => 40,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => 30]))
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.description_initial'))
+        ->assertSee(trans_choice('filament/pages/dashboard.meetings.syncing.emails_processed', 12, ['count' => 12]))
+        ->assertDontSee(trans_choice('filament/pages/dashboard.meetings.syncing.meetings_processed', 0, ['count' => 0]))
+        ->assertSee('role="progressbar"', false)
+        ->assertSee('aria-valuenow="30"', false)
+        ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
+});
+
+it('shows mailbox sync progress during email-only history import', function (): void {
+    $this->account->update([
+        'capabilities' => ['email' => true, 'calendar' => false],
+        'sync_cursor' => null,
+        'initial_sync_imported' => 0,
+        'initial_sync_estimated' => 100,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => 0]))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
+});
+
+it('hides meetings while mailbox sync is in progress', function (): void {
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Board review',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+
+    $this->account->update([
+        'sync_cursor' => null,
+        'initial_sync_imported' => 8,
+        'initial_sync_estimated' => 100,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertDontSee('Board review')
+        ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
+});
+
+it('hides meetings while calendar sync is in progress', function (): void {
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Board review',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+
+    $this->account->update([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => null,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertDontSee('Board review')
+        ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
+});
+
+it('shows reconnect sync progress with percent and new item counts', function (): void {
+    $this->account->update([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'sync_cursor' => 'done',
+        'calendar_sync_cursor' => 'done',
+    ]);
+
+    MailboxSyncTracker::markEmailStarted($this->account);
+    MailboxSyncTracker::setEmailRunTotal($this->account, 10);
+    MailboxSyncTracker::bumpEmailProcessed($this->account);
+    MailboxSyncTracker::bumpEmailProcessed($this->account);
+
+    MailboxSyncTracker::markCalendarStarted($this->account);
+    MailboxSyncTracker::setCalendarRunTotal($this->account, 4);
+    MailboxSyncTracker::bumpCalendarProcessed($this->account);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => 25]))
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.description_update'))
+        ->assertSee(trans_choice('filament/pages/dashboard.meetings.syncing.emails_updated', 2, ['count' => 2]))
+        ->assertSee(trans_choice('filament/pages/dashboard.meetings.syncing.meetings_updated', 1, ['count' => 1]))
+        ->assertSee('aria-valuenow="25"', false);
+});
+
+it('hides zero counts during reconnect sync before new items arrive', function (): void {
+    $this->account->update([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'sync_cursor' => 'done',
+        'calendar_sync_cursor' => 'done',
+        'initial_sync_imported' => 643,
+        'initial_calendar_sync_imported' => 120,
+    ]);
+
+    MailboxSyncTracker::markEmailStarted($this->account);
+    MailboxSyncTracker::markCalendarStarted($this->account);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title'))
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.description_update'))
+        ->assertDontSee(trans_choice('filament/pages/dashboard.meetings.syncing.emails_processed', 643, ['count' => 643]))
+        ->assertDontSee(trans_choice('filament/pages/dashboard.meetings.syncing.emails_updated', 0, ['count' => 0]))
+        ->assertDontSee('aria-valuenow=', false);
+});
+
+it('shows meetings after calendar sync finishes', function (): void {
+    $this->account->update([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => 'done',
+    ]);
+
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Board review',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+
+    MailboxSyncTracker::markCalendarStarted($this->account);
+
+    $component = livewire(MeetingsHomeWidget::class)
+        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertDontSee('Board review');
+
+    MailboxSyncTracker::markCalendarFinished($this->account);
+
+    $component->call('refreshMailboxSync')
+        ->assertDontSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertSee('Board review');
+});
+
+it('shows mailbox sync progress on the dashboard inside meetings', function (): void {
+    $this->account->update([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'sync_cursor' => null,
+        'calendar_sync_cursor' => null,
+        'initial_sync_imported' => 4,
+        'initial_sync_estimated' => 100,
+    ]);
+
+    livewire(Dashboard::class)
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => 4]))
+        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertDontSee('data-mailbox-import="home"', false);
 });
 
 it('moves to tomorrow and yesterday from the date controls', function (): void {

--- a/tests/Feature/EmailIntegration/MailboxImportStatusTest.php
+++ b/tests/Feature/EmailIntegration/MailboxImportStatusTest.php
@@ -172,39 +172,13 @@ it('lists meetings processed above emails on home when calendar is enabled', fun
         ->and($meetingsPosition)->toBeLessThan($emailsPosition);
 });
 
-it('shows the home sync section on the dashboard page', function (): void {
-    $account = importingAccount(['initial_sync_imported' => 57, 'initial_sync_estimated' => 100]);
+it('shows mailbox sync in the meetings section on the dashboard page', function (): void {
+    importingAccount(['initial_sync_imported' => 57, 'initial_sync_estimated' => 100]);
 
     livewire(Dashboard::class)
-        ->assertSee(__('filament/pages/email-accounts.sync_status.title_syncing'))
-        ->assertSee($account->email_address)
-        ->assertSee(trans_choice('filament/pages/email-accounts.sync_status.emails_processed', 57, ['count' => 57]))
-        ->assertSee(__('filament/pages/email-accounts.importing_percent', ['percent' => 57]))
-        ->assertSee('role="progressbar"', false);
-});
-
-it('shows meetings processed above emails on the dashboard', function (): void {
-    $account = importingAccount([
-        'capabilities' => ['email' => true, 'calendar' => true],
-        'initial_calendar_sync_imported' => 12,
-        'initial_sync_imported' => 57,
-        'initial_sync_estimated' => 100,
-    ]);
-
-    $html = livewire(Dashboard::class)->html();
-    $meetings = trans_choice('filament/pages/email-accounts.sync_status.meetings_processed', 12, ['count' => 12]);
-    $emails = trans_choice('filament/pages/email-accounts.sync_status.emails_processed', 57, ['count' => 57]);
-
-    expect($html)->toContain($account->email_address)
-        ->toContain($meetings)
-        ->toContain($emails);
-
-    $meetingsPosition = strpos($html, $meetings);
-    $emailsPosition = strpos($html, $emails);
-
-    expect($meetingsPosition)->toBeInt()
-        ->and($emailsPosition)->toBeInt()
-        ->and($meetingsPosition)->toBeLessThan($emailsPosition);
+        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
+        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => 57]))
+        ->assertDontSee('data-mailbox-import="home"', false);
 });
 
 it('shows the syncing badge on the accounts page without the progress section', function (): void {


### PR DESCRIPTION
## Summary
- Move Home mailbox sync UI into the meetings section, hide the list while a sync is running, and show reconnect-aware copy when the mailbox needs attention.
- Report run-level counts for incremental sync so a quiet pass does not look like a failed import with zero totals.
- This branch also carries the Home meetings work: date navigation, guest naming from CRM or mailbox history, and typed linked records in the meeting modal.

## Test plan
- [x] Open Home during an initial mailbox import and confirm progress lives in the meetings section, not as a standalone prompt.
- [x] Confirm meetings stay hidden until the import finishes.
- [x] Trigger an incremental sync and confirm the counts describe that run, not a zeroed lifetime total.
- [x] Disconnect or expire a mailbox and confirm the reconnect copy appears.
- [x] After sync completes, confirm today's meetings render with guest names and expandable rows.
- [x] `php artisan test --compact tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php tests/Feature/EmailIntegration/MailboxImportStatusTest.php tests/Feature/CalendarIntegration/MeetingDetailTest.php`