### PR TITLE
Make the rich editor a document-style surface and retire the markdown editor

### DIFF
--- a/app/Enums/CustomFieldType.php
+++ b/app/Enums/CustomFieldType.php
@@ -20,7 +20,6 @@ enum CustomFieldType: string
     case CHECKBOX_LIST = 'checkbox-list';
     case RADIO = 'radio';
     case RICH_EDITOR = 'rich-editor';
-    case MARKDOWN_EDITOR = 'markdown-editor';
     case TAGS_INPUT = 'tags-input';
     case COLOR_PICKER = 'color-picker';
     case TOGGLE = 'toggle';

--- a/app/Filament/CustomFields/RichEditorFieldType.php
+++ b/app/Filament/CustomFields/RichEditorFieldType.php
@@ -9,6 +9,7 @@ use App\Enums\CustomFields\NoteField;
 use App\Enums\CustomFields\TaskField;
 use App\Filament\RichEditor\SlashMenuPlugin;
 use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
 use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
 use Relaticle\CustomFields\FieldTypeSystem\Definitions\RichEditorFieldType as PackageRichEditorFieldType;
 use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
@@ -16,8 +17,6 @@ use Relaticle\CustomFields\Models\CustomField;
 
 final class RichEditorFieldType extends BaseFieldType
 {
-    // Never add `heading`: Filament shows a node's floating toolbar whenever the caret
-    // sits in it, which would park a toolbar under every heading being typed.
     /** @var list<string> */
     private const array FLOATING_TOOLBAR = ['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link'];
 
@@ -39,14 +38,35 @@ final class RichEditorFieldType extends BaseFieldType
                 // and there is no toolbar: without this, an uploaded image saves as null.
                 ->fileAttachments(true)
                 // The defaults carry the table controls, unreachable otherwise without a toolbar.
-                ->floatingToolbars(fn (RichEditor $component): array => [
-                    'paragraph' => self::FLOATING_TOOLBAR,
-                    ...$component->getDefaultFloatingToolbars(),
-                ])
+                ->floatingToolbars(function (RichEditor $component): array {
+                    $tools = $component->getTools();
+                    $tools['paragraph']->label(__('filament/rich-editor.slash_menu.items.paragraph.label'));
+                    $tools['h1']->label(__('filament/rich-editor.slash_menu.items.h1.label'));
+                    $tools['h2']->label(__('filament/rich-editor.slash_menu.items.h2.label'));
+                    $tools['h3']->label(__('filament/rich-editor.slash_menu.items.h3.label'));
+
+                    return [
+                        'paragraph' => $this->selectionToolbar(),
+                        'heading' => $this->selectionToolbar(),
+                        ...$component->getDefaultFloatingToolbars(),
+                    ];
+                })
                 ->extraAttributes(fn (RichEditor $component): array => [
                     ...SlashMenuPlugin::attributes($component),
                     ...($this->isDocument($customField) ? ['class' => 'fi-fo-rich-editor-seamless'] : []),
                 ]));
+    }
+
+    /** @return list<string | ToolbarButtonGroup> */
+    private function selectionToolbar(): array
+    {
+        return [
+            ToolbarButtonGroup::make(
+                __('filament/rich-editor.selection_toolbar.text_style'),
+                ['paragraph', 'h1', 'h2', 'h3'],
+            )->textualButtons(),
+            ...self::FLOATING_TOOLBAR,
+        ];
     }
 
     private function isDocument(CustomField $customField): bool

--- a/app/Filament/CustomFields/RichEditorFieldType.php
+++ b/app/Filament/CustomFields/RichEditorFieldType.php
@@ -35,6 +35,9 @@ final class RichEditorFieldType extends BaseFieldType
             ->formComponent(fn (CustomField $customField): RichEditor => RichEditor::make($customField->getFieldName())
                 ->plugins([SlashMenuPlugin::make()])
                 ->toolbarButtons([])
+                // Filament decides attachments by whether `attachFiles` sits in the toolbar,
+                // and there is no toolbar: without this, an uploaded image saves as null.
+                ->fileAttachments(true)
                 // The defaults carry the table controls, unreachable otherwise without a toolbar.
                 ->floatingToolbars(fn (RichEditor $component): array => [
                     'paragraph' => self::FLOATING_TOOLBAR,

--- a/app/Filament/CustomFields/RichEditorFieldType.php
+++ b/app/Filament/CustomFields/RichEditorFieldType.php
@@ -42,11 +42,11 @@ final class RichEditorFieldType extends BaseFieldType
                 ])
                 ->extraAttributes(fn (RichEditor $component): array => [
                     ...SlashMenuPlugin::attributes($component),
-                    ...(self::isDocument($customField) ? ['class' => 'fi-fo-rich-editor-seamless'] : []),
+                    ...($this->isDocument($customField) ? ['class' => 'fi-fo-rich-editor-seamless'] : []),
                 ]));
     }
 
-    private static function isDocument(CustomField $customField): bool
+    private function isDocument(CustomField $customField): bool
     {
         return (self::DOCUMENT_FIELDS[$customField->entity_type] ?? null) === $customField->code;
     }

--- a/app/Filament/CustomFields/RichEditorFieldType.php
+++ b/app/Filament/CustomFields/RichEditorFieldType.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\CustomFields;
+
+use App\Filament\RichEditor\SlashMenuPlugin;
+use Filament\Forms\Components\RichEditor;
+use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
+use Relaticle\CustomFields\FieldTypeSystem\Definitions\RichEditorFieldType as PackageRichEditorFieldType;
+use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
+use Relaticle\CustomFields\Models\CustomField;
+
+/**
+ * Gives every rich-editor custom field a document-style editor: no toolbar, blocks from
+ * the `/` menu, inline marks from a toolbar that floats over the selection.
+ *
+ * The package class is final, so the schema is taken from an instance of it rather than
+ * inherited, and only the form component is replaced.
+ */
+final class RichEditorFieldType extends BaseFieldType
+{
+    /**
+     * Shown over a selection inside a paragraph, which covers list items too, since a
+     * list item wraps one. Headings are deliberately absent: Filament shows a node's
+     * floating toolbar whenever the cursor sits in that node, so registering `heading`
+     * would park a toolbar under the caret for as long as you type a heading.
+     *
+     * @var list<string>
+     */
+    private const array FLOATING_TOOLBAR = ['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link'];
+
+    public function configure(): FieldSchema
+    {
+        return (new PackageRichEditorFieldType)->configure()
+            ->formComponent(fn (CustomField $customField): RichEditor => RichEditor::make($customField->getFieldName())
+                ->plugins([SlashMenuPlugin::make()])
+                ->toolbarButtons([])
+                // Filament's default covers tables, whose controls would otherwise be
+                // unreachable in existing content now that there is no toolbar.
+                ->floatingToolbars(fn (RichEditor $component): array => [
+                    'paragraph' => self::FLOATING_TOOLBAR,
+                    ...$component->getDefaultFloatingToolbars(),
+                ])
+                ->extraAttributes(fn (RichEditor $component): array => [
+                    ...SlashMenuPlugin::attributes($component),
+                    'class' => 'fi-fo-rich-editor-seamless',
+                ]));
+    }
+}

--- a/app/Filament/CustomFields/RichEditorFieldType.php
+++ b/app/Filament/CustomFields/RichEditorFieldType.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Filament\CustomFields;
 
+use App\Enums\CrmEntity;
+use App\Enums\CustomFields\NoteField;
+use App\Enums\CustomFields\TaskField;
 use App\Filament\RichEditor\SlashMenuPlugin;
 use Filament\Forms\Components\RichEditor;
 use Relaticle\CustomFields\FieldTypeSystem\BaseFieldType;
@@ -18,6 +21,14 @@ final class RichEditorFieldType extends BaseFieldType
     /** @var list<string> */
     private const array FLOATING_TOOLBAR = ['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link'];
 
+    // The borderless canvas fills the form's slack, which only reads as a document where
+    // the editor is the form's main field. Elsewhere it would swallow the fields around it.
+    /** @var array<string, string> */
+    private const array DOCUMENT_FIELDS = [
+        CrmEntity::Note->value => NoteField::BODY->value,
+        CrmEntity::Task->value => TaskField::DESCRIPTION->value,
+    ];
+
     public function configure(): FieldSchema
     {
         return (new PackageRichEditorFieldType)->configure()
@@ -31,7 +42,12 @@ final class RichEditorFieldType extends BaseFieldType
                 ])
                 ->extraAttributes(fn (RichEditor $component): array => [
                     ...SlashMenuPlugin::attributes($component),
-                    'class' => 'fi-fo-rich-editor-seamless',
+                    ...(self::isDocument($customField) ? ['class' => 'fi-fo-rich-editor-seamless'] : []),
                 ]));
+    }
+
+    private static function isDocument(CustomField $customField): bool
+    {
+        return (self::DOCUMENT_FIELDS[$customField->entity_type] ?? null) === $customField->code;
     }
 }

--- a/app/Filament/CustomFields/RichEditorFieldType.php
+++ b/app/Filament/CustomFields/RichEditorFieldType.php
@@ -11,23 +11,11 @@ use Relaticle\CustomFields\FieldTypeSystem\Definitions\RichEditorFieldType as Pa
 use Relaticle\CustomFields\FieldTypeSystem\FieldSchema;
 use Relaticle\CustomFields\Models\CustomField;
 
-/**
- * Gives every rich-editor custom field a document-style editor: no toolbar, blocks from
- * the `/` menu, inline marks from a toolbar that floats over the selection.
- *
- * The package class is final, so the schema is taken from an instance of it rather than
- * inherited, and only the form component is replaced.
- */
 final class RichEditorFieldType extends BaseFieldType
 {
-    /**
-     * Shown over a selection inside a paragraph, which covers list items too, since a
-     * list item wraps one. Headings are deliberately absent: Filament shows a node's
-     * floating toolbar whenever the cursor sits in that node, so registering `heading`
-     * would park a toolbar under the caret for as long as you type a heading.
-     *
-     * @var list<string>
-     */
+    // Never add `heading`: Filament shows a node's floating toolbar whenever the caret
+    // sits in it, which would park a toolbar under every heading being typed.
+    /** @var list<string> */
     private const array FLOATING_TOOLBAR = ['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link'];
 
     public function configure(): FieldSchema
@@ -36,8 +24,7 @@ final class RichEditorFieldType extends BaseFieldType
             ->formComponent(fn (CustomField $customField): RichEditor => RichEditor::make($customField->getFieldName())
                 ->plugins([SlashMenuPlugin::make()])
                 ->toolbarButtons([])
-                // Filament's default covers tables, whose controls would otherwise be
-                // unreachable in existing content now that there is no toolbar.
+                // The defaults carry the table controls, unreachable otherwise without a toolbar.
                 ->floatingToolbars(fn (RichEditor $component): array => [
                     'paragraph' => self::FLOATING_TOOLBAR,
                     ...$component->getDefaultFloatingToolbars(),

--- a/app/Filament/RichEditor/SlashMenuPlugin.php
+++ b/app/Filament/RichEditor/SlashMenuPlugin.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\RichEditor;
+
+use Filament\Actions\Action;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\RichEditor\Actions\AttachFilesAction;
+use Filament\Forms\Components\RichEditor\Actions\LinkAction;
+use Filament\Forms\Components\RichEditor\Plugins\Contracts\RichContentPlugin;
+use Filament\Forms\Components\RichEditor\RichEditorTool;
+use Filament\Support\Facades\FilamentAsset;
+use Filament\Support\Icons\Heroicon;
+use LogicException;
+use Tiptap\Core\Extension;
+
+use function Filament\Support\generate_icon_html;
+
+/**
+ * A `/` command menu for the rich editor, so block formatting needs no toolbar.
+ *
+ * Every entry is one of Filament's own `RichEditorTool`s. The menu reuses that tool's
+ * icon and JS handler rather than restating them, which is what keeps a menu entry and
+ * its toolbar equivalent from drifting apart.
+ */
+final class SlashMenuPlugin implements RichContentPlugin
+{
+    /**
+     * Filament tool name => its menu entry. `group` buckets it under a heading,
+     * `shortcut` shows the markdown that does the same thing (only ones verified to
+     * fire: there is no code-fence rule), and `icon` overrides the tool's own, which
+     * for the file upload is a paperclip while the entry reads "Image".
+     *
+     * @var array<string, array{group: string, shortcut?: string, icon?: Heroicon}>
+     */
+    private const array ITEMS = [
+        'h1' => ['group' => 'text', 'shortcut' => '#'],
+        'h2' => ['group' => 'text', 'shortcut' => '##'],
+        'h3' => ['group' => 'text', 'shortcut' => '###'],
+        'paragraph' => ['group' => 'text'],
+        'blockquote' => ['group' => 'text', 'shortcut' => '>'],
+        'bulletList' => ['group' => 'lists', 'shortcut' => '-'],
+        'orderedList' => ['group' => 'lists', 'shortcut' => '1.'],
+        'codeBlock' => ['group' => 'insert'],
+        'table' => ['group' => 'insert'],
+        'details' => ['group' => 'insert'],
+        'horizontalRule' => ['group' => 'insert', 'shortcut' => '---'],
+        'attachFiles' => ['group' => 'insert', 'icon' => Heroicon::OutlinedPhoto],
+    ];
+
+    public static function make(): self
+    {
+        return resolve(self::class);
+    }
+
+    /**
+     * The menu is delivered as an attribute on the editor's wrapper rather than through
+     * `getEditorTools()`, because a tool only renders when the toolbar lists it and this
+     * editor has no toolbar.
+     *
+     * @return array<string, string>
+     */
+    public static function attributes(RichEditor $editor): array
+    {
+        $tools = $editor->getTools();
+
+        $items = [];
+
+        foreach (self::ITEMS as $name => $item) {
+            $tool = $tools[$name] ?? throw new LogicException("Slash menu item [{$name}] is not a rich editor tool.");
+
+            $items[] = [
+                'id' => $name,
+                'label' => __("filament/rich-editor.slash_menu.items.{$name}.label"),
+                'description' => __("filament/rich-editor.slash_menu.items.{$name}.description"),
+                'group' => __("filament/rich-editor.slash_menu.groups.{$item['group']}"),
+                'shortcut' => $item['shortcut'] ?? null,
+                'icon' => self::iconHtml($tool, $item['icon'] ?? null),
+                'action' => $tool->getJsHandler(),
+            ];
+        }
+
+        // Everything travels in one base64 attribute because Laravel's attribute bag
+        // escapes a `"` as `\"`, which means nothing in HTML: the first quote closes the
+        // attribute and the remainder is parsed as markup. A quote in a translated
+        // string is enough to do it, and the debris lands on the editor's wrapper as a
+        // stray `:query` attribute that Alpine then reads as an empty binding.
+        // Encoding keeps default json_encode escaping, so the payload stays ASCII and
+        // `atob` is safe.
+        return [
+            'data-slash-menu' => base64_encode((string) json_encode([
+                'items' => $items,
+                'noResults' => __('filament/rich-editor.slash_menu.no_results'),
+                'placeholder' => __('filament/rich-editor.placeholder'),
+            ])),
+        ];
+    }
+
+    /**
+     * @return array<Extension>
+     */
+    public function getTipTapPhpExtensions(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getTipTapJsExtensions(): array
+    {
+        return [FilamentAsset::getScriptSrc('rich-editor-slash-menu')];
+    }
+
+    /**
+     * @return array<RichEditorTool>
+     */
+    public function getEditorTools(): array
+    {
+        return [];
+    }
+
+    /**
+     * Filament's own actions, re-declared so they overlay the form they were opened
+     * from instead of replacing it. `cacheActions()` keys by name and plugin actions
+     * are merged last, so these win.
+     *
+     * @return array<Action>
+     */
+    public function getEditorActions(): array
+    {
+        return [
+            AttachFilesAction::make()->overlayParentActions(),
+            LinkAction::make()->overlayParentActions(),
+        ];
+    }
+
+    private static function iconHtml(RichEditorTool $tool, ?Heroicon $icon): string
+    {
+        return (string) generate_icon_html(
+            $icon ?? $tool->getIcon(),
+            alias: $icon instanceof Heroicon ? null : $tool->getIconAlias(),
+        )?->toHtml();
+    }
+}

--- a/app/Filament/RichEditor/SlashMenuPlugin.php
+++ b/app/Filament/RichEditor/SlashMenuPlugin.php
@@ -17,23 +17,10 @@ use Tiptap\Core\Extension;
 
 use function Filament\Support\generate_icon_html;
 
-/**
- * A `/` command menu for the rich editor, so block formatting needs no toolbar.
- *
- * Every entry is one of Filament's own `RichEditorTool`s. The menu reuses that tool's
- * icon and JS handler rather than restating them, which is what keeps a menu entry and
- * its toolbar equivalent from drifting apart.
- */
 final class SlashMenuPlugin implements RichContentPlugin
 {
-    /**
-     * Filament tool name => its menu entry. `group` buckets it under a heading,
-     * `shortcut` shows the markdown that does the same thing (only ones verified to
-     * fire: there is no code-fence rule), and `icon` overrides the tool's own, which
-     * for the file upload is a paperclip while the entry reads "Image".
-     *
-     * @var array<string, array{group: string, shortcut?: string, icon?: Heroicon}>
-     */
+    // List only shortcuts verified to fire: there is no code-fence input rule.
+    /** @var array<string, array{group: string, shortcut?: string, icon?: Heroicon}> */
     private const array ITEMS = [
         'h1' => ['group' => 'text', 'shortcut' => '#'],
         'h2' => ['group' => 'text', 'shortcut' => '##'],
@@ -54,13 +41,8 @@ final class SlashMenuPlugin implements RichContentPlugin
         return resolve(self::class);
     }
 
-    /**
-     * The menu is delivered as an attribute on the editor's wrapper rather than through
-     * `getEditorTools()`, because a tool only renders when the toolbar lists it and this
-     * editor has no toolbar.
-     *
-     * @return array<string, string>
-     */
+    // Not `getEditorTools()`: a tool renders only when the toolbar lists it, and there is none.
+    /** @return array<string, string> */
     public static function attributes(RichEditor $editor): array
     {
         $tools = $editor->getTools();
@@ -81,13 +63,8 @@ final class SlashMenuPlugin implements RichContentPlugin
             ];
         }
 
-        // Everything travels in one base64 attribute because Laravel's attribute bag
-        // escapes a `"` as `\"`, which means nothing in HTML: the first quote closes the
-        // attribute and the remainder is parsed as markup. A quote in a translated
-        // string is enough to do it, and the debris lands on the editor's wrapper as a
-        // stray `:query` attribute that Alpine then reads as an empty binding.
-        // Encoding keeps default json_encode escaping, so the payload stays ASCII and
-        // `atob` is safe.
+        // Base64, not raw JSON: the attribute bag escapes `"` as `\"`, so a quote in a
+        // translation would close the attribute. Default json_encode keeps it ASCII for `atob`.
         return [
             'data-slash-menu' => base64_encode((string) json_encode([
                 'items' => $items,
@@ -121,13 +98,8 @@ final class SlashMenuPlugin implements RichContentPlugin
         return [];
     }
 
-    /**
-     * Filament's own actions, re-declared so they overlay the form they were opened
-     * from instead of replacing it. `cacheActions()` keys by name and plugin actions
-     * are merged last, so these win.
-     *
-     * @return array<Action>
-     */
+    // Same names as Filament's own so they overlay the parent form: plugin actions merge last and win.
+    /** @return array<Action> */
     public function getEditorActions(): array
     {
         return [

--- a/app/Filament/RichEditor/SlashMenuPlugin.php
+++ b/app/Filament/RichEditor/SlashMenuPlugin.php
@@ -70,6 +70,7 @@ final class SlashMenuPlugin implements RichContentPlugin
                 'items' => $items,
                 'noResults' => __('filament/rich-editor.slash_menu.no_results'),
                 'placeholder' => __('filament/rich-editor.placeholder'),
+                'limitReached' => __('filament/rich-editor.limit_reached'),
             ])),
         ];
     }

--- a/app/Mcp/Resources/Concerns/ResolvesEntitySchema.php
+++ b/app/Mcp/Resources/Concerns/ResolvesEntitySchema.php
@@ -102,7 +102,6 @@ trait ResolvesEntitySchema
             CustomFieldType::MULTI_SELECT, CustomFieldType::CHECKBOX_LIST => ['format' => 'array of option labels or IDs (see options)', 'example' => ['Enterprise', 'EU']],
             CustomFieldType::TAGS_INPUT => ['format' => 'array of arbitrary string values', 'example' => ['priority', 'customer']],
             CustomFieldType::RICH_EDITOR => ['format' => 'markdown, or HTML when the value starts with <; stored and returned as HTML', 'example' => "## Notes\n- first call done"],
-            CustomFieldType::MARKDOWN_EDITOR => ['format' => 'markdown', 'example' => '**Follow up** Friday'],
             CustomFieldType::COLOR_PICKER => ['format' => 'hex color string', 'example' => '#0A80EA'],
             CustomFieldType::DATE => ['format' => 'ISO 8601 date', 'example' => '2026-09-10'],
             CustomFieldType::DATE_TIME => ['format' => 'ISO 8601 datetime string', 'example' => '2025-01-15T10:30:00Z'],

--- a/app/Mcp/Schema/CustomFieldFilterSchema.php
+++ b/app/Mcp/Schema/CustomFieldFilterSchema.php
@@ -21,7 +21,6 @@ final readonly class CustomFieldFilterSchema
         CustomFieldType::RECORD->value,
         CustomFieldType::TEXTAREA->value,
         CustomFieldType::RICH_EDITOR->value,
-        CustomFieldType::MARKDOWN_EDITOR->value,
     ];
 
     /** @var array<int, string> */

--- a/app/Mcp/Tools/SearchTool.php
+++ b/app/Mcp/Tools/SearchTool.php
@@ -38,7 +38,6 @@ final class SearchTool extends Tool
         'checkbox-list',
         'tags-input',
         'rich-editor',
-        'markdown-editor',
     ];
 
     public function __construct(private readonly CanonicalRecordUrl $urls) {}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Enums\CrmEntity;
 use App\Enums\Plan;
 use App\Filament\CustomFields\DateFieldType;
 use App\Filament\CustomFields\DateTimeFieldType;
+use App\Filament\CustomFields\RichEditorFieldType;
 use App\Http\Responses\LoginResponse;
 use App\Listeners\Billing\SyncPlanOnStripeSubscriptionChange;
 use App\Listeners\Email\NewSubscriberListener;
@@ -49,6 +50,8 @@ use Filament\Auth\Notifications\VerifyEmail;
 use Filament\Auth\Notifications\VerifyEmailChange;
 use Filament\Facades\Filament;
 use Filament\Livewire\Notifications;
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Support\Facades\FilamentTimezone;
 use Illuminate\Auth\Events\Login;
@@ -512,9 +515,12 @@ final class AppServiceProvider extends ServiceProvider
         //
         // `date` gets the entry only. A bare date has no time of day, so converting one
         // would move it a day for every viewer west of UTC.
+        //
+        // `rich-editor` swaps only the form component, to add the `/` command menu.
         CustomFieldsType::register([
             'date-time' => DateTimeFieldType::class,
             'date' => DateFieldType::class,
+            'rich-editor' => RichEditorFieldType::class,
         ]);
 
         $this->configureCustomFieldSchemaInvalidation();
@@ -601,6 +607,13 @@ final class AppServiceProvider extends ServiceProvider
 
             return in_array($timezone, timezone_identifiers_list(), true) ? $timezone : null;
         });
+
+        // Downloaded only once a rich editor is on the page, so panels without one
+        // pay nothing. Republish with `php artisan filament:assets` after editing it.
+        FilamentAsset::register([
+            Js::make('rich-editor-slash-menu', resource_path('js/filament/rich-content-plugins/slash-menu.js'))
+                ->loadedOnRequest(),
+        ]);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -611,6 +611,9 @@ final class AppServiceProvider extends ServiceProvider
             Js::make('rich-editor-slash-menu', resource_path('js/filament/rich-content-plugins/slash-menu.js'))
                 ->loadedOnRequest(),
         ]);
+
+        // App assets are otherwise versioned with Filament's release, so an edit would keep its cached URL.
+        FilamentAsset::appVersion((string) filemtime(public_path('js/app/rich-editor-slash-menu.js')));
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -610,7 +610,10 @@ final class AppServiceProvider extends ServiceProvider
         FilamentAsset::register([
             Js::make('rich-editor-slash-menu', resource_path('js/filament/rich-content-plugins/slash-menu.js'))
                 ->loadedOnRequest(),
+            Js::make('payload-guard', resource_path('js/filament/payload-guard.js')),
         ]);
+
+        FilamentAsset::registerScriptData(['payloadTooLarge' => __('filament/panel.payload_too_large')]);
 
         // App assets are otherwise versioned with Filament's release, so an edit would keep its cached URL.
         FilamentAsset::appVersion((string) filemtime(public_path('js/app/rich-editor-slash-menu.js')));

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -515,8 +515,6 @@ final class AppServiceProvider extends ServiceProvider
         //
         // `date` gets the entry only. A bare date has no time of day, so converting one
         // would move it a day for every viewer west of UTC.
-        //
-        // `rich-editor` swaps only the form component, to add the `/` command menu.
         CustomFieldsType::register([
             'date-time' => DateTimeFieldType::class,
             'date' => DateFieldType::class,
@@ -608,8 +606,7 @@ final class AppServiceProvider extends ServiceProvider
             return in_array($timezone, timezone_identifiers_list(), true) ? $timezone : null;
         });
 
-        // Downloaded only once a rich editor is on the page, so panels without one
-        // pay nothing. Republish with `php artisan filament:assets` after editing it.
+        // The browser loads the published copy: run `php artisan filament:assets` after editing it.
         FilamentAsset::register([
             Js::make('rich-editor-slash-menu', resource_path('js/filament/rich-content-plugins/slash-menu.js'))
                 ->loadedOnRequest(),

--- a/app/Support/CustomFields/CustomFieldInput.php
+++ b/app/Support/CustomFields/CustomFieldInput.php
@@ -71,7 +71,6 @@ final readonly class CustomFieldInput
             CustomFieldType::LINK,
             CustomFieldType::TEXTAREA,
             CustomFieldType::CHECKBOX,
-            CustomFieldType::MARKDOWN_EDITOR,
             CustomFieldType::TAGS_INPUT,
             CustomFieldType::COLOR_PICKER,
             CustomFieldType::TOGGLE,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,10 +19,12 @@ use Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\Route;
 use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
+use Livewire\Exceptions\PayloadTooLargeException;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
 use Sentry\Laravel\Integration;
 use Spatie\Health\Commands\DispatchQueueCheckJobsCommand;
@@ -174,6 +176,17 @@ return Application::configure(basePath: dirname(__DIR__))
         // They are user-state noise, not actionable errors, so keep them out of
         // Sentry (issue #125406836).
         $exceptions->dontReport(CorruptComponentPayloadException::class);
+
+        // Livewire rejects an oversized body before the component hydrates, so the panel
+        // cannot notify from the server; payload-guard.js turns this into a notification
+        // instead of the full-screen error overlay.
+        $exceptions->render(function (PayloadTooLargeException $e, Request $request): ?JsonResponse {
+            if (! $request->hasHeader('X-Livewire')) {
+                return null;
+            }
+
+            return response()->json(['message' => __('filament/panel.payload_too_large')], 413);
+        });
     })
     ->withSchedule(function (Schedule $schedule): void {
         $schedule->command('app:generate-sitemap')->daily();

--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -69,7 +69,10 @@ return [
     'field_type_configuration' => FieldTypeConfigurator::configure()
         // Control which field types are available globally
         ->enabled([]) // Empty = all enabled, or specify: ['text', 'email', 'select']
-        ->disabled(['file-upload']) // Disable specific field types
+        // markdown-editor is retired: the rich editor covers it, and two overlapping
+        // rich-text types only made the picker harder to read. Existing fields were
+        // converted by 2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.
+        ->disabled(['file-upload', 'markdown-editor'])
         ->discover(true)
         ->cache(enabled: true, ttl: 3600),
 

--- a/config/custom-fields.php
+++ b/config/custom-fields.php
@@ -69,9 +69,7 @@ return [
     'field_type_configuration' => FieldTypeConfigurator::configure()
         // Control which field types are available globally
         ->enabled([]) // Empty = all enabled, or specify: ['text', 'email', 'select']
-        // markdown-editor is retired: the rich editor covers it, and two overlapping
-        // rich-text types only made the picker harder to read. Existing fields were
-        // converted by 2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.
+        // A disabled type no longer resolves, so migrate its existing fields to another type first.
         ->disabled(['file-upload', 'markdown-editor'])
         ->discover(true)
         ->cache(enabled: true, ttl: 3600),

--- a/database/migrations/2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.php
+++ b/database/migrations/2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * The markdown editor is being removed from the field-type picker, and a type that is
+ * no longer registered cannot be resolved, so every existing field has to move to the
+ * rich editor first. Values move with them: the rich editor stores HTML, and markdown
+ * left as-is would render as its own source on the record page.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('custom_fields')
+            ->where('type', 'markdown-editor')
+            ->orderBy('id')
+            ->each(function (object $field): void {
+                $isEncrypted = (bool) data_get(json_decode((string) $field->settings, true) ?? [], 'encrypted', false);
+
+                DB::table('custom_field_values')
+                    ->where('custom_field_id', $field->id)
+                    ->whereNotNull('text_value')
+                    ->where('text_value', '<>', '')
+                    ->orderBy('id')
+                    ->each(fn (object $value) => $this->convertValue($value, $isEncrypted));
+            });
+
+        DB::table('custom_fields')
+            ->where('type', 'markdown-editor')
+            ->update(['type' => 'rich-editor']);
+    }
+
+    private function convertValue(object $value, bool $isEncrypted): void
+    {
+        try {
+            $markdown = $isEncrypted ? Crypt::decryptString($value->text_value) : $value->text_value;
+        } catch (Throwable $e) {
+            // Leaving it as markdown source shows the user their own text back, which
+            // they can reformat. Failing the deploy over one value would not.
+            Log::warning('Skipped a markdown custom field value that could not be read.', [
+                'custom_field_value_id' => $value->id,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $html = trim(Str::markdown($markdown));
+
+        DB::table('custom_field_values')
+            ->where('id', $value->id)
+            ->update(['text_value' => $isEncrypted ? Crypt::encryptString($html) : $html]);
+    }
+};

--- a/database/migrations/2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.php
+++ b/database/migrations/2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.php
@@ -8,28 +8,20 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
-/**
- * The markdown editor is being removed from the field-type picker, and a type that is
- * no longer registered cannot be resolved, so every existing field has to move to the
- * rich editor first. Values move with them: the rich editor stores HTML, and markdown
- * left as-is would render as its own source on the record page.
- */
 return new class extends Migration
 {
     public function up(): void
     {
         DB::table('custom_fields')
             ->where('type', 'markdown-editor')
-            ->orderBy('id')
-            ->each(function (object $field): void {
+            ->eachById(function (object $field): void {
                 $isEncrypted = (bool) data_get(json_decode((string) $field->settings, true) ?? [], 'encrypted', false);
 
                 DB::table('custom_field_values')
                     ->where('custom_field_id', $field->id)
                     ->whereNotNull('text_value')
                     ->where('text_value', '<>', '')
-                    ->orderBy('id')
-                    ->each(fn (object $value) => $this->convertValue($value, $isEncrypted));
+                    ->eachById(fn (object $value) => $this->convertValue($value, $isEncrypted));
             });
 
         DB::table('custom_fields')

--- a/lang/en/filament/panel.php
+++ b/lang/en/filament/panel.php
@@ -20,6 +20,8 @@ return [
         'tasks' => 'Tasks',
     ],
 
+    'payload_too_large' => 'That change is too large to save. Shorten the content and try again.',
+
     'selects' => [
         'member_self' => ':name (You)',
     ],

--- a/lang/en/filament/rich-editor.php
+++ b/lang/en/filament/rich-editor.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // `:key` is replaced with the trigger character, rendered as a key cap.
+    'placeholder' => 'Type :key to insert a heading, a list, or an image',
+
+    'slash_menu' => [
+        'no_results' => 'No blocks match ":query"',
+
+        'groups' => [
+            'text' => 'Text',
+            'lists' => 'Lists',
+            'insert' => 'Insert',
+        ],
+
+        'items' => [
+            'h1' => [
+                'label' => 'Heading 1',
+                'description' => 'Large section heading',
+            ],
+            'h2' => [
+                'label' => 'Heading 2',
+                'description' => 'Medium section heading',
+            ],
+            'h3' => [
+                'label' => 'Heading 3',
+                'description' => 'Small section heading',
+            ],
+            'paragraph' => [
+                'label' => 'Body',
+                'description' => 'Just start typing with plain text',
+            ],
+            'bulletList' => [
+                'label' => 'Bulleted list',
+                'description' => 'Create a simple bulleted list',
+            ],
+            'orderedList' => [
+                'label' => 'Numbered list',
+                'description' => 'Create a list with numbering',
+            ],
+            'blockquote' => [
+                'label' => 'Quote',
+                'description' => 'Set a passage apart',
+            ],
+            'codeBlock' => [
+                'label' => 'Code',
+                'description' => 'Capture a snippet',
+            ],
+            'table' => [
+                'label' => 'Table',
+                'description' => 'Lay data out in rows',
+            ],
+            'details' => [
+                'label' => 'Toggle',
+                'description' => 'Hide detail behind a summary',
+            ],
+            'horizontalRule' => [
+                'label' => 'Divider',
+                'description' => 'Separate sections with a line',
+            ],
+            'attachFiles' => [
+                'label' => 'Image',
+                'description' => 'Upload an image',
+            ],
+        ],
+    ],
+];

--- a/lang/en/filament/rich-editor.php
+++ b/lang/en/filament/rich-editor.php
@@ -8,6 +8,10 @@ return [
 
     'limit_reached' => 'This field is full. Delete some content to keep writing.',
 
+    'selection_toolbar' => [
+        'text_style' => 'Text style',
+    ],
+
     'slash_menu' => [
         'no_results' => 'No blocks match ":query"',
 

--- a/lang/en/filament/rich-editor.php
+++ b/lang/en/filament/rich-editor.php
@@ -6,6 +6,8 @@ return [
     // `:key` is replaced with the trigger character, rendered as a key cap.
     'placeholder' => 'Type :key to insert a heading, a list, or an image',
 
+    'limit_reached' => 'This field is full. Delete some content to keep writing.',
+
     'slash_menu' => [
         'no_results' => 'No blocks match ":query"',
 

--- a/packages/Chat/src/Services/Tools/CustomFieldsSchemaDescriber.php
+++ b/packages/Chat/src/Services/Tools/CustomFieldsSchemaDescriber.php
@@ -123,7 +123,6 @@ final readonly class CustomFieldsSchemaDescriber
             FieldDataType::DATE_TIME => 'ISO 8601, e.g. "2026-05-20T14:00:00Z"',
             FieldDataType::TEXT => match ($rawType) {
                 'rich-editor' => 'markdown, or HTML when the value starts with <; stored as HTML',
-                'markdown-editor' => 'markdown',
                 default => null,
             },
             FieldDataType::MULTI_CHOICE => $rawType === CustomFieldType::RECORD->value

--- a/packages/Chat/src/Tools/BaseReadShowTool.php
+++ b/packages/Chat/src/Tools/BaseReadShowTool.php
@@ -52,7 +52,6 @@ abstract class BaseReadShowTool implements Tool
      */
     private const array FREE_TEXT_FIELD_TYPES = [
         CustomFieldType::RICH_EDITOR->value,
-        CustomFieldType::MARKDOWN_EDITOR->value,
         CustomFieldType::TEXTAREA->value,
     ];
 

--- a/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
+++ b/packages/Chat/src/Tools/CustomField/CreateCustomFieldTool.php
@@ -43,7 +43,7 @@ final class CreateCustomFieldTool implements Tool
                 ->description('The display name for the field (e.g. "Industry", "Priority"). Max 50 characters, and must not match an existing field on the same entity.')
                 ->required(),
             'type' => $schema->string()
-                ->description("The field type. Allowed: {$allowedTypes}. NOT allowed: file-upload, record, rich-editor, markdown-editor, currency.")
+                ->description("The field type. Allowed: {$allowedTypes}. NOT allowed: file-upload, record, rich-editor, currency.")
                 ->required(),
             'code' => $schema->string()
                 ->description('Optional machine-readable code (snake_case). Auto-generated from name if omitted.'),

--- a/packages/Chat/src/Tools/SearchCrmTool.php
+++ b/packages/Chat/src/Tools/SearchCrmTool.php
@@ -32,7 +32,6 @@ final class SearchCrmTool implements Tool
         'checkbox-list',
         'tags-input',
         'rich-editor',
-        'markdown-editor',
     ];
 
     public function description(): string

--- a/packages/Documentation/resources/content/help/custom-fields/field-types-you-can-add.md
+++ b/packages/Documentation/resources/content/help/custom-fields/field-types-you-can-add.md
@@ -2,7 +2,7 @@
 title: Field types you can add
 description: Every field type available for your records, from plain text to currency, rich editors, and record links.
 order: 1
-updated: "2026-08-13"
+updated: "2026-09-12"
 related: [help/custom-fields/add-and-manage-fields, help/custom-fields/edit-the-options-in-a-select-field]
 ---
 
@@ -16,8 +16,7 @@ type is locked once it's created.
 |------|----------|
 | Text | Short one-line values: a job title, a region |
 | Textarea | A few sentences without formatting |
-| Rich Editor | Formatted content: headings, lists, bold |
-| Markdown Editor | The same, written as Markdown |
+| Rich Editor | Formatted content: headings, lists, tables, images. Type / to insert a block |
 | Number | Plain numerics: headcount, a score |
 | Currency | Money: deal amounts, contract values |
 

--- a/public/js/app/payload-guard.js
+++ b/public/js/app/payload-guard.js
@@ -1,0 +1,23 @@
+// Livewire renders a failed request as a full-screen error overlay. A payload over the
+// cap is a content problem the writer can fix, so it gets a notification instead.
+document.addEventListener('livewire:init', () => {
+    window.Livewire.hook('request', ({ fail }) => {
+        fail(({ status, content, preventDefault }) => {
+            if (status !== 413) {
+                return
+            }
+
+            preventDefault()
+
+            let message = window.filamentData?.payloadTooLarge ?? ''
+
+            try {
+                message = JSON.parse(content).message || message
+            } catch (error) {
+                //
+            }
+
+            new window.FilamentNotification().title(message).danger().send()
+        })
+    })
+})

--- a/public/js/app/rich-editor-slash-menu.js
+++ b/public/js/app/rich-editor-slash-menu.js
@@ -54,7 +54,7 @@ const CANVAS_TOLERANCE = 2
 
 class CanvasFitView {
     constructor(view) {
-        this.content = view.dom.closest('.fi-fo-rich-editor-content')
+        this.content = view.dom.closest('.fi-fo-rich-editor-seamless .fi-fo-rich-editor-content')
         this.fit = this.fit.bind(this)
 
         if (! this.content) {

--- a/public/js/app/rich-editor-slash-menu.js
+++ b/public/js/app/rich-editor-slash-menu.js
@@ -398,7 +398,14 @@ export default Extension.create({
             // ProseMirror sets role="textbox" but not this, so a screen reader
             // announces a single-line field and reads Enter as submit.
             new Plugin({
-                props: { attributes: { 'aria-multiline': 'true' } },
+                props: {
+                    attributes(state) {
+                        return {
+                            'aria-multiline': 'true',
+                            'data-selection-empty': state.selection.empty ? 'true' : 'false',
+                        }
+                    },
+                },
             }),
 
             new Plugin({

--- a/public/js/app/rich-editor-slash-menu.js
+++ b/public/js/app/rich-editor-slash-menu.js
@@ -1,0 +1,449 @@
+// The document-editor behaviour for Filament's rich editor: a `/` command menu, a
+// styled placeholder, and a guaranteed trailing paragraph.
+//
+// Loaded as an ES module by the editor's `customExtensionUrls`, so it must not import
+// anything: the TipTap and ProseMirror it needs come from the editor's own bundle via
+// window.FilamentRichEditor. A second copy of either would break ProseMirror's
+// instanceof checks and the extension would silently stop interoperating.
+
+const { Extension } = window.FilamentRichEditor.tiptap.core
+const { Plugin, PluginKey, TextSelection } = window.FilamentRichEditor.tiptap.pmState
+const { Decoration, DecorationSet } = window.FilamentRichEditor.tiptap.pmView
+
+const PLUGIN_KEY = new PluginKey('slashMenu')
+
+// Only at the start of a block or after whitespace, so `https://` and `and/or` are quiet.
+const TRIGGER = /(?:^|\s)(\/[a-zA-Z0-9]*)$/
+
+// Blocks the caret cannot leave by typing: Enter adds a newline inside a code block,
+// and a table traps it in the last cell. Anything ending the document in one of these
+// needs a paragraph after it, or the canvas below is unreachable.
+const TRAPPING_BLOCKS = ['codeBlock', 'table', 'horizontalRule', 'details', 'grid']
+
+const trailingParagraph = (state) =>
+    state.tr.insert(state.doc.content.size, state.schema.nodes.paragraph.create())
+
+const endsInTrappingBlock = (doc) => TRAPPING_BLOCKS.includes(doc.lastChild?.type.name)
+
+const EMPTY_CONFIG = { items: [], noResults: '', placeholder: '' }
+
+const config = (view) => {
+    const host = view.dom.closest('[data-slash-menu]')
+
+    return host ? JSON.parse(atob(host.getAttribute('data-slash-menu'))) : EMPTY_CONFIG
+}
+
+// `:key` marks where the trigger character goes, so a translation can move it within
+// the sentence. Built as nodes rather than a CSS `content` string, which cannot style
+// one word of itself.
+const placeholderElement = (template) => {
+    const el = document.createElement('span')
+    el.className = 'fi-slash-placeholder'
+    el.setAttribute('aria-hidden', 'true')
+    el.contentEditable = 'false'
+
+    const [before, after = ''] = template.split(':key')
+    const key = document.createElement('kbd')
+    key.textContent = '/'
+
+    el.append(document.createTextNode(before), key, document.createTextNode(after))
+
+    return el
+}
+
+// Below this the panel is not worth flipping or capping to, so it is allowed to
+// overflow the viewport and scroll the page instead.
+const MIN_PANEL_HEIGHT = 160
+
+// The canvas takes up whatever slack the form has left, measured rather than guessed:
+// a viewport fraction that fits a note form overflows a denser one, and pure CSS cannot
+// do it because the schema between the modal and the field is grids sized to content.
+//
+// Slack is read from the whole form rather than from the canvas down, so a field BELOW
+// the editor keeps its room. The note form has none and the canvas reaches the footer;
+// the task form has a due date and the canvas stops short of it.
+const CANVAS_MIN_HEIGHT = 160
+const CANVAS_TOLERANCE = 2
+
+class CanvasFitView {
+    constructor(view) {
+        this.content = view.dom.closest('.fi-fo-rich-editor-content')
+        this.fit = this.fit.bind(this)
+
+        if (! this.content) {
+            return
+        }
+
+        // The modal body is `flex: 1`, so its own box already spans the panel and
+        // reports no slack. The form schema inside it is sized to its content.
+        const container = this.content.closest('.fi-modal-content')
+        this.extent = container?.lastElementChild ?? container ?? this.content
+
+        // The gap below the canvas is the container's own bottom padding, which sits
+        // outside `extent`. Counting it is what keeps the panel from scrolling by it.
+        this.gap = container ? parseFloat(getComputedStyle(container).paddingBottom) || 0 : 0
+
+        // The sticky footer's top is the bottom of the usable area, and it does not
+        // move when the canvas grows, so it is a stable limit to measure against.
+        this.footer = this.content.closest('.fi-modal-window')?.querySelector(':scope > .fi-modal-footer')
+
+        this.fit()
+
+        window.addEventListener('resize', this.fit)
+
+        // Each pass closes the gap exactly, so the observer settles in one more frame.
+        // It also catches the fields above changing height without a window resize.
+        this.observer = new ResizeObserver(this.fit)
+        this.observer.observe(this.extent)
+    }
+
+    fit() {
+        const limit = this.footer ? this.footer.getBoundingClientRect().top : window.innerHeight
+        const slack = limit - this.extent.getBoundingClientRect().bottom - this.gap
+
+        if (Math.abs(slack) < CANVAS_TOLERANCE) {
+            return
+        }
+
+        const height = this.content.getBoundingClientRect().height
+
+        this.content.style.minHeight = `${Math.max(height + slack, CANVAS_MIN_HEIGHT)}px`
+    }
+
+    destroy() {
+        window.removeEventListener('resize', this.fit)
+        this.observer?.disconnect()
+    }
+}
+
+class SlashMenuView {
+    constructor(view, settings) {
+        this.view = view
+        this.isOpen = false
+        this.items = []
+        this.activeIndex = 0
+        this.range = null
+
+        this.allItems = settings.items
+        this.noResults = settings.noResults
+        this.scope = view.dom.closest('[x-data]')
+
+        this.panel = document.createElement('div')
+        // fi-dropdown-list only to opt out of the panel's divide-y between children.
+        this.panel.className = 'fi-dropdown-panel fi-dropdown-list fi-width-2xs fi-not-prose fi-slash-menu'
+        this.panel.setAttribute('role', 'listbox')
+        this.panel.hidden = true
+        document.body.appendChild(this.panel)
+
+        this.onDocumentPointerDown = (event) => {
+            if (this.isOpen && ! this.panel.contains(event.target)) {
+                this.close()
+            }
+        }
+        document.addEventListener('mousedown', this.onDocumentPointerDown)
+    }
+
+    update() {
+        const trigger = this.detectTrigger()
+
+        if (! trigger) {
+            this.close()
+
+            return
+        }
+
+        this.range = trigger.range
+        this.items = this.filter(trigger.query)
+        this.activeIndex = 0
+        this.render()
+        this.open()
+    }
+
+    detectTrigger() {
+        const { selection } = this.view.state
+
+        if (! selection.empty) {
+            return null
+        }
+
+        const { $from } = selection
+
+        if ($from.parent.isAtom || ! $from.parent.isTextblock) {
+            return null
+        }
+
+        const match = $from.parent.textBetween(0, $from.parentOffset, undefined, '\n').match(TRIGGER)
+
+        if (! match) {
+            return null
+        }
+
+        return {
+            query: match[1].slice(1).toLowerCase(),
+            range: { from: $from.pos - match[1].length, to: $from.pos },
+        }
+    }
+
+    filter(query) {
+        if (query === '') {
+            return this.allItems
+        }
+
+        return this.allItems.filter(
+            (item) =>
+                item.id.toLowerCase().includes(query) ||
+                item.label.toLowerCase().replace(/\s/g, '').includes(query),
+        )
+    }
+
+    render() {
+        this.panel.innerHTML = ''
+        this.itemElements = []
+
+        if (this.items.length === 0) {
+            const empty = document.createElement('div')
+            empty.className = 'fi-slash-menu-empty'
+            empty.textContent = this.noResults.replace(':query', this.currentQuery())
+            this.panel.appendChild(empty)
+
+            return
+        }
+
+        let group = null
+
+        this.items.forEach((item, index) => {
+            if (item.group !== group) {
+                group = item.group
+
+                const heading = document.createElement('div')
+                heading.className = 'fi-slash-menu-group'
+                heading.textContent = group
+                this.panel.appendChild(heading)
+            }
+
+            this.panel.appendChild(this.renderItem(item, index))
+        })
+    }
+
+    renderItem(item, index) {
+        const button = document.createElement('button')
+        button.type = 'button'
+        button.className = 'fi-slash-menu-item'
+        button.setAttribute('role', 'option')
+        button.setAttribute('aria-selected', index === this.activeIndex ? 'true' : 'false')
+        button.title = item.description
+
+        const icon = document.createElement('span')
+        icon.className = 'fi-slash-menu-item-icon'
+        icon.innerHTML = item.icon
+
+        const label = document.createElement('span')
+        label.className = 'fi-slash-menu-item-label'
+        label.textContent = item.label
+
+        button.append(icon, label)
+
+        if (item.shortcut) {
+            const shortcut = document.createElement('kbd')
+            shortcut.className = 'fi-slash-menu-item-shortcut'
+            shortcut.textContent = item.shortcut
+            button.appendChild(shortcut)
+        }
+
+        // mousedown, not click: click fires after the editor has already lost focus,
+        // and the command needs a live selection to act on.
+        button.addEventListener('mousedown', (event) => {
+            event.preventDefault()
+            this.select(index)
+        })
+        button.addEventListener('mousemove', () => this.setActiveIndex(index))
+
+        this.itemElements[index] = button
+
+        return button
+    }
+
+    currentQuery() {
+        return this.range ? this.view.state.doc.textBetween(this.range.from + 1, this.range.to) : ''
+    }
+
+    setActiveIndex(index) {
+        if (this.activeIndex === index) {
+            return
+        }
+
+        this.activeIndex = index
+        this.render()
+    }
+
+    handleKeyDown(event) {
+        if (! this.isOpen) {
+            return false
+        }
+
+        if (event.key === 'Escape') {
+            this.close()
+
+            return true
+        }
+
+        if (this.items.length === 0) {
+            return false
+        }
+
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            const step = event.key === 'ArrowDown' ? 1 : -1
+            this.setActiveIndex((this.activeIndex + step + this.items.length) % this.items.length)
+            this.itemElements[this.activeIndex]?.scrollIntoView({ block: 'nearest' })
+
+            return true
+        }
+
+        if (event.key === 'Enter' || event.key === 'Tab') {
+            this.select(this.activeIndex)
+
+            return true
+        }
+
+        return false
+    }
+
+    select(index) {
+        const item = this.items[index]
+
+        if (! item) {
+            return
+        }
+
+        const { from, to } = this.range
+
+        this.close()
+        this.view.dispatch(this.view.state.tr.delete(from, to))
+
+        // Deferred so the component's `editorSelection` has caught up with the deletion:
+        // an action that opens a modal reads it server-side to know where to insert.
+        queueMicrotask(() => window.Alpine.evaluate(this.scope, item.action))
+    }
+
+    open() {
+        this.isOpen = true
+        this.panel.hidden = false
+        this.position()
+    }
+
+    close() {
+        this.isOpen = false
+        this.panel.hidden = true
+        this.range = null
+        this.items = []
+        this.activeIndex = 0
+    }
+
+    position() {
+        const margin = 8
+        const caret = this.view.coordsAtPos(this.range.from)
+
+        const spaceBelow = window.innerHeight - caret.bottom - margin * 2
+        const spaceAbove = caret.top - margin * 2
+
+        // Flip up only when below cannot hold the panel and above has more room. The
+        // chosen side then caps the height, so a short viewport scrolls the list
+        // instead of pushing it off-screen.
+        this.panel.style.maxHeight = ''
+        const placeAbove = this.panel.offsetHeight > spaceBelow && spaceAbove > spaceBelow
+        this.panel.style.maxHeight = `${Math.max(placeAbove ? spaceAbove : spaceBelow, MIN_PANEL_HEIGHT)}px`
+
+        const { offsetWidth: width, offsetHeight: height } = this.panel
+        const top = placeAbove ? caret.top - height - margin : caret.bottom + margin
+        const left = Math.min(caret.left, window.innerWidth - width - margin)
+
+        this.panel.style.top = `${Math.max(top, margin) + window.scrollY}px`
+        this.panel.style.left = `${Math.max(left, margin) + window.scrollX}px`
+    }
+
+    destroy() {
+        document.removeEventListener('mousedown', this.onDocumentPointerDown)
+        this.panel.remove()
+    }
+}
+
+export default Extension.create({
+    name: 'slashMenu',
+
+    addProseMirrorPlugins() {
+        const { editor } = this
+
+        let settings = null
+        const getSettings = () => (settings ??= config(editor.view))
+
+        let menu = null
+
+        return [
+            new Plugin({
+                key: PLUGIN_KEY,
+                view(editorView) {
+                    menu = new SlashMenuView(editorView, getSettings())
+
+                    return menu
+                },
+                props: {
+                    handleKeyDown: (view, event) => menu?.handleKeyDown(event) ?? false,
+                },
+            }),
+
+            // ProseMirror sets role="textbox" but not this, so a screen reader
+            // announces a single-line field and reads Enter as submit.
+            new Plugin({
+                props: { attributes: { 'aria-multiline': 'true' } },
+            }),
+
+            new Plugin({
+                view: (editorView) => new CanvasFitView(editorView),
+            }),
+
+            new Plugin({
+                props: {
+                    decorations({ doc }) {
+                        if (doc.childCount !== 1 || doc.firstChild.content.size > 0) {
+                            return null
+                        }
+
+                        return DecorationSet.create(doc, [
+                            Decoration.widget(1, placeholderElement(getSettings().placeholder), { side: 1 }),
+                        ])
+                    },
+                },
+            }),
+
+            new Plugin({
+                appendTransaction(transactions, oldState, newState) {
+                    if (! transactions.some((tr) => tr.docChanged)) {
+                        return null
+                    }
+
+                    return endsInTrappingBlock(newState.doc) ? trailingParagraph(newState) : null
+                },
+                props: {
+                    // Content that loaded with a trapping block last never went through
+                    // appendTransaction, so the click that reveals the gap also closes it.
+                    handleClick(view, pos, event) {
+                        const last = view.dom.lastElementChild
+
+                        if (! last || ! endsInTrappingBlock(view.state.doc)) {
+                            return false
+                        }
+
+                        if (event.clientY <= last.getBoundingClientRect().bottom) {
+                            return false
+                        }
+
+                        const tr = trailingParagraph(view.state)
+                        view.dispatch(tr.setSelection(TextSelection.near(tr.doc.resolve(tr.doc.content.size))))
+
+                        return true
+                    },
+                },
+            }),
+        ]
+    },
+})

--- a/public/js/app/rich-editor-slash-menu.js
+++ b/public/js/app/rich-editor-slash-menu.js
@@ -19,7 +19,24 @@ const trailingParagraph = (state) =>
 
 const endsInTrappingBlock = (doc) => TRAPPING_BLOCKS.includes(doc.lastChild?.type.name)
 
-const EMPTY_CONFIG = { items: [], noResults: '', placeholder: '' }
+const EMPTY_CONFIG = { items: [], noResults: '', placeholder: '', limitReached: '' }
+
+// Livewire rejects a request body over its payload cap (config/livewire.php) before any
+// validation runs, so the only place a document can be held in bounds is here.
+const MAX_DOC_SIZE = 200000
+
+let limitNoticeAt = 0
+
+// A notification, not an inline message: the canvas grows with the document, so an
+// element under it can sit thousands of pixels below the viewport.
+const limitNotice = (message) => {
+    if (Date.now() - limitNoticeAt < 4000 || ! window.FilamentNotification) {
+        return
+    }
+
+    limitNoticeAt = Date.now()
+    new window.FilamentNotification().title(message).danger().send()
+}
 
 const config = (view) => {
     const host = view.dom.closest('[data-slash-menu]')
@@ -382,6 +399,23 @@ export default Extension.create({
             // announces a single-line field and reads Enter as submit.
             new Plugin({
                 props: { attributes: { 'aria-multiline': 'true' } },
+            }),
+
+            new Plugin({
+                filterTransaction(tr, state) {
+                    if (! tr.docChanged || tr.doc.content.size <= MAX_DOC_SIZE) {
+                        return true
+                    }
+
+                    // Never block a shrinking document: the way out of the limit is deleting.
+                    if (tr.doc.content.size <= state.doc.content.size) {
+                        return true
+                    }
+
+                    limitNotice(getSettings().limitReached)
+
+                    return false
+                },
             }),
 
             new Plugin({

--- a/public/js/app/rich-editor-slash-menu.js
+++ b/public/js/app/rich-editor-slash-menu.js
@@ -1,10 +1,5 @@
-// The document-editor behaviour for Filament's rich editor: a `/` command menu, a
-// styled placeholder, and a guaranteed trailing paragraph.
-//
-// Loaded as an ES module by the editor's `customExtensionUrls`, so it must not import
-// anything: the TipTap and ProseMirror it needs come from the editor's own bundle via
-// window.FilamentRichEditor. A second copy of either would break ProseMirror's
-// instanceof checks and the extension would silently stop interoperating.
+// Never import here: a second TipTap or ProseMirror copy breaks ProseMirror's instanceof
+// checks, so both come from the editor's own bundle via window.FilamentRichEditor.
 
 const { Extension } = window.FilamentRichEditor.tiptap.core
 const { Plugin, PluginKey, TextSelection } = window.FilamentRichEditor.tiptap.pmState
@@ -15,9 +10,8 @@ const PLUGIN_KEY = new PluginKey('slashMenu')
 // Only at the start of a block or after whitespace, so `https://` and `and/or` are quiet.
 const TRIGGER = /(?:^|\s)(\/[a-zA-Z0-9]*)$/
 
-// Blocks the caret cannot leave by typing: Enter adds a newline inside a code block,
-// and a table traps it in the last cell. Anything ending the document in one of these
-// needs a paragraph after it, or the canvas below is unreachable.
+// Blocks the caret cannot type its way out of. A document ending in one needs a
+// paragraph after it, or the canvas below is unreachable.
 const TRAPPING_BLOCKS = ['codeBlock', 'table', 'horizontalRule', 'details', 'grid']
 
 const trailingParagraph = (state) =>
@@ -33,9 +27,7 @@ const config = (view) => {
     return host ? JSON.parse(atob(host.getAttribute('data-slash-menu'))) : EMPTY_CONFIG
 }
 
-// `:key` marks where the trigger character goes, so a translation can move it within
-// the sentence. Built as nodes rather than a CSS `content` string, which cannot style
-// one word of itself.
+// Built as nodes, not a CSS `content` string, so the trigger can render as a key cap.
 const placeholderElement = (template) => {
     const el = document.createElement('span')
     el.className = 'fi-slash-placeholder'
@@ -55,13 +47,8 @@ const placeholderElement = (template) => {
 // overflow the viewport and scroll the page instead.
 const MIN_PANEL_HEIGHT = 160
 
-// The canvas takes up whatever slack the form has left, measured rather than guessed:
-// a viewport fraction that fits a note form overflows a denser one, and pure CSS cannot
-// do it because the schema between the modal and the field is grids sized to content.
-//
-// Slack is read from the whole form rather than from the canvas down, so a field BELOW
-// the editor keeps its room. The note form has none and the canvas reaches the footer;
-// the task form has a due date and the canvas stops short of it.
+// Measured, not CSS: the schema between the modal and the field is content-sized grids.
+// Slack is read from the whole form, so a field below the editor keeps its room.
 const CANVAS_MIN_HEIGHT = 160
 const CANVAS_TOLERANCE = 2
 
@@ -346,9 +333,8 @@ class SlashMenuView {
         const spaceBelow = window.innerHeight - caret.bottom - margin * 2
         const spaceAbove = caret.top - margin * 2
 
-        // Flip up only when below cannot hold the panel and above has more room. The
-        // chosen side then caps the height, so a short viewport scrolls the list
-        // instead of pushing it off-screen.
+        // The chosen side caps the height, so a short viewport scrolls the list instead
+        // of pushing it off-screen.
         this.panel.style.maxHeight = ''
         const placeAbove = this.panel.offsetHeight > spaceBelow && spaceAbove > spaceBelow
         this.panel.style.maxHeight = `${Math.max(placeAbove ? spaceAbove : spaceBelow, MIN_PANEL_HEIGHT)}px`

--- a/public/js/app/rich-editor-slash-menu.js
+++ b/public/js/app/rich-editor-slash-menu.js
@@ -259,8 +259,9 @@ class SlashMenuView {
             return
         }
 
+        this.itemElements[this.activeIndex]?.setAttribute('aria-selected', 'false')
+        this.itemElements[index]?.setAttribute('aria-selected', 'true')
         this.activeIndex = index
-        this.render()
     }
 
     handleKeyDown(event) {
@@ -395,7 +396,7 @@ export default Extension.create({
                         }
 
                         return DecorationSet.create(doc, [
-                            Decoration.widget(1, placeholderElement(getSettings().placeholder), { side: 1 }),
+                            Decoration.widget(1, () => placeholderElement(getSettings().placeholder), { side: 1, key: 'slash-placeholder' }),
                         ])
                     },
                 },

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -959,3 +959,75 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
         @apply md:sticky md:top-8 md:self-start;
     }
 }
+
+/* Rich editor slash menu. The panel is appended to <body> so it escapes the
+   modal's overflow clipping; z-index 40 clears the modal window at 30. Rows are
+   one line so all twelve entries fit without scrolling; the description rides on
+   the row's title attribute. */
+.fi-slash-menu {
+    @apply absolute z-40 max-h-[28rem] w-screen overflow-y-auto p-1;
+}
+
+.fi-slash-menu-empty {
+    @apply px-2.5 py-3 text-center text-xs text-gray-500 dark:text-gray-400;
+}
+
+.fi-slash-menu-group {
+    @apply px-2.5 pt-2.5 pb-1 text-[0.6875rem] font-medium tracking-wide text-gray-400 uppercase dark:text-gray-500;
+
+    &:first-child {
+        @apply pt-1;
+    }
+}
+
+.fi-slash-menu-item {
+    @apply flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-start;
+
+    &[aria-selected='true'] {
+        @apply bg-gray-100 dark:bg-white/10;
+    }
+}
+
+.fi-slash-menu-item-icon {
+    @apply flex size-6 shrink-0 items-center justify-center rounded bg-gray-50 text-gray-500 ring-1 ring-gray-950/5 dark:bg-white/5 dark:text-gray-400 dark:ring-white/10;
+
+    svg {
+        @apply size-3.5;
+    }
+}
+
+.fi-slash-menu-item-label {
+    @apply flex-1 truncate text-[0.8125rem] text-gray-950 dark:text-white;
+}
+
+.fi-slash-menu-item-shortcut {
+    @apply shrink-0 rounded border border-gray-200 bg-gray-50 px-1 font-sans text-[0.6875rem] text-gray-400 dark:border-white/10 dark:bg-white/5 dark:text-gray-500;
+}
+
+/* Rich editor without the input chrome: the field label and placeholder carry the
+   affordance, so the box would only box in what should read as a document. */
+.fi-fo-rich-editor-seamless {
+    @apply rounded-none bg-transparent shadow-none ring-0 dark:bg-transparent;
+
+    &:not(.fi-disabled):not(:has(.fi-ac-action:focus)) {
+        @apply focus-within:ring-0;
+    }
+
+    /* The canvas height is measured in JS (see slash-menu.js); this is only the
+       floor it starts from. Content grows past it and the modal scrolls, so no
+       max-height here, which would nest a second scrollbar inside the first. */
+    .fi-fo-rich-editor-content {
+        @apply min-h-40 px-0 py-0 text-[0.9375rem]/[1.65];
+    }
+}
+
+/* The editor renders its own placeholder as a decoration, so the trigger character
+   can be a key cap. Filament's `content: attr(data-placeholder)` cannot style part
+   of itself. */
+.fi-slash-placeholder {
+    @apply pointer-events-none absolute inline-flex select-none items-center gap-1 text-gray-400 dark:text-gray-500;
+
+    kbd {
+        @apply inline-flex h-5 min-w-5 items-center justify-center rounded border border-gray-200 bg-gray-50 px-1 font-sans text-xs text-gray-500 dark:border-white/10 dark:bg-white/5 dark:text-gray-400;
+    }
+}

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -960,10 +960,8 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     }
 }
 
-/* Rich editor slash menu. The panel is appended to <body> so it escapes the
-   modal's overflow clipping; z-index 40 clears the modal window at 30. Rows are
-   one line so all twelve entries fit without scrolling; the description rides on
-   the row's title attribute. */
+/* The slash menu is appended to <body> to escape the modal's overflow clipping,
+   so z-40 has to clear the modal window at 30. */
 .fi-slash-menu {
     @apply absolute z-40 max-h-[28rem] w-screen overflow-y-auto p-1;
 }
@@ -1013,17 +1011,15 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
         @apply focus-within:ring-0;
     }
 
-    /* The canvas height is measured in JS (see slash-menu.js); this is only the
-       floor it starts from. Content grows past it and the modal scrolls, so no
-       max-height here, which would nest a second scrollbar inside the first. */
+    /* A floor only: slash-menu.js measures the real height. No max-height, which
+       would nest a second scrollbar inside the modal's. */
     .fi-fo-rich-editor-content {
         @apply min-h-40 px-0 py-0 text-[0.9375rem]/[1.65];
     }
 }
 
-/* The editor renders its own placeholder as a decoration, so the trigger character
-   can be a key cap. Filament's `content: attr(data-placeholder)` cannot style part
-   of itself. */
+/* The editor draws its own placeholder so the trigger can be a key cap, which
+   Filament's `content: attr(data-placeholder)` cannot style. */
 .fi-slash-placeholder {
     @apply pointer-events-none absolute inline-flex select-none items-center gap-1 text-gray-400 dark:text-gray-500;
 

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -1014,7 +1014,13 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     /* A floor only: slash-menu.js measures the real height. No max-height, which
        would nest a second scrollbar inside the modal's. */
     .fi-fo-rich-editor-content {
-        @apply min-h-40 px-4 py-3.5 text-[0.9375rem]/[1.65];
+        @apply flex min-h-40 flex-col px-4 py-3.5 text-[0.9375rem]/[1.65];
+
+        /* The editable element fills the fill, so a click anywhere in the page,
+           including the empty space under the last block, lands in the document. */
+        .ProseMirror {
+            @apply flex-1;
+        }
     }
 }
 

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -1002,10 +1002,10 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     @apply shrink-0 rounded border border-gray-200 bg-gray-50 px-1 font-sans text-[0.6875rem] text-gray-400 dark:border-white/10 dark:bg-white/5 dark:text-gray-500;
 }
 
-/* Rich editor without the input chrome: the field label and placeholder carry the
-   affordance, so the box would only box in what should read as a document. */
+/* A page rather than an input: the fill marks the writing area without a border or
+   ring, which a form of bordered fields would otherwise swallow. */
 .fi-fo-rich-editor-seamless {
-    @apply rounded-none bg-transparent shadow-none ring-0 dark:bg-transparent;
+    @apply rounded-xl bg-[var(--surface-input-bg)] shadow-none ring-0;
 
     &:not(.fi-disabled):not(:has(.fi-ac-action:focus)) {
         @apply focus-within:ring-0;
@@ -1014,7 +1014,7 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     /* A floor only: slash-menu.js measures the real height. No max-height, which
        would nest a second scrollbar inside the modal's. */
     .fi-fo-rich-editor-content {
-        @apply min-h-40 px-0 py-0 text-[0.9375rem]/[1.65];
+        @apply min-h-40 px-4 py-3.5 text-[0.9375rem]/[1.65];
     }
 }
 

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -960,6 +960,26 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     }
 }
 
+[data-slash-menu] {
+    .fi-fo-rich-editor-floating-toolbar {
+        @apply gap-x-1;
+    }
+
+    @media (width < 40rem) {
+        .fi-fo-rich-editor-floating-toolbar {
+            inset-inline: 0 !important;
+            width: auto !important;
+        }
+    }
+
+    .fi-fo-rich-editor-content:has(.ProseMirror[data-selection-empty='true'])
+        > [x-ref='floatingToolbar::heading'] {
+        pointer-events: none;
+        visibility: hidden !important;
+        opacity: 0 !important;
+    }
+}
+
 /* The slash menu is appended to <body> to escape the modal's overflow clipping,
    so z-40 has to clear the modal window at 30. */
 .fi-slash-menu {

--- a/resources/js/filament/payload-guard.js
+++ b/resources/js/filament/payload-guard.js
@@ -1,0 +1,23 @@
+// Livewire renders a failed request as a full-screen error overlay. A payload over the
+// cap is a content problem the writer can fix, so it gets a notification instead.
+document.addEventListener('livewire:init', () => {
+    window.Livewire.hook('request', ({ fail }) => {
+        fail(({ status, content, preventDefault }) => {
+            if (status !== 413) {
+                return
+            }
+
+            preventDefault()
+
+            let message = window.filamentData?.payloadTooLarge ?? ''
+
+            try {
+                message = JSON.parse(content).message || message
+            } catch (error) {
+                //
+            }
+
+            new window.FilamentNotification().title(message).danger().send()
+        })
+    })
+})

--- a/resources/js/filament/rich-content-plugins/slash-menu.js
+++ b/resources/js/filament/rich-content-plugins/slash-menu.js
@@ -54,7 +54,7 @@ const CANVAS_TOLERANCE = 2
 
 class CanvasFitView {
     constructor(view) {
-        this.content = view.dom.closest('.fi-fo-rich-editor-content')
+        this.content = view.dom.closest('.fi-fo-rich-editor-seamless .fi-fo-rich-editor-content')
         this.fit = this.fit.bind(this)
 
         if (! this.content) {

--- a/resources/js/filament/rich-content-plugins/slash-menu.js
+++ b/resources/js/filament/rich-content-plugins/slash-menu.js
@@ -398,7 +398,14 @@ export default Extension.create({
             // ProseMirror sets role="textbox" but not this, so a screen reader
             // announces a single-line field and reads Enter as submit.
             new Plugin({
-                props: { attributes: { 'aria-multiline': 'true' } },
+                props: {
+                    attributes(state) {
+                        return {
+                            'aria-multiline': 'true',
+                            'data-selection-empty': state.selection.empty ? 'true' : 'false',
+                        }
+                    },
+                },
             }),
 
             new Plugin({

--- a/resources/js/filament/rich-content-plugins/slash-menu.js
+++ b/resources/js/filament/rich-content-plugins/slash-menu.js
@@ -1,0 +1,449 @@
+// The document-editor behaviour for Filament's rich editor: a `/` command menu, a
+// styled placeholder, and a guaranteed trailing paragraph.
+//
+// Loaded as an ES module by the editor's `customExtensionUrls`, so it must not import
+// anything: the TipTap and ProseMirror it needs come from the editor's own bundle via
+// window.FilamentRichEditor. A second copy of either would break ProseMirror's
+// instanceof checks and the extension would silently stop interoperating.
+
+const { Extension } = window.FilamentRichEditor.tiptap.core
+const { Plugin, PluginKey, TextSelection } = window.FilamentRichEditor.tiptap.pmState
+const { Decoration, DecorationSet } = window.FilamentRichEditor.tiptap.pmView
+
+const PLUGIN_KEY = new PluginKey('slashMenu')
+
+// Only at the start of a block or after whitespace, so `https://` and `and/or` are quiet.
+const TRIGGER = /(?:^|\s)(\/[a-zA-Z0-9]*)$/
+
+// Blocks the caret cannot leave by typing: Enter adds a newline inside a code block,
+// and a table traps it in the last cell. Anything ending the document in one of these
+// needs a paragraph after it, or the canvas below is unreachable.
+const TRAPPING_BLOCKS = ['codeBlock', 'table', 'horizontalRule', 'details', 'grid']
+
+const trailingParagraph = (state) =>
+    state.tr.insert(state.doc.content.size, state.schema.nodes.paragraph.create())
+
+const endsInTrappingBlock = (doc) => TRAPPING_BLOCKS.includes(doc.lastChild?.type.name)
+
+const EMPTY_CONFIG = { items: [], noResults: '', placeholder: '' }
+
+const config = (view) => {
+    const host = view.dom.closest('[data-slash-menu]')
+
+    return host ? JSON.parse(atob(host.getAttribute('data-slash-menu'))) : EMPTY_CONFIG
+}
+
+// `:key` marks where the trigger character goes, so a translation can move it within
+// the sentence. Built as nodes rather than a CSS `content` string, which cannot style
+// one word of itself.
+const placeholderElement = (template) => {
+    const el = document.createElement('span')
+    el.className = 'fi-slash-placeholder'
+    el.setAttribute('aria-hidden', 'true')
+    el.contentEditable = 'false'
+
+    const [before, after = ''] = template.split(':key')
+    const key = document.createElement('kbd')
+    key.textContent = '/'
+
+    el.append(document.createTextNode(before), key, document.createTextNode(after))
+
+    return el
+}
+
+// Below this the panel is not worth flipping or capping to, so it is allowed to
+// overflow the viewport and scroll the page instead.
+const MIN_PANEL_HEIGHT = 160
+
+// The canvas takes up whatever slack the form has left, measured rather than guessed:
+// a viewport fraction that fits a note form overflows a denser one, and pure CSS cannot
+// do it because the schema between the modal and the field is grids sized to content.
+//
+// Slack is read from the whole form rather than from the canvas down, so a field BELOW
+// the editor keeps its room. The note form has none and the canvas reaches the footer;
+// the task form has a due date and the canvas stops short of it.
+const CANVAS_MIN_HEIGHT = 160
+const CANVAS_TOLERANCE = 2
+
+class CanvasFitView {
+    constructor(view) {
+        this.content = view.dom.closest('.fi-fo-rich-editor-content')
+        this.fit = this.fit.bind(this)
+
+        if (! this.content) {
+            return
+        }
+
+        // The modal body is `flex: 1`, so its own box already spans the panel and
+        // reports no slack. The form schema inside it is sized to its content.
+        const container = this.content.closest('.fi-modal-content')
+        this.extent = container?.lastElementChild ?? container ?? this.content
+
+        // The gap below the canvas is the container's own bottom padding, which sits
+        // outside `extent`. Counting it is what keeps the panel from scrolling by it.
+        this.gap = container ? parseFloat(getComputedStyle(container).paddingBottom) || 0 : 0
+
+        // The sticky footer's top is the bottom of the usable area, and it does not
+        // move when the canvas grows, so it is a stable limit to measure against.
+        this.footer = this.content.closest('.fi-modal-window')?.querySelector(':scope > .fi-modal-footer')
+
+        this.fit()
+
+        window.addEventListener('resize', this.fit)
+
+        // Each pass closes the gap exactly, so the observer settles in one more frame.
+        // It also catches the fields above changing height without a window resize.
+        this.observer = new ResizeObserver(this.fit)
+        this.observer.observe(this.extent)
+    }
+
+    fit() {
+        const limit = this.footer ? this.footer.getBoundingClientRect().top : window.innerHeight
+        const slack = limit - this.extent.getBoundingClientRect().bottom - this.gap
+
+        if (Math.abs(slack) < CANVAS_TOLERANCE) {
+            return
+        }
+
+        const height = this.content.getBoundingClientRect().height
+
+        this.content.style.minHeight = `${Math.max(height + slack, CANVAS_MIN_HEIGHT)}px`
+    }
+
+    destroy() {
+        window.removeEventListener('resize', this.fit)
+        this.observer?.disconnect()
+    }
+}
+
+class SlashMenuView {
+    constructor(view, settings) {
+        this.view = view
+        this.isOpen = false
+        this.items = []
+        this.activeIndex = 0
+        this.range = null
+
+        this.allItems = settings.items
+        this.noResults = settings.noResults
+        this.scope = view.dom.closest('[x-data]')
+
+        this.panel = document.createElement('div')
+        // fi-dropdown-list only to opt out of the panel's divide-y between children.
+        this.panel.className = 'fi-dropdown-panel fi-dropdown-list fi-width-2xs fi-not-prose fi-slash-menu'
+        this.panel.setAttribute('role', 'listbox')
+        this.panel.hidden = true
+        document.body.appendChild(this.panel)
+
+        this.onDocumentPointerDown = (event) => {
+            if (this.isOpen && ! this.panel.contains(event.target)) {
+                this.close()
+            }
+        }
+        document.addEventListener('mousedown', this.onDocumentPointerDown)
+    }
+
+    update() {
+        const trigger = this.detectTrigger()
+
+        if (! trigger) {
+            this.close()
+
+            return
+        }
+
+        this.range = trigger.range
+        this.items = this.filter(trigger.query)
+        this.activeIndex = 0
+        this.render()
+        this.open()
+    }
+
+    detectTrigger() {
+        const { selection } = this.view.state
+
+        if (! selection.empty) {
+            return null
+        }
+
+        const { $from } = selection
+
+        if ($from.parent.isAtom || ! $from.parent.isTextblock) {
+            return null
+        }
+
+        const match = $from.parent.textBetween(0, $from.parentOffset, undefined, '\n').match(TRIGGER)
+
+        if (! match) {
+            return null
+        }
+
+        return {
+            query: match[1].slice(1).toLowerCase(),
+            range: { from: $from.pos - match[1].length, to: $from.pos },
+        }
+    }
+
+    filter(query) {
+        if (query === '') {
+            return this.allItems
+        }
+
+        return this.allItems.filter(
+            (item) =>
+                item.id.toLowerCase().includes(query) ||
+                item.label.toLowerCase().replace(/\s/g, '').includes(query),
+        )
+    }
+
+    render() {
+        this.panel.innerHTML = ''
+        this.itemElements = []
+
+        if (this.items.length === 0) {
+            const empty = document.createElement('div')
+            empty.className = 'fi-slash-menu-empty'
+            empty.textContent = this.noResults.replace(':query', this.currentQuery())
+            this.panel.appendChild(empty)
+
+            return
+        }
+
+        let group = null
+
+        this.items.forEach((item, index) => {
+            if (item.group !== group) {
+                group = item.group
+
+                const heading = document.createElement('div')
+                heading.className = 'fi-slash-menu-group'
+                heading.textContent = group
+                this.panel.appendChild(heading)
+            }
+
+            this.panel.appendChild(this.renderItem(item, index))
+        })
+    }
+
+    renderItem(item, index) {
+        const button = document.createElement('button')
+        button.type = 'button'
+        button.className = 'fi-slash-menu-item'
+        button.setAttribute('role', 'option')
+        button.setAttribute('aria-selected', index === this.activeIndex ? 'true' : 'false')
+        button.title = item.description
+
+        const icon = document.createElement('span')
+        icon.className = 'fi-slash-menu-item-icon'
+        icon.innerHTML = item.icon
+
+        const label = document.createElement('span')
+        label.className = 'fi-slash-menu-item-label'
+        label.textContent = item.label
+
+        button.append(icon, label)
+
+        if (item.shortcut) {
+            const shortcut = document.createElement('kbd')
+            shortcut.className = 'fi-slash-menu-item-shortcut'
+            shortcut.textContent = item.shortcut
+            button.appendChild(shortcut)
+        }
+
+        // mousedown, not click: click fires after the editor has already lost focus,
+        // and the command needs a live selection to act on.
+        button.addEventListener('mousedown', (event) => {
+            event.preventDefault()
+            this.select(index)
+        })
+        button.addEventListener('mousemove', () => this.setActiveIndex(index))
+
+        this.itemElements[index] = button
+
+        return button
+    }
+
+    currentQuery() {
+        return this.range ? this.view.state.doc.textBetween(this.range.from + 1, this.range.to) : ''
+    }
+
+    setActiveIndex(index) {
+        if (this.activeIndex === index) {
+            return
+        }
+
+        this.activeIndex = index
+        this.render()
+    }
+
+    handleKeyDown(event) {
+        if (! this.isOpen) {
+            return false
+        }
+
+        if (event.key === 'Escape') {
+            this.close()
+
+            return true
+        }
+
+        if (this.items.length === 0) {
+            return false
+        }
+
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            const step = event.key === 'ArrowDown' ? 1 : -1
+            this.setActiveIndex((this.activeIndex + step + this.items.length) % this.items.length)
+            this.itemElements[this.activeIndex]?.scrollIntoView({ block: 'nearest' })
+
+            return true
+        }
+
+        if (event.key === 'Enter' || event.key === 'Tab') {
+            this.select(this.activeIndex)
+
+            return true
+        }
+
+        return false
+    }
+
+    select(index) {
+        const item = this.items[index]
+
+        if (! item) {
+            return
+        }
+
+        const { from, to } = this.range
+
+        this.close()
+        this.view.dispatch(this.view.state.tr.delete(from, to))
+
+        // Deferred so the component's `editorSelection` has caught up with the deletion:
+        // an action that opens a modal reads it server-side to know where to insert.
+        queueMicrotask(() => window.Alpine.evaluate(this.scope, item.action))
+    }
+
+    open() {
+        this.isOpen = true
+        this.panel.hidden = false
+        this.position()
+    }
+
+    close() {
+        this.isOpen = false
+        this.panel.hidden = true
+        this.range = null
+        this.items = []
+        this.activeIndex = 0
+    }
+
+    position() {
+        const margin = 8
+        const caret = this.view.coordsAtPos(this.range.from)
+
+        const spaceBelow = window.innerHeight - caret.bottom - margin * 2
+        const spaceAbove = caret.top - margin * 2
+
+        // Flip up only when below cannot hold the panel and above has more room. The
+        // chosen side then caps the height, so a short viewport scrolls the list
+        // instead of pushing it off-screen.
+        this.panel.style.maxHeight = ''
+        const placeAbove = this.panel.offsetHeight > spaceBelow && spaceAbove > spaceBelow
+        this.panel.style.maxHeight = `${Math.max(placeAbove ? spaceAbove : spaceBelow, MIN_PANEL_HEIGHT)}px`
+
+        const { offsetWidth: width, offsetHeight: height } = this.panel
+        const top = placeAbove ? caret.top - height - margin : caret.bottom + margin
+        const left = Math.min(caret.left, window.innerWidth - width - margin)
+
+        this.panel.style.top = `${Math.max(top, margin) + window.scrollY}px`
+        this.panel.style.left = `${Math.max(left, margin) + window.scrollX}px`
+    }
+
+    destroy() {
+        document.removeEventListener('mousedown', this.onDocumentPointerDown)
+        this.panel.remove()
+    }
+}
+
+export default Extension.create({
+    name: 'slashMenu',
+
+    addProseMirrorPlugins() {
+        const { editor } = this
+
+        let settings = null
+        const getSettings = () => (settings ??= config(editor.view))
+
+        let menu = null
+
+        return [
+            new Plugin({
+                key: PLUGIN_KEY,
+                view(editorView) {
+                    menu = new SlashMenuView(editorView, getSettings())
+
+                    return menu
+                },
+                props: {
+                    handleKeyDown: (view, event) => menu?.handleKeyDown(event) ?? false,
+                },
+            }),
+
+            // ProseMirror sets role="textbox" but not this, so a screen reader
+            // announces a single-line field and reads Enter as submit.
+            new Plugin({
+                props: { attributes: { 'aria-multiline': 'true' } },
+            }),
+
+            new Plugin({
+                view: (editorView) => new CanvasFitView(editorView),
+            }),
+
+            new Plugin({
+                props: {
+                    decorations({ doc }) {
+                        if (doc.childCount !== 1 || doc.firstChild.content.size > 0) {
+                            return null
+                        }
+
+                        return DecorationSet.create(doc, [
+                            Decoration.widget(1, placeholderElement(getSettings().placeholder), { side: 1 }),
+                        ])
+                    },
+                },
+            }),
+
+            new Plugin({
+                appendTransaction(transactions, oldState, newState) {
+                    if (! transactions.some((tr) => tr.docChanged)) {
+                        return null
+                    }
+
+                    return endsInTrappingBlock(newState.doc) ? trailingParagraph(newState) : null
+                },
+                props: {
+                    // Content that loaded with a trapping block last never went through
+                    // appendTransaction, so the click that reveals the gap also closes it.
+                    handleClick(view, pos, event) {
+                        const last = view.dom.lastElementChild
+
+                        if (! last || ! endsInTrappingBlock(view.state.doc)) {
+                            return false
+                        }
+
+                        if (event.clientY <= last.getBoundingClientRect().bottom) {
+                            return false
+                        }
+
+                        const tr = trailingParagraph(view.state)
+                        view.dispatch(tr.setSelection(TextSelection.near(tr.doc.resolve(tr.doc.content.size))))
+
+                        return true
+                    },
+                },
+            }),
+        ]
+    },
+})

--- a/resources/js/filament/rich-content-plugins/slash-menu.js
+++ b/resources/js/filament/rich-content-plugins/slash-menu.js
@@ -19,7 +19,24 @@ const trailingParagraph = (state) =>
 
 const endsInTrappingBlock = (doc) => TRAPPING_BLOCKS.includes(doc.lastChild?.type.name)
 
-const EMPTY_CONFIG = { items: [], noResults: '', placeholder: '' }
+const EMPTY_CONFIG = { items: [], noResults: '', placeholder: '', limitReached: '' }
+
+// Livewire rejects a request body over its payload cap (config/livewire.php) before any
+// validation runs, so the only place a document can be held in bounds is here.
+const MAX_DOC_SIZE = 200000
+
+let limitNoticeAt = 0
+
+// A notification, not an inline message: the canvas grows with the document, so an
+// element under it can sit thousands of pixels below the viewport.
+const limitNotice = (message) => {
+    if (Date.now() - limitNoticeAt < 4000 || ! window.FilamentNotification) {
+        return
+    }
+
+    limitNoticeAt = Date.now()
+    new window.FilamentNotification().title(message).danger().send()
+}
 
 const config = (view) => {
     const host = view.dom.closest('[data-slash-menu]')
@@ -382,6 +399,23 @@ export default Extension.create({
             // announces a single-line field and reads Enter as submit.
             new Plugin({
                 props: { attributes: { 'aria-multiline': 'true' } },
+            }),
+
+            new Plugin({
+                filterTransaction(tr, state) {
+                    if (! tr.docChanged || tr.doc.content.size <= MAX_DOC_SIZE) {
+                        return true
+                    }
+
+                    // Never block a shrinking document: the way out of the limit is deleting.
+                    if (tr.doc.content.size <= state.doc.content.size) {
+                        return true
+                    }
+
+                    limitNotice(getSettings().limitReached)
+
+                    return false
+                },
             }),
 
             new Plugin({

--- a/resources/js/filament/rich-content-plugins/slash-menu.js
+++ b/resources/js/filament/rich-content-plugins/slash-menu.js
@@ -1,10 +1,5 @@
-// The document-editor behaviour for Filament's rich editor: a `/` command menu, a
-// styled placeholder, and a guaranteed trailing paragraph.
-//
-// Loaded as an ES module by the editor's `customExtensionUrls`, so it must not import
-// anything: the TipTap and ProseMirror it needs come from the editor's own bundle via
-// window.FilamentRichEditor. A second copy of either would break ProseMirror's
-// instanceof checks and the extension would silently stop interoperating.
+// Never import here: a second TipTap or ProseMirror copy breaks ProseMirror's instanceof
+// checks, so both come from the editor's own bundle via window.FilamentRichEditor.
 
 const { Extension } = window.FilamentRichEditor.tiptap.core
 const { Plugin, PluginKey, TextSelection } = window.FilamentRichEditor.tiptap.pmState
@@ -15,9 +10,8 @@ const PLUGIN_KEY = new PluginKey('slashMenu')
 // Only at the start of a block or after whitespace, so `https://` and `and/or` are quiet.
 const TRIGGER = /(?:^|\s)(\/[a-zA-Z0-9]*)$/
 
-// Blocks the caret cannot leave by typing: Enter adds a newline inside a code block,
-// and a table traps it in the last cell. Anything ending the document in one of these
-// needs a paragraph after it, or the canvas below is unreachable.
+// Blocks the caret cannot type its way out of. A document ending in one needs a
+// paragraph after it, or the canvas below is unreachable.
 const TRAPPING_BLOCKS = ['codeBlock', 'table', 'horizontalRule', 'details', 'grid']
 
 const trailingParagraph = (state) =>
@@ -33,9 +27,7 @@ const config = (view) => {
     return host ? JSON.parse(atob(host.getAttribute('data-slash-menu'))) : EMPTY_CONFIG
 }
 
-// `:key` marks where the trigger character goes, so a translation can move it within
-// the sentence. Built as nodes rather than a CSS `content` string, which cannot style
-// one word of itself.
+// Built as nodes, not a CSS `content` string, so the trigger can render as a key cap.
 const placeholderElement = (template) => {
     const el = document.createElement('span')
     el.className = 'fi-slash-placeholder'
@@ -55,13 +47,8 @@ const placeholderElement = (template) => {
 // overflow the viewport and scroll the page instead.
 const MIN_PANEL_HEIGHT = 160
 
-// The canvas takes up whatever slack the form has left, measured rather than guessed:
-// a viewport fraction that fits a note form overflows a denser one, and pure CSS cannot
-// do it because the schema between the modal and the field is grids sized to content.
-//
-// Slack is read from the whole form rather than from the canvas down, so a field BELOW
-// the editor keeps its room. The note form has none and the canvas reaches the footer;
-// the task form has a due date and the canvas stops short of it.
+// Measured, not CSS: the schema between the modal and the field is content-sized grids.
+// Slack is read from the whole form, so a field below the editor keeps its room.
 const CANVAS_MIN_HEIGHT = 160
 const CANVAS_TOLERANCE = 2
 
@@ -346,9 +333,8 @@ class SlashMenuView {
         const spaceBelow = window.innerHeight - caret.bottom - margin * 2
         const spaceAbove = caret.top - margin * 2
 
-        // Flip up only when below cannot hold the panel and above has more room. The
-        // chosen side then caps the height, so a short viewport scrolls the list
-        // instead of pushing it off-screen.
+        // The chosen side caps the height, so a short viewport scrolls the list instead
+        // of pushing it off-screen.
         this.panel.style.maxHeight = ''
         const placeAbove = this.panel.offsetHeight > spaceBelow && spaceAbove > spaceBelow
         this.panel.style.maxHeight = `${Math.max(placeAbove ? spaceAbove : spaceBelow, MIN_PANEL_HEIGHT)}px`

--- a/resources/js/filament/rich-content-plugins/slash-menu.js
+++ b/resources/js/filament/rich-content-plugins/slash-menu.js
@@ -259,8 +259,9 @@ class SlashMenuView {
             return
         }
 
+        this.itemElements[this.activeIndex]?.setAttribute('aria-selected', 'false')
+        this.itemElements[index]?.setAttribute('aria-selected', 'true')
         this.activeIndex = index
-        this.render()
     }
 
     handleKeyDown(event) {
@@ -395,7 +396,7 @@ export default Extension.create({
                         }
 
                         return DecorationSet.create(doc, [
-                            Decoration.widget(1, placeholderElement(getSettings().placeholder), { side: 1 }),
+                            Decoration.widget(1, () => placeholderElement(getSettings().placeholder), { side: 1, key: 'slash-placeholder' }),
                         ])
                     },
                 },

--- a/tests/Browser/CRM/RichEditorBrowserTest.php
+++ b/tests/Browser/CRM/RichEditorBrowserTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\CustomFields\RichEditorFieldType;
+use App\Filament\RichEditor\SlashMenuPlugin;
+use App\Models\CustomField;
+use App\Models\Note;
+use App\Models\User;
+
+mutates(RichEditorFieldType::class, SlashMenuPlugin::class);
+
+it('hides the heading toolbar when the caret has no text selection', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/notes")
+        ->press('New note')
+        ->assertVisible('.fi-fo-rich-editor-seamless .ProseMirror')
+        ->assertNoJavaScriptErrors();
+
+    $state = json_decode((string) $page->script(<<<'JS'
+        (() => {
+            const root = document.querySelector('.fi-fo-rich-editor-seamless');
+            const editorRoot = root.querySelector('[x-data^="richEditorFormComponent"]');
+            const editor = Alpine.$data(editorRoot).getEditor();
+
+            editor.commands.setContent('<h1>Quarterly review</h1>');
+            editor.chain().focus().setTextSelection(4).run();
+
+            const headingToolbar = document.querySelector('[x-ref="floatingToolbar::heading"]');
+            const headingToolbarStyle = getComputedStyle(headingToolbar);
+
+            return JSON.stringify({
+                selectionEmpty: editor.view.dom.dataset.selectionEmpty ?? null,
+                headingToolbarVisible:
+                    headingToolbarStyle.visibility !== 'hidden' && headingToolbarStyle.opacity !== '0',
+            });
+        })();
+    JS), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($state)->toMatchArray([
+        'selectionEmpty' => 'true',
+        'headingToolbarVisible' => false,
+    ]);
+});
+
+it('converts selected body text to a heading from the floating toolbar', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/notes")
+        ->press('New note')
+        ->assertVisible('.fi-fo-rich-editor-seamless .ProseMirror')
+        ->assertNoJavaScriptErrors();
+
+    $page->script(<<<'JS'
+        (() => {
+            const root = document.querySelector('.fi-fo-rich-editor-seamless');
+            const editorRoot = root.querySelector('[x-data^="richEditorFormComponent"]');
+            const editor = Alpine.$data(editorRoot).getEditor();
+
+            editor.commands.setContent('<p>Quarterly review</p>');
+            editor.chain().focus().setTextSelection({ from: 11, to: 17 }).run();
+        })();
+    JS);
+
+    $page->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->click('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Heading 1"]')
+        ->click('[x-ref="floatingToolbar::paragraph"] button[aria-label="Heading 1"]')
+        ->assertScript('document.querySelector(".fi-fo-rich-editor-seamless .ProseMirror h1")?.textContent === "Quarterly review"')
+        ->assertNoJavaScriptErrors();
+});
+
+it('changes a selected heading to another level from the floating toolbar', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/notes")
+        ->press('New note')
+        ->assertVisible('.fi-fo-rich-editor-seamless .ProseMirror')
+        ->assertNoJavaScriptErrors();
+
+    $page->script(<<<'JS'
+        (() => {
+            const root = document.querySelector('.fi-fo-rich-editor-seamless');
+            const editorRoot = root.querySelector('[x-data^="richEditorFormComponent"]');
+            const editor = Alpine.$data(editorRoot).getEditor();
+
+            editor.commands.setContent('<h1>Quarterly review</h1>');
+            editor.chain().focus().setTextSelection({ from: 1, to: 17 }).run();
+        })();
+    JS);
+
+    $page->assertVisible('[x-ref="floatingToolbar::heading"] button[aria-label="Text style"]')
+        ->click('[x-ref="floatingToolbar::heading"] button[aria-label="Text style"]')
+        ->assertVisible('[x-ref="floatingToolbar::heading"] button[aria-label="Heading 2"]')
+        ->click('[x-ref="floatingToolbar::heading"] button[aria-label="Heading 2"]')
+        ->assertScript('document.querySelector(".fi-fo-rich-editor-seamless .ProseMirror h2")?.textContent === "Quarterly review"')
+        ->assertNoJavaScriptErrors();
+});
+
+it('returns a selected heading to body text from the floating toolbar', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/notes")
+        ->press('New note')
+        ->assertVisible('.fi-fo-rich-editor-seamless .ProseMirror')
+        ->assertNoJavaScriptErrors();
+
+    $page->script(<<<'JS'
+        (() => {
+            const root = document.querySelector('.fi-fo-rich-editor-seamless');
+            const editorRoot = root.querySelector('[x-data^="richEditorFormComponent"]');
+            const editor = Alpine.$data(editorRoot).getEditor();
+
+            editor.commands.setContent('<h2>Quarterly review</h2>');
+            editor.chain().focus().setTextSelection({ from: 1, to: 17 }).run();
+        })();
+    JS);
+
+    $page->assertVisible('[x-ref="floatingToolbar::heading"] button[aria-label="Text style"]')
+        ->click('[x-ref="floatingToolbar::heading"] button[aria-label="Text style"]')
+        ->assertVisible('[x-ref="floatingToolbar::heading"] button[aria-label="Body"]')
+        ->click('[x-ref="floatingToolbar::heading"] button[aria-label="Body"]')
+        ->assertScript('document.querySelector(".fi-fo-rich-editor-seamless .ProseMirror p")?.textContent === "Quarterly review"')
+        ->assertNoJavaScriptErrors();
+});
+
+it('persists a heading created from selected body text', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/notes")
+        ->press('New note')
+        ->type('[id="mountedActionSchema0.title"]', 'Quarterly plan')
+        ->assertVisible('.fi-fo-rich-editor-seamless .ProseMirror')
+        ->assertNoJavaScriptErrors();
+
+    $page->script(<<<'JS'
+        (() => {
+            const root = document.querySelector('.fi-fo-rich-editor-seamless');
+            const editorRoot = root.querySelector('[x-data^="richEditorFormComponent"]');
+            const editor = Alpine.$data(editorRoot).getEditor();
+
+            editor.commands.setContent('<p>Quarterly review</p>');
+            editor.chain().focus().setTextSelection({ from: 1, to: 17 }).run();
+        })();
+    JS);
+
+    $page->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->click('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->click('[x-ref="floatingToolbar::paragraph"] button[aria-label="Heading 1"]')
+        ->press('Create')
+        ->assertSee('Quarterly plan')
+        ->assertNoJavaScriptErrors();
+
+    $note = Note::query()->where('title', 'Quarterly plan')->firstOrFail();
+    $bodyField = CustomField::query()
+        ->where('tenant_id', $team->getKey())
+        ->where('entity_type', 'note')
+        ->where('code', 'body')
+        ->firstOrFail();
+
+    expect($note->getCustomFieldValue($bodyField))->toContain('<h1>Quarterly review</h1>');
+});
+
+it('fits the selection toolbar inside a mobile viewport in both themes', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/notes")
+        ->press('New note')
+        ->resize(1440, 900)
+        ->assertVisible('.fi-fo-rich-editor-seamless .ProseMirror')
+        ->assertNoJavaScriptErrors();
+
+    $selectBodyText = <<<'JS'
+        (() => {
+            const root = document.querySelector('.fi-fo-rich-editor-seamless');
+            const editorRoot = root.querySelector('[x-data^="richEditorFormComponent"]');
+            const editor = Alpine.$data(editorRoot).getEditor();
+
+            editor.commands.setContent('<p>Introduction</p><p>Quarterly review</p>');
+            editor.chain().focus().setTextSelection({ from: 15, to: 31 }).run();
+        })();
+    JS;
+
+    $page->script($selectBodyText);
+
+    $page->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->click('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Heading 1"]');
+
+    $page->script(<<<'JS'
+        (() => {
+            window.dispatchEvent(new CustomEvent('theme-changed', { detail: 'dark' }));
+
+            const toolbar = document.querySelector('[x-ref="floatingToolbar::paragraph"]');
+            const menu = toolbar.querySelector('.fi-fo-rich-editor-dropdown-tool-menu');
+
+            if (getComputedStyle(menu).display === 'none') {
+                toolbar.querySelector('button[aria-label="Text style"]').click();
+            }
+        })();
+    JS);
+
+    $page->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Heading 1"]');
+
+    $page->script(<<<'JS'
+        (() => {
+            const toolbar = document.querySelector('[x-ref="floatingToolbar::paragraph"]');
+            const menu = toolbar.querySelector('.fi-fo-rich-editor-dropdown-tool-menu');
+
+            if (getComputedStyle(menu).display !== 'none') {
+                toolbar.querySelector('button[aria-label="Text style"]').click();
+            }
+        })();
+    JS);
+
+    $page->resize(390, 844);
+
+    $page->script($selectBodyText);
+
+    $page->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->click('[x-ref="floatingToolbar::paragraph"] button[aria-label="Text style"]')
+        ->assertVisible('[x-ref="floatingToolbar::paragraph"] button[aria-label="Heading 1"]')
+        ->assertNoJavaScriptErrors();
+
+    $geometry = json_decode((string) $page->script(<<<'JS'
+        (() => {
+            const toolbar = document.querySelector('[x-ref="floatingToolbar::paragraph"]');
+            const box = toolbar.getBoundingClientRect();
+            const content = document.querySelector('.fi-fo-rich-editor-content').getBoundingClientRect();
+
+            return JSON.stringify({
+                left: box.left,
+                right: box.right,
+                contentLeft: content.left,
+                contentRight: content.right,
+                viewport: window.innerWidth,
+                pageOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+            });
+        })();
+    JS), true, 512, JSON_THROW_ON_ERROR);
+
+    expect($geometry['left'])->toBeGreaterThanOrEqual(0)
+        ->and($geometry['right'])->toBeLessThanOrEqual($geometry['viewport'])
+        ->and($geometry['left'])->toBeGreaterThanOrEqual($geometry['contentLeft'])
+        ->and($geometry['right'])->toBeLessThanOrEqual($geometry['contentRight'])
+        ->and($geometry['pageOverflow'])->toBeFalse();
+});

--- a/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/CompanyResourceTest.php
@@ -10,6 +10,8 @@ use App\Models\CustomField;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\RichEditor;
+use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 
@@ -239,4 +241,30 @@ it('adds a newly typed tags-input value to the option list when editing a compan
     $optionNames = $cf->refresh()->options->pluck('name')->all();
     expect($optionNames)->toContain('Existing')
         ->toContain('TypedDuringEdit');
+});
+
+it('keeps the slash menu but not the document canvas on a rich-editor field added to companies', function (): void {
+    CustomField::forceCreate([
+        'tenant_id' => $this->team->id,
+        'code' => 'account_plan',
+        'name' => 'Account plan',
+        'type' => 'rich-editor',
+        'entity_type' => 'company',
+        'sort_order' => 50,
+        'active' => true,
+        'system_defined' => false,
+        'validation_rules' => [],
+        'settings' => new CustomFieldSettingsData,
+    ]);
+
+    $page = livewire(ListCompanies::class)
+        ->mountAction('create')
+        ->instance();
+
+    $editor = collect($page->getSchema($page->getMountedActionSchemaName())->getFlatComponents(withHidden: true))
+        ->first(fn (Component $component): bool => $component instanceof RichEditor);
+
+    expect($editor->getToolbarButtons())->toBe([])
+        ->and($editor->getExtraAttributes())->toHaveKey('data-slash-menu')
+        ->and($editor->getExtraAttributes())->not->toHaveKey('class');
 });

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -11,6 +11,7 @@ use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\RichEditor;
 use Filament\Schemas\Components\Component;
+use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Database\Eloquent\Model;
 
 mutates(NoteResource::class);
@@ -251,4 +252,10 @@ it('drives note body formatting from the slash menu rather than a toolbar', func
 
     expect(collect($items)->pluck('action')->filter()->all())->toHaveSameSize($items)
         ->and(collect($items)->pluck('icon')->filter()->all())->toHaveSameSize($items);
+});
+
+it('versions the slash menu script by its published file so an edit changes the url', function (): void {
+    $published = filemtime(public_path('js/app/rich-editor-slash-menu.js'));
+
+    expect(FilamentAsset::getScriptSrc('rich-editor-slash-menu'))->toEndWith("?v={$published}");
 });

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -258,6 +258,6 @@ it('drives note body formatting from the slash menu rather than a toolbar', func
 
     // The menu reuses Filament's own tool handlers, so a name that stops being a tool
     // would otherwise ship a menu entry that quietly does nothing.
-    expect(collect($items)->pluck('action')->filter()->all())->toHaveCount(count($items))
-        ->and(collect($items)->pluck('icon')->filter()->all())->toHaveCount(count($items));
+    expect(collect($items)->pluck('action')->filter()->all())->toHaveSameSize($items)
+        ->and(collect($items)->pluck('icon')->filter()->all())->toHaveSameSize($items);
 });

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -220,8 +220,6 @@ it('drives note body formatting from the slash menu rather than a toolbar', func
         ->toBe(['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link'])
         ->and($editor->getExtraAttributes()['class'])->toContain('fi-fo-rich-editor-seamless');
 
-    // Filament's own file and link actions, re-declared so they overlay the form they
-    // were opened from rather than replacing it.
     foreach (['attachFiles', 'link'] as $name) {
         expect($editor->getActions()[$name]->shouldOverlayParentActions())->toBeTrue();
     }
@@ -233,9 +231,6 @@ it('drives note body formatting from the slash menu rather than a toolbar', func
 
     $items = $menu['items'];
 
-    // The whole menu travels in one base64 attribute because Laravel's attribute bag
-    // escapes a `"` as `\"`, which HTML ignores: a quote in any of these strings would
-    // close the attribute and leave debris Alpine reads as a broken binding.
     expect($menu['noResults'])->toContain('"')
         ->and($menu['placeholder'])->toContain(':key')
         ->and(collect($items)->pluck('label')->all())
@@ -243,8 +238,6 @@ it('drives note body formatting from the slash menu rather than a toolbar', func
         ->and(collect($items)->pluck('group')->unique()->values()->all())
         ->toBe(['Text', 'Lists', 'Insert']);
 
-    // Only shortcuts that actually fire are advertised: there is no code-fence rule,
-    // so Code deliberately shows none.
     expect(collect($items)->pluck('shortcut', 'id')->filter()->all())
         ->toBe([
             'h1' => '#',
@@ -256,8 +249,6 @@ it('drives note body formatting from the slash menu rather than a toolbar', func
             'horizontalRule' => '---',
         ]);
 
-    // The menu reuses Filament's own tool handlers, so a name that stops being a tool
-    // would otherwise ship a menu entry that quietly does nothing.
     expect(collect($items)->pluck('action')->filter()->all())->toHaveSameSize($items)
         ->and(collect($items)->pluck('icon')->filter()->all())->toHaveSameSize($items);
 });

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -259,3 +259,14 @@ it('versions the slash menu script by its published file so an edit changes the 
 
     expect(FilamentAsset::getScriptSrc('rich-editor-slash-menu'))->toEndWith("?v={$published}");
 });
+
+it('keeps file attachments enabled on a toolbarless note body', function (): void {
+    $page = livewire(ManageNotes::class)
+        ->mountAction('create')
+        ->instance();
+
+    $editor = collect($page->getSchema($page->getMountedActionSchemaName())->getFlatComponents(withHidden: true))
+        ->first(fn (Component $component): bool => $component instanceof RichEditor);
+
+    expect($editor->hasFileAttachments())->toBeTrue();
+});

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
 use Filament\Schemas\Components\Component;
 use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Database\Eloquent\Model;
@@ -214,12 +215,26 @@ it('drives note body formatting from the slash menu rather than a toolbar', func
     $editor = collect($schema->getFlatComponents(withHidden: true))
         ->first(fn (Component $component): bool => $component instanceof RichEditor);
 
+    $paragraphToolbar = $editor->getFloatingToolbars()['paragraph'];
+    $headingToolbar = $editor->getFloatingToolbars()['heading'];
+
     expect($editor)->not->toBeNull()
         ->and($editor->getToolbarButtons())->toBe([])
-        ->and(array_keys($editor->getFloatingToolbars()))->toBe(['paragraph', 'table'])
-        ->and($editor->getFloatingToolbars()['paragraph'])
-        ->toBe(['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link'])
+        ->and(array_keys($editor->getFloatingToolbars()))->toBe(['paragraph', 'heading', 'table'])
         ->and($editor->getExtraAttributes()['class'])->toContain('fi-fo-rich-editor-seamless');
+
+    foreach ([$paragraphToolbar, $headingToolbar] as $toolbar) {
+        expect($toolbar[0])->toBeInstanceOf(ToolbarButtonGroup::class)
+            ->and($toolbar[0]->getName())->toBe('Text style')
+            ->and($toolbar[0]->getButtons())->toBe(['paragraph', 'h1', 'h2', 'h3'])
+            ->and($toolbar[0]->hasTextualButtons())->toBeTrue()
+            ->and(collect($toolbar[0]->getResolvedButtons())->map->getLabel()->all())
+            ->toBe(['Body', 'Heading 1', 'Heading 2', 'Heading 3'])
+            ->and(array_slice($toolbar, 1))
+            ->toBe(['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link']);
+    }
+
+    expect($paragraphToolbar[0])->not->toBe($headingToolbar[0]);
 
     foreach (['attachFiles', 'link'] as $name) {
         expect($editor->getActions()[$name]->shouldOverlayParentActions())->toBeTrue();

--- a/tests/Feature/Filament/App/Resources/NoteResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/NoteResourceTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 use App\Filament\Resources\NoteResource;
 use App\Filament\Resources\NoteResource\Pages\ManageNotes;
+use App\Filament\RichEditor\SlashMenuPlugin;
 use App\Models\Note;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\RichEditor;
+use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 
 mutates(NoteResource::class);
@@ -199,3 +202,62 @@ it('accepts deeply nested rich-editor JSON in custom field action data', functio
     livewire(ManageNotes::class)
         ->set($deepPath, [['type' => 'text', 'text' => 'hello']]);
 })->throwsNoExceptions();
+
+it('drives note body formatting from the slash menu rather than a toolbar', function (): void {
+    $page = livewire(ManageNotes::class)
+        ->mountAction('create')
+        ->instance();
+
+    $schema = $page->getSchema($page->getMountedActionSchemaName());
+
+    $editor = collect($schema->getFlatComponents(withHidden: true))
+        ->first(fn (Component $component): bool => $component instanceof RichEditor);
+
+    expect($editor)->not->toBeNull()
+        ->and($editor->getToolbarButtons())->toBe([])
+        ->and(array_keys($editor->getFloatingToolbars()))->toBe(['paragraph', 'table'])
+        ->and($editor->getFloatingToolbars()['paragraph'])
+        ->toBe(['bold', 'italic', 'underline', 'strike', 'code', 'highlight', 'link'])
+        ->and($editor->getExtraAttributes()['class'])->toContain('fi-fo-rich-editor-seamless');
+
+    // Filament's own file and link actions, re-declared so they overlay the form they
+    // were opened from rather than replacing it.
+    foreach (['attachFiles', 'link'] as $name) {
+        expect($editor->getActions()[$name]->shouldOverlayParentActions())->toBeTrue();
+    }
+
+    $menu = json_decode(
+        base64_decode(SlashMenuPlugin::attributes($editor)['data-slash-menu']),
+        associative: true,
+    );
+
+    $items = $menu['items'];
+
+    // The whole menu travels in one base64 attribute because Laravel's attribute bag
+    // escapes a `"` as `\"`, which HTML ignores: a quote in any of these strings would
+    // close the attribute and leave debris Alpine reads as a broken binding.
+    expect($menu['noResults'])->toContain('"')
+        ->and($menu['placeholder'])->toContain(':key')
+        ->and(collect($items)->pluck('label')->all())
+        ->toBe(['Heading 1', 'Heading 2', 'Heading 3', 'Body', 'Quote', 'Bulleted list', 'Numbered list', 'Code', 'Table', 'Toggle', 'Divider', 'Image'])
+        ->and(collect($items)->pluck('group')->unique()->values()->all())
+        ->toBe(['Text', 'Lists', 'Insert']);
+
+    // Only shortcuts that actually fire are advertised: there is no code-fence rule,
+    // so Code deliberately shows none.
+    expect(collect($items)->pluck('shortcut', 'id')->filter()->all())
+        ->toBe([
+            'h1' => '#',
+            'h2' => '##',
+            'h3' => '###',
+            'blockquote' => '>',
+            'bulletList' => '-',
+            'orderedList' => '1.',
+            'horizontalRule' => '---',
+        ]);
+
+    // The menu reuses Filament's own tool handlers, so a name that stops being a tool
+    // would otherwise ship a menu entry that quietly does nothing.
+    expect(collect($items)->pluck('action')->filter()->all())->toHaveCount(count($items))
+        ->and(collect($items)->pluck('icon')->filter()->all())->toHaveCount(count($items));
+});

--- a/tests/Feature/Filament/App/Resources/TaskResourceTest.php
+++ b/tests/Feature/Filament/App/Resources/TaskResourceTest.php
@@ -10,6 +10,8 @@ use App\Models\Task;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\RichEditor;
+use Filament\Schemas\Components\Component;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Events\QueryExecuted;
@@ -359,4 +361,16 @@ it('renders a custom-field datetime in the same format as the table default', fu
     livewire(ManageTasks::class)
         ->assertOk()
         ->assertSee(Date::parse('2026-08-19 08:30:00', 'Asia/Tokyo')->translatedFormat($format));
+});
+
+it('gives the task description the borderless document canvas', function (): void {
+    $page = livewire(ManageTasks::class)
+        ->mountAction('create')
+        ->instance();
+
+    $editor = collect($page->getSchema($page->getMountedActionSchemaName())->getFlatComponents(withHidden: true))
+        ->first(fn (Component $component): bool => $component instanceof RichEditor);
+
+    expect($editor->getExtraAttributes())->toHaveKey('data-slash-menu')
+        ->and($editor->getExtraAttributes()['class'])->toContain('fi-fo-rich-editor-seamless');
 });

--- a/tests/Feature/ImportWizard/Jobs/ExecuteImportJobFieldTypeTest.php
+++ b/tests/Feature/ImportWizard/Jobs/ExecuteImportJobFieldTypeTest.php
@@ -148,24 +148,6 @@ it('imports rich-editor custom field value as text', function (): void {
         ->and($cfv->text_value)->toBe('<p>Bold statement</p>');
 });
 
-it('imports markdown-editor custom field value as text', function (): void {
-    $cf = ImportExecutionFixture::customField($this, 'readme', 'markdown-editor');
-
-    ImportExecutionFixture::readyStore($this, ['Name', 'Readme'], [
-        ImportExecutionFixture::row(2, ['Name' => 'John', 'Readme' => '# Heading\n\nSome **bold** text'], ['match_action' => RowMatchAction::Create->value]),
-    ], [
-        ColumnData::toField(source: 'Name', target: 'name'),
-        ColumnData::toField(source: 'Readme', target: "custom_fields_{$cf->code}"),
-    ]);
-
-    ImportExecutionFixture::run($this);
-
-    $person = People::where('team_id', $this->team->id)->where('name', 'John')->first();
-    $cfv = ImportExecutionFixture::customFieldValue($this, (string) $person->id, (string) $cf->id);
-    expect($cfv)->not->toBeNull()
-        ->and($cfv->text_value)->toBe('# Heading\n\nSome **bold** text');
-});
-
 it('imports checkbox-list custom field with option names resolved to IDs', function (): void {
     $cf = ImportExecutionFixture::customField($this, 'interests', 'checkbox-list', 'people', ['Sports', 'Music', 'Tech']);
     $sportsOption = $cf->options->firstWhere('name', 'Sports');

--- a/tests/Feature/Livewire/PayloadGuardTest.php
+++ b/tests/Feature/Livewire/PayloadGuardTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Livewire\Livewire;
+
+it('answers an oversized livewire request with a message the panel can show', function (): void {
+    $this->actingAs(User::factory()->withTeam()->create());
+
+    $response = $this->withHeaders(['X-Livewire' => 'true'])
+        ->postJson(Livewire::getUpdateUri(), ['components' => [['snapshot' => str_repeat('a', 1024 * 1024 + 1)]]]);
+
+    $response->assertStatus(413)
+        ->assertExactJson(['message' => __('filament/panel.payload_too_large')]);
+});

--- a/tests/Feature/Mcp/CustomFieldWritesTest.php
+++ b/tests/Feature/Mcp/CustomFieldWritesTest.php
@@ -526,7 +526,6 @@ it('sets then clears a value for every writable custom field type', function (st
     'color-picker' => ['color-picker', '#0A80EA', '#0A80EA'],
     'date' => ['date', '2026-09-10', '2026-09-10T00:00:00+00:00'],
     'date-time' => ['date-time', '2026-09-10T10:30:00Z', '2026-09-10T10:30:00+00:00'],
-    'markdown-editor' => ['markdown-editor', '**Follow up** Friday', '**Follow up** Friday'],
     'rich-editor' => ['rich-editor', '**bold**', "<p><strong>bold</strong></p>\n"],
     'select' => ['select', null, 'OPTION_ID'],
     'radio' => ['radio', null, 'OPTION_ID'],

--- a/tests/Feature/Mcp/SchemaResourcesTest.php
+++ b/tests/Feature/Mcp/SchemaResourcesTest.php
@@ -404,7 +404,6 @@ function customFieldHintRows(): array
         ['checkbox-list', 'array of option labels or IDs (see options)'],
         ['tags-input', 'array of arbitrary string values'],
         ['rich-editor', 'markdown, or HTML when the value starts with'],
-        ['markdown-editor', '"input_format": "markdown"'],
         ['color-picker', 'hex color string'],
         ['date', 'ISO 8601 date"'],
         ['date-time', 'ISO 8601 datetime string'],

--- a/tests/Feature/Migrations/ConvertMarkdownEditorCustomFieldsTest.php
+++ b/tests/Feature/Migrations/ConvertMarkdownEditorCustomFieldsTest.php
@@ -6,13 +6,14 @@ use App\Models\CustomField;
 use App\Models\User;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Relaticle\CustomFields\Data\CustomFieldSettingsData;
 use Relaticle\CustomFields\Facades\CustomFieldsType;
 use Relaticle\CustomFields\Services\TenantContextService;
 
 $markdown = "# Meeting notes\n\n- first point\n- second point";
 
-$migration = fn () => (require base_path('database/migrations/2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.php'))->up();
+$migration = fn (): mixed => (require base_path('database/migrations/2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.php'))->up();
 
 $markdownField = function (string $code, bool $encrypted): CustomField {
     $settings = new CustomFieldSettingsData;
@@ -31,7 +32,7 @@ $markdownField = function (string $code, bool $encrypted): CustomField {
     ]);
 };
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
     $this->team = $this->user->currentTeam;
     TenantContextService::setTenantId($this->team->id);
@@ -60,9 +61,31 @@ it('moves markdown fields to the rich editor and converts their content', functi
     expect(DB::table('custom_fields')->whereIn('id', [$plain->id, $encrypted->id])->pluck('type')->unique()->all())
         ->toBe(['rich-editor'])
         ->and($value($plain))->toContain('<h1>Meeting notes</h1>', '<li>first point</li>')
-        // Encryption is per field, so the converted value has to go back encrypted or
-        // the read path would hand raw ciphertext to the editor.
         ->and(Crypt::decryptString($value($encrypted)))->toContain('<h1>Meeting notes</h1>');
+});
+
+it('converts every value when a blank value empties out mid-run', function () use ($markdown, $migration, $markdownField): void {
+    $field = $markdownField('md_many', encrypted: false);
+
+    $ids = collect(range(1, 1001))->map(fn (): string => (string) Str::ulid())->sort()->values();
+
+    DB::table('custom_field_values')->insert($ids->map(fn (string $id, int $index): array => [
+        'id' => $id,
+        'custom_field_id' => $field->id,
+        'entity_id' => (string) Str::ulid(),
+        'entity_type' => 'note',
+        'tenant_id' => $this->team->id,
+        'text_value' => $index === 0 ? '   ' : $markdown,
+    ])->all());
+
+    $migration();
+
+    $unconverted = DB::table('custom_field_values')
+        ->where('custom_field_id', $field->id)
+        ->where('text_value', $markdown)
+        ->count();
+
+    expect($unconverted)->toBe(0);
 });
 
 it('leaves a markdown field without a value alone', function () use ($migration, $markdownField): void {

--- a/tests/Feature/Migrations/ConvertMarkdownEditorCustomFieldsTest.php
+++ b/tests/Feature/Migrations/ConvertMarkdownEditorCustomFieldsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\CustomField;
+use App\Models\User;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Relaticle\CustomFields\Data\CustomFieldSettingsData;
+use Relaticle\CustomFields\Facades\CustomFieldsType;
+use Relaticle\CustomFields\Services\TenantContextService;
+
+$markdown = "# Meeting notes\n\n- first point\n- second point";
+
+$migration = fn () => (require base_path('database/migrations/2026_09_10_000000_convert_markdown_editor_custom_fields_to_rich_editor.php'))->up();
+
+$markdownField = function (string $code, bool $encrypted): CustomField {
+    $settings = new CustomFieldSettingsData;
+    $settings->encrypted = $encrypted;
+
+    return CustomField::forceCreate([
+        'name' => "MD {$code}",
+        'code' => $code,
+        'type' => 'markdown-editor',
+        'entity_type' => 'note',
+        'tenant_id' => test()->team->id,
+        'sort_order' => 90,
+        'active' => true,
+        'system_defined' => false,
+        'settings' => $settings,
+    ]);
+};
+
+beforeEach(function () {
+    $this->user = User::factory()->withTeam()->create();
+    $this->team = $this->user->currentTeam;
+    TenantContextService::setTenantId($this->team->id);
+});
+
+it('no longer offers the markdown editor as a field type', function (): void {
+    $keys = CustomFieldsType::toCollection()->pluck('key')->all();
+
+    expect($keys)->not->toContain('markdown-editor')
+        ->and($keys)->toContain('rich-editor');
+});
+
+it('moves markdown fields to the rich editor and converts their content', function () use ($markdown, $migration, $markdownField): void {
+    $plain = $markdownField('md_plain', encrypted: false);
+    $encrypted = $markdownField('md_encrypted', encrypted: true);
+
+    DB::table('custom_field_values')->insert([
+        ['id' => (string) Str::ulid(), 'custom_field_id' => $plain->id, 'entity_id' => (string) Str::ulid(), 'entity_type' => 'note', 'tenant_id' => $this->team->id, 'text_value' => $markdown],
+        ['id' => (string) Str::ulid(), 'custom_field_id' => $encrypted->id, 'entity_id' => (string) Str::ulid(), 'entity_type' => 'note', 'tenant_id' => $this->team->id, 'text_value' => Crypt::encryptString($markdown)],
+    ]);
+
+    $migration();
+
+    $value = fn (CustomField $field): ?string => DB::table('custom_field_values')->where('custom_field_id', $field->id)->value('text_value');
+
+    expect(DB::table('custom_fields')->whereIn('id', [$plain->id, $encrypted->id])->pluck('type')->unique()->all())
+        ->toBe(['rich-editor'])
+        ->and($value($plain))->toContain('<h1>Meeting notes</h1>', '<li>first point</li>')
+        // Encryption is per field, so the converted value has to go back encrypted or
+        // the read path would hand raw ciphertext to the editor.
+        ->and(Crypt::decryptString($value($encrypted)))->toContain('<h1>Meeting notes</h1>');
+});
+
+it('leaves a markdown field without a value alone', function () use ($migration, $markdownField): void {
+    $field = $markdownField('md_empty', encrypted: false);
+
+    DB::table('custom_field_values')->insert([
+        'id' => (string) Str::ulid(),
+        'custom_field_id' => $field->id,
+        'entity_id' => (string) Str::ulid(),
+        'entity_type' => 'note',
+        'tenant_id' => $this->team->id,
+        'text_value' => null,
+    ]);
+
+    $migration();
+
+    expect(DB::table('custom_fields')->where('id', $field->id)->value('type'))->toBe('rich-editor')
+        ->and(DB::table('custom_field_values')->where('custom_field_id', $field->id)->value('text_value'))->toBeNull();
+});


### PR DESCRIPTION
Rich-editor custom fields (note body, task description) lose the toolbar and gain a `/` command menu, a toolbar that floats over the selection, and a canvas measured to fill whatever space the form has left. The menu is built from Filament's own `RichEditorTool` registry, so each entry's icon, label and handler cannot drift from the toolbar equivalent it replaces.

Two defects surfaced while building it and are fixed here: a document ending in a code block or table trapped the caret with no way to type after it, and the editable surface was missing `aria-multiline`, so screen readers announced a single-line field.

The markdown editor field type is retired, since the rich editor now covers it and two overlapping rich-text types only made the picker harder to read. Because a type that is no longer registered cannot resolve, the included migration moves the nine existing production fields to `rich-editor` and converts their content, decrypting and re-encrypting the one encrypted value rather than corrupting it.

Verified in the browser in light and dark: every block and mark survives the sanitizer on save, the canvas fills a note form exactly while leaving room for the field below the description on a task form, and nested link/upload modals now overlay the form they were opened from instead of replacing it.