### PR TITLE
Polish meetings UI and keep the Home date picker open when changing months

### DIFF
--- a/packages/EmailIntegration/resources/views/filament/tables/columns/meeting-participants-stack.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/tables/columns/meeting-participants-stack.blade.php
@@ -1,0 +1,45 @@
+@php
+    /** @var \Relaticle\EmailIntegration\Models\Meeting $record */
+    $record = $getRecord();
+    $stack = resolve(\Relaticle\EmailIntegration\Services\MeetingParticipantStackPresenter::class)->forMeeting($record);
+@endphp
+
+<div class="px-3">
+@if ($stack['avatars'] === [])
+    <span class="text-sm text-gray-400 dark:text-gray-500">&mdash;</span>
+@else
+    <div class="flex items-center gap-1.5">
+        <span class="flex -space-x-1.5" aria-hidden="true">
+            @foreach ($stack['avatars'] as $avatar)
+                <span
+                    x-tooltip="{
+                        content: @js($avatar['tooltip']),
+                        theme: $store.theme,
+                    }"
+                    class="inline-flex"
+                >
+                    @include('email-integration::filament.infolists.partials.meeting-attendee-avatar', [
+                        'src' => $avatar['src'],
+                        'alt' => $avatar['alt'],
+                        'hasName' => $avatar['has_name'],
+                        'size' => 'sm',
+                        'class' => 'ring-2 ring-white dark:ring-gray-900',
+                    ])
+                </span>
+            @endforeach
+        </span>
+
+        @if ($stack['overflow'] > 0)
+            <span
+                class="text-xs text-gray-500 dark:text-gray-400"
+                x-tooltip="{
+                    content: @js($stack['overflow_tooltip']),
+                    theme: $store.theme,
+                }"
+            >
+                {{ __('filament/pages/dashboard.meetings.more_participants', ['count' => $stack['overflow']]) }}
+            </span>
+        @endif
+    </div>
+@endif
+</div>

--- a/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
@@ -14,11 +14,12 @@
         <div class="flex shrink-0 items-center gap-1">
             {{-- The prefix is server-rendered and the date comes from the picker's
                  own state, so a click anywhere on "Today, Sep 10" opens the calendar. --}}
-            <div
-                class="fi-meetings-date flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
-                x-on:click="$event.target.closest('.fi-meetings-date-trigger') || $el.querySelector('.fi-meetings-date-trigger')?.click()"
-            >
-                <span aria-hidden="true">{{ $this->datePrefix() }}</span>
+            <div class="fi-meetings-date flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                <span
+                    aria-hidden="true"
+                    class="cursor-pointer"
+                    x-on:click="$el.parentElement.querySelector('.fi-meetings-date-trigger')?.click()"
+                >{{ $this->datePrefix() }}</span>
                 {{ $this->getSchema('datePickerSchema') }}
             </div>
 

--- a/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/CommunicationIntelligenceInfolist.php
@@ -8,7 +8,6 @@ use App\Models\Company;
 use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
-use Carbon\CarbonInterface;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
@@ -26,7 +25,7 @@ final class CommunicationIntelligenceInfolist
         return Section::make(__("{$translationKey}.heading"))
             ->icon(Heroicon::ChartBar)
             ->schema([
-                Section::make(__("{$translationKey}.groups.connection"))
+                Fieldset::make(__("{$translationKey}.groups.connection"))
                     ->schema([
                         TextEntry::make('visible_first_interaction_at')
                             ->label(__("{$translationKey}.fields.first_interaction.label"))
@@ -50,9 +49,7 @@ final class CommunicationIntelligenceInfolist
                             ->placeholder(__("{$translationKey}.fields.strongest_connection.placeholder")),
                     ])
                     ->columns(2)
-                    ->columnSpanFull()
-                    ->collapsible()
-                    ->collapsed(),
+                    ->columnSpanFull(),
 
                 Fieldset::make(__("{$translationKey}.groups.email"))
                     ->schema([
@@ -97,7 +94,7 @@ final class CommunicationIntelligenceInfolist
             ->columns(1)
             ->columnSpanFull()
             ->collapsible()
-            ->collapsed(fn (People|Company|Opportunity $record): bool => ! self::metrics($record)->lastInteractionAt() instanceof CarbonInterface);
+            ->collapsed();
     }
 
     /**

--- a/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
+++ b/packages/EmailIntegration/src/Filament/RelationManagers/BaseMeetingsRelationManager.php
@@ -9,10 +9,12 @@ use App\Models\Opportunity;
 use App\Models\People;
 use App\Models\User;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ViewColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -73,9 +75,9 @@ abstract class BaseMeetingsRelationManager extends RelationManager
                     ->label(__('filament/relation-managers/meetings.columns.starts_at.label'))
                     ->dateTime('M j, Y · g:i a')
                     ->sortable(),
-                TextColumn::make('attendees_count')
-                    ->counts('attendees')
-                    ->label(__('filament/relation-managers/meetings.columns.attendees_count.label')),
+                ViewColumn::make('attendees')
+                    ->label(__('filament/relation-managers/meetings.columns.attendees_count.label'))
+                    ->view('email-integration::filament.tables.columns.meeting-participants-stack'),
                 TextColumn::make('status')
                     ->badge(),
                 TextColumn::make('response_status')
@@ -103,35 +105,38 @@ abstract class BaseMeetingsRelationManager extends RelationManager
             ])
             ->recordActions([
                 MeetingDetailInfolist::viewAction(),
-                Action::make('linkToRecord')
-                    ->label(__('filament/relation-managers/meetings.actions.link_to_record.label'))
-                    ->icon(Heroicon::Link)
-                    ->color('gray')
-                    ->schema(MeetingDetailInfolist::linkRecordFields())
-                    ->action(function (array $data, Meeting $record): void {
-                        resolve(LinkMeetingToRecordAction::class)
-                            ->execute($record, $this->resolveRecord((string) $data['target_type'], (string) $data['target_id']));
 
-                        Notification::make()
-                            ->success()
-                            ->title(__('filament/relation-managers/meetings.notifications.linked.title'))
-                            ->send();
-                    }),
-                Action::make('unlinkFromRecord')
-                    ->label(__('filament/relation-managers/meetings.actions.unlink_from_record.label'))
-                    ->icon(Heroicon::LinkSlash)
-                    ->color('danger')
-                    ->visible(fn (Meeting $record): bool => $record->isLinkedTo($this->getOwnerRecord()))
-                    ->requiresConfirmation()
-                    ->action(function (Meeting $record): void {
-                        resolve(UnlinkMeetingFromRecordAction::class)
-                            ->execute($record, $this->getOwnerRecord());
+                ActionGroup::make([
+                    Action::make('linkToRecord')
+                        ->label(__('filament/relation-managers/meetings.actions.link_to_record.label'))
+                        ->icon(Heroicon::Link)
+                        ->color('gray')
+                        ->schema(MeetingDetailInfolist::linkRecordFields())
+                        ->action(function (array $data, Meeting $record): void {
+                            resolve(LinkMeetingToRecordAction::class)
+                                ->execute($record, $this->resolveRecord((string) $data['target_type'], (string) $data['target_id']));
 
-                        Notification::make()
-                            ->success()
-                            ->title(__('filament/relation-managers/meetings.notifications.unlinked.title'))
-                            ->send();
-                    }),
+                            Notification::make()
+                                ->success()
+                                ->title(__('filament/relation-managers/meetings.notifications.linked.title'))
+                                ->send();
+                        }),
+                    Action::make('unlinkFromRecord')
+                        ->label(__('filament/relation-managers/meetings.actions.unlink_from_record.label'))
+                        ->icon(Heroicon::LinkSlash)
+                        ->color('danger')
+                        ->visible(fn (Meeting $record): bool => $record->isLinkedTo($this->getOwnerRecord()))
+                        ->requiresConfirmation()
+                        ->action(function (Meeting $record): void {
+                            resolve(UnlinkMeetingFromRecordAction::class)
+                                ->execute($record, $this->getOwnerRecord());
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('filament/relation-managers/meetings.notifications.unlinked.title'))
+                                ->send();
+                        }),
+                ]),
             ]);
     }
 

--- a/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
+++ b/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
@@ -26,18 +26,17 @@ use Relaticle\EmailIntegration\Filament\Concerns\HasConnectMailboxActions;
 use Relaticle\EmailIntegration\Filament\Infolists\MeetingDetailInfolist;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
-use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
 use Relaticle\EmailIntegration\Services\ListMeetingsForDay;
 use Relaticle\EmailIntegration\Services\MailboxDisplayNameDirectory;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
-use Relaticle\EmailIntegration\Services\MeetingAttendeePresenter;
+use Relaticle\EmailIntegration\Services\MeetingParticipantStackPresenter;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 
 /**
  * @property-read Collection<int, Meeting> $meetings
  * @property-read list<array{id: string, email: string, emailsImported: int, meetingsImported: int, percent: int, hasCalendar: bool, isInitialImport: bool}> $mailboxSyncRows
- * @property-read list<array{id: string, title: string, all_day: bool, participants: array{attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>, avatars: list<array{src: string, alt: string, has_name: bool}>, overflow: int}, response_status: AttendeeResponseStatus, time: array{start: string, end: string|null, range: string, datetime: string}, happening_now: bool}> $meetingCards
+ * @property-read list<array{id: string, title: string, all_day: bool, participants: array{attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>, avatars: list<array{src: string, alt: string, has_name: bool, tooltip: string}>, overflow: int, overflow_tooltip: string|null}, response_status: AttendeeResponseStatus, time: array{start: string, end: string|null, range: string, datetime: string}, happening_now: bool}> $meetingCards
  * @property-read Action $connectGmailAction
  */
 final class MeetingsHomeWidget extends Component implements HasActions, HasSchemas
@@ -323,7 +322,7 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
     }
 
     /**
-     * @return list<array{id: string, title: string, all_day: bool, participants: array{attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>, avatars: list<array{src: string, alt: string, has_name: bool}>, overflow: int}, response_status: AttendeeResponseStatus, time: array{start: string, end: string|null, range: string, datetime: string}, happening_now: bool}>
+     * @return list<array{id: string, title: string, all_day: bool, participants: array{attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>, avatars: list<array{src: string, alt: string, has_name: bool, tooltip: string}>, overflow: int, overflow_tooltip: string|null}, response_status: AttendeeResponseStatus, time: array{start: string, end: string|null, range: string, datetime: string}, happening_now: bool}>
      */
     #[Computed]
     public function meetingCards(): array
@@ -338,7 +337,7 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
     }
 
     /**
-     * @return array{id: string, title: string, all_day: bool, participants: array{attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>, avatars: list<array{src: string, alt: string, has_name: bool}>, overflow: int}, response_status: AttendeeResponseStatus, time: array{start: string, end: string|null, range: string, datetime: string}, happening_now: bool}
+     * @return array{id: string, title: string, all_day: bool, participants: array{attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>, avatars: list<array{src: string, alt: string, has_name: bool, tooltip: string}>, overflow: int, overflow_tooltip: string|null}, response_status: AttendeeResponseStatus, time: array{start: string, end: string|null, range: string, datetime: string}, happening_now: bool}
      */
     private function meetingCard(Meeting $meeting): array
     {
@@ -346,21 +345,11 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
             'id' => (string) $meeting->getKey(),
             'title' => (string) $meeting->title,
             'all_day' => $meeting->all_day,
-            'participants' => $this->cardParticipants($meeting),
+            'participants' => resolve(MeetingParticipantStackPresenter::class)->forMeeting($meeting),
             'response_status' => $this->viewerResponseStatus($meeting),
             'time' => $this->meetingTime($meeting),
             'happening_now' => $this->isHappeningNow($meeting),
         ];
-    }
-
-    /**
-     * @return list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>
-     */
-    private function attendeeState(Meeting $meeting): array
-    {
-        return array_values($meeting->attendees->values()->map(
-            fn (MeetingAttendee $attendee): array => resolve(MeetingAttendeePresenter::class)->present($attendee),
-        )->all());
     }
 
     /**
@@ -413,28 +402,6 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
     }
 
     /**
-     * @return array{attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>, avatars: list<array{src: string, alt: string, has_name: bool}>, overflow: int}
-     */
-    private function cardParticipants(Meeting $meeting): array
-    {
-        $states = $this->uniqueAttendeeStates($meeting);
-        $visible = 3;
-
-        return [
-            'attendees' => $states,
-            'overflow' => max(0, count($states) - $visible),
-            'avatars' => array_map(
-                fn (array $state): array => [
-                    'src' => $state['avatar'],
-                    'alt' => $state['name'],
-                    'has_name' => $state['has_name'],
-                ],
-                array_slice($states, 0, $visible),
-            ),
-        ];
-    }
-
-    /**
      * The viewer's own RSVP. Colour is paired with the status label so the
      * card never relies on the rail or dot alone.
      */
@@ -471,24 +438,6 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
     {
         $this->visibleCount = self::PAGE_SIZE;
         unset($this->meetings, $this->meetingCards);
-    }
-
-    /**
-     * @return list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>
-     */
-    private function uniqueAttendeeStates(Meeting $meeting): array
-    {
-        $states = [];
-
-        foreach ($this->attendeeState($meeting) as $state) {
-            $key = $state['email'] !== '' ? $state['email'] : $state['name'];
-
-            if (! isset($states[$key])) {
-                $states[$key] = $state;
-            }
-        }
-
-        return array_values($states);
     }
 
     /**

--- a/packages/EmailIntegration/src/Services/MeetingParticipantStackPresenter.php
+++ b/packages/EmailIntegration/src/Services/MeetingParticipantStackPresenter.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final readonly class MeetingParticipantStackPresenter
+{
+    public function __construct(
+        private MeetingAttendeePresenter $attendeePresenter,
+    ) {}
+
+    /**
+     * @return array{
+     *     attendees: list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>,
+     *     avatars: list<array{src: string, alt: string, has_name: bool, tooltip: string}>,
+     *     overflow: int,
+     *     overflow_tooltip: string|null
+     * }
+     */
+    public function forMeeting(Meeting $meeting, int $visible = 3): array
+    {
+        $states = $this->uniqueAttendeeStates($meeting);
+        $visibleStates = array_slice($states, 0, $visible);
+        $overflowStates = array_slice($states, $visible);
+
+        return [
+            'attendees' => $states,
+            'avatars' => array_map(
+                fn (array $state): array => [
+                    'src' => $state['avatar'],
+                    'alt' => $state['name'],
+                    'has_name' => $state['has_name'],
+                    'tooltip' => $this->tooltip($state),
+                ],
+                $visibleStates,
+            ),
+            'overflow' => count($overflowStates),
+            'overflow_tooltip' => $overflowStates === []
+                ? null
+                : implode("\n", array_map(
+                    fn (array $state): string => $this->tooltip($state),
+                    $overflowStates,
+                )),
+        ];
+    }
+
+    /**
+     * @param  array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}  $state
+     */
+    private function tooltip(array $state): string
+    {
+        $email = $state['email'];
+        $name = $state['name'];
+
+        if ($state['has_name'] && $email !== '' && mb_strtolower($name) !== $email) {
+            return "{$name}\n{$email}";
+        }
+
+        if ($email !== '') {
+            return $email;
+        }
+
+        return $name;
+    }
+
+    /**
+     * @return list<array{name: string, email: string, avatar: string, has_name: bool, is_organizer: bool, response_status: AttendeeResponseStatus|null}>
+     */
+    private function uniqueAttendeeStates(Meeting $meeting): array
+    {
+        $states = [];
+
+        foreach ($meeting->attendees as $attendee) {
+            $state = $this->attendeePresenter->present($attendee);
+            $key = $state['email'] !== '' ? $state['email'] : $state['name'];
+
+            if (! isset($states[$key])) {
+                $states[$key] = $state;
+            }
+        }
+
+        return array_values($states);
+    }
+}

--- a/packages/EmailIntegration/src/Services/MeetingParticipantStackPresenter.php
+++ b/packages/EmailIntegration/src/Services/MeetingParticipantStackPresenter.php
@@ -42,7 +42,7 @@ final readonly class MeetingParticipantStackPresenter
             'overflow_tooltip' => $overflowStates === []
                 ? null
                 : implode("\n", array_map(
-                    fn (array $state): string => $this->tooltip($state),
+                    $this->tooltip(...),
                     $overflowStates,
                 )),
         ];

--- a/tests/Feature/CalendarIntegration/MeetingsRelationManagerTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsRelationManagerTest.php
@@ -22,8 +22,9 @@ use Relaticle\EmailIntegration\Models\EmailBlocklist;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
 use Relaticle\EmailIntegration\Services\EmailVisibilityService;
+use Relaticle\EmailIntegration\Services\MeetingParticipantStackPresenter;
 
-mutates(MeetingsRelationManager::class, BaseMeetingsRelationManager::class, EmailVisibilityService::class, MeetingDetailInfolist::class);
+mutates(MeetingsRelationManager::class, BaseMeetingsRelationManager::class, EmailVisibilityService::class, MeetingDetailInfolist::class, MeetingParticipantStackPresenter::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -200,6 +201,31 @@ it('hides meetings on a protected person', function (): void {
     ])
         ->assertSee(__('filament/pages/record-emails.protected.heading'))
         ->assertCanNotSeeTableRecords([$meeting]);
+});
+
+it('shows attendee avatars and overflow in the attendees column', function (): void {
+    $person = People::factory()->for($this->team)->create();
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Stacked Attendees Meeting',
+    ]);
+    $meeting->people()->attach($person, ['link_source' => 'manual']);
+
+    foreach (['Alice Alpha', 'Bob Beta', 'Carol Gamma', 'Dave Delta'] as $name) {
+        MeetingAttendee::factory()->create([
+            'meeting_id' => $meeting->id,
+            'name' => $name,
+            'email_address' => mb_strtolower(str_replace(' ', '.', $name)).'@example.test',
+        ]);
+    }
+
+    livewire(MeetingsRelationManager::class, [
+        'ownerRecord' => $person,
+        'pageClass' => ViewPeople::class,
+    ])
+        ->assertSee('attendee-avatar-initials', escape: false)
+        ->assertSee(__('filament/pages/dashboard.meetings.more_participants', ['count' => 1]));
 });
 
 it('shows the shared meeting detail in the relation manager view modal', function (): void {


### PR DESCRIPTION
## Summary
- Show attendee avatar stacks on record meeting tables, with name and email tooltips and an overflow count.
- Group link and unlink into an overflow menu so View stays the primary row action.
- Keep Communication Intelligence collapsed by default, and render connection metrics as a fieldset.
- Open the Home date picker from the Today prefix without closing the calendar when changing month or year.

## Test plan
- [ ] Open a person, company, or deal Meetings tab and confirm attendee avatars, tooltips, and overflow count.
- [ ] Confirm View is the visible row action and link/unlink live in the overflow group.
- [ ] Open Home, click the Today prefix to open the picker, then change month or year without the calendar closing.
- [ ] Open a person, company, or deal and confirm Communication Intelligence starts collapsed.
- [ ] `php artisan test --compact tests/Feature/CalendarIntegration/MeetingsRelationManagerTest.php tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php`