### PR TITLE
Respect email visibility when resolving attendee names

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -33,9 +33,11 @@ viewer has no share.
 ## Meeting attendee "self"
 
 `MeetingAttendee.is_self` is the mailbox that owns that meeting copy, not the
-current viewer. Name that row from `meeting.connectedAccount.user` (or the
-account display name). Never substitute `auth()->user()`. Alice viewing
-Bob's copy must still show Bob.
+current viewer. Name that row from `meeting.connectedAccount.user` only when
+the mailbox address is that user's email. Never substitute `auth()->user()`,
+and never apply the connecting user's workspace name to a different mailbox
+address. A shared inbox stays that address, or its calendar name. Alice viewing
+Bob's copy still shows Bob when the mailbox is Bob's email.
 
 ## Meeting attendee mailbox names
 

--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -37,6 +37,12 @@ current viewer. Name that row from `meeting.connectedAccount.user` (or the
 account display name). Never substitute `auth()->user()`. Alice viewing
 Bob's copy must still show Bob.
 
+## Meeting attendee mailbox names
+
+`MailboxDisplayNameDirectory` must resolve names through `VisibleEmailScope`
+for the current viewer. A team-wide participant search leaks names from
+private and mailbox-blocked mail onto another user's meeting.
+
 ## Personal calendar vs workspace meetings
 
 Home (`ListMeetingsForDay`, `MeetingsHomeWidget`) is a personal calendar.

--- a/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
@@ -7,6 +7,7 @@ namespace Relaticle\EmailIntegration\Filament\Infolists;
 use App\Models\Company;
 use App\Models\Opportunity;
 use App\Models\People;
+use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Select;
@@ -60,7 +61,12 @@ final class MeetingDetailInfolist
                 $record->attendees->each(
                     fn (MeetingAttendee $attendee) => $attendee->setRelation('meeting', $record),
                 );
-                resolve(MailboxDisplayNameDirectory::class)->primeFromMeetings([$record]);
+
+                $viewer = auth()->user();
+
+                if ($viewer instanceof User) {
+                    resolve(MailboxDisplayNameDirectory::class)->primeFromMeetings($viewer, [$record]);
+                }
             }
 
             $rsvpGroup = MeetingRsvpActions::group();

--- a/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
+++ b/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
@@ -469,7 +469,7 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
             ->find($meetingId);
 
         if ($meeting instanceof Meeting) {
-            resolve(MailboxDisplayNameDirectory::class)->primeFromMeetings([$meeting]);
+            resolve(MailboxDisplayNameDirectory::class)->primeFromMeetings($user, [$meeting]);
         }
 
         return $meeting;

--- a/packages/EmailIntegration/src/Services/ListMeetingsForDay.php
+++ b/packages/EmailIntegration/src/Services/ListMeetingsForDay.php
@@ -64,7 +64,7 @@ final readonly class ListMeetingsForDay
             ->orderBy('id')
             ->get();
 
-        resolve(MailboxDisplayNameDirectory::class)->primeFromMeetings($meetings);
+        resolve(MailboxDisplayNameDirectory::class)->primeFromMeetings($user, $meetings);
 
         return $meetings;
     }

--- a/packages/EmailIntegration/src/Services/MailboxDisplayNameDirectory.php
+++ b/packages/EmailIntegration/src/Services/MailboxDisplayNameDirectory.php
@@ -4,33 +4,42 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\Meeting;
+use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 
 final class MailboxDisplayNameDirectory
 {
     /** @var array<string, array<string, string|null>> */
-    private array $namesByTeam = [];
+    private array $namesByViewer = [];
 
     /**
+     * Resolve display names from mail the viewer is allowed to see.
+     *
+     * Restricted to mail VisibleEmailScope would list. Without that gate,
+     * names from private, mailbox-blocked, protected, and internal messages
+     * leak onto another user's meeting.
+     *
      * @param  list<string>  $emails
      */
-    public function prime(string $teamId, array $emails): void
+    public function prime(User $viewer, array $emails): void
     {
+        $cacheKey = $this->cacheKey($viewer);
         $missing = [];
 
-        $this->namesByTeam[$teamId] ??= [];
+        $this->namesByViewer[$cacheKey] ??= [];
 
         foreach ($emails as $email) {
             $normalized = Str::lower(trim($email));
 
-            if ($normalized === '' || array_key_exists($normalized, $this->namesByTeam[$teamId])) {
+            if ($normalized === '' || array_key_exists($normalized, $this->namesByViewer[$cacheKey])) {
                 continue;
             }
 
-            $this->namesByTeam[$teamId][$normalized] = null;
+            $this->namesByViewer[$cacheKey][$normalized] = null;
             $missing[] = $normalized;
         }
 
@@ -47,7 +56,8 @@ final class MailboxDisplayNameDirectory
             ->whereRaw('lower(btrim(email_participants.name)) <> email_participants.email_address')
             ->whereHas(
                 'email',
-                fn (Builder $query): Builder => $query->where('team_id', $teamId),
+                fn (Builder $query): Builder => $query
+                    ->withGlobalScope('visible', new VisibleEmailScope($viewer)),
             )
             ->groupBy('email_participants.email_address', 'email_participants.name')
             ->orderByDesc('mentions')
@@ -57,38 +67,31 @@ final class MailboxDisplayNameDirectory
             $email = Str::lower(trim((string) $row->email_address));
             $name = trim((string) $row->name);
 
-            if ($email === '' || $name === '' || $this->namesByTeam[$teamId][$email] !== null) {
+            if ($email === '' || $name === '' || $this->namesByViewer[$cacheKey][$email] !== null) {
                 continue;
             }
 
-            $this->namesByTeam[$teamId][$email] = $name;
+            $this->namesByViewer[$cacheKey][$email] = $name;
         }
     }
 
     /**
      * @param  iterable<int, Meeting>  $meetings
      */
-    public function primeFromMeetings(iterable $meetings): void
+    public function primeFromMeetings(User $viewer, iterable $meetings): void
     {
         $emails = [];
-        $teamId = null;
 
         foreach ($meetings as $meeting) {
-            $teamId ??= (string) $meeting->team_id;
-
             foreach ($meeting->attendees as $attendee) {
                 $emails[] = (string) $attendee->email_address;
             }
         }
 
-        if ($teamId === null) {
-            return;
-        }
-
-        $this->prime($teamId, $emails);
+        $this->prime($viewer, $emails);
     }
 
-    public function find(string $teamId, string $email): ?string
+    public function find(User $viewer, string $email): ?string
     {
         $normalized = Str::lower(trim($email));
 
@@ -96,10 +99,17 @@ final class MailboxDisplayNameDirectory
             return null;
         }
 
-        if (! isset($this->namesByTeam[$teamId]) || ! array_key_exists($normalized, $this->namesByTeam[$teamId])) {
-            $this->prime($teamId, [$normalized]);
+        $cacheKey = $this->cacheKey($viewer);
+
+        if (! isset($this->namesByViewer[$cacheKey]) || ! array_key_exists($normalized, $this->namesByViewer[$cacheKey])) {
+            $this->prime($viewer, [$normalized]);
         }
 
-        return $this->namesByTeam[$teamId][$normalized] ?? null;
+        return $this->namesByViewer[$cacheKey][$normalized] ?? null;
+    }
+
+    private function cacheKey(User $viewer): string
+    {
+        return $viewer->getKey().':'.$viewer->current_team_id;
     }
 }

--- a/packages/EmailIntegration/src/Services/MeetingAttendeePresenter.php
+++ b/packages/EmailIntegration/src/Services/MeetingAttendeePresenter.php
@@ -36,7 +36,7 @@ final readonly class MeetingAttendeePresenter
         $selfName = $mailboxPerson !== null ? $this->usableName($mailboxPerson['name'], $email) : null;
         $memberName = $member !== null ? $this->usableName($member['name'], $email) : null;
         $calendarName = $this->usableName($attendee->name, $email);
-        $mailboxName = $email !== '' ? $this->mailboxName($attendee, $email) : null;
+        $mailboxName = $email !== '' ? $this->mailboxName($email) : null;
         $named = $contactName
             ?? $selfName
             ?? $memberName
@@ -114,15 +114,15 @@ final readonly class MeetingAttendeePresenter
         return $this->teamMembers->find($teamId, $email);
     }
 
-    private function mailboxName(MeetingAttendee $attendee, string $email): ?string
+    private function mailboxName(string $email): ?string
     {
-        $teamId = $this->teamId($attendee);
+        $viewer = auth()->user();
 
-        if ($teamId === null) {
+        if (! $viewer instanceof User) {
             return null;
         }
 
-        return $this->mailboxNames->find($teamId, $email);
+        return $this->mailboxNames->find($viewer, $email);
     }
 
     private function usableName(mixed $name, string $email): ?string

--- a/packages/EmailIntegration/src/Services/MeetingAttendeePresenter.php
+++ b/packages/EmailIntegration/src/Services/MeetingAttendeePresenter.php
@@ -86,17 +86,21 @@ final readonly class MeetingAttendeePresenter
         $user = $account->relationLoaded('user')
             ? $account->getRelation('user')
             : null;
-        $name = $user instanceof User && trim($user->name) !== ''
-            ? trim($user->name)
-            : trim((string) ($account->display_name ?? ''));
 
-        if ($name === '' || Str::lower($name) === Str::lower(trim($account->email_address))) {
+        if (! $user instanceof User) {
+            return null;
+        }
+
+        $mailboxEmail = Str::lower(trim($account->email_address));
+        $userEmail = Str::lower(trim($user->email));
+
+        if ($mailboxEmail === '' || $mailboxEmail !== $userEmail || trim($user->name) === '') {
             return null;
         }
 
         return [
-            'name' => $name,
-            'avatar' => $user instanceof User ? $user->profile_photo_url : null,
+            'name' => trim($user->name),
+            'avatar' => $user->profile_photo_url,
         ];
     }
 

--- a/packages/EmailIntegration/src/Services/TeamMemberDirectory.php
+++ b/packages/EmailIntegration/src/Services/TeamMemberDirectory.php
@@ -7,7 +7,6 @@ namespace Relaticle\EmailIntegration\Services;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
-use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 final class TeamMemberDirectory
 {
@@ -48,32 +47,6 @@ final class TeamMemberDirectory
                 $members[$email] = [
                     'name' => trim($user->name),
                     'avatar' => $user->profile_photo_url,
-                ];
-            });
-
-        ConnectedAccount::query()
-            ->where('team_id', $teamId)
-            ->with('user')
-            ->get()
-            ->each(function (ConnectedAccount $account) use (&$members): void {
-                $email = Str::lower(trim($account->email_address));
-
-                if ($email === '' || isset($members[$email])) {
-                    return;
-                }
-
-                $user = $account->user;
-                $name = $user instanceof User && trim($user->name) !== ''
-                    ? trim($user->name)
-                    : trim((string) ($account->display_name ?? ''));
-
-                if ($name === '' || Str::lower($name) === $email) {
-                    return;
-                }
-
-                $members[$email] = [
-                    'name' => $name,
-                    'avatar' => $user instanceof User ? $user->profile_photo_url : null,
                 ];
             });
 

--- a/tests/Feature/CalendarIntegration/MeetingDetailTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingDetailTest.php
@@ -213,6 +213,12 @@ it('shows an empty participants line when there are no attendees', function (): 
 });
 
 it('shows the current user attendee row when is_self is true', function (): void {
+    $this->user->forceFill([
+        'name' => 'Oliver Workspace',
+        'email' => 'oliver@relaticle.test',
+    ])->save();
+    $this->account->forceFill(['email_address' => 'oliver@relaticle.test'])->save();
+
     $meeting = Meeting::factory()->create([
         'team_id' => $this->team->id,
         'connected_account_id' => $this->account->id,
@@ -220,22 +226,83 @@ it('shows the current user attendee row when is_self is true', function (): void
 
     MeetingAttendee::factory()->create([
         'meeting_id' => $meeting->id,
-        'name' => 'Current User',
-        'email_address' => 'self@example.test',
+        'name' => 'Calendar Oliver',
+        'email_address' => 'oliver@relaticle.test',
         'is_self' => true,
         'is_organizer' => false,
         'response_status' => AttendeeResponseStatus::ACCEPTED,
     ]);
 
-    // A self attendee is named from this meeting copy's mailbox owner,
-    // not the calendar copy of the name.
     meetingDetailsOnRecord([$meeting])
         ->mountAction(TestAction::make('view')->table($meeting))
-        ->assertMountedActionModalSee($this->user->name)
-        ->assertMountedActionModalSee('self@example.test')
+        ->assertMountedActionModalSee('Oliver Workspace')
+        ->assertMountedActionModalSee('oliver@relaticle.test')
+        ->assertMountedActionModalDontSee('Calendar Oliver')
         ->assertMountedActionModalSee('attendee-avatar-initials', escape: false)
         ->assertMountedActionModalDontSee('attendee-avatar-guest', escape: false)
         ->assertMountedActionModalSee(AttendeeResponseStatus::ACCEPTED->getLabel());
+});
+
+it('does not name a self attendee from the workspace user when the mailbox address differs', function (): void {
+    $this->user->forceFill([
+        'name' => 'Oliver Workspace',
+        'email' => 'oliver@relaticle.test',
+    ])->save();
+    $this->account->forceFill([
+        'email_address' => 'whiteshark.devs@example.test',
+        'display_name' => 'Whiteshark',
+    ])->save();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => null,
+        'email_address' => 'whiteshark.devs@example.test',
+        'is_self' => true,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    meetingDetailsOnRecord([$meeting])
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('whiteshark.devs@example.test')
+        ->assertMountedActionModalDontSee('Oliver Workspace')
+        ->assertMountedActionModalDontSee('Whiteshark');
+});
+
+it('keeps the calendar name for a guest on a different connected mailbox', function (): void {
+    $this->user->forceFill([
+        'name' => 'Oliver Workspace',
+        'email' => 'oliver@relaticle.test',
+    ])->save();
+    $this->account->forceFill([
+        'email_address' => 'whiteshark.devs@example.test',
+        'display_name' => 'Whiteshark',
+    ])->save();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => 'Whiteshark Devs',
+        'email_address' => 'whiteshark.devs@example.test',
+        'is_self' => false,
+        'is_organizer' => false,
+        'response_status' => AttendeeResponseStatus::NEEDS_ACTION,
+    ]);
+
+    meetingDetailsOnRecord([$meeting])
+        ->mountAction(TestAction::make('view')->table($meeting))
+        ->assertMountedActionModalSee('Whiteshark Devs')
+        ->assertMountedActionModalSee('whiteshark.devs@example.test')
+        ->assertMountedActionModalDontSee('Oliver Workspace');
 });
 
 it('shows the linked person name above the attendee email', function (): void {

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -706,6 +706,37 @@ it('collapses duplicate guest emails on the card', function (): void {
         ->assertDontSee('maya@example.test');
 });
 
+it('does not name a card guest from the workspace user for a different connected mailbox', function (): void {
+    $this->user->forceFill([
+        'name' => 'Oliver Workspace',
+        'email' => 'oliver@relaticle.test',
+    ])->save();
+    $this->account->forceFill([
+        'email_address' => 'whiteshark.devs@example.test',
+        'display_name' => 'Whiteshark',
+    ])->save();
+
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Call',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => 'Whiteshark Devs',
+        'email_address' => 'whiteshark.devs@example.test',
+        'is_self' => false,
+        'is_organizer' => false,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('Whiteshark Devs')
+        ->assertDontSee('Oliver Workspace');
+});
+
 it('shows a person icon when the attendee has no name', function (): void {
     $meeting = Meeting::factory()->create([
         'team_id' => $this->team->id,
@@ -923,7 +954,10 @@ it('does not list a teammate meeting on home when the viewer is not invited', fu
 it('names a self attendee from the meeting mailbox when viewing a teammate copy', function (): void {
     $this->user->forceFill(['name' => 'Alice Viewer'])->save();
 
-    $bob = User::factory()->create(['name' => 'Bob Owner']);
+    $bob = User::factory()->create([
+        'name' => 'Bob Owner',
+        'email' => 'bob@example.com',
+    ]);
     $bob->teams()->attach($this->team, ['role' => 'admin']);
     $bob->forceFill(['current_team_id' => $this->team->id])->save();
 

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -15,6 +15,7 @@ use Relaticle\EmailIntegration\Filament\Concerns\HasConnectMailboxActions;
 use Relaticle\EmailIntegration\Livewire\MeetingsHomeWidget;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailBlocklist;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\MeetingAttendee;
@@ -478,6 +479,158 @@ it('names a card guest from mailbox history without a person record', function (
         ->assertDontSee('mail2asmitnepali@gmail.com')
         ->assertSee('attendee-avatar-initials', escape: false)
         ->assertDontSee('attendee-avatar-guest', escape: false);
+});
+
+it('names a card guest from the viewer own private email', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Call',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+    $mail = Email::factory()->private()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+    ]);
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $mail->id,
+        'email_address' => 'own.private@example.test',
+        'name' => 'Own Private Guest',
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => null,
+        'email_address' => 'own.private@example.test',
+        'is_organizer' => false,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('Own Private Guest')
+        ->assertDontSee('own.private@example.test');
+});
+
+it('does not name a card guest from a teammate private email', function (): void {
+    $teammate = User::factory()->create(['current_team_id' => $this->team->id]);
+    $teammateAccount = ConnectedAccount::withoutEvents(
+        fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $teammate->id,
+        ])
+    );
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Call',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+    $mail = Email::factory()->private()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'connected_account_id' => $teammateAccount->id,
+    ]);
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $mail->id,
+        'email_address' => 'secret.guest@example.test',
+        'name' => 'Secret Guest',
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => null,
+        'email_address' => 'secret.guest@example.test',
+        'is_organizer' => false,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertDontSee('Secret Guest')
+        ->assertSee('secret.guest@example.test');
+});
+
+it('does not name a card guest from a mailbox-blocked email', function (): void {
+    $teammate = User::factory()->create(['current_team_id' => $this->team->id]);
+    $teammateAccount = ConnectedAccount::withoutEvents(
+        fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $teammate->id,
+        ])
+    );
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Call',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+    $mail = Email::factory()->full()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'connected_account_id' => $teammateAccount->id,
+        'is_internal' => false,
+    ]);
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $mail->id,
+        'email_address' => 'spam@badactor.test',
+        'name' => 'Blocked Sender',
+    ]);
+    EmailBlocklist::factory()->email('spam@badactor.test')->create([
+        'user_id' => $teammate->id,
+        'team_id' => $this->team->id,
+        'connected_account_id' => $teammateAccount->id,
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => null,
+        'email_address' => 'spam@badactor.test',
+        'is_organizer' => false,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertDontSee('Blocked Sender')
+        ->assertSee('spam@badactor.test');
+});
+
+it('names a card guest from a teammate workspace-visible email', function (): void {
+    $teammate = User::factory()->create(['current_team_id' => $this->team->id]);
+    $teammateAccount = ConnectedAccount::withoutEvents(
+        fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $teammate->id,
+        ])
+    );
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Call',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+    $mail = Email::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $teammate->id,
+        'connected_account_id' => $teammateAccount->id,
+        'is_internal' => false,
+    ]);
+    EmailParticipant::factory()->from()->create([
+        'email_id' => $mail->id,
+        'email_address' => 'shared.guest@acme.test',
+        'name' => 'Shared Guest',
+    ]);
+
+    MeetingAttendee::factory()->create([
+        'meeting_id' => $meeting->id,
+        'name' => null,
+        'email_address' => 'shared.guest@acme.test',
+        'is_organizer' => false,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('Shared Guest')
+        ->assertDontSee('shared.guest@acme.test');
 });
 
 it('colours the card dot by the viewer RSVP', function (string $status, string $expectedClass, string $expectedLabel): void {


### PR DESCRIPTION
## Summary
- Meeting attendee names from mailbox history now resolve only through mail the current viewer can see (`VisibleEmailScope`).
- Private and mailbox-blocked messages no longer leak display names onto another user's meeting.
- Cache is keyed per viewer so one user's visible names cannot bleed into another request.

## Test plan
- [x] Open Home meetings with a guest that has no calendar name and no person record. A name from your own mailbox history still appears.
- [x] Same guest, name only on a teammate's private email: the card shows the email address, not that private name.
- [x] Same guest, name only on a mailbox-blocked message: the card shows the email address, not that blocked name.
- [x] A name from a teammate's workspace-visible email still appears on your meeting card.