### PR TITLE
Filter all-day Home meetings by calendar date

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -47,3 +47,12 @@ list (user email plus every connected-account address).
 Record Meetings tabs, communication-intelligence aggregates, and other
 workspace surfaces keep the default `VisibleMeetingScope` (teammate meetings
 with an external guest stay visible there).
+
+## All-day meetings are calendar dates
+
+All-day events are stored as a UTC date at midnight (`GoogleCalendarService`
+parses the provider's bare `Y-m-d` in UTC). Filter them with `whereDate` on
+that calendar date. Do not convert them through the viewer's timezone: a
+Los Angeles day window starts at 07:00 UTC, so a September 10 all-day event
+would otherwise appear on the 9th. Timed meetings still use local-day UTC
+bounds.

--- a/packages/EmailIntegration/src/Services/ListMeetingsForDay.php
+++ b/packages/EmailIntegration/src/Services/ListMeetingsForDay.php
@@ -6,7 +6,9 @@ namespace Relaticle\EmailIntegration\Services;
 
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
@@ -19,19 +21,41 @@ final readonly class ListMeetingsForDay
     public function nextDayWithMeetings(User $user, CarbonImmutable $day): ?CarbonImmutable
     {
         $timezone = $user->effectiveTimezone();
+        $localDay = $day->timezone($timezone)->startOfDay();
+        $calendarDate = $localDay->toDateString();
+        $endUtc = $localDay->endOfDay()->utc();
 
-        $next = Meeting::query()
-            ->withGlobalScope('visible', VisibleMeetingScope::personal($user))
-            ->where('starts_at', '>', $day->timezone($timezone)->endOfDay()->utc())
+        $nextTimed = $this->visibleMeetings($user)
+            ->where('all_day', false)
+            ->where('starts_at', '>', $endUtc)
             ->reorder()
             ->oldest('starts_at')
             ->value('starts_at');
 
-        if (! $next instanceof CarbonImmutable) {
+        $nextAllDay = $this->visibleMeetings($user)
+            ->where('all_day', true)
+            ->whereDate('starts_at', '>', $calendarDate)
+            ->reorder()
+            ->oldest('starts_at')
+            ->value('starts_at');
+
+        $nextDays = [];
+
+        if ($nextTimed instanceof CarbonImmutable) {
+            $nextDays[] = $nextTimed->timezone($timezone)->startOfDay();
+        }
+
+        if ($nextAllDay instanceof CarbonImmutable) {
+            $nextDays[] = Date::parse($nextAllDay->utc()->toDateString(), $timezone)->startOfDay();
+        }
+
+        if ($nextDays === []) {
             return null;
         }
 
-        return $next->timezone($timezone)->startOfDay();
+        usort($nextDays, fn (CarbonImmutable $left, CarbonImmutable $right): int => $left <=> $right);
+
+        return $nextDays[0];
     }
 
     /**
@@ -40,12 +64,21 @@ final readonly class ListMeetingsForDay
     public function execute(User $user, CarbonImmutable $day): Collection
     {
         $timezone = $user->effectiveTimezone();
-        $startUtc = $day->timezone($timezone)->startOfDay()->utc();
-        $endUtc = $day->timezone($timezone)->endOfDay()->utc();
+        $localDay = $day->timezone($timezone)->startOfDay();
+        $calendarDate = $localDay->toDateString();
+        $startUtc = $localDay->utc();
+        $endUtc = $localDay->endOfDay()->utc();
 
-        $query = Meeting::query()
-            ->withGlobalScope('visible', VisibleMeetingScope::personal($user))
-            ->whereBetween('starts_at', [$startUtc, $endUtc]);
+        $query = $this->visibleMeetings($user)
+            ->where(function (Builder $query) use ($startUtc, $endUtc, $calendarDate): void {
+                $query->where(function (Builder $timed) use ($startUtc, $endUtc): void {
+                    $timed->where('all_day', false)
+                        ->whereBetween('starts_at', [$startUtc, $endUtc]);
+                })->orWhere(function (Builder $allDay) use ($calendarDate): void {
+                    $allDay->where('all_day', true)
+                        ->whereDate('starts_at', $calendarDate);
+                });
+            });
 
         $identity = "COALESCE('uid:' || NULLIF(meetings.ical_uid, ''), 'id:' || meetings.id)";
         $copies = (clone $query)
@@ -67,5 +100,14 @@ final readonly class ListMeetingsForDay
         resolve(MailboxDisplayNameDirectory::class)->primeFromMeetings($meetings);
 
         return $meetings;
+    }
+
+    /**
+     * @return Builder<Meeting>
+     */
+    private function visibleMeetings(User $user): Builder
+    {
+        return Meeting::query()
+            ->withGlobalScope('visible', VisibleMeetingScope::personal($user));
     }
 }

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -342,6 +342,85 @@ it('does not show a meeting that starts on another day', function (): void {
         ->assertSee(__('filament/pages/dashboard.meetings.empty.title'));
 });
 
+/**
+ * All-day events are stored as a UTC date at midnight. Converting that timestamp
+ * into the viewer's zone moves the day for anyone west of UTC. Los Angeles is
+ * UTC-7 in September, so 2026-09-10 00:00 UTC would otherwise land on the 9th.
+ */
+it('shows an all-day event on its calendar date for a viewer west of UTC', function (): void {
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Company offsite',
+        'starts_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'ends_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'all_day' => true,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->set('selectedDate', '2026-09-10')
+        ->assertSee('Company offsite')
+        ->assertSee(__('filament/pages/dashboard.meetings.all_day'))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
+});
+
+it('does not show an all-day event on the previous local day for a viewer west of UTC', function (): void {
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Company offsite',
+        'starts_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'ends_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'all_day' => true,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertDontSee('Company offsite')
+        ->assertSee(__('filament/pages/dashboard.meetings.empty.title'));
+});
+
+it('jumps to the calendar date of a later all-day event for a viewer west of UTC', function (): void {
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Company offsite',
+        'starts_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'ends_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'all_day' => true,
+    ]);
+
+    $component = livewire(MeetingsHomeWidget::class)
+        ->assertSee(__('filament/pages/dashboard.meetings.empty.next_with_meetings'))
+        ->call('goToNextDayWithMeetings')
+        ->assertSee('Company offsite');
+
+    expect($component->instance()->selectedDate)->toBe('2026-09-10');
+});
+
+it('lists a late-evening timed meeting on the local day for a viewer west of UTC', function (): void {
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'West coast standup',
+        'starts_at' => Date::parse('2026-09-10 04:00:00', 'UTC'),
+        'ends_at' => Date::parse('2026-09-10 05:00:00', 'UTC'),
+        'all_day' => false,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertSee('West coast standup')
+        ->set('selectedDate', '2026-09-10')
+        ->assertDontSee('West coast standup');
+});
+
 it('shows one copy when two calendars share an ical uid', function (): void {
     $teammate = User::factory()->create();
     $otherAccount = ConnectedAccount::withoutEvents(


### PR DESCRIPTION
## Summary
- All-day events are stored as a UTC date at midnight. Home was filtering them with the viewer's local day converted to UTC, so a Los Angeles window starts at 07:00 UTC and a September 10 all-day event appeared on the 9th.
- `ListMeetingsForDay` now matches all-day meetings with `whereDate` on that calendar date, and keeps timed meetings on local-day UTC bounds.
- Jump to next day uses the same split, so an all-day event is not skipped or mapped back a day.

## Test plan
- [x] Open Home as a user on `America/Los_Angeles`.
- [x] Confirm a September 10 all-day event shows on the 10th, not the 9th.
- [x] From the 9th empty state, jump to next day with meetings and land on the 10th.
- [x] Confirm a late-evening timed meeting still lists on the local day.