### PR TITLE
Fix all-day meeting date range and past-state on home

### DIFF
--- a/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
+++ b/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
@@ -405,7 +405,7 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
         $now = Date::now($this->viewerTimezone());
 
         if ($meeting->all_day) {
-            return $now->gte($meeting->starts_at->timezone($this->viewerTimezone())->endOfDay());
+            return $now->toDateString() > $meeting->ends_at->utc()->toDateString();
         }
 
         return $now->gte($meeting->ends_at->timezone($this->viewerTimezone()));

--- a/packages/EmailIntegration/src/Services/ListMeetingsForDay.php
+++ b/packages/EmailIntegration/src/Services/ListMeetingsForDay.php
@@ -76,7 +76,8 @@ final readonly class ListMeetingsForDay
                         ->whereBetween('starts_at', [$startUtc, $endUtc]);
                 })->orWhere(function (Builder $allDay) use ($calendarDate): void {
                     $allDay->where('all_day', true)
-                        ->whereDate('starts_at', $calendarDate);
+                        ->whereDate('starts_at', '<=', $calendarDate)
+                        ->whereDate('ends_at', '>=', $calendarDate);
                 });
             });
 

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -367,6 +367,47 @@ it('shows an all-day event on its calendar date for a viewer west of UTC', funct
         ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
 });
 
+it('shows a multi-day all-day event on every day in its range', function (): void {
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Company offsite',
+        'starts_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'ends_at' => Date::parse('2026-09-12 00:00:00', 'UTC'),
+        'all_day' => true,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->set('selectedDate', '2026-09-10')
+        ->assertSee('Company offsite')
+        ->set('selectedDate', '2026-09-11')
+        ->assertSee('Company offsite')
+        ->set('selectedDate', '2026-09-12')
+        ->assertSee('Company offsite')
+        ->set('selectedDate', '2026-09-13')
+        ->assertDontSee('Company offsite');
+});
+
+it('does not mark todays all-day event as past for a viewer west of UTC', function (): void {
+    $this->travelTo(Date::parse('2026-09-10 17:00:00', 'UTC'));
+    $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
+
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Company offsite',
+        'starts_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'ends_at' => Date::parse('2026-09-10 00:00:00', 'UTC'),
+        'all_day' => true,
+    ]);
+
+    $html = html_entity_decode(livewire(MeetingsHomeWidget::class)->html());
+
+    expect($html)
+        ->toContain('Company offsite')
+        ->not->toMatch('/Company offsite.*line-through/s');
+});
+
 it('does not show an all-day event on the previous local day for a viewer west of UTC', function (): void {
     $this->user->forceFill(['timezone' => 'America/Los_Angeles'])->save();
 


### PR DESCRIPTION
## Summary
- List multi-day all-day events on every day they span, not just the start date.
- Stop marking today's all-day events as past for viewers west of UTC by comparing calendar dates instead of timezone-shifting stored UTC dates.

## Test plan
- [x] `php artisan test --compact tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php --filter="multi-day|todays all-day|all-day event"`
- [x] `php artisan test --compact tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php`