### PR TITLE
fix(email): authorize signature block expansion by user and workspace

### DIFF
--- a/packages/EmailIntegration/src/Filament/RichContent/SignatureBlock.php
+++ b/packages/EmailIntegration/src/Filament/RichContent/SignatureBlock.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\RichContent;
 
+use Filament\Facades\Filament;
 use Filament\Forms\Components\RichEditor\RichContentCustomBlock;
+use Illuminate\Support\Facades\Auth;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 
 /**
@@ -61,8 +63,17 @@ final class SignatureBlock extends RichContentCustomBlock
             return null;
         }
 
+        $userId = Auth::id();
+        $teamId = Filament::getTenant()?->getKey();
+
+        if ($userId === null || $teamId === null) {
+            return null;
+        }
+
         return EmailSignature::query()
             ->whereKey($signatureId)
+            ->where('user_id', $userId)
+            ->where('team_id', $teamId)
             ->value('content_html');
     }
 }

--- a/tests/Feature/EmailIntegration/SignatureBlockTest.php
+++ b/tests/Feature/EmailIntegration/SignatureBlockTest.php
@@ -60,3 +60,57 @@ it('expands the signature block into signature html when rendered for sending', 
         ->toContain('Best, Jane')
         ->not->toContain('data-type="customBlock"');
 });
+
+it('does not expand a signature block referencing another users signature', function (): void {
+    $otherUser = User::factory()->withTeam()->create();
+    $otherAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $otherUser->currentTeam->id,
+        'user_id' => $otherUser->id,
+    ]));
+    $foreignSignature = EmailSignature::withoutEvents(fn () => EmailSignature::factory()->create([
+        'connected_account_id' => $otherAccount->id,
+        'content_html' => '<p>Secret signature</p>',
+    ]));
+
+    $configAttr = htmlspecialchars(
+        (string) json_encode(['signature_id' => $foreignSignature->getKey()]),
+        ENT_QUOTES,
+        'UTF-8',
+    );
+
+    $body = '<p>Hello</p><div data-type="customBlock"'
+        .' data-id="'.SignatureBlock::ID.'"'
+        .' data-config="'.$configAttr.'"></div>';
+
+    $sent = $this->service->renderForSending($body);
+
+    expect($sent)->toContain('Hello')
+        ->not->toContain('Secret signature');
+});
+
+it('does not expand a signature block from another workspace', function (): void {
+    $otherTeam = User::factory()->withTeam()->create()->currentTeam;
+    $otherAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'team_id' => $otherTeam->id,
+        'user_id' => $this->user->id,
+    ]));
+    $foreignSignature = EmailSignature::withoutEvents(fn () => EmailSignature::factory()->create([
+        'connected_account_id' => $otherAccount->id,
+        'content_html' => '<p>Other workspace signature</p>',
+    ]));
+
+    $configAttr = htmlspecialchars(
+        (string) json_encode(['signature_id' => $foreignSignature->getKey()]),
+        ENT_QUOTES,
+        'UTF-8',
+    );
+
+    $body = '<p>Hello</p><div data-type="customBlock"'
+        .' data-id="'.SignatureBlock::ID.'"'
+        .' data-config="'.$configAttr.'"></div>';
+
+    $sent = $this->service->renderForSending($body);
+
+    expect($sent)->toContain('Hello')
+        ->not->toContain('Other workspace signature');
+});


### PR DESCRIPTION
## Summary
- Scope signature block expansion to the authenticated user and current Filament tenant.
- Return no signature HTML when auth or tenant context is missing, so crafted `signature_id` values cannot leak another user's signature into preview or outbound email bodies.
- Add regression tests for cross-user and cross-workspace signature block payloads.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/SignatureBlockTest.php`
- [x] `vendor/bin/phpstan analyse packages/EmailIntegration/src/Filament/RichContent/SignatureBlock.php`