### PR TITLE
Skip Gmail messages that disappeared before fetching

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -5,6 +5,13 @@ paths:
 
 # Email integration
 
+## Vanished provider messages must not fail the mailbox
+
+A listed Gmail or Graph id can be permanently deleted before `StoreEmailJob`
+fetches it. That 404 is skippable: returning from the job keeps the store batch
+successful so later mail still imports. Retrying until failure marks the mailbox
+`ERROR`, which excludes it from scheduled incremental syncs.
+
 ## Never import provider drafts
 
 Gmail drafts carry the `DRAFT` label and not `SENT`, so `fetchMessage()` classifies

--- a/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/StoreEmailJob.php
@@ -8,6 +8,7 @@ use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
 use Relaticle\EmailIntegration\Actions\StoreEmailAction;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
@@ -71,6 +72,12 @@ final class StoreEmailJob implements ShouldBeUnique, ShouldQueue
                 return;
             }
 
+            // Permanently deleted between list and fetch. Retrying a 404 fails
+            // the batch and parks the mailbox as ERROR, stopping later imports.
+            if ($this->isMissingProviderMessage($exception)) {
+                return;
+            }
+
             throw $exception;
         }
 
@@ -102,5 +109,26 @@ final class StoreEmailJob implements ShouldBeUnique, ShouldQueue
             ->where('connected_account_id', $this->connectedAccount->getKey())
             ->where('provider_message_id', $this->messageId)
             ->exists();
+    }
+
+    private function isMissingProviderMessage(Throwable $exception): bool
+    {
+        $current = $exception;
+
+        while ($current instanceof Throwable) {
+            if ($current instanceof RequestException) {
+                return $current->response->status() === 404;
+            }
+
+            $code = $current->getCode();
+
+            if (is_int($code) && $code === 404) {
+                return true;
+            }
+
+            $current = $current->getPrevious();
+        }
+
+        return false;
     }
 }

--- a/tests/Feature/EmailIntegration/StoreEmailJobTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailJobTest.php
@@ -15,7 +15,6 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 use Relaticle\EmailIntegration\Services\ProviderRateLimit;
-use Throwable;
 
 mutates(StoreEmailJob::class, ProviderRateLimit::class, ReleasesOnProviderRateLimit::class);
 
@@ -101,7 +100,7 @@ it('does not call the mailbox for other messages while that account is cooling d
     runStoreEmailJobWithQueue($account, 'msg-second', $quietFactory, $secondQueue);
 });
 
-it('skips storing when the provider reports the message as gone', function (Throwable $exception): void {
+it('skips storing when the provider reports the message as gone', function (GoogleServiceException|RequestException $exception): void {
     $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
 
     $service = Mockery::mock(MailServiceInterface::class);

--- a/tests/Feature/EmailIntegration/StoreEmailJobTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailJobTest.php
@@ -15,6 +15,7 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 use Relaticle\EmailIntegration\Services\ProviderRateLimit;
+use Throwable;
 
 mutates(StoreEmailJob::class, ProviderRateLimit::class, ReleasesOnProviderRateLimit::class);
 
@@ -99,6 +100,28 @@ it('does not call the mailbox for other messages while that account is cooling d
 
     runStoreEmailJobWithQueue($account, 'msg-second', $quietFactory, $secondQueue);
 });
+
+it('skips storing when the provider reports the message as gone', function (Throwable $exception): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchMessage')
+        ->once()
+        ->andThrow($exception);
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    $queueJob = Mockery::mock(QueueJob::class);
+    $queueJob->shouldReceive('release')->never();
+
+    runStoreEmailJobWithQueue($account, 'msg-gone', $factory, $queueJob);
+
+    expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(0);
+})->with([
+    'Gmail 404' => fn (): GoogleServiceException => new GoogleServiceException('Requested entity was not found.', 404),
+    'Microsoft Graph 404' => fn (): RequestException => new RequestException(new Response(new Psr7Response(404, [], '{}'))),
+]);
 
 it('still fails when the provider error is not a rate limit', function (): void {
     $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());


### PR DESCRIPTION
## Summary
- Skip Gmail and Graph 404s in `StoreEmailJob` when a listed message is deleted before fetch.
- A vanished message no longer retries until the store batch marks the mailbox ERROR and stops later imports.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/StoreEmailJobTest.php`
- [x] Confirm a mailbox with one vanished id still imports the rest of the batch and stays ACTIVE.