### PR TITLE
Run a mailbox history backfill on re-import

### DIFF
--- a/packages/EmailIntegration/src/Actions/StartMailboxHistoryImportAction.php
+++ b/packages/EmailIntegration/src/Actions/StartMailboxHistoryImportAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Actions;
 
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
-use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\RelinkMailboxHistoryJob;
@@ -19,11 +18,13 @@ final readonly class StartMailboxHistoryImportAction
         dispatch(new RelinkMailboxHistoryJob($connectedAccount))->afterCommit();
 
         if ($connectedAccount->sync_cursor !== null) {
-            MailboxSyncTracker::markEmailStarted($connectedAccount);
-            dispatch(new IncrementalEmailSyncJob($connectedAccount))->afterCommit();
-        } else {
-            dispatch(new InitialEmailSyncJob($connectedAccount))->afterCommit();
+            $connectedAccount->update([
+                'sync_cursor' => null,
+                'initial_sync_estimated' => null,
+            ]);
         }
+
+        dispatch(new InitialEmailSyncJob($connectedAccount))->afterCommit();
 
         if (! $connectedAccount->hasCalendar()) {
             return;

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -16,6 +16,7 @@ use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Filament\Pages\EmailSignaturesPage;
 use Relaticle\EmailIntegration\Filament\Pages\UserEmailPrivacyPage;
 use Relaticle\EmailIntegration\Filament\Resources\EmailTemplateResource;
+use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\RelinkMailboxHistoryJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -224,12 +225,15 @@ it('lists the default account first', function (): void {
 it('queues mailbox history import from the account menu', function (): void {
     Bus::fake();
 
+    $this->account->update(['sync_cursor' => 'mail-cursor']);
+
     livewire(EmailAccountsPage::class)
         ->callAction('reimportHistory', arguments: ['account_id' => $this->account->id])
         ->assertNotified();
 
     Bus::assertDispatched(RelinkMailboxHistoryJob::class, fn (RelinkMailboxHistoryJob $job): bool => $job->connectedAccount->is($this->account));
     Bus::assertDispatched(InitialEmailSyncJob::class, fn (InitialEmailSyncJob $job): bool => $job->connectedAccount->is($this->account));
+    Bus::assertNotDispatched(IncrementalEmailSyncJob::class);
 });
 
 it('does not re-import another user\'s account', function (): void {

--- a/tests/Feature/EmailIntegration/StartMailboxHistoryImportActionTest.php
+++ b/tests/Feature/EmailIntegration/StartMailboxHistoryImportActionTest.php
@@ -41,11 +41,12 @@ it('also queues initial calendar sync when the account has calendar', function (
     Bus::assertDispatched(InitialCalendarSyncJob::class, fn (InitialCalendarSyncJob $job): bool => $job->connectedAccount->is($account));
 });
 
-it('queues incremental sync when calendar and mailbox cursors already exist', function (): void {
+it('queues an email backfill when a mailbox cursor already exists', function (): void {
     Bus::fake();
 
     $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
         'sync_cursor' => 'mail-cursor',
+        'initial_sync_estimated' => 80,
         'calendar_sync_cursor' => 'calendar-cursor',
         'capabilities' => [
             'email' => true,
@@ -55,10 +56,16 @@ it('queues incremental sync when calendar and mailbox cursors already exist', fu
 
     resolve(StartMailboxHistoryImportAction::class)->execute($account);
 
-    Bus::assertDispatched(IncrementalEmailSyncJob::class, fn (IncrementalEmailSyncJob $job): bool => $job->connectedAccount->is($account));
+    Bus::assertDispatched(InitialEmailSyncJob::class, fn (InitialEmailSyncJob $job): bool => $job->connectedAccount->is($account));
+    Bus::assertNotDispatched(IncrementalEmailSyncJob::class);
     Bus::assertDispatched(fn (IncrementalCalendarSyncJob $job): bool => $job->connectedAccount->is($account) && $job->reconcileAfter);
-    Bus::assertNotDispatched(InitialEmailSyncJob::class);
     Bus::assertNotDispatched(InitialCalendarSyncJob::class);
 
-    expect(MailboxSyncTracker::isCalendarSyncing($account))->toBeTrue();
+    expect($account->fresh())
+        ->sync_cursor->toBeNull()
+        ->initial_sync_estimated->toBeNull()
+        ->calendar_sync_cursor->toBe('calendar-cursor');
+
+    expect(MailboxSyncTracker::isCalendarSyncing($account))->toBeTrue()
+        ->and(MailboxSyncTracker::isEmailSyncing($account))->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- Re-import history now always queues an email backfill, even when a mailbox cursor already exists.
- Incremental sync only fetches mail newer than the cursor, so messages skipped while a folder toggle such as `sync_sent` was off stayed missing. Relink cannot recover rows that were never stored.
- Clearing the cursor and size estimate keeps scheduled incremental sync from racing the backfill and shows history-import progress in the UI. Calendar re-import is unchanged.

## Test plan
- [ ] Enable sent-mail sync on a mailbox that previously imported with it off, then choose Re-import history.
- [ ] Confirm missing sent messages from the import window appear after the backfill finishes.
- [ ] Confirm already-stored messages are not duplicated.
- [ ] Confirm calendar still incremental-syncs with reconcile when a calendar cursor exists.
- [ ] Confirm first-time connect (no cursor) still queues the initial email import.