### PR TITLE
Keep personalized email subjects as plain text

### DIFF
--- a/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
@@ -63,7 +63,7 @@ final readonly class SendEmailBatchAction
                 $rendered = $template instanceof EmailTemplate
                     ? $this->renderService->render($template, $person)
                     : [
-                        'subject' => $this->renderService->renderContent($payload['subject'], $person),
+                        'subject' => $this->renderService->renderPlainText($payload['subject'], $person),
                         'body_html' => $this->renderService->renderContent($payload['body_html'], $person),
                     ];
 

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -329,7 +329,7 @@ trait HasEmailComposeActions
 
         return [
             'connected_account_id' => $data['connected_account_id'],
-            'subject' => $renderer->renderContent((string) $data['subject'], $record),
+            'subject' => $renderer->renderPlainText((string) $data['subject'], $record),
             'body_html' => $bodyHtml,
             'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['to'] ?? []),
             'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['cc'] ?? []),

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -644,7 +644,7 @@ final class EmailInboxPage extends Page
 
         return [
             'connected_account_id' => $data['connected_account_id'],
-            'subject' => $renderer->renderContent((string) $data['subject']),
+            'subject' => $renderer->renderPlainText((string) $data['subject']),
             'body_html' => $bodyHtml,
             'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['to'] ?? []),
             'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $data['cc'] ?? []),

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -464,7 +464,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $email = resolve(SendEmailAction::class)->execute(
             data: [
                 'connected_account_id' => (string) $this->accountId,
-                'subject' => $renderer->renderContent((string) $this->subject),
+                'subject' => $renderer->renderPlainText((string) $this->subject),
                 'body_html' => $this->withQuotedBody($renderer->renderForSending($bodyHtml)),
                 'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->to),
                 'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->cc),

--- a/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
+++ b/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
@@ -126,6 +126,14 @@ final readonly class EmailTemplateRenderService
     }
 
     /**
+     * Substitute merge-tag placeholders in a plain-text string.
+     */
+    public function renderPlainText(string $content, ?Model $record = null): string
+    {
+        return $this->substitute($content, $this->buildVariables($record));
+    }
+
+    /**
      * Substitute merge-tag placeholders in a content string.
      */
     public function renderContent(string $content, ?Model $record = null): string

--- a/tests/Feature/EmailIntegration/EmailTemplateRenderTest.php
+++ b/tests/Feature/EmailIntegration/EmailTemplateRenderTest.php
@@ -75,6 +75,18 @@ it('HTML-escapes merge values in the body but not the plain-text subject', funct
     expect($result['subject'])->toBe('Hello <img src=x onerror=alert(1)> & Co');
 });
 
+it('substitutes merge tags in plain text without HTML-escaping', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Smith & Sons',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $rendered = app(EmailTemplateRenderService::class)->renderPlainText('Hello {name}', $person);
+
+    expect($rendered)->toBe('Hello Smith & Sons');
+});
+
 it('renders {name} for a Company record', function (): void {
     $company = Company::create([
         'team_id' => $this->team->id,

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -210,6 +210,34 @@ it('shows warning notification when no valid recipients exist', function (): voi
     expect(EmailBatch::count())->toBe(0);
 });
 
+it('sends a personalized subject as plain text when no template is saved', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Smith & Sons',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($person, 'smith@example.com');
+
+    livewire(ListPeople::class)
+        ->callTableBulkAction(
+            'massSend',
+            records: [$person],
+            data: [
+                'connected_account_id' => $this->account->id,
+                'subject' => 'Hello {name}',
+                'body_html' => '<p>Hi {name}</p>',
+            ],
+        )
+        ->assertNotified();
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+    $email = Email::where('batch_id', $batch->id)->firstOrFail();
+
+    expect($email->subject)->toBe('Hello Smith & Sons');
+    expect($email->body->body_html)->toBe('<p>Hi Smith &amp; Sons</p>');
+});
+
 it('applies template variables per recipient', function (): void {
     $personA = People::create([
         'team_id' => $this->team->id,


### PR DESCRIPTION
## Summary
- Without a saved template, subject personalization used the HTML-escaping renderer, so `Hello {name}` became `Hello Smith &amp; Sons`.
- Subjects now use plain-text substitution on mass send, compose, inbox, and the composer. Bodies still HTML-escape merge values.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/MassSendEmailTest.php tests/Feature/EmailIntegration/EmailTemplateRenderTest.php`
- [ ] Mass-send without a template using subject `Hello {name}` to a contact named Smith & Sons. The queued subject should be `Hello Smith & Sons`, not `Hello Smith &amp; Sons`.
- [ ] Confirm the body still shows `Smith &amp; Sons` in HTML.