### PR TITLE
Send submitted bulk-email content when a template is selected

### DIFF
--- a/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
@@ -12,7 +12,6 @@ use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\EmailBatch;
-use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 
 final readonly class SendEmailBatchAction
@@ -35,7 +34,7 @@ final readonly class SendEmailBatchAction
      * @param  list<array{person: People, email: string}>  $recipients
      * @param  array{connected_account_id: string, subject: string, body_html: string}  $payload
      */
-    public function execute(User $user, array $recipients, array $payload, ?EmailTemplate $template = null): EmailBatch
+    public function execute(User $user, array $recipients, array $payload): EmailBatch
     {
         $accountId = $payload['connected_account_id'];
 
@@ -47,7 +46,7 @@ final readonly class SendEmailBatchAction
             ->whereKey($accountId)
             ->firstOrFail();
 
-        return DB::transaction(function () use ($user, $recipients, $payload, $template, $accountId): EmailBatch {
+        return DB::transaction(function () use ($user, $recipients, $payload, $accountId): EmailBatch {
             $batch = EmailBatch::query()->create([
                 'team_id' => $user->currentTeam?->getKey(),
                 'user_id' => $user->getKey(),
@@ -60,18 +59,11 @@ final readonly class SendEmailBatchAction
             foreach ($recipients as $recipient) {
                 $person = $recipient['person'];
 
-                $rendered = $template instanceof EmailTemplate
-                    ? $this->renderService->render($template, $person)
-                    : [
-                        'subject' => $this->renderService->renderContent($payload['subject'], $person),
-                        'body_html' => $this->renderService->renderContent($payload['body_html'], $person),
-                    ];
-
                 $this->sendEmail->execute(
                     data: [
                         'connected_account_id' => $accountId,
-                        'subject' => $rendered['subject'],
-                        'body_html' => $rendered['body_html'],
+                        'subject' => $this->renderService->renderContent($payload['subject'], $person),
+                        'body_html' => $this->renderService->renderContent($payload['body_html'], $person),
                         'to' => [['email' => $recipient['email'], 'name' => $person->name]],
                         'cc' => [],
                         'bcc' => [],

--- a/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
@@ -87,6 +87,7 @@ final class MassSendBulkAction extends BulkAction
                         }
 
                         $set('subject', $template->subject ?? '');
+                        $set('body_html', $template->body_html ?? '');
                     }),
 
                 TextInput::make('subject')
@@ -149,12 +150,6 @@ final class MassSendBulkAction extends BulkAction
                     return;
                 }
 
-                /** @var EmailTemplate|null $template */
-                $template = isset($data['template_id']) ? EmailTemplate::query()
-                    ->where('team_id', filament()->getTenant()?->getKey())
-                    ->whereKey($data['template_id'])
-                    ->first() : null;
-
                 resolve(SendEmailBatchAction::class)->execute(
                     user: $user,
                     recipients: $recipients,
@@ -163,7 +158,6 @@ final class MassSendBulkAction extends BulkAction
                         'subject' => (string) $data['subject'],
                         'body_html' => (string) $data['body_html'],
                     ],
-                    template: $template,
                 );
 
                 Notification::make()

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -252,6 +252,43 @@ it('applies template variables per recipient', function (): void {
         ->and(Email::where('batch_id', $batch->id)->where('subject', 'Hi Bob')->exists())->toBeTrue();
 });
 
+it('sends the edited subject and body when a template is selected', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($person, 'alice@example.com');
+
+    $template = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->user->id,
+        'name' => 'Saved template',
+        'subject' => 'Saved subject for {name}',
+        'body_html' => '<p>Saved body for {name}</p>',
+    ]);
+
+    livewire(ListPeople::class)
+        ->callTableBulkAction(
+            'massSend',
+            records: [$person],
+            data: [
+                'connected_account_id' => $this->account->id,
+                'template_id' => $template->id,
+                'subject' => 'Edited hello {name}',
+                'body_html' => '<p>Edited body for {name}</p>',
+            ],
+        )
+        ->assertNotified();
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+    $email = Email::where('batch_id', $batch->id)->firstOrFail();
+
+    expect($email->subject)->toBe('Edited hello Alice')
+        ->and($email->body->body_html)->toBe('<p>Edited body for Alice</p>');
+});
+
 it('scopes the template dropdown to the current team', function (): void {
     $person = People::create([
         'team_id' => $this->team->id,


### PR DESCRIPTION
## Summary
- Bulk send now renders the submitted subject and body, even when a template is selected. Recipients get the copy the sender reviewed, not the saved template.
- Selecting a template also fills the body field, so sending without further edits still uses the template text shown in the form.

## Test plan
- [ ] Select people, open mass send, pick a template, edit subject and body, send. Recipients should get the edited copy with merge tags applied.
- [ ] Select a template and send without editing. Recipients should get the template subject and body.
- [ ] Send without a template. Behavior should stay the same.