### PR TITLE
fix(calendar): reconcile removed meetings after sync token expiry

### DIFF
--- a/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/IncrementalCalendarSyncJob.php
@@ -47,7 +47,7 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         }
 
         if (! $account->calendar_sync_cursor) {
-            dispatch(new InitialCalendarSyncJob($account));
+            dispatch(new InitialCalendarSyncJob($account, reconcileAfter: $this->reconcileAfter));
 
             return;
         }
@@ -61,7 +61,9 @@ final class IncrementalCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         } catch (CalendarSyncTokenExpired) {
             MailboxSyncTracker::markCalendarFinished($account);
             $account->update(['calendar_sync_cursor' => null]);
-            dispatch(new InitialCalendarSyncJob($account));
+            // Expired deltas omit cancelled events. Rebuild from a full list, then
+            // delete local meetings the provider no longer returns.
+            dispatch(new InitialCalendarSyncJob($account, reconcileAfter: true));
 
             return;
         }

--- a/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
+++ b/packages/EmailIntegration/src/Jobs/InitialCalendarSyncJob.php
@@ -8,10 +8,12 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Queue\Attributes\DeleteWhenMissingModels;
+use Relaticle\EmailIntegration\Actions\ReconcileCalendarMeetingsAction;
 use Relaticle\EmailIntegration\Data\CalendarEventData;
 use Relaticle\EmailIntegration\Enums\CalendarEventStatus;
 use Relaticle\EmailIntegration\Enums\CalendarVisibility;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
+use Relaticle\EmailIntegration\Exceptions\ReconcileCalendarMeetingsFailed;
 use Relaticle\EmailIntegration\Jobs\Concerns\DetectsAuthErrors;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Meeting;
@@ -32,6 +34,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
     public function __construct(
         public readonly ConnectedAccount $connectedAccount,
         public readonly ?string $pageToken = null,
+        public readonly bool $reconcileAfter = false,
     ) {
         $this->onQueue('emails-sync');
     }
@@ -55,8 +58,10 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
         $eventsToStore = array_values($result->events);
 
+        $reconcileAfter = $this->reconcileAfter;
+
         if ($eventsToStore === []) {
-            self::continueOrFinish($account, $result->nextPageToken, $result->nextSyncToken);
+            self::continueOrFinish($account, $result->nextPageToken, $result->nextSyncToken, $reconcileAfter);
 
             return;
         }
@@ -74,8 +79,8 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
             account: $account,
             pageEvents: $pageEvents,
             eventsToStore: $eventsToStore,
-            onPageStored: static function (ConnectedAccount $account) use ($nextPageToken, $nextSyncToken): void {
-                self::continueOrFinish($account, $nextPageToken, $nextSyncToken);
+            onPageStored: static function (ConnectedAccount $account) use ($nextPageToken, $nextSyncToken, $reconcileAfter): void {
+                self::continueOrFinish($account, $nextPageToken, $nextSyncToken, $reconcileAfter);
             },
         );
     }
@@ -99,6 +104,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         ConnectedAccount $account,
         ?string $nextPageToken,
         ?string $nextSyncToken,
+        bool $reconcileAfter,
     ): void {
         $imported = Meeting::query()
             ->where('connected_account_id', $account->getKey())
@@ -106,7 +112,7 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
 
         if ($nextPageToken !== null && $nextPageToken !== '') {
             $account->update(['initial_calendar_sync_imported' => $imported]);
-            dispatch(new self($account, $nextPageToken));
+            dispatch(new self($account, $nextPageToken, $reconcileAfter));
 
             return;
         }
@@ -123,6 +129,17 @@ final class InitialCalendarSyncJob implements ShouldBeUnique, ShouldQueue
         }
 
         $account->update($update);
+
+        if ($reconcileAfter) {
+            try {
+                resolve(ReconcileCalendarMeetingsAction::class)->execute($account);
+            } catch (ReconcileCalendarMeetingsFailed $exception) {
+                $account->update([
+                    'status' => EmailAccountStatus::ERROR,
+                    'last_error' => $exception->getMessage(),
+                ]);
+            }
+        }
 
         MailboxSyncTracker::markCalendarFinished($account);
 

--- a/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/IncrementalCalendarSyncJobTest.php
@@ -39,7 +39,29 @@ it('resets cursor and dispatches initial sync on 410', function (): void {
     (new IncrementalCalendarSyncJob($account))->handle($factory);
 
     expect($account->fresh()?->calendar_sync_cursor)->toBeNull();
-    Bus::assertDispatched(InitialCalendarSyncJob::class);
+    Bus::assertDispatched(
+        InitialCalendarSyncJob::class,
+        fn (InitialCalendarSyncJob $job): bool => $job->reconcileAfter,
+    );
+});
+
+it('forwards requested reconciliation when delegating to initial sync without a cursor', function (): void {
+    Bus::fake([InitialCalendarSyncJob::class]);
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+        'calendar_sync_cursor' => null,
+    ]));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldNotReceive('make');
+
+    (new IncrementalCalendarSyncJob($account, reconcileAfter: true))->handle($factory);
+
+    Bus::assertDispatched(
+        InitialCalendarSyncJob::class,
+        fn (InitialCalendarSyncJob $job): bool => $job->reconcileAfter,
+    );
 });
 
 it('batches a StoreMeetingJob per delta event and does not advance the cursor until the page stores', function (): void {

--- a/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
+++ b/tests/Feature/CalendarIntegration/InitialCalendarSyncJobTest.php
@@ -191,6 +191,169 @@ it('chains the next calendar page after the store batch completes', function ():
     expect($account->fresh()?->calendar_sync_cursor)->toBeNull();
 });
 
+it('preserves requested reconciliation when chaining the next calendar page', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: null, nextPageToken: 'page-2'));
+    $service->shouldNotReceive('listActiveProviderEventIds');
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new InitialCalendarSyncJob($account, reconcileAfter: true))->handle($factory);
+
+    Bus::assertDispatched(
+        InitialCalendarSyncJob::class,
+        fn (InitialCalendarSyncJob $job): bool => $job->pageToken === 'page-2' && $job->reconcileAfter,
+    );
+    expect($account->fresh()?->calendar_sync_cursor)->toBeNull();
+});
+
+it('removes meetings absent from the provider when the initial sync requested reconciliation', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $stale = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'deleted-on-provider',
+    ]);
+    $current = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'still-on-provider',
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: 'token-xyz'));
+    $service->shouldReceive('listActiveProviderEventIds')->once()->andReturn(['still-on-provider']);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    (new InitialCalendarSyncJob($account, reconcileAfter: true))->handle($factory);
+
+    expect($stale->fresh()?->trashed())->toBeTrue()
+        ->and($current->fresh()?->trashed())->toBeFalse()
+        ->and($account->fresh()?->calendar_sync_cursor)->toBe('token-xyz');
+});
+
+it('removes meetings absent from the provider after the last store batch completes', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $stale = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'deleted-on-provider',
+    ]);
+
+    $event = new CalendarEventData(
+        providerEventId: 'still-on-provider',
+        providerRecurringEventId: null,
+        iCalUid: null,
+        title: 'Still there',
+        description: null,
+        startsAt: Date::now()->addDay(),
+        endsAt: Date::now()->addDay()->addHour(),
+        isAllDay: false,
+        location: null,
+        htmlLink: null,
+        status: 'confirmed',
+        visibility: 'default',
+        organizerEmail: null,
+        organizerName: null,
+        attendees: [],
+    );
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: [$event], nextSyncToken: 'token-batch'));
+    $service->shouldReceive('listActiveProviderEventIds')->once()->andReturn(['still-on-provider']);
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    (new InitialCalendarSyncJob($account, reconcileAfter: true))->handle($factory);
+
+    $current = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'still-on-provider',
+    ]);
+
+    invokeInitialCalendarSyncBatchFinallyCallbacks();
+
+    expect($stale->fresh()?->trashed())->toBeTrue()
+        ->and($current->fresh()?->trashed())->toBeFalse()
+        ->and($account->fresh()?->calendar_sync_cursor)->toBe('token-batch');
+});
+
+it('does not reconcile meetings when the initial sync did not request it', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $stored = Meeting::factory()->create([
+        'connected_account_id' => $account->getKey(),
+        'team_id' => $account->team_id,
+        'provider_event_id' => 'locally-stored',
+    ]);
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: 'token-xyz'));
+    $service->shouldNotReceive('listActiveProviderEventIds');
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    (new InitialCalendarSyncJob($account))->handle($factory);
+
+    expect($stored->fresh()?->trashed())->toBeFalse();
+});
+
+it('records a reconciliation failure after the initial sync finishes', function (): void {
+    Bus::fake();
+
+    $account = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+        'capabilities' => ['email' => true, 'calendar' => true],
+    ]));
+
+    $service = Mockery::mock(CalendarServiceInterface::class);
+    $service->shouldReceive('initialSync')->once()
+        ->andReturn(new CalendarSyncResult(events: [], nextSyncToken: 'token-xyz'));
+    $service->shouldReceive('listActiveProviderEventIds')->once()
+        ->andThrow(new RuntimeException('Graph unavailable'));
+
+    $factory = Mockery::mock(CalendarServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->andReturn($service);
+    app()->instance(CalendarServiceFactoryInterface::class, $factory);
+
+    (new InitialCalendarSyncJob($account, reconcileAfter: true))->handle($factory);
+
+    expect($account->fresh()?->status)->toBe(EmailAccountStatus::ERROR)
+        ->and($account->fresh()?->last_error)->toStartWith('Calendar reconciliation failed:')
+        ->and($account->fresh()?->calendar_sync_cursor)->toBe('token-xyz');
+});
+
 it('stores the sync token immediately when the last page has no events', function (): void {
     Bus::fake();
 


### PR DESCRIPTION
## Summary
- After a 410 expired calendar cursor, run a full import and then delete local meetings the provider no longer returns.
- Keep a requested reconcile when incremental sync hands off to initial sync, including across paginated pages.

Google recovery from an invalid sync token is a full list of current events. Cancelled meetings are absent from that list, so they stayed visible until this pass.

## Test plan
- [ ] Force a 410 on incremental calendar sync and confirm a deleted meeting disappears after recovery.
- [ ] Click Sync now with no cursor and confirm reconciliation still runs.
- [ ] Connect a mailbox for the first time and confirm the extra reconcile list is skipped.