### PR TITLE
fix(email): inset the reader body for HTML and plain text

### DIFF
--- a/resources/views/components/emails/email-view.blade.php
+++ b/resources/views/components/emails/email-view.blade.php
@@ -325,7 +325,7 @@
             >
                 <div
                     x-bind:class="ready ? '' : 'min-h-0 flex-1'"
-                    class="relative w-full overflow-hidden border-y border-gray-100 bg-white dark:border-gray-800 dark:bg-neutral-950"
+                    class="relative w-full overflow-hidden border-y border-gray-100 bg-white px-6 py-6 sm:px-8 lg:px-10 dark:border-gray-800 dark:bg-neutral-950"
                 >
                     <div
                         x-show="! ready"
@@ -350,9 +350,9 @@
                 </div>
             </div>
         @else
-            <div class="shrink-0 px-6 py-5">
+            <div class="shrink-0 px-6 py-6 sm:px-8 lg:px-10">
                 @if ($record->body?->body_text)
-                    <pre class="whitespace-pre-wrap font-sans text-sm leading-relaxed text-gray-700 dark:text-gray-300">{{ $record->body->body_text }}</pre>
+                    <pre class="max-w-prose whitespace-pre-wrap font-sans text-sm leading-relaxed text-gray-700 dark:text-gray-300">{{ $record->body->body_text }}</pre>
                 @else
                     <p class="text-sm italic text-gray-400 dark:text-gray-500">(no message body)</p>
                 @endif

--- a/resources/views/filament/emails/email-thread.blade.php
+++ b/resources/views/filament/emails/email-thread.blade.php
@@ -164,17 +164,19 @@
                 <div class="bg-gray-50 px-6 pb-5 dark:bg-gray-950">
                     <div class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xs dark:border-white/25 dark:bg-neutral-900">
                         @if ($safeHtml)
-                            <iframe
-                                srcdoc="{{ $safeHtml }}"
-                                sandbox="allow-popups allow-popups-to-escape-sandbox"
-                                referrerpolicy="no-referrer"
-                                class="w-full border-0 bg-white [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]"
-                                style="min-height: 200px; height: 60vh"
-                            ></iframe>
+                            <div class="px-6 py-6 sm:px-8 lg:px-10">
+                                <iframe
+                                    srcdoc="{{ $safeHtml }}"
+                                    sandbox="allow-popups allow-popups-to-escape-sandbox"
+                                    referrerpolicy="no-referrer"
+                                    class="w-full border-0 bg-white [color-scheme:light] dark:bg-neutral-900 dark:[color-scheme:dark]"
+                                    style="min-height: 200px; height: 60vh"
+                                ></iframe>
+                            </div>
                         @elseif ($email->body?->body_text)
-                            <pre class="whitespace-pre-wrap font-sans text-sm leading-relaxed text-gray-700 dark:text-gray-300">{{ $email->body->body_text }}</pre>
+                            <pre class="max-w-prose whitespace-pre-wrap px-6 py-6 font-sans text-sm leading-relaxed text-gray-700 sm:px-8 lg:px-10 dark:text-gray-300">{{ $email->body->body_text }}</pre>
                         @else
-                            <p class="text-sm italic text-gray-400">(no message body)</p>
+                            <p class="px-6 py-6 text-sm italic text-gray-400 sm:px-8 lg:px-10">(no message body)</p>
                         @endif
                     </div>
                 </div>

--- a/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
+++ b/tests/Feature/EmailIntegration/EmailBodySanitizationTest.php
@@ -56,6 +56,26 @@ function makeEmailWithBody(string $html): Email
     return $email->fresh(['body', 'participants', 'labels', 'attachments']);
 }
 
+function makeEmailWithPlainText(string $text): Email
+{
+    /** @var Email $email */
+    $email = Email::factory()->create([
+        'team_id' => test()->team->id,
+        'user_id' => test()->owner->id,
+        'connected_account_id' => test()->account->getKey(),
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    $email->body()->create([
+        'body_text' => $text,
+        'body_html' => null,
+    ]);
+
+    test()->person->emails()->attach($email);
+
+    return $email->fresh(['body', 'participants', 'labels', 'attachments']);
+}
+
 /**
  * Render the email reader through the relation-manager overlay, the same
  * `x-emails.email-view` used on company and people Emails tabs.
@@ -196,6 +216,24 @@ it('splits inline attachments and sanitizes body html from the email model', fun
         ->not->toContain('cid:logo@example.test');
 });
 
+it('renders a plain-text-only body in the email view without an iframe', function (): void {
+    $email = makeEmailWithPlainText('Please review the invoice by Friday.');
+
+    mountEmailView($email)
+        ->assertSee('Please review the invoice by Friday.')
+        ->assertDontSeeHtml('<iframe');
+});
+
+it('renders a plain-text-only body in the threaded view without an iframe', function (): void {
+    $email = makeEmailWithPlainText('Please review the invoice by Friday.');
+
+    $html = view('filament.emails.email-thread', ['emails' => collect([$email])])->render();
+
+    expect($html)
+        ->toContain('Please review the invoice by Friday.')
+        ->not->toContain('<iframe');
+});
+
 it('renders the email view iframe without scripts and with same-origin height measurement', function (): void {
     $email = makeEmailWithBody('<p>body</p>');
 
@@ -203,6 +241,7 @@ it('renders the email view iframe without scripts and with same-origin height me
         ->assertSeeHtml('<iframe')
         ->assertSeeHtml('sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"')
         ->assertSeeHtml('referrerpolicy="no-referrer"')
+        ->assertSeeHtml('px-6 py-6 sm:px-8 lg:px-10')
         ->assertSeeHtml('dark:bg-neutral-950 dark:[color-scheme:dark]')
         ->assertSeeHtml('dark:bg-gray-950')
         ->assertDontSeeHtml('allow-scripts');
@@ -226,6 +265,7 @@ it('sandboxes the threaded iframe without same-origin access', function (): void
 
     expect($html)
         ->toContain('sandbox="allow-popups allow-popups-to-escape-sandbox"')
+        ->toContain('px-6 py-6 sm:px-8 lg:px-10')
         ->toContain('dark:bg-neutral-900 dark:[color-scheme:dark]')
         ->toContain('dark:bg-gray-950')
         ->not->toContain('allow-scripts')


### PR DESCRIPTION
## Summary
- Add reading padding around the email body in the view modal and thread card, including the HTML iframe path that most sends actually use.
- Cap plain-text-only bodies at `max-w-prose` so lines stay readable on the wide reader.
- Cover the text-only branch and assert the iframe wrapper keeps the inset.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailBodySanitizationTest.php`
- [x] Open View email on an HTML send and confirm left and right gutters.
- [x] Open a text-only body and confirm the same inset plus a constrained reading column.