### PR TITLE
Fix inline images missing from sent email view

### DIFF
--- a/packages/EmailIntegration/src/Actions/SendEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailAction.php
@@ -26,10 +26,15 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Services\EmailInlineImageEmbedder;
 use RuntimeException;
 
 final readonly class SendEmailAction
 {
+    public function __construct(
+        private EmailInlineImageEmbedder $inlineImageEmbedder,
+    ) {}
+
     /**
      * Persist a queued Email row. The scheduled dispatcher releases it later.
      *
@@ -71,16 +76,28 @@ final readonly class SendEmailAction
 
         $scheduledFor = $this->resolveScheduledFor($data, $priority);
 
+        $embedded = $this->inlineImageEmbedder->embed(
+            (string) $data['body_html'],
+            array_values($data['attachments'] ?? []),
+            $data['attachment_file_names'] ?? [],
+            $data['attachment_attributes'] ?? [],
+        );
+
+        $data['body_html'] = $embedded['body_html'];
+
         /** @var array<int, string> $attachmentPaths */
-        $attachmentPaths = array_values($data['attachments'] ?? []);
+        $attachmentPaths = $embedded['attachments'];
 
         /** @var array<string, array{is_inline?: bool, content_id?: ?string}> $attachmentAttributes */
-        $attachmentAttributes = $data['attachment_attributes'] ?? [];
+        $attachmentAttributes = $embedded['attachment_attributes'];
+
+        /** @var array<string, string> $attachmentFileNames */
+        $attachmentFileNames = $embedded['attachment_file_names'];
 
         $hasDownloadableAttachments = collect($attachmentPaths)
             ->contains(fn (string $path): bool => ($attachmentAttributes[$path]['is_inline'] ?? false) !== true);
 
-        return DB::transaction(function () use ($account, $data, $priority, $scheduledFor, $linkToType, $linkToId, $attachmentPaths, $attachmentAttributes, $hasDownloadableAttachments): Email {
+        return DB::transaction(function () use ($account, $data, $priority, $scheduledFor, $linkToType, $linkToId, $attachmentPaths, $attachmentAttributes, $attachmentFileNames, $hasDownloadableAttachments): Email {
             // Scope the reply lookup to the sender's team. in_reply_to_email_id arrives
             // from a client-controlled hidden field and Email has no team global scope,
             // so an unscoped lookup would let a user thread their outbound mail onto
@@ -152,7 +169,7 @@ final readonly class SendEmailAction
                 }
             }
 
-            $this->storeAttachments($email, $attachmentPaths, $data['attachment_file_names'] ?? [], $attachmentAttributes);
+            $this->storeAttachments($email, $attachmentPaths, $attachmentFileNames, $attachmentAttributes);
 
             if ($linkToType !== null && $linkToId !== null && in_array($linkToType, [Company::class, Opportunity::class, People::class], true)) {
                 $linked = $linkToType::query()->whereKey($linkToId)->first();

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -426,13 +426,17 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             'subject' => ['required', 'string', 'max:255'],
         ]);
 
-        $bodyHtml = $this->bodyHtmlValue();
+        $bodyHtml = $this->bodyHtmlForPersistence();
 
         // `bodyHtml`'s raw state is never truly "empty" (an untouched RichEditor still
         // holds a structural `<p></p>` doc), so `required` can never catch a blank
         // message. Check the dehydrated text instead. A signature-only email (no
         // free text, just the signature block) is legitimate and must still send.
-        if (trim(strip_tags($bodyHtml)) === '' && ! str_contains($bodyHtml, 'data-id="'.SignatureBlock::ID.'"')) {
+        if (
+            trim(strip_tags($bodyHtml)) === ''
+            && ! str_contains($bodyHtml, 'data-id="'.SignatureBlock::ID.'"')
+            && ! str_contains($bodyHtml, '<img')
+        ) {
             $this->addError('bodyHtml', __('filament/emails/composer.validation.body_required'));
 
             return;
@@ -670,6 +674,9 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             RichEditor::make('bodyHtml')
                 ->hiddenLabel()
                 ->resizableImages()
+                ->fileAttachmentsDisk(EmailAttachment::DISK)
+                ->fileAttachmentsDirectory('email-attachments')
+                ->fileAttachmentsVisibility('private')
                 ->statePath('bodyHtml')
                 ->mergeTags(EmailTemplateRenderService::MERGE_TAGS)
                 ->customBlocks([SignatureBlock::class])
@@ -1226,6 +1233,19 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         return is_string($state) ? $state : '';
     }
 
+    /**
+     * Dehydrate the composer body for persistence or send. RichEditor keeps inline
+     * images as Livewire upload ids until {@see RichEditor::saveFileAttachments()}
+     * runs; Filament forms do that automatically on submit, but this composer sends
+     * through a custom Livewire action instead.
+     */
+    private function bodyHtmlForPersistence(): string
+    {
+        $this->bodyField()->saveFileAttachments();
+
+        return $this->bodyHtmlValue();
+    }
+
     private function bodyField(): RichEditor
     {
         $component = $this->getSchema('bodySchema')?->getComponent('bodyHtml');
@@ -1632,7 +1652,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             data: [
                 'connected_account_id' => $accountId,
                 'subject' => $this->subject,
-                'body_html' => $this->bodyHtmlValue(),
+                'body_html' => $this->bodyHtmlForPersistence(),
                 'to' => $this->to,
                 'cc' => $this->cc,
                 'bcc' => $this->bcc,

--- a/packages/EmailIntegration/src/Services/EmailInlineImageEmbedder.php
+++ b/packages/EmailIntegration/src/Services/EmailInlineImageEmbedder.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use DOMDocument;
+use DOMElement;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
+use Symfony\Component\Mime\MimeTypes;
+
+final readonly class EmailInlineImageEmbedder
+{
+    /**
+     * Turn RichEditor embedded images into CID inline attachments the reader can
+     * serve through {@see EmailHtmlSanitizer}. Composer images are stored on disk
+     * with a `data-id` path while the HTML still references a transient URL.
+     *
+     * @param  array<int, string>  $attachmentPaths
+     * @param  array<string, string>  $attachmentFileNames
+     * @param  array<string, array{is_inline?: bool, content_id?: ?string}>  $attachmentAttributes
+     * @return array{
+     *     body_html: string,
+     *     attachments: array<int, string>,
+     *     attachment_file_names: array<string, string>,
+     *     attachment_attributes: array<string, array{is_inline?: bool, content_id?: ?string}>,
+     * }
+     */
+    public function embed(
+        string $bodyHtml,
+        array $attachmentPaths = [],
+        array $attachmentFileNames = [],
+        array $attachmentAttributes = [],
+    ): array {
+        if (! str_contains($bodyHtml, '<img')) {
+            return [
+                'body_html' => $bodyHtml,
+                'attachments' => $attachmentPaths,
+                'attachment_file_names' => $attachmentFileNames,
+                'attachment_attributes' => $attachmentAttributes,
+            ];
+        }
+
+        $document = $this->loadDocument($bodyHtml);
+        $images = $document->getElementsByTagName('img');
+
+        if ($images->length === 0) {
+            return [
+                'body_html' => $bodyHtml,
+                'attachments' => $attachmentPaths,
+                'attachment_file_names' => $attachmentFileNames,
+                'attachment_attributes' => $attachmentAttributes,
+            ];
+        }
+
+        /** @var array<string, string> $contentIdsBySourcePath */
+        $contentIdsBySourcePath = [];
+
+        for ($index = $images->length - 1; $index >= 0; $index--) {
+            $image = $images->item($index);
+
+            if (! $image instanceof DOMElement) {
+                continue;
+            }
+
+            $src = trim($image->getAttribute('src'));
+
+            if ($src !== '' && str_starts_with(mb_strtolower($src), 'cid:')) {
+                continue;
+            }
+
+            $sourcePath = $this->resolveSourcePath($image, $src);
+
+            if ($sourcePath === null) {
+                continue;
+            }
+
+            if (! isset($contentIdsBySourcePath[$sourcePath])) {
+                $embedded = $this->copyToEmailAttachmentDisk($sourcePath);
+
+                if ($embedded === null) {
+                    continue;
+                }
+
+                $contentIdsBySourcePath[$sourcePath] = $embedded['content_id'];
+                $attachmentPaths[] = $embedded['path'];
+                $attachmentFileNames[$embedded['path']] = $embedded['filename'];
+                $attachmentAttributes[$embedded['path']] = [
+                    'is_inline' => true,
+                    'content_id' => $embedded['content_id'],
+                ];
+            }
+
+            $image->setAttribute('src', 'cid:'.$contentIdsBySourcePath[$sourcePath]);
+            $image->removeAttribute('data-id');
+        }
+
+        return [
+            'body_html' => $this->serializeDocument($document),
+            'attachments' => $attachmentPaths,
+            'attachment_file_names' => $attachmentFileNames,
+            'attachment_attributes' => $attachmentAttributes,
+        ];
+    }
+
+    private function loadDocument(string $html): DOMDocument
+    {
+        $document = new DOMDocument;
+        $previous = libxml_use_internal_errors(true);
+
+        $document->loadHTML(
+            '<?xml encoding="UTF-8"><div id="email-inline-image-root">'.$html.'</div>',
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD,
+        );
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        return $document;
+    }
+
+    private function serializeDocument(DOMDocument $document): string
+    {
+        $root = $document->getElementById('email-inline-image-root');
+
+        if (! $root instanceof DOMElement) {
+            return $document->saveHTML() ?: '';
+        }
+
+        $html = '';
+
+        foreach ($root->childNodes as $child) {
+            $html .= $document->saveHTML($child);
+        }
+
+        return $html;
+    }
+
+    private function resolveSourcePath(DOMElement $image, string $src): ?string
+    {
+        $dataId = trim($image->getAttribute('data-id'));
+
+        if ($dataId !== '') {
+            return $dataId;
+        }
+
+        if ($src === '') {
+            return null;
+        }
+
+        if (str_starts_with(mb_strtolower($src), 'data:image/')) {
+            return $src;
+        }
+
+        $path = parse_url($src, PHP_URL_PATH);
+
+        if (! is_string($path) || $path === '') {
+            return null;
+        }
+
+        if (str_starts_with($path, '/storage/')) {
+            return ltrim(mb_substr($path, mb_strlen('/storage/')), '/');
+        }
+
+        return ltrim($path, '/');
+    }
+
+    /**
+     * @return array{path: string, filename: string, content_id: string}|null
+     */
+    private function copyToEmailAttachmentDisk(string $sourcePath): ?array
+    {
+        if (str_starts_with(mb_strtolower($sourcePath), 'data:image/')) {
+            return $this->copyDataUri($sourcePath);
+        }
+
+        foreach ($this->candidateDisks() as $diskName) {
+            $disk = Storage::disk($diskName);
+
+            foreach ($this->candidateStoragePaths($sourcePath) as $path) {
+                if (! $disk->exists($path)) {
+                    continue;
+                }
+
+                $mimeType = $disk->mimeType($path) ?: 'application/octet-stream';
+                $extension = $this->extensionFromMimeType($mimeType);
+                $destination = 'email-attachments/'.Str::ulid().'.'.$extension;
+
+                Storage::disk(EmailAttachment::DISK)->put($destination, $disk->get($path) ?? '');
+
+                if (! Storage::disk(EmailAttachment::DISK)->exists($destination)) {
+                    continue;
+                }
+
+                return [
+                    'path' => $destination,
+                    'filename' => basename($path) !== '' && basename($path) !== '.'
+                        ? basename($path)
+                        : "inline.{$extension}",
+                    'content_id' => $this->makeContentId(),
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateStoragePaths(string $sourcePath): array
+    {
+        $paths = [$sourcePath];
+
+        if (! str_contains($sourcePath, '/')) {
+            $paths[] = 'email-attachments/'.$sourcePath;
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    /**
+     * @return array{path: string, filename: string, content_id: string}|null
+     */
+    private function copyDataUri(string $dataUri): ?array
+    {
+        if (! preg_match('#^data:(image/[^;]+);base64,(.+)$#i', $dataUri, $matches)) {
+            return null;
+        }
+
+        $binary = base64_decode($matches[2], true);
+
+        if ($binary === false) {
+            return null;
+        }
+
+        $mimeType = mb_strtolower($matches[1]);
+        $extension = $this->extensionFromMimeType($mimeType);
+        $destination = 'email-attachments/'.Str::ulid().'.'.$extension;
+
+        Storage::disk(EmailAttachment::DISK)->put($destination, $binary);
+
+        return [
+            'path' => $destination,
+            'filename' => "inline.{$extension}",
+            'content_id' => $this->makeContentId(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateDisks(): array
+    {
+        $defaultDisk = (string) config('filament.default_filesystem_disk', 'local');
+
+        return array_values(array_unique([
+            EmailAttachment::DISK,
+            'public',
+            $defaultDisk,
+            $defaultDisk === 'local' ? 'public' : 'local',
+        ]));
+    }
+
+    private function makeContentId(): string
+    {
+        return Str::ulid().'@relaticle';
+    }
+
+    private function extensionFromMimeType(string $mimeType): string
+    {
+        $extensions = MimeTypes::getDefault()->getExtensions($mimeType);
+
+        return $extensions[0] ?? 'bin';
+    }
+}

--- a/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
+++ b/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\RichEditor\RichContentRenderer;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
 use Relaticle\EmailIntegration\Filament\RichContent\SignatureBlock;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 
@@ -97,6 +98,8 @@ final readonly class EmailTemplateRenderService
     {
         $html = RichContentRenderer::make($bodyHtml)
             ->customBlocks([SignatureBlock::class])
+            ->fileAttachmentsDisk(EmailAttachment::DISK)
+            ->fileAttachmentsVisibility('private')
             ->toHtml();
 
         return $this->renderContent($html, $record);

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -253,6 +253,29 @@ it('queues an email through SendEmailAction on send with the persisted body and 
         ->and($email->scheduled_for)->not->toBeNull();
 });
 
+it('persists rich editor inline images when sending from the composer', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+
+    $uploadId = 'a2b7d3cd-2222-4ac2-b3aa-6a12efe24763';
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['lead@example.com'])
+        ->set('subject', 'Inline editor image')
+        ->set('bodyHtml', '<p><img data-id="'.$uploadId.'" width="100" height="100"></p><p>Inline image body</p>')
+        ->set('componentFileAttachments.bodyHtml.'.$uploadId, UploadedFile::fake()->image('inline.jpg', 100, 100))
+        ->call('send')
+        ->assertHasNoErrors()
+        ->assertSet('isOpen', false);
+
+    $email = Email::query()->where('subject', 'Inline editor image')->sole();
+
+    expect($email->attachments)->toHaveCount(1)
+        ->and($email->attachments->first()->is_inline)->toBeTrue()
+        ->and($email->body?->body_html)->toContain('cid:')
+        ->and($email->body?->body_html)->not->toContain($uploadId);
+});
+
 it('links a queued send to the record the composer was opened from', function (): void {
     $person = People::factory()->recycle([$this->user, $this->user->currentTeam])->create();
 

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -20,10 +20,12 @@ use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailThread;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
+use Relaticle\EmailIntegration\Services\EmailInlineImageEmbedder;
 use Relaticle\EmailIntegration\Services\EmailSendingService;
+use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-mutates(SendEmailAction::class, LinkEmailAction::class, EmailSendingService::class, ConnectedAccount::class);
+mutates(SendEmailAction::class, LinkEmailAction::class, EmailSendingService::class, ConnectedAccount::class, EmailInlineImageEmbedder::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -526,4 +528,39 @@ it('persists inline cid attachments and includes them in the provider payload', 
         ->and($captured['attachments'][0]['is_inline'])->toBeTrue()
         ->and($captured['attachments'][0]['content_id'])->toBe('logo@example.test')
         ->and($captured['attachments'][0]['content'])->toBe('png-bytes');
+});
+
+it('embeds rich editor inline images from data-id paths when queuing send', function (): void {
+    Storage::fake('local');
+    Storage::fake('public');
+
+    $editorPath = 'email-attachments/editor-image.png';
+    Storage::disk('local')->put($editorPath, 'png-bytes');
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Inline image',
+        'body_html' => '<p>See below</p><img data-id="'.$editorPath.'" src="">',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]);
+
+    $attachment = $email->attachments()->first();
+
+    expect($email->attachments)->toHaveCount(1)
+        ->and($attachment->is_inline)->toBeTrue()
+        ->and($attachment->content_id)->not->toBeEmpty()
+        ->and($email->body?->body_html)->toContain('cid:'.$attachment->content_id)
+        ->and($email->body?->body_html)->not->toContain('data-id');
+
+    $sanitized = EmailHtmlSanitizer::sanitize($email->body?->body_html, $email->inlineAttachments());
+
+    expect($sanitized)
+        ->toContain(route('email-attachments.inline', ['attachment' => $attachment->getKey()]))
+        ->not->toContain('cid:'.$attachment->content_id);
 });


### PR DESCRIPTION
## Summary

- Persist RichEditor inline image uploads before send so composer HTML references stored files instead of transient URLs.
- Embed those images as CID inline attachments during send so the email reader can resolve and display them after delivery.
- Add `EmailInlineImageEmbedder` and wire it through `SendEmailAction`, `EmailComposer`, and template rendering.

## Test plan

- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailComposerTest.php tests/Feature/EmailIntegration/SendEmailActionTest.php`
- [x] Send an email from the composer with an inline image and confirm it renders in the sent email reader
- [x] Confirm regular file attachments still send separately from inline images