### PR TITLE
Composer draft toast and home meetings polish

### DIFF
--- a/lang/en/filament/emails/composer.php
+++ b/lang/en/filament/emails/composer.php
@@ -79,6 +79,9 @@ return [
             'title' => 'Original account no longer connected',
             'body' => 'The account this draft was written from isn\'t connected anymore, so it\'s been switched to your default account. Double-check the sender before sending.',
         ],
+        'draft_saved' => [
+            'title' => 'Draft saved',
+        ],
     ],
     'validation' => [
         'body_required' => 'Write a message before sending.',

--- a/packages/EmailIntegration/resources/views/filament/infolists/meeting-header.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/infolists/meeting-header.blade.php
@@ -8,7 +8,10 @@
         <span class="text-xl font-semibold">{{ $state['day'] }}</span>
     </div>
 
-    <h2 class="flex-1 text-xl font-semibold">{{ $state['title'] }}</h2>
+    <h2 @class([
+        'flex-1 text-xl font-semibold',
+        'text-gray-400 line-through dark:text-gray-500' => $state['is_past'],
+    ])>{{ $state['title'] }}</h2>
 
     @if ($state['response_status'] !== null && ! $state['can_respond'])
         @include('email-integration::filament.infolists.partials.rsvp-pill', ['status' => $state['response_status']])

--- a/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
@@ -109,7 +109,7 @@
             @endif
         </div>
     @else
-        <div class="flex flex-col divide-y divide-[var(--surface-block-border)]">
+        <ul class="divide-y divide-[var(--surface-block-border)] overflow-hidden rounded-xl border border-[var(--surface-block-border)] bg-[var(--surface-block-bg)]">
             @foreach (array_slice($this->meetingCards, 0, $this->visibleCount) as $card)
                 @php
                     $responseStatus = $card['response_status'];
@@ -123,110 +123,92 @@
                         ? \Filament\Support\Icons\Heroicon::OutlinedCalendarDays
                         : \Filament\Support\Icons\Heroicon::OutlinedClock;
                 @endphp
-                <div
+                <li
                     wire:key="meeting-home-{{ $meetingKey }}"
                     data-testid="meeting-card"
-                    class="px-2.5 py-2"
                 >
-                    <button
-                        type="button"
-                        data-testid="meeting-card-row"
-                        class="group/row flex min-h-9 w-full cursor-pointer items-center gap-2.5 rounded-md text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-default"
-                        wire:click="{{ $openTarget }}"
-                        wire:loading.attr="disabled"
-                        wire:loading.class="pointer-events-none opacity-60"
-                        wire:target="{{ $openTarget }}"
-                        aria-label="{{ __('filament/pages/dashboard.meetings.open_named', ['title' => $card['title']]) }}"
-                    >
-                        <span class="inline-flex size-3.5 shrink-0 items-center justify-center">
-                            <span
-                                wire:loading.remove
-                                wire:target="{{ $openTarget }}"
-                                @class([
-                                    'size-1.5 rounded-full',
-                                    'bg-success-500' => $dotColor === 'success',
-                                    'bg-danger-500' => $dotColor === 'danger',
-                                    'bg-warning-500' => $dotColor === 'warning',
-                                    'bg-gray-400' => $dotColor === 'gray',
-                                ])
-                                aria-hidden="true"
-                            ></span>
-                            <x-filament::loading-indicator
-                                wire:loading
-                                wire:target="{{ $openTarget }}"
-                                @class([
-                                    'size-3.5',
-                                    'text-success-500' => $dotColor === 'success',
-                                    'text-danger-500' => $dotColor === 'danger',
-                                    'text-warning-500' => $dotColor === 'warning',
-                                    'text-gray-400' => $dotColor === 'gray',
-                                ])
-                                role="status"
-                                aria-label="{{ __('filament/pages/dashboard.meetings.open_named', ['title' => $card['title']]) }}"
-                            />
-                        </span>
-
-                        <span
-                            class="flex min-w-0 flex-1 items-center gap-1.5"
-                            data-testid="meeting-card-title"
+                    <div class="flex items-center gap-3 overflow-hidden pl-4 transition hover:bg-gray-50 dark:hover:bg-white/5">
+                        <button
+                            type="button"
+                            data-testid="meeting-card-row"
+                            class="flex flex-1 cursor-pointer items-center gap-3 py-3 pr-4 text-left focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-default"
+                            wire:click="{{ $openTarget }}"
+                            wire:loading.attr="disabled"
+                            wire:loading.class="pointer-events-none opacity-60"
+                            wire:target="{{ $openTarget }}"
+                            aria-label="{{ __('filament/pages/dashboard.meetings.open_named', ['title' => $card['title']]) }}"
                         >
-                            <span @class([
-                                'min-w-0 truncate text-sm font-medium',
-                                'text-gray-400 line-through dark:text-gray-500' => $isPast,
-                                'text-gray-950 dark:text-white' => ! $isPast,
-                            ])>
+                            <span class="inline-flex size-4 shrink-0 items-center justify-center">
+                                <span
+                                    wire:loading.remove
+                                    wire:target="{{ $openTarget }}"
+                                    @class([
+                                        'size-1.5 rounded-full',
+                                        'bg-success-500' => $dotColor === 'success',
+                                        'bg-danger-500' => $dotColor === 'danger',
+                                        'bg-warning-500' => $dotColor === 'warning',
+                                        'bg-gray-400' => $dotColor === 'gray',
+                                    ])
+                                    aria-hidden="true"
+                                ></span>
+                                <x-filament::loading-indicator
+                                    wire:loading
+                                    wire:target="{{ $openTarget }}"
+                                    @class([
+                                        'size-4',
+                                        'text-success-500' => $dotColor === 'success',
+                                        'text-danger-500' => $dotColor === 'danger',
+                                        'text-warning-500' => $dotColor === 'warning',
+                                        'text-gray-400' => $dotColor === 'gray',
+                                    ])
+                                    role="status"
+                                    aria-label="{{ __('filament/pages/dashboard.meetings.open_named', ['title' => $card['title']]) }}"
+                                />
+                            </span>
+
+                            <span
+                                class="min-w-0 flex-1 truncate text-sm"
+                                data-testid="meeting-card-title"
+                                @class([
+                                    'text-gray-400 line-through dark:text-gray-500' => $isPast,
+                                    'text-gray-900 dark:text-white' => ! $isPast,
+                                ])
+                            >
                                 {{ $card['title'] }}
                             </span>
 
-                            <span
-                                data-testid="meeting-card-open"
-                                @class([
-                                    'inline-flex shrink-0 items-center justify-center rounded-md p-0.5 opacity-0 transition-opacity group-focus-visible/row:opacity-100 group-hover/row:opacity-100',
-                                    'text-success-600 dark:text-success-400' => $dotColor === 'success',
-                                    'text-danger-600 dark:text-danger-400' => $dotColor === 'danger',
-                                    'text-warning-600 dark:text-warning-400' => $dotColor === 'warning',
-                                    'text-gray-500 dark:text-gray-400' => $dotColor === 'gray',
-                                ])
-                                aria-hidden="true"
+                            <time
+                                class="inline-flex shrink-0 items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+                                datetime="{{ $time['datetime'] }}"
                             >
                                 <x-filament::icon
-                                    :icon="\Filament\Support\Icons\Heroicon::OutlinedArrowsPointingOut"
-                                    class="size-3.5 shrink-0"
+                                    :icon="$timeIcon"
+                                    class="size-3.5 shrink-0 text-gray-400 dark:text-gray-500"
                                 />
-                            </span>
-                        </span>
-
-                        <time
-                            class="inline-flex shrink-0 items-center gap-1.5 text-xs font-normal tabular-nums text-gray-500 dark:text-gray-400"
-                            datetime="{{ $time['datetime'] }}"
-                        >
-                            <x-filament::icon
-                                :icon="$timeIcon"
-                                class="size-3.5 shrink-0 text-gray-400 dark:text-gray-500"
-                            />
-                            <span class="whitespace-nowrap">{{ $time['range'] }}</span>
-                            @if ($happeningNow)
-                                <x-filament::badge color="primary" size="sm">
-                                    {{ __('filament/pages/dashboard.meetings.happening_now') }}
-                                </x-filament::badge>
-                            @endif
-                        </time>
-                    </button>
-                </div>
+                                <span class="whitespace-nowrap tabular-nums">{{ $time['range'] }}</span>
+                                @if ($happeningNow)
+                                    <x-filament::badge color="primary" size="sm">
+                                        {{ __('filament/pages/dashboard.meetings.happening_now') }}
+                                    </x-filament::badge>
+                                @endif
+                            </time>
+                        </button>
+                    </div>
+                </li>
             @endforeach
+        </ul>
 
-            @if ($this->hasMoreMeetings())
-                <button
-                    type="button"
-                    data-testid="meetings-load-more"
-                    wire:click="loadMore"
-                    wire:loading.attr="disabled"
-                    class="w-full rounded-sm py-2 text-center text-xs text-gray-500 transition hover:text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-wait dark:text-gray-400 dark:hover:text-white"
-                >
-                    {{ __('filament/pages/dashboard.meetings.load_more') }}
-                </button>
-            @endif
-        </div>
+        @if ($this->hasMoreMeetings())
+            <button
+                type="button"
+                data-testid="meetings-load-more"
+                wire:click="loadMore"
+                wire:loading.attr="disabled"
+                class="mt-1 w-full rounded-sm py-2 text-center text-xs text-gray-500 transition hover:text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500 disabled:cursor-wait dark:text-gray-400 dark:hover:text-white"
+            >
+                {{ __('filament/pages/dashboard.meetings.load_more') }}
+            </button>
+        @endif
     @endif
 
     <x-filament-actions::modals />

--- a/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/Entries/MeetingHeaderEntry.php
@@ -9,13 +9,14 @@ use Filament\Infolists\Components\Entry;
 use Relaticle\EmailIntegration\Enums\AttendeeResponseStatus;
 use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
+use Relaticle\EmailIntegration\Services\MeetingTemporalState;
 
 final class MeetingHeaderEntry extends Entry
 {
     protected string $view = 'email-integration::filament.infolists.meeting-header';
 
     /**
-     * @return array{title: string, month: string, day: string, response_status: AttendeeResponseStatus|null, can_respond: bool}
+     * @return array{title: string, month: string, day: string, response_status: AttendeeResponseStatus|null, can_respond: bool, is_past: bool}
      */
     public function getState(): array
     {
@@ -28,10 +29,12 @@ final class MeetingHeaderEntry extends Entry
                 'day' => '',
                 'response_status' => null,
                 'can_respond' => false,
+                'is_past' => false,
             ];
         }
 
         $user = auth()->user();
+        $timezone = $user instanceof User ? $user->effectiveTimezone() : (string) config('app.timezone');
         $responseStatus = $user instanceof User
             ? resolve(MeetingRespondentResolver::class)->viewerResponseStatus($user, $record)
             : ($record->response_status ?? AttendeeResponseStatus::NEEDS_ACTION);
@@ -42,6 +45,7 @@ final class MeetingHeaderEntry extends Entry
             'day' => $record->starts_at->format('j'),
             'response_status' => $responseStatus,
             'can_respond' => $user instanceof User && $user->can('respond', $record),
+            'is_past' => resolve(MeetingTemporalState::class)->isPast($record, $timezone),
         ];
     }
 }

--- a/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
+++ b/packages/EmailIntegration/src/Filament/Infolists/MeetingDetailInfolist.php
@@ -22,6 +22,7 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Alignment;
 use Filament\Support\Enums\FontWeight;
+use Filament\Support\Enums\Size;
 use Filament\Support\Enums\TextSize;
 use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
@@ -42,7 +43,7 @@ final class MeetingDetailInfolist
         return ViewAction::make()
             ->slideOver(false)
             ->modalHeading(__('filament/resources/meeting.view.heading'))
-            ->modalWidth(Width::SevenExtraLarge)
+            ->modalWidth(Width::FiveExtraLarge)
             ->modalCancelAction(false)
             ->schema(fn (Schema $schema): Schema => self::configure($schema))
             ->registerModalActions([
@@ -161,12 +162,12 @@ final class MeetingDetailInfolist
                                     ->description(__('filament/resources/meeting.sections.linked_records.empty.description'))
                                     ->icon(Heroicon::OutlinedLink)
                                     ->contained(false)
-
                                     ->footer([
-                                        self::linkRecordsAction('linkRecords', asButton: true),
+                                        self::linkRecordsAction('linkRecords')->button()->size(Size::ExtraSmall),
                                     ])
                                     ->visible(fn (Meeting $record): bool => self::linkedCount($record) === 0),
                             ])
+                            ->compact(true)
                             ->columnSpan(2),
                     ]),
                 Section::make(__('filament/resources/meeting.sections.description.heading'))
@@ -234,7 +235,7 @@ final class MeetingDetailInfolist
         ];
     }
 
-    public static function linkRecordsAction(string $name, bool $asButton = false): Action
+    public static function linkRecordsAction(string $name): Action
     {
         $action = Action::make($name)
             ->label(__('filament/resources/meeting.actions.link_records.label'))
@@ -253,10 +254,6 @@ final class MeetingDetailInfolist
                     ->title(__('filament/relation-managers/meetings.notifications.linked.title'))
                     ->send();
             });
-
-        if ($asButton) {
-            return $action->button();
-        }
 
         return $action->link();
     }

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -535,7 +535,10 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
     public function minimize(): void
     {
-        $this->persistDraft();
+        if ($this->persistDraft()) {
+            $this->notifyDraftSaved();
+        }
+
         $this->isMinimized = true;
     }
 
@@ -557,7 +560,10 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      */
     public function close(): void
     {
-        $this->persistDraft();
+        if ($this->persistDraft()) {
+            $this->notifyDraftSaved();
+        }
+
         $this->closeComposer();
     }
 
@@ -1625,16 +1631,16 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * rather than wiping it: {@see SaveEmailDraftAction} never runs in that
      * case, so there is nothing to reconcile.
      */
-    private function persistDraft(): void
+    private function persistDraft(): bool
     {
         if ($this->isDraftEmpty()) {
-            return;
+            return false;
         }
 
         $accountId = $this->ownedAccountId();
 
         if ($accountId === null) {
-            return;
+            return false;
         }
 
         [$attachmentPaths, $attachmentNames, $attachmentAttributes] = $this->storeAttachments();
@@ -1681,6 +1687,16 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         // The drafts tab and its badge are rendered by other components; without
         // this they only pick the new draft up on a full page load.
         $this->dispatch('drafts:changed');
+
+        return true;
+    }
+
+    private function notifyDraftSaved(): void
+    {
+        Notification::make()
+            ->success()
+            ->title(__('filament/emails/composer.notifications.draft_saved.title'))
+            ->send();
     }
 
     /**

--- a/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
+++ b/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
@@ -31,6 +31,7 @@ use Relaticle\EmailIntegration\Services\ListMeetingsForDay;
 use Relaticle\EmailIntegration\Services\MailboxDisplayNameDirectory;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
+use Relaticle\EmailIntegration\Services\MeetingTemporalState;
 
 /**
  * @property-read Collection<int, Meeting> $meetings
@@ -346,8 +347,8 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
             'all_day' => $meeting->all_day,
             'response_status' => $this->viewerResponseStatus($meeting),
             'time' => $this->meetingTime($meeting),
-            'happening_now' => $this->isHappeningNow($meeting),
-            'is_past' => $this->isPast($meeting),
+            'happening_now' => resolve(MeetingTemporalState::class)->isHappeningNow($meeting, $this->viewerTimezone()),
+            'is_past' => resolve(MeetingTemporalState::class)->isPast($meeting, $this->viewerTimezone()),
         ];
     }
 
@@ -385,30 +386,6 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
                 ]),
             'datetime' => $start->toIso8601String(),
         ];
-    }
-
-    private function isHappeningNow(Meeting $meeting): bool
-    {
-        if ($meeting->all_day) {
-            return false;
-        }
-
-        $now = Date::now($this->viewerTimezone());
-        $start = $meeting->starts_at->timezone($this->viewerTimezone());
-        $end = $meeting->ends_at->timezone($this->viewerTimezone());
-
-        return $now->gte($start) && $now->lt($end);
-    }
-
-    private function isPast(Meeting $meeting): bool
-    {
-        $now = Date::now($this->viewerTimezone());
-
-        if ($meeting->all_day) {
-            return $now->toDateString() > $meeting->ends_at->utc()->toDateString();
-        }
-
-        return $now->gte($meeting->ends_at->timezone($this->viewerTimezone()));
     }
 
     /** The viewer's own RSVP status, used for the home-list status dot color. */

--- a/packages/EmailIntegration/src/Services/MeetingTemporalState.php
+++ b/packages/EmailIntegration/src/Services/MeetingTemporalState.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use Illuminate\Support\Facades\Date;
+use Relaticle\EmailIntegration\Models\Meeting;
+
+final readonly class MeetingTemporalState
+{
+    public function isHappeningNow(Meeting $meeting, string $timezone): bool
+    {
+        if ($meeting->all_day) {
+            return false;
+        }
+
+        $now = Date::now($timezone);
+        $start = $meeting->starts_at->timezone($timezone);
+        $end = $meeting->ends_at->timezone($timezone);
+
+        return $now->gte($start) && $now->lt($end);
+    }
+
+    public function isPast(Meeting $meeting, string $timezone): bool
+    {
+        $now = Date::now($timezone);
+
+        if ($meeting->all_day) {
+            return $now->toDateString() > $meeting->ends_at->utc()->toDateString();
+        }
+
+        return $now->gte($meeting->ends_at->timezone($timezone));
+    }
+}

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -24,9 +24,10 @@ use Relaticle\EmailIntegration\Services\ListMeetingsForDay;
 use Relaticle\EmailIntegration\Services\MailboxDisplayNameDirectory;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Relaticle\EmailIntegration\Services\MeetingAttendeePresenter;
+use Relaticle\EmailIntegration\Services\MeetingTemporalState;
 use Relaticle\EmailIntegration\Services\TeamMemberDirectory;
 
-mutates(MeetingsHomeWidget::class, ListMeetingsForDay::class, MeetingAttendeePresenter::class, TeamMemberDirectory::class, MailboxDisplayNameDirectory::class, Dashboard::class, HasConnectMailboxActions::class);
+mutates(MeetingsHomeWidget::class, ListMeetingsForDay::class, MeetingAttendeePresenter::class, MeetingTemporalState::class, TeamMemberDirectory::class, MailboxDisplayNameDirectory::class, Dashboard::class, HasConnectMailboxActions::class);
 
 beforeEach(function (): void {
     $this->travelTo(Date::parse('2026-09-09 15:00:00'));
@@ -943,6 +944,62 @@ it('strikes through the title when a meeting is in the past', function (): void 
         ->not->toMatch('/Afternoon review.*line-through/s');
 });
 
+it('applies a hover background to meeting list rows', function (): void {
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Call',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+
+    $html = html_entity_decode(livewire(MeetingsHomeWidget::class)->html());
+
+    expect($html)
+        ->toContain('hover:bg-gray-50')
+        ->toContain('dark:hover:bg-white/5')
+        ->toContain('py-3 pr-4');
+});
+
+it('renders load more outside the meeting list card', function (): void {
+    foreach (range(1, 5) as $index) {
+        Meeting::factory()->create([
+            'team_id' => $this->team->id,
+            'connected_account_id' => $this->account->id,
+            'title' => "Meeting {$index}",
+            'starts_at' => Date::parse('2026-09-09 10:00:00')->addHours($index),
+            'ends_at' => Date::parse('2026-09-09 10:30:00')->addHours($index),
+        ]);
+    }
+
+    $html = html_entity_decode(livewire(MeetingsHomeWidget::class)->html());
+
+    expect($html)
+        ->toContain('data-testid="meetings-load-more"')
+        ->toMatch('/<\/ul>[\s\S]*data-testid="meetings-load-more"/')
+        ->not->toMatch('/data-testid="meetings-load-more"[^>]*hover:bg-gray-50/s');
+});
+
+it('strikes through the modal title when a meeting is in the past', function (): void {
+    $meeting = Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Morning sync',
+        'starts_at' => Date::parse('2026-09-09 10:00:00'),
+        'ends_at' => Date::parse('2026-09-09 10:30:00'),
+    ]);
+
+    $html = html_entity_decode(
+        livewire(MeetingsHomeWidget::class)
+            ->call('openMeeting', $meeting->id)
+            ->html()
+    );
+
+    expect($html)
+        ->toContain('Morning sync')
+        ->toMatch('/Morning sync.*line-through/s');
+});
+
 it('does not mark a later meeting as happening now', function (): void {
     Meeting::factory()->create([
         'team_id' => $this->team->id,
@@ -958,7 +1015,7 @@ it('does not mark a later meeting as happening now', function (): void {
         ->assertDontSee(__('filament/pages/dashboard.meetings.happening_now'));
 });
 
-it('opens the meeting slideover from the title expand control', function (): void {
+it('opens the meeting modal from the row', function (): void {
     $meeting = Meeting::factory()->create([
         'team_id' => $this->team->id,
         'connected_account_id' => $this->account->id,
@@ -974,7 +1031,7 @@ it('opens the meeting slideover from the title expand control', function (): voi
         ->assertMountedActionModalSee(__('filament/resources/meeting.view.heading'));
 });
 
-it('opens the meeting modal from the row and title expand control', function (): void {
+it('opens the meeting modal when the row is clicked', function (): void {
     $meeting = Meeting::factory()->create([
         'team_id' => $this->team->id,
         'connected_account_id' => $this->account->id,
@@ -987,14 +1044,13 @@ it('opens the meeting modal from the row and title expand control', function ():
 
     expect($html)
         ->toContain('data-testid="meeting-card-title"')
-        ->toContain('data-testid="meeting-card-open"')
         ->toContain('data-testid="meeting-card-row"')
         ->toContain('type="button"')
         ->toContain("openMeeting('{$meeting->id}')")
-        ->toContain('group-hover/row:opacity-100')
         ->toContain('wire:loading.remove')
         ->toContain('wire:loading.class="pointer-events-none opacity-60"')
         ->toContain('fi-loading-indicator')
+        ->not->toContain('data-testid="meeting-card-open"')
         ->not->toContain('data-testid="meeting-card-participants"')
         ->not->toContain('cursor-wait')
         ->not->toContain('aria-expanded=');

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -510,7 +510,8 @@ it('saves a draft when minimized and reopens it with state intact', function ():
         ->set('to', ['draft@example.com'])
         ->set('subject', 'Half-written')
         ->set('bodyHtml', '<p>wip</p>')
-        ->call('minimize');
+        ->call('minimize')
+        ->assertNotified(__('filament/emails/composer.notifications.draft_saved.title'));
 
     $draft = Email::query()->where('status', EmailStatus::DRAFT)->sole();
     expect($draft->subject)->toBe('Half-written')
@@ -521,6 +522,47 @@ it('saves a draft when minimized and reopens it with state intact', function ():
         ->assertSet('subject', 'Half-written')
         ->assertSet('to', ['draft@example.com'])
         ->assertSet('draftId', $draft->id);
+});
+
+it('notifies when a draft is saved on close', function (): void {
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['draft@example.com'])
+        ->set('subject', 'Parked draft')
+        ->set('bodyHtml', '<p>Come back later</p>')
+        ->call('close')
+        ->assertNotified(__('filament/emails/composer.notifications.draft_saved.title'))
+        ->assertSet('isOpen', false);
+
+    expect(Email::query()->where('status', EmailStatus::DRAFT)->where('subject', 'Parked draft')->exists())->toBeTrue();
+});
+
+it('does not notify when closing an empty composer', function (): void {
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->call('close')
+        ->assertNotNotified(__('filament/emails/composer.notifications.draft_saved.title'))
+        ->assertSet('isOpen', false);
+
+    expect(Email::query()->where('status', EmailStatus::DRAFT)->exists())->toBeFalse();
+});
+
+it('notifies when an inline reply draft is saved on dismiss', function (): void {
+    $email = Email::factory()->create([
+        'team_id' => $this->user->current_team_id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->id,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+    ]);
+
+    Livewire::test(EmailComposer::class, ['dock' => 'inline'])
+        ->dispatch('composer:reply', emailId: $email->id, mode: 'reply')
+        ->set('to', ['recipient@example.com'])
+        ->set('subject', 'Inline draft')
+        ->set('bodyHtml', '<p>Reply in progress</p>')
+        ->dispatch('composer:dismiss-inline')
+        ->assertNotified(__('filament/emails/composer.notifications.draft_saved.title'))
+        ->assertSet('isOpen', false);
 });
 
 it('deletes the draft after a successful send', function (): void {


### PR DESCRIPTION
## Summary

- Show a "draft saved" toast when the email composer parks a draft on minimize, close, or inline dismiss.
- Polish the dashboard meetings list: align rows with the tasks list, strike through past meeting titles in the list and modal, and centralize past/upcoming logic in `MeetingTemporalState`.

Stacks on #715 (`fix/email-composer-inline-images`).

## Test plan

- [x] Minimize, close, and dismiss the composer after editing a draft; confirm the saved toast appears only when `persistDraft` writes.
- [x] Open Home with past and upcoming meetings; confirm past titles are struck through in the list and meeting slideover.
- [x] `php artisan test --compact --filter='EmailComposerTest|MeetingsHomeWidgetTest'`