### PR TITLE
Authorize mass-send templates before filling the editor

### DIFF
--- a/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
@@ -18,6 +18,7 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
 use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Actions\SendEmailBatchAction;
@@ -62,12 +63,7 @@ final class MassSendBulkAction extends BulkAction
                 Select::make('template_id')
                     ->label(__('filament/actions/mass-send.fields.template.label'))
                     ->placeholder(__('filament/actions/mass-send.fields.template.placeholder'))
-                    ->options(fn (): array => EmailTemplate::query()
-                        ->where('team_id', filament()->getTenant()?->getKey())
-                        ->where(fn (Builder $q) => $q
-                            ->where('created_by', auth()->id())
-                            ->orWhere('is_shared', true)
-                        )
+                    ->options(fn (): array => self::authorizedTemplates()
                         ->pluck('name', 'id')
                         ->all()
                     )
@@ -78,9 +74,7 @@ final class MassSendBulkAction extends BulkAction
                             return;
                         }
 
-                        $template = EmailTemplate::query()
-                            ->where('team_id', filament()->getTenant()?->getKey())
-                            ->find($state);
+                        $template = self::authorizedTemplates()->find($state);
 
                         if ($template === null) {
                             return;
@@ -171,6 +165,19 @@ final class MassSendBulkAction extends BulkAction
                     ->success()
                     ->send();
             });
+    }
+
+    /**
+     * @return EloquentBuilder<EmailTemplate>
+     */
+    private static function authorizedTemplates(): EloquentBuilder
+    {
+        return EmailTemplate::query()
+            ->where('team_id', filament()->getTenant()?->getKey())
+            ->where(fn (Builder $query): Builder => $query
+                ->where('created_by', auth()->id())
+                ->orWhere('is_shared', true)
+            );
     }
 
     /**

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -342,6 +342,15 @@ it('scopes the template dropdown to the current team', function (): void {
         'is_shared' => true,
     ]);
 
+    $teammatePrivate = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => User::factory()->create()->id,
+        'name' => 'Teammate private template',
+        'subject' => 'Private',
+        'body_html' => '<p>Private</p>',
+        'is_shared' => false,
+    ]);
+
     // A shared template owned by a different team must never appear here.
     $foreignUser = User::factory()->withTeam()->create();
     $foreignShared = EmailTemplate::create([
@@ -364,6 +373,7 @@ it('scopes the template dropdown to the current team', function (): void {
     expect(array_keys($options))
         ->toContain($ownPrivate->id)
         ->toContain($teammateShared->id)
+        ->not->toContain($teammatePrivate->id)
         ->not->toContain($foreignShared->id);
 });
 
@@ -402,4 +412,65 @@ it('rejects a cross-team template id submitted on send', function (): void {
         ->assertHasTableActionErrors(['template_id']);
 
     expect(EmailBatch::where('team_id', $this->team->id)->exists())->toBeFalse();
+});
+
+it('fills subject and body when an authorized template is selected', function (bool $own, bool $shared): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Recipient',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $template = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => $own ? $this->user->id : User::factory()->create()->id,
+        'name' => 'Authorized template',
+        'subject' => 'Authorized subject',
+        'body_html' => '<p>Authorized body</p>',
+        'is_shared' => $shared,
+    ]);
+
+    livewire(ListPeople::class)
+        ->mountTableBulkAction('massSend', records: [$person])
+        ->fillForm([
+            'template_id' => $template->id,
+        ])
+        ->assertSchemaStateSet([
+            'subject' => 'Authorized subject',
+            'body_html' => '<p>Authorized body</p>',
+        ]);
+})->with([
+    'own private' => [true, false],
+    'teammate shared' => [false, true],
+]);
+
+it('does not copy a teammate\'s private template into the editor', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Recipient',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $teammatePrivate = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => User::factory()->create()->id,
+        'name' => 'Teammate private template',
+        'subject' => 'SECRET SUBJECT',
+        'body_html' => '<p>SECRET BODY</p>',
+        'is_shared' => false,
+    ]);
+
+    livewire(ListPeople::class)
+        ->mountTableBulkAction('massSend', records: [$person])
+        ->fillForm([
+            'subject' => 'Original subject',
+            'body_html' => '<p>Original body</p>',
+        ])
+        ->fillForm([
+            'template_id' => $teammatePrivate->id,
+        ])
+        ->assertSchemaStateSet([
+            'subject' => 'Original subject',
+            'body_html' => '<p>Original body</p>',
+        ]);
 });


### PR DESCRIPTION
## Summary
- Mass send loaded a template's subject and body after checking only `team_id`.
- A crafted live update with a teammate's private template ID copied its contents into the editor before submit validation.
- The lookup now uses the same `created_by` / `is_shared` restriction as the dropdown.

## Test plan
- [x] Open People, select records, Mass send, pick your own private template. Subject and body fill.
- [x] Pick a teammate's shared template. Subject and body fill.
- [x] A teammate's private template does not appear in the dropdown, and a crafted ID does not copy its contents into the editor.