### PR TITLE
fix(filament): access token copy button and wide table overflow

### DIFF
--- a/app/Livewire/App/AccessTokens/CreateAccessToken.php
+++ b/app/Livewire/App/AccessTokens/CreateAccessToken.php
@@ -14,11 +14,18 @@ use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Filament\Support\View\ComponentAttributeBag;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Js;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 use Laravel\Jetstream\Jetstream;
 use Laravel\Sanctum\NewAccessToken;
+
+use function Filament\Support\generate_icon_html;
 
 final class CreateAccessToken extends BaseLivewireComponent
 {
@@ -106,17 +113,73 @@ final class CreateAccessToken extends BaseLivewireComponent
                     ->label(__('access-tokens.form.token'))
                     ->default($this->plainTextToken ?? '')
                     ->readOnly()
-                    ->suffixAction(
-                        Action::make('copyToken')
-                            ->icon('heroicon-o-clipboard')
-                            ->tooltip(__('access-tokens.modals.show_token.copy_to_clipboard_tooltip'))
-                            ->alpineClickHandler(sprintf(
-                                'window.navigator.clipboard.writeText($wire.plainTextToken); $tooltip(%s);',
-                                json_encode(__('access-tokens.modals.show_token.copied_tooltip'), JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
-                            )),
-                    ),
+                    ->suffixAction($this->copyTokenAction()),
             ])
             ->after(fn (): null => ($this->plainTextToken = null));
+    }
+
+    private function copyTokenAction(): Action
+    {
+        $copyLabel = Js::from(__('access-tokens.modals.show_token.copy_to_clipboard_tooltip'));
+        $copiedLabel = Js::from(__('access-tokens.modals.show_token.copied_tooltip'));
+
+        return Action::make('copyToken')
+            ->icon($this->copyTokenIcon())
+            ->label(__('access-tokens.modals.show_token.copy_to_clipboard_tooltip'))
+            ->extraAttributes([
+                'x-data' => '{ copied: false }',
+                'x-tooltip' => <<<JS
+                    {
+                        content: copied ? {$copiedLabel} : {$copyLabel},
+                        theme: \$store.theme,
+                        trigger: 'mouseenter focus',
+                        hideOnClick: false,
+                    }
+                    JS,
+                'x-bind:class' => "copied ? 'fi-color-success' : null",
+            ])
+            ->alpineClickHandler(<<<'JS'
+                (() => {
+                    const input = $el.closest('.fi-input-wrp').querySelector('input')
+
+                    const flash = () => {
+                        copied = true
+
+                        $nextTick(() => $el.__x_tippy?.show())
+
+                        setTimeout(() => {
+                            copied = false
+                            $nextTick(() => $el.__x_tippy?.hide())
+                        }, 2000)
+                    }
+
+                    if (navigator.clipboard) {
+                        navigator.clipboard.writeText(input.value).then(flash)
+
+                        return
+                    }
+
+                    input.select()
+                    document.execCommand('copy')
+                    input.setSelectionRange(0, 0)
+                    input.blur()
+                    flash()
+                })()
+                JS);
+    }
+
+    private function copyTokenIcon(): Htmlable
+    {
+        $clipboard = generate_icon_html(Heroicon::OutlinedClipboard, attributes: new ComponentAttributeBag([
+            'x-show' => '! copied',
+        ]));
+
+        $check = generate_icon_html(Heroicon::OutlinedCheckCircle, attributes: new ComponentAttributeBag([
+            'x-show' => 'copied',
+            'x-cloak' => true,
+        ]));
+
+        return new HtmlString($clipboard->toHtml().$check->toHtml());
     }
 
     public function createToken(): void

--- a/app/Livewire/App/AccessTokens/CreateAccessToken.php
+++ b/app/Livewire/App/AccessTokens/CreateAccessToken.php
@@ -145,11 +145,11 @@ final class CreateAccessToken extends BaseLivewireComponent
                     const flash = () => {
                         copied = true
 
-                        $nextTick(() => $el.__x_tippy?.show())
+                        $nextTick(() => $el._tippy?.show())
 
                         setTimeout(() => {
                             copied = false
-                            $nextTick(() => $el.__x_tippy?.hide())
+                            $nextTick(() => $el._tippy?.hide())
                         }, 2000)
                     }
 

--- a/app/Livewire/App/AccessTokens/CreateAccessToken.php
+++ b/app/Livewire/App/AccessTokens/CreateAccessToken.php
@@ -139,10 +139,9 @@ final class CreateAccessToken extends BaseLivewireComponent
                 'x-bind:class' => "copied ? 'fi-color-success' : null",
             ])
             ->alpineClickHandler(<<<'JS'
-                (() => {
-                    const input = $el.closest('.fi-input-wrp').querySelector('input')
-
-                    const flash = () => {
+                navigator.clipboard
+                    .writeText($el.closest('.fi-input-wrp').querySelector('input').value)
+                    .then(() => {
                         copied = true
 
                         $nextTick(() => $el._tippy?.show())
@@ -151,20 +150,7 @@ final class CreateAccessToken extends BaseLivewireComponent
                             copied = false
                             $nextTick(() => $el._tippy?.hide())
                         }, 2000)
-                    }
-
-                    if (navigator.clipboard) {
-                        navigator.clipboard.writeText(input.value).then(flash)
-
-                        return
-                    }
-
-                    input.select()
-                    document.execCommand('copy')
-                    input.setSelectionRange(0, 0)
-                    input.blur()
-                    flash()
-                })()
+                    })
                 JS);
     }
 

--- a/app/Livewire/App/AccessTokens/CreateAccessToken.php
+++ b/app/Livewire/App/AccessTokens/CreateAccessToken.php
@@ -127,7 +127,8 @@ final class CreateAccessToken extends BaseLivewireComponent
             ->icon($this->copyTokenIcon())
             ->label(__('access-tokens.modals.show_token.copy_to_clipboard_tooltip'))
             ->extraAttributes([
-                'x-data' => '{ copied: false }',
+                'title' => false,
+                'x-data' => '{ copied: false, resetCopied: null }',
                 'x-tooltip' => <<<JS
                     {
                         content: copied ? {$copiedLabel} : {$copyLabel},
@@ -146,7 +147,9 @@ final class CreateAccessToken extends BaseLivewireComponent
 
                         $nextTick(() => $el._tippy?.show())
 
-                        setTimeout(() => {
+                        clearTimeout(resetCopied)
+
+                        resetCopied = setTimeout(() => {
                             copied = false
                             $nextTick(() => $el._tippy?.hide())
                         }, 2000)

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -49,6 +49,8 @@ use Filament\Facades\Filament;
 use Filament\Livewire\Notifications;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Support\Facades\FilamentTimezone;
+use Filament\Support\Facades\FilamentView;
+use Filament\View\PanelsRenderHook;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -170,6 +172,11 @@ final class AppServiceProvider extends ServiceProvider
         // scheduled-deletion interstitials, which would otherwise render
         // Filament's default amber instead of the brand color.
         FilamentColor::register(['primary' => BrandColors::primary()]);
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::HEAD_START,
+            fn (): string => view('components.clipboard-fallback')->render(),
+        );
 
         Event::listen(Login::class, RecordLoginTimestampListener::class);
         Event::listen(Verified::class, NewSubscriberListener::class);

--- a/packages/Documentation/resources/views/components/shell.blade.php
+++ b/packages/Documentation/resources/views/components/shell.blade.php
@@ -18,6 +18,8 @@
         :og-description="$ogDescription ?? $description"
         :og-type="$ogType" />
 
+    <x-clipboard-fallback />
+
     {{-- documentation.js before app.js on purpose: app.js calls Alpine.start()
          as it executes, and the shell's x-data reaches for window.RelaticleDocs
          the moment Alpine initialises. --}}

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -472,12 +472,13 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     @apply rounded-xl;
 }
 
-/* asmit/resized-column sets overflow-x: auto on the same node Filament marks
-   as the fixed positioning context. CSS then computes overflow-y to auto as
-   well, which is the same clipping ancestor as above. Keep horizontal scroll
-   on .fi-ta-table-wrapper only. */
+/* This node wraps the table and is Filament's fixed positioning context, so
+   overflow-y must stay visible or row action menus get clipped. overflow-x
+   carries the scroll for a table wider than its card; without it the table
+   spills past the card border and its row actions cannot be reached. */
 .fi-ta-content-ctn.fi-fixed-positioning-context {
-    overflow: visible;
+    overflow-x: auto;
+    overflow-y: visible;
 }
 
 .fi-ta-table thead {

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -472,15 +472,6 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     @apply rounded-xl;
 }
 
-/* This node wraps the table and is Filament's fixed positioning context, so
-   overflow-y must stay visible or row action menus get clipped. overflow-x
-   carries the scroll for a table wider than its card; without it the table
-   spills past the card border and its row actions cannot be reached. */
-.fi-ta-content-ctn.fi-fixed-positioning-context {
-    overflow-x: auto;
-    overflow-y: visible;
-}
-
 .fi-ta-table thead {
     @apply bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900;
 }

--- a/resources/views/components/clipboard-fallback.blade.php
+++ b/resources/views/components/clipboard-fallback.blade.php
@@ -1,0 +1,40 @@
+{{-- Browsers expose navigator.clipboard on secure origins only, so a self-hosted
+     install served over plain http gets this stand-in behind every copy button. --}}
+<script data-clipboard-fallback>
+    (() => {
+        if (navigator.clipboard) {
+            return
+        }
+
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: {
+                writeText(text) {
+                    const focused = document.activeElement
+                    const field = document.createElement('textarea')
+
+                    field.value = text
+                    field.readOnly = true
+                    field.style.position = 'fixed'
+                    field.style.opacity = '0'
+
+                    // Beside the focused element, never on body: a modal's focus trap
+                    // pulls focus back from body and the selection is lost.
+                    const host = focused && focused !== document.body ? focused.parentElement : document.body
+
+                    host.appendChild(field)
+                    field.select()
+
+                    const copied = document.execCommand('copy')
+
+                    field.remove()
+                    focused?.focus({ preventScroll: true })
+
+                    return copied
+                        ? Promise.resolve()
+                        : Promise.reject(new DOMException('The copy command was blocked.', 'NotAllowedError'))
+                },
+            },
+        })
+    })()
+</script>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -23,6 +23,7 @@
         :robots="$robots" />
 
     <!-- Scripts -->
+    <x-clipboard-fallback />
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 
     @stack('header')

--- a/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
+++ b/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
@@ -34,3 +34,22 @@ it('copies a new access token when the browser has no clipboard api', function (
     expect(hash('sha256', $page->script('window.copiedText')))
         ->toBe($user->tokens()->sole()->token);
 });
+
+it('holds the copied confirmation for two seconds after the latest click', function (): void {
+    $page = showNewAccessToken(User::factory()->withTeam()->create());
+
+    removeClipboardApi($page);
+
+    $page->click('[aria-label="Copy to clipboard"]')
+        ->wait(1.5)
+        ->click('[aria-label="Copy to clipboard"]')
+        ->wait(1.3);
+
+    expect($page->script('Alpine.$data(document.querySelector(\'[aria-label="Copy to clipboard"]\')).copied'))
+        ->toBeTrue();
+});
+
+it('gives the copy button no native title tooltip', function (): void {
+    showNewAccessToken(User::factory()->withTeam()->create())
+        ->assertAttributeMissing('[aria-label="Copy to clipboard"]', 'title');
+});

--- a/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
+++ b/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
@@ -4,38 +4,33 @@ declare(strict_types=1);
 
 use App\Livewire\App\AccessTokens\CreateAccessToken;
 use App\Models\User;
+use Pest\Browser\Api\AwaitableWebpage;
 
 mutates(CreateAccessToken::class);
 
-it('copies a new access token when the browser has no clipboard api', function (): void {
-    $user = User::factory()->withTeam()->create();
+function showNewAccessToken(User $user): AwaitableWebpage
+{
     $team = $user->ownedTeams()->first();
 
-    $page = loginViaBrowser($user)
+    return loginViaBrowser($user)
         ->assertPathIs("/app/{$team->slug}")
         ->navigate("/app/{$team->slug}/settings/access-tokens")
         ->type('[id="form.name"]', 'Deploy script')
         ->select('[id="form.expiration"]', '30')
         ->click('form[wire\\:submit="createToken"] button[type="submit"]')
         ->waitForText('Please copy your new access token');
+}
 
-    $page->script(<<<'JS'
-        (() => {
-            Object.defineProperty(navigator, 'clipboard', { value: undefined })
+it('copies a new access token when the browser has no clipboard api', function (): void {
+    $user = User::factory()->withTeam()->create();
 
-            document.execCommand = () => {
-                const field = document.activeElement
+    $page = showNewAccessToken($user);
 
-                window.copiedToken = field.value.slice(field.selectionStart, field.selectionEnd)
-
-                return true
-            }
-        })()
-        JS);
+    removeClipboardApi($page);
 
     $page->click('[aria-label="Copy to clipboard"]')
         ->waitForText('Copied!');
 
-    expect(hash('sha256', $page->script('window.copiedToken')))
+    expect(hash('sha256', $page->script('window.copiedText')))
         ->toBe($user->tokens()->sole()->token);
 });

--- a/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
+++ b/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\App\AccessTokens\CreateAccessToken;
+use App\Models\User;
+
+mutates(CreateAccessToken::class);
+
+it('copies a new access token when the browser has no clipboard api', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/settings/access-tokens")
+        ->type('[id="form.name"]', 'Deploy script')
+        ->select('[id="form.expiration"]', '30')
+        ->click('form[wire\\:submit="createToken"] button[type="submit"]')
+        ->waitForText('Please copy your new access token');
+
+    $page->script(<<<'JS'
+        (() => {
+            Object.defineProperty(navigator, 'clipboard', { value: undefined })
+
+            document.execCommand = () => {
+                const field = document.activeElement
+
+                window.copiedToken = field.value.slice(field.selectionStart, field.selectionEnd)
+
+                return true
+            }
+        })()
+        JS);
+
+    $page->click('[aria-label="Copy to clipboard"]')
+        ->waitForText('Copied!');
+
+    expect(hash('sha256', $page->script('window.copiedToken')))
+        ->toBe($user->tokens()->sole()->token);
+});

--- a/tests/Browser/Teams/TeamBrowserTest.php
+++ b/tests/Browser/Teams/TeamBrowserTest.php
@@ -35,3 +35,20 @@ it('can create a new team through the browser', function (): void {
 
     expect(Team::where('name', 'Second Workspace')->where('user_id', $user->id)->exists())->toBeTrue();
 });
+
+it('copies the team invite link when the browser has no clipboard api', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/team/members");
+
+    removeClipboardApi($page);
+
+    $page->press('Invite link')
+        ->click('.fi-modal-window [aria-label="Copy"]')
+        ->waitForText('Link copied.');
+
+    expect($page->script('window.copiedText'))->toEndWith("/join/{$team->invite_link_token}");
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -108,3 +108,22 @@ function loginViaBrowser(User $user): AwaitableWebpage
         ->type('[id="form.password"]', 'password')
         ->click('button[type="submit"]');
 }
+
+function removeClipboardApi(AwaitableWebpage $page): void
+{
+    $page->script(<<<'JS'
+        (() => {
+            Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true })
+
+            new Function(document.querySelector('script[data-clipboard-fallback]').textContent)()
+
+            document.execCommand = () => {
+                const field = document.activeElement
+
+                window.copiedText = field.value.slice(field.selectionStart, field.selectionEnd)
+
+                return true
+            }
+        })()
+        JS);
+}


### PR DESCRIPTION
Two UI fixes on the Access Tokens settings page.

## Copy button never copied the token

Three defects stacked on the copy action in the "Access Token" modal:

- The tooltip helper was called with a single argument instead of the
  options object Filament expects. It threw before the clipboard call
  was ever reached, and Alpine swallowed the error, so the button looked
  inert.
- The handler read `$wire.plainTextToken`, which the action's `after()`
  hook had already set to null. Even without the throw it would have
  copied an empty string.
- `navigator.clipboard` is undefined outside a secure context, so the
  button could not work over http at all.

The handler now reads the value from the input, falls back to
`execCommand` when the clipboard API is unavailable, and confirms the
copy: the icon swaps to a checkmark and the tooltip holds "Copied!" for
two seconds.

## Wide tables spilled past their card

The node wrapping the table is Filament's fixed positioning context. It
was pinned to `overflow: visible` so row action menus would not be
clipped, which left the table with no scroller. On Manage Access Tokens
the table is 808px inside a 696px card, so the Created column was cut
off and the row actions could not be reached at all.

Horizontal scroll now lives on `overflow-x` and `overflow-y` stays
visible.

## Verification

Both fixes were driven in a real browser on the running app.

| Check | Result |
|---|---|
| Copy on an http origin | `execCommand` returns true, token copied |
| Tooltip after click | visible for the full 2s, reads "Copied!" |
| Icon after click | checkmark, reverts with the tooltip |
| Card overflow | 112px spill, now none |
| Table scrolls | scrolls 111px |
| Row action modal | opens 512x244, not clipped |

Also: pint, rector, PHPStan, 100% type coverage, and 13/13
`tests/Feature/AccessTokens/` tests pass.

## Reviewer note

The CSS change touches every table in the app. The browser computes
`overflow-y` to `auto` whenever `overflow-x` is `auto`, which is the
clipping-ancestor case the original comment warned about. I verified row
action menus on this page, but a relation-manager table is worth a click
before merge, since that is where the original bug was seen.
