### PR TITLE
Open bulk send in the floating email composer

### DIFF
--- a/app/Filament/Resources/CompanyResource.php
+++ b/app/Filament/Resources/CompanyResource.php
@@ -39,6 +39,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Relaticle\ActivityLog\Filament\RelationManagers\ActivityLogRelationManager;
 use Relaticle\CustomFields\Facades\CustomFields;
+use Relaticle\EmailIntegration\Filament\Actions\MassSendBulkAction;
 
 final class CompanyResource extends Resource
 {
@@ -126,6 +127,7 @@ final class CompanyResource extends Resource
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
+                    MassSendBulkAction::forCompanies(),
                     ExportBulkAction::make()
                         ->exporter(CompanyExporter::class),
                     DeleteBulkAction::make(),

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -277,7 +277,7 @@ return [
             'maxJobs' => 0,
             'memory' => 256,
             'tries' => 3,
-            'timeout' => 300,
+            'timeout' => 330,
             'nice' => 5,
         ],
     ],
@@ -372,7 +372,7 @@ return [
                 'balanceCooldown' => 2,
                 'memory' => 256,
                 'tries' => 3,
-                'timeout' => 300,
+                'timeout' => 330,
                 'nice' => 5,
             ],
             'chat-supervisor' => [

--- a/database/factories/EmailTemplateFactory.php
+++ b/database/factories/EmailTemplateFactory.php
@@ -40,8 +40,8 @@ final class EmailTemplateFactory extends Factory
     {
         return $this->state(fn (): array => [
             'subject' => 'Hello {name}',
-            'body_html' => '<p>Hi {first_name}, from {company}</p>',
-            'variables' => ['name', 'first_name', 'company'],
+            'body_html' => '<p>Hi {name}, from {company}</p>',
+            'variables' => ['name', 'company'],
         ]);
     }
 }

--- a/lang/en/filament/actions/mass-send.php
+++ b/lang/en/filament/actions/mass-send.php
@@ -23,6 +23,10 @@ return [
             'title' => 'No valid recipients',
             'body' => 'None of the selected people have an email address.',
         ],
+        'skipped' => [
+            'title' => 'Some recipients skipped',
+            'body' => ':skipped selected record(s) have no email address and were not added.',
+        ],
         'queued' => [
             'title' => 'Mass email queued',
             'body' => 'Sending to :count recipient(s).',

--- a/lang/en/filament/emails/composer.php
+++ b/lang/en/filament/emails/composer.php
@@ -32,6 +32,15 @@ return [
         'alignment' => 'Alignment',
     ],
 
+    'mass_send' => [
+        'summary' => 'Sending individual emails to :count recipients',
+        'toggle' => 'Mass sending',
+        'send_button' => 'Send emails (:count)',
+        'add_recipients' => 'Add recipients',
+        'outbox_hint' => 'Delivery time will depend on items in your outbox.',
+        'view_outbox' => 'View outbox',
+        'no_recipients' => 'Add at least one recipient before sending.',
+    ],
     'actions' => [
         'send' => 'Send email',
         'attach' => 'Attach files',
@@ -60,6 +69,10 @@ return [
         'description' => 'Please grant permission to enable email sending.',
     ],
     'notifications' => [
+        'mass_queued' => [
+            'title' => 'Mass email queued',
+            'body' => 'Sending to :count recipient(s).',
+        ],
         'queued' => ['title' => 'Email queued for sending'],
         'signature_created' => ['title' => 'Signature created'],
         'template_created' => ['title' => 'Template saved'],
@@ -85,5 +98,6 @@ return [
     ],
     'validation' => [
         'body_required' => 'Write a message before sending.',
+        'recipient_not_allowed' => 'Choose a recipient from your workspace records or suggested addresses.',
     ],
 ];

--- a/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
@@ -32,7 +32,14 @@ final readonly class SendEmailBatchAction
      * all of it back, leaving no orphaned batch.
      *
      * @param  list<array{person: People, email: string}>  $recipients
-     * @param  array{connected_account_id: string, subject: string, body_html: string}  $payload
+     * @param  array{
+     *     connected_account_id: string,
+     *     subject: string,
+     *     body_html: string,
+     *     attachments?: array<int, string>,
+     *     attachment_file_names?: array<string, string>,
+     *     attachment_attributes?: array<string, array{is_inline?: bool, content_id?: ?string}>,
+     * }  $payload
      */
     public function execute(User $user, array $recipients, array $payload): EmailBatch
     {
@@ -71,6 +78,9 @@ final readonly class SendEmailBatchAction
                         'creation_source' => EmailCreationSource::MASS_SEND,
                         'privacy_tier' => EmailPrivacyTier::FULL,
                         'batch_id' => $batch->getKey(),
+                        'attachments' => $payload['attachments'] ?? [],
+                        'attachment_file_names' => $payload['attachment_file_names'] ?? [],
+                        'attachment_attributes' => $payload['attachment_attributes'] ?? [],
                     ],
                     linkToType: People::class,
                     linkToId: $person->getKey(),

--- a/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailBatchAction.php
@@ -70,7 +70,7 @@ final readonly class SendEmailBatchAction
                     data: [
                         'connected_account_id' => $accountId,
                         'subject' => $this->renderService->renderPlainText($payload['subject'], $person),
-                        'body_html' => $this->renderService->renderContent($payload['body_html'], $person),
+                        'body_html' => $this->renderService->renderForSending($payload['body_html'], $person),
                         'to' => [['email' => $recipient['email'], 'name' => $person->name]],
                         'cc' => [],
                         'bcc' => [],

--- a/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
@@ -4,27 +4,15 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Actions;
 
-use App\Enums\CustomFields\PeopleField;
 use App\Features\EmailIntegration;
-use App\Models\CustomField;
-use App\Models\People;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Actions\BulkAction;
-use Filament\Forms\Components\RichEditor;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\TextInput;
-use Filament\Notifications\Notification;
-use Filament\Schemas\Components\Utilities\Set;
-use Filament\Support\Enums\Width;
-use Illuminate\Contracts\Database\Query\Builder;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
 use Laravel\Pennant\Feature;
-use Relaticle\EmailIntegration\Actions\SendEmailBatchAction;
+use Livewire\Component;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
-use Relaticle\EmailIntegration\Models\EmailTemplate;
-use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
+use Relaticle\EmailIntegration\Services\OpenMassSendComposer;
 
 final class MassSendBulkAction extends BulkAction
 {
@@ -33,10 +21,22 @@ final class MassSendBulkAction extends BulkAction
         /** @var static $action */
         $action = parent::make($name ?? 'massSend');
 
-        return $action
+        return $action->setupMassSendAction(forCompanies: false);
+    }
+
+    public static function forCompanies(?string $name = null): static
+    {
+        /** @var static $action */
+        $action = parent::make($name ?? 'massSend');
+
+        return $action->setupMassSendAction(forCompanies: true);
+    }
+
+    private function setupMassSendAction(bool $forCompanies): static
+    {
+        return $this
             ->label(__('filament/actions/mass-send.label'))
             ->icon('heroicon-o-paper-airplane')
-            ->modalWidth(Width::ThreeExtraLarge)
             ->visible(function (): bool {
                 /** @var User|null $user */
                 $user = auth()->user();
@@ -47,152 +47,11 @@ final class MassSendBulkAction extends BulkAction
                     && $user instanceof User
                     && ConnectedAccount::hasSendableFor($user, $team);
             })
-            ->schema([
-                Select::make('connected_account_id')
-                    ->label(__('filament/actions/mass-send.fields.from.label'))
-                    ->options(fn (): array => ConnectedAccount::query()
-                        ->where('user_id', auth()->id())
-                        ->where('team_id', filament()->getTenant()?->getKey())
-                        ->where('status', 'active')
-                        ->get()
-                        ->mapWithKeys(fn (ConnectedAccount $account): array => [$account->getKey() => $account->label])
-                        ->all()
-                    )
-                    ->required(),
+            ->action(function (Collection $records) use ($forCompanies): void {
+                /** @var Component $page */
+                $page = $this->getLivewire();
 
-                Select::make('template_id')
-                    ->label(__('filament/actions/mass-send.fields.template.label'))
-                    ->placeholder(__('filament/actions/mass-send.fields.template.placeholder'))
-                    ->options(fn (): array => self::authorizedTemplates()
-                        ->pluck('name', 'id')
-                        ->all()
-                    )
-                    ->nullable()
-                    ->live()
-                    ->afterStateUpdated(function (?string $state, Set $set): void {
-                        if ($state === null) {
-                            return;
-                        }
-
-                        $template = self::authorizedTemplates()->find($state);
-
-                        if ($template === null) {
-                            return;
-                        }
-
-                        $set('subject', $template->subject ?? '');
-                        $set('body_html', $template->body_html ?? '');
-                    }),
-
-                TextInput::make('subject')
-                    ->required()
-                    ->maxLength(255),
-
-                RichEditor::make('body_html')
-                    ->label(__('filament/actions/mass-send.fields.body.label'))
-                    ->required()
-                    ->mergeTags(EmailTemplateRenderService::MERGE_TAGS)
-                    ->toolbarButtons([
-                        'bold', 'italic', 'underline',
-                        'link', 'bulletList', 'orderedList',
-                    ]),
-            ])
-            ->action(function (Collection $records, array $data): void {
-                /** @var User $user */
-                $user = auth()->user();
-
-                // Resolve each selected person's send-to address from the People EMAILS
-                // custom field, the canonical source LinkEmailAction matches participants
-                // against. Resolving from participant rows alone would silently drop people
-                // you have never emailed (those rows are a side effect of past exchange).
-                $emailsField = CustomField::query()
-                    ->withoutGlobalScopes()
-                    ->where('tenant_id', filament()->getTenant()?->getKey())
-                    ->where('entity_type', 'people')
-                    ->where('code', PeopleField::EMAILS->value)
-                    ->first();
-
-                /** @var list<array{person: People, email: string}> $recipients */
-                $recipients = [];
-                $skipped = 0;
-
-                // ponytail: getCustomFieldValue lazy-loads per person (N+1), fine for a
-                // manual bulk selection; eager-load customFieldValues if selections grow huge.
-                foreach ($records as $person) {
-                    if (! $person instanceof People) {
-                        continue;
-                    }
-
-                    $email = self::resolvePrimaryEmail($person, $emailsField);
-
-                    if ($email === null) {
-                        $skipped++;
-
-                        continue;
-                    }
-
-                    $recipients[] = ['person' => $person, 'email' => $email];
-                }
-
-                if ($recipients === []) {
-                    Notification::make()
-                        ->title(__('filament/actions/mass-send.notifications.no_recipients.title'))
-                        ->body(__('filament/actions/mass-send.notifications.no_recipients.body'))
-                        ->warning()
-                        ->send();
-
-                    return;
-                }
-
-                resolve(SendEmailBatchAction::class)->execute(
-                    user: $user,
-                    recipients: $recipients,
-                    payload: [
-                        'connected_account_id' => $data['connected_account_id'],
-                        'subject' => (string) $data['subject'],
-                        'body_html' => (string) $data['body_html'],
-                    ],
-                );
-
-                Notification::make()
-                    ->title(__('filament/actions/mass-send.notifications.queued.title'))
-                    ->body($skipped > 0
-                        ? __('filament/actions/mass-send.notifications.queued.body_with_skipped', [
-                            'count' => count($recipients),
-                            'skipped' => $skipped,
-                        ])
-                        : __('filament/actions/mass-send.notifications.queued.body', ['count' => count($recipients)]))
-                    ->success()
-                    ->send();
+                resolve(OpenMassSendComposer::class)->execute($page, $records, $forCompanies);
             });
-    }
-
-    /**
-     * @return EloquentBuilder<EmailTemplate>
-     */
-    private static function authorizedTemplates(): EloquentBuilder
-    {
-        return EmailTemplate::query()
-            ->where('team_id', filament()->getTenant()?->getKey())
-            ->where(fn (Builder $query): Builder => $query
-                ->where('created_by', auth()->id())
-                ->orWhere('is_shared', true)
-            );
-    }
-
-    /**
-     * Resolve a person's first email address from the EMAILS custom field
-     * (stored as a JSON array). Returns null when the person has no email.
-     */
-    private static function resolvePrimaryEmail(People $person, ?CustomField $emailsField): ?string
-    {
-        if (! $emailsField instanceof CustomField) {
-            return null;
-        }
-
-        $value = $person->getCustomFieldValue($emailsField);
-        $email = is_array($value) ? ($value[0] ?? null) : $value;
-
-        return filled($email) ? (string) $email : null;
     }
 }

--- a/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
+++ b/packages/EmailIntegration/src/Filament/Actions/MassSendBulkAction.php
@@ -18,6 +18,7 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection;
 use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Actions\SendEmailBatchAction;
@@ -62,12 +63,7 @@ final class MassSendBulkAction extends BulkAction
                 Select::make('template_id')
                     ->label(__('filament/actions/mass-send.fields.template.label'))
                     ->placeholder(__('filament/actions/mass-send.fields.template.placeholder'))
-                    ->options(fn (): array => EmailTemplate::query()
-                        ->where('team_id', filament()->getTenant()?->getKey())
-                        ->where(fn (Builder $q) => $q
-                            ->where('created_by', auth()->id())
-                            ->orWhere('is_shared', true)
-                        )
+                    ->options(fn (): array => self::authorizedTemplates()
                         ->pluck('name', 'id')
                         ->all()
                     )
@@ -78,9 +74,7 @@ final class MassSendBulkAction extends BulkAction
                             return;
                         }
 
-                        $template = EmailTemplate::query()
-                            ->where('team_id', filament()->getTenant()?->getKey())
-                            ->find($state);
+                        $template = self::authorizedTemplates()->find($state);
 
                         if ($template === null) {
                             return;
@@ -171,6 +165,19 @@ final class MassSendBulkAction extends BulkAction
                     ->success()
                     ->send();
             });
+    }
+
+    /**
+     * @return EloquentBuilder<EmailTemplate>
+     */
+    private static function authorizedTemplates(): EloquentBuilder
+    {
+        return EmailTemplate::query()
+            ->where('team_id', filament()->getTenant()?->getKey())
+            ->where(fn (Builder $query): Builder => $query
+                ->where('created_by', auth()->id())
+                ->orWhere('is_shared', true)
+            );
     }
 
     /**

--- a/packages/EmailIntegration/src/Filament/Concerns/AssertsAllowedEmailRecipients.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/AssertsAllowedEmailRecipients.php
@@ -52,10 +52,10 @@ trait AssertsAllowedEmailRecipients
             return [];
         }
 
-        return $email->participants
+        return array_values($email->participants
             ->pluck('email_address')
             ->filter(fn (?string $address): bool => filled($address))
             ->map(fn (string $address): string => $address)
-            ->all();
+            ->all());
     }
 }

--- a/packages/EmailIntegration/src/Filament/Concerns/AssertsAllowedEmailRecipients.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/AssertsAllowedEmailRecipients.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Concerns;
+
+use App\Models\User;
+use Filament\Notifications\Notification;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Services\AllowedRecipientService;
+
+trait AssertsAllowedEmailRecipients
+{
+    /**
+     * @param  list<string>  $to
+     * @param  list<string>  $cc
+     * @param  list<string>  $bcc
+     */
+    protected function assertAllowedEmailRecipients(
+        User $user,
+        array $to,
+        array $cc,
+        array $bcc,
+        ?Email $threadSource = null,
+    ): bool {
+        $errors = resolve(AllowedRecipientService::class)->validationErrors(
+            $user,
+            $to,
+            $cc,
+            $bcc,
+            $this->threadParticipantAddresses($threadSource),
+        );
+
+        if ($errors === []) {
+            return true;
+        }
+
+        Notification::make()
+            ->title($errors[array_key_first($errors)][0])
+            ->danger()
+            ->send();
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function threadParticipantAddresses(?Email $email): array
+    {
+        if (! $email instanceof Email) {
+            return [];
+        }
+
+        return $email->participants
+            ->pluck('email_address')
+            ->filter(fn (?string $address): bool => filled($address))
+            ->map(fn (string $address): string => $address)
+            ->all();
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Concerns/AssertsAllowedEmailRecipients.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/AssertsAllowedEmailRecipients.php
@@ -36,7 +36,7 @@ trait AssertsAllowedEmailRecipients
         }
 
         Notification::make()
-            ->title($errors[array_key_first($errors)][0])
+            ->title(array_first($errors)[0])
             ->danger()
             ->send();
 

--- a/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasEmailComposeActions.php
@@ -36,6 +36,7 @@ use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
 trait HasEmailComposeActions
 {
+    use AssertsAllowedEmailRecipients;
     use RedirectsToGrantSend;
 
     /**
@@ -188,6 +189,20 @@ trait HasEmailComposeActions
         if (! $account instanceof ConnectedAccount || ! $account->isSendable()) {
             $this->redirectToGrantSend($account);
 
+            return;
+        }
+
+        $threadSource = in_array($mode, ['reply', 'reply_all'], true)
+            ? $this->resolveComposableEmail($data['in_reply_to_email_id'] ?? null)
+            : null;
+
+        if (! $this->assertAllowedEmailRecipients(
+            $this->getAuthenticatedUser(),
+            $data['to'] ?? [],
+            $data['cc'] ?? [],
+            $data['bcc'] ?? [],
+            $threadSource,
+        )) {
             return;
         }
 

--- a/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailInboxPage.php
@@ -35,6 +35,7 @@ use Relaticle\EmailIntegration\Enums\EmailPageTab;
 use Relaticle\EmailIntegration\Enums\EmailPriority;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
+use Relaticle\EmailIntegration\Filament\Concerns\AssertsAllowedEmailRecipients;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailReaderActions;
 use Relaticle\EmailIntegration\Filament\Concerns\RedirectsToGrantSend;
@@ -52,6 +53,7 @@ use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 
 final class EmailInboxPage extends Page
 {
+    use AssertsAllowedEmailRecipients;
     use HasEmailFeatureFlag;
     use HasEmailReaderActions;
     use RedirectsToGrantSend;
@@ -492,6 +494,24 @@ final class EmailInboxPage extends Page
         if (! $account instanceof ConnectedAccount || ! $account->isSendable()) {
             $this->redirectToGrantSend($account);
 
+            return;
+        }
+
+        $threadSource = in_array($mode, ['reply', 'reply_all'], true)
+            ? $this->resolveTeamEmail($data['in_reply_to_email_id'] ?? null, 'view')
+            : null;
+
+        if ($threadSource instanceof Email) {
+            $threadSource->loadMissing('participants');
+        }
+
+        if (! $this->assertAllowedEmailRecipients(
+            $this->authUser(),
+            $data['to'] ?? [],
+            $data['cc'] ?? [],
+            $data['bcc'] ?? [],
+            $threadSource,
+        )) {
             return;
         }
 

--- a/packages/EmailIntegration/src/Livewire/DraftsTable.php
+++ b/packages/EmailIntegration/src/Livewire/DraftsTable.php
@@ -70,6 +70,11 @@ final class DraftsTable extends Component implements HasActions, HasSchemas, Has
                     ->limit(60)
                     ->searchable(),
                 TextColumn::make('participants_to')
+                    ->badge()
+                    ->listWithLineBreaks()
+                    ->separator(', ')
+                    ->limitList(5)
+                    ->expandableLimitedList()
                     ->label(__('filament/pages/email-inbox.drafts.columns.recipients'))
                     ->placeholder(__('filament/pages/email-inbox.drafts.columns.no_recipients'))
                     ->state(fn (Email $record): string => $record->participants

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -42,6 +42,7 @@ use Relaticle\EmailIntegration\Actions\DeleteDraftAttachmentAction;
 use Relaticle\EmailIntegration\Actions\DeleteEmailDraftAction;
 use Relaticle\EmailIntegration\Actions\SaveEmailDraftAction;
 use Relaticle\EmailIntegration\Actions\SendEmailAction;
+use Relaticle\EmailIntegration\Actions\SendEmailBatchAction;
 use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailParticipantRole;
 use Relaticle\EmailIntegration\Enums\EmailPriority;
@@ -55,10 +56,12 @@ use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
+use Relaticle\EmailIntegration\Services\AllowedRecipientService;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
+use Relaticle\EmailIntegration\Support\PersonRecipientFormatter;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 use Throwable;
 
@@ -146,6 +149,13 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
     /** @var list<string> */
     public array $bcc = [];
 
+    public bool $isMassSend = false;
+
+    /**
+     * @var list<array{personId: string, email: string, name: string}>
+     */
+    public array $massRecipients = [];
+
     public bool $showCc = false;
 
     public bool $showBcc = false;
@@ -194,7 +204,13 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      * A same-named `$payload['draftId']` entry is never populated by either
      * caller; only a literal `draftId` parameter is.
      *
-     * @param  array{to?: list<string>, linkRecordType?: class-string, linkRecordId?: string}  $payload
+     * @param  array{
+     *     to?: list<string>,
+     *     massSend?: bool,
+     *     recipients?: list<array{personId: string, email: string, name: string}>,
+     *     linkRecordType?: class-string,
+     *     linkRecordId?: string,
+     * }  $payload
      */
     #[On('composer:open')]
     public function open(array $payload = [], ?string $draftId = null): void
@@ -222,7 +238,11 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $this->resetComposerState();
 
         $this->accountId = (string) $account->getKey();
-        $this->to = $payload['to'] ?? [];
+        $this->isMassSend = (bool) ($payload['massSend'] ?? false);
+        $this->massRecipients = $this->isMassSend
+            ? ($payload['recipients'] ?? [])
+            : [];
+        $this->to = $this->isMassSend ? [] : ($payload['to'] ?? []);
         $this->linkRecordType = $payload['linkRecordType'] ?? null;
         $this->linkRecordId = $payload['linkRecordId'] ?? null;
         $this->privacyTier = resolve(PrivacyService::class)
@@ -417,6 +437,12 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             return;
         }
 
+        if ($this->isMassSend) {
+            $this->sendMass();
+
+            return;
+        }
+
         $this->validate([
             'accountId' => ['required'],
             'to' => ['required', 'array', 'min:1'],
@@ -425,6 +451,24 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             'bcc.*' => ['email'],
             'subject' => ['required', 'string', 'max:255'],
         ]);
+
+        $recipientErrors = resolve(AllowedRecipientService::class)->validationErrors(
+            $this->authUser(),
+            $this->to,
+            $this->cc,
+            $this->bcc,
+            $this->threadRecipientAllowlist(),
+        );
+
+        foreach ($recipientErrors as $key => $messages) {
+            foreach ($messages as $message) {
+                $this->addError($key, $message);
+            }
+        }
+
+        if ($recipientErrors !== []) {
+            return;
+        }
 
         $bodyHtml = $this->bodyHtmlForPersistence();
 
@@ -507,14 +551,166 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $this->dispatch('outbox:changed');
     }
 
+    private function sendMass(): void
+    {
+        $this->validate([
+            'accountId' => ['required'],
+            'subject' => ['required', 'string', 'max:255'],
+        ]);
+
+        if ($this->massRecipients === []) {
+            $this->addError('massRecipients', __('filament/emails/composer.mass_send.no_recipients'));
+
+            return;
+        }
+
+        $bodyHtml = $this->bodyHtmlForPersistence();
+
+        if (
+            trim(strip_tags($bodyHtml)) === ''
+            && ! str_contains($bodyHtml, 'data-id="'.SignatureBlock::ID.'"')
+            && ! str_contains($bodyHtml, '<img')
+        ) {
+            $this->addError('bodyHtml', __('filament/emails/composer.validation.body_required'));
+
+            return;
+        }
+
+        [$attachmentPaths, $attachmentNames, $attachmentAttributes, $unavailable] = $this->collectOutgoingAttachments();
+
+        if ($unavailable !== []) {
+            return;
+        }
+
+        /** @var list<array{person: People, email: string}> $recipients */
+        $recipients = [];
+        $peopleById = People::query()
+            ->with('company')
+            ->where('team_id', $this->authUser()->current_team_id)
+            ->whereKey(array_column($this->massRecipients, 'personId'))
+            ->get()
+            ->keyBy(fn (People $person): string => (string) $person->getKey());
+
+        foreach ($this->massRecipients as $massRecipient) {
+            $person = $peopleById->get($massRecipient['personId']);
+
+            if (! $person instanceof People) {
+                continue;
+            }
+
+            $recipients[] = [
+                'person' => $person,
+                'email' => $massRecipient['email'],
+            ];
+        }
+
+        if ($recipients === []) {
+            $this->addError('massRecipients', __('filament/emails/composer.mass_send.no_recipients'));
+
+            return;
+        }
+
+        resolve(SendEmailBatchAction::class)->execute(
+            user: $this->authUser(),
+            recipients: $recipients,
+            payload: [
+                'connected_account_id' => (string) $this->accountId,
+                'subject' => (string) $this->subject,
+                'body_html' => $bodyHtml,
+                'attachments' => $attachmentPaths,
+                'attachment_file_names' => $attachmentNames,
+                'attachment_attributes' => $attachmentAttributes,
+            ],
+        );
+
+        Notification::make()
+            ->success()
+            ->title(__('filament/emails/composer.notifications.mass_queued.title'))
+            ->body(__('filament/emails/composer.notifications.mass_queued.body', [
+                'count' => count($recipients),
+            ]))
+            ->send();
+
+        $this->closeComposer();
+        $this->dispatch('outbox:changed');
+    }
+
+    /**
+     * @return array{
+     *     0: list<string>,
+     *     1: array<string, string>,
+     *     2: array<string, array{is_inline?: bool, content_id?: ?string}>,
+     *     3: list<EmailAttachment>,
+     * }
+     */
+    private function collectOutgoingAttachments(): array
+    {
+        [$copiedPaths, $copiedNames, $copiedAttributes, $copiedUnavailable] = $this->copySavedAttachments();
+        [$forwardedPaths, $forwardedNames, $forwardedAttributes, $unavailable] = $this->copyForwardedSourceAttachments();
+        [$inlinePaths, $inlineNames, $inlineAttributes, $inlineUnavailable] = $this->copyForwardedInlineAttachments();
+
+        $unavailable = [...$copiedUnavailable, ...$unavailable, ...$inlineUnavailable];
+
+        if ($unavailable !== []) {
+            $this->notifyUnavailableForwardedAttachments($unavailable, abortingSend: true);
+            $this->deleteCopiedAttachmentFiles([...$copiedPaths, ...$forwardedPaths, ...$inlinePaths]);
+
+            return [[], [], [], $unavailable];
+        }
+
+        [$pendingPaths, $pendingNames, $pendingAttributes] = $this->storeAttachments();
+
+        return [
+            [...$pendingPaths, ...$copiedPaths, ...$forwardedPaths, ...$inlinePaths],
+            [...$pendingNames, ...$copiedNames, ...$forwardedNames, ...$inlineNames],
+            [...$pendingAttributes, ...$copiedAttributes, ...$forwardedAttributes, ...$inlineAttributes],
+            [],
+        ];
+    }
+
     private function creationSource(): EmailCreationSource
     {
+        if ($this->isMassSend) {
+            return EmailCreationSource::MASS_SEND;
+        }
+
         return match ($this->replyMode) {
             'reply' => EmailCreationSource::REPLY,
             'reply_all' => EmailCreationSource::REPLY_ALL,
             'forward' => EmailCreationSource::FORWARD,
             default => EmailCreationSource::COMPOSE,
         };
+    }
+
+    /**
+     * Reply and reply-all pre-fill thread participants that may not yet appear in
+     * CRM records or autocomplete. Forwards and net-new compose do not get extras.
+     *
+     * @return list<string>
+     */
+    private function threadRecipientAllowlist(): array
+    {
+        if (! in_array($this->replyMode, ['reply', 'reply_all'], true)) {
+            return [];
+        }
+
+        $emailId = $this->sourceEmailId ?? $this->inReplyToEmailId;
+
+        if ($emailId === null) {
+            return [];
+        }
+
+        $email = $this->replyableEmail($emailId);
+
+        if (! $email instanceof Email) {
+            return [];
+        }
+
+        return $email->participants
+            ->pluck('email_address')
+            ->filter(fn (?string $address): bool => filled($address))
+            ->map(fn (string $address): string => $address)
+            ->all();
     }
 
     /**
@@ -581,6 +777,178 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         }
 
         $this->closeComposer();
+    }
+
+    public function updatedIsMassSend(bool $value): void
+    {
+        if ($value) {
+            $this->syncMassRecipientsFromTo();
+            $this->to = [];
+            $this->cc = [];
+            $this->bcc = [];
+            $this->showCc = false;
+            $this->showBcc = false;
+
+            return;
+        }
+
+        $this->to = $this->massRecipientEmails();
+    }
+
+    public function removeMassRecipient(string $personId): void
+    {
+        $this->massRecipients = array_values(array_filter(
+            $this->massRecipients,
+            fn (array $recipient): bool => $recipient['personId'] !== $personId,
+        ));
+    }
+
+    public function addMassRecipient(string $personId): void
+    {
+        foreach ($this->massRecipients as $recipient) {
+            if ($recipient['personId'] === $personId) {
+                return;
+            }
+        }
+
+        $teamId = (string) $this->authUser()->current_team_id;
+
+        $person = People::query()
+            ->where('team_id', $teamId)
+            ->whereKey($personId)
+            ->first(['id', 'name']);
+
+        if (! $person instanceof People) {
+            return;
+        }
+
+        $entries = $this->primaryEmailEntriesForPeople([(string) $person->getKey()], $teamId);
+        $email = $this->primaryEmailForPersonId($entries, (string) $person->getKey());
+
+        if ($email === null) {
+            return;
+        }
+
+        $this->massRecipients[] = [
+            'personId' => (string) $person->getKey(),
+            'email' => $email,
+            'name' => PersonRecipientFormatter::displayName($person, $email),
+        ];
+    }
+
+    public function addMassCompanyTeamRecipients(string $companyId): void
+    {
+        $teamId = (string) $this->authUser()->current_team_id;
+
+        $people = People::query()
+            ->where('team_id', $teamId)
+            ->where('company_id', $companyId)
+            ->get(['id', 'name']);
+
+        if ($people->isEmpty()) {
+            return;
+        }
+
+        /** @var list<string> $peopleIds */
+        $peopleIds = [];
+
+        foreach ($people as $person) {
+            $peopleIds[] = (string) $person->getKey();
+        }
+
+        $entries = $this->primaryEmailEntriesForPeople($peopleIds, $teamId);
+        $existingPersonIds = array_column($this->massRecipients, 'personId');
+
+        foreach ($people as $person) {
+            $personId = (string) $person->getKey();
+
+            if (in_array($personId, $existingPersonIds, true)) {
+                continue;
+            }
+
+            $email = $this->primaryEmailForPersonId($entries, $personId);
+
+            if ($email === null) {
+                continue;
+            }
+
+            $existingPersonIds[] = $personId;
+            $this->massRecipients[] = [
+                'personId' => $personId,
+                'email' => $email,
+                'name' => PersonRecipientFormatter::displayName($person, $email),
+            ];
+        }
+    }
+
+    private function syncMassRecipientsFromTo(): void
+    {
+        if ($this->to === []) {
+            return;
+        }
+
+        $teamId = (string) $this->authUser()->current_team_id;
+        $existingPersonIds = array_column($this->massRecipients, 'personId');
+
+        foreach ($this->to as $address) {
+            $email = PersonRecipientFormatter::primaryEmailFromValue($address);
+
+            if ($email === null) {
+                continue;
+            }
+
+            $person = $this->personForEmail($email, $teamId);
+
+            if (! $person instanceof People) {
+                continue;
+            }
+
+            $personId = (string) $person->getKey();
+
+            if (in_array($personId, $existingPersonIds, true)) {
+                continue;
+            }
+
+            $existingPersonIds[] = $personId;
+            $this->massRecipients[] = [
+                'personId' => $personId,
+                'email' => $email,
+                'name' => PersonRecipientFormatter::displayName($person, $email),
+            ];
+        }
+    }
+
+    private function personForEmail(string $emailAddress, string $teamId): ?People
+    {
+        $emailField = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $teamId)
+            ->where('entity_type', 'people')
+            ->where('code', 'emails')
+            ->first();
+
+        if (! $emailField instanceof CustomField) {
+            return null;
+        }
+
+        return People::query()
+            ->where('team_id', $teamId)
+            ->whereHas('customFieldValues', fn (Builder $valueQuery): Builder => $valueQuery
+                ->where('custom_field_id', $emailField->getKey())
+                ->whereJsonContains('json_value', $emailAddress))
+            ->first(['id', 'name']);
+    }
+
+    /**
+     * @return list<string>
+     */
+    #[Computed]
+    public function massRecipientEmails(): array
+    {
+        return array_map(
+            fn (array $recipient): string => $recipient['email'],
+            $this->massRecipients,
+        );
     }
 
     public function toggleCc(): void
@@ -752,7 +1120,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             $options[] = [
                 'type' => 'person',
                 'id' => $personId,
-                'label' => $person->name,
+                'label' => PersonRecipientFormatter::displayName($person, $email),
                 'description' => $email,
                 'email' => $email,
             ];
@@ -983,15 +1351,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
     private function primaryEmailFromValue(mixed $value): ?string
     {
-        $emails = $value instanceof Collection
-            ? $value
-            : collect(is_array($value) ? $value : []);
-
-        $email = $emails
-            ->filter(fn (mixed $item): bool => is_string($item) && trim($item) !== '')
-            ->first();
-
-        return is_string($email) ? $email : null;
+        return PersonRecipientFormatter::primaryEmailFromValue($value);
     }
 
     /**
@@ -1633,6 +1993,10 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
      */
     private function persistDraft(): bool
     {
+        if ($this->isMassSend) {
+            return false;
+        }
+
         if ($this->isDraftEmpty()) {
             return false;
         }
@@ -1722,6 +2086,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             && $this->to === []
             && $this->cc === []
             && $this->bcc === []
+            && $this->massRecipients === []
             && $this->attachments === []
             && $this->savedAttachments === [];
     }
@@ -1855,7 +2220,27 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
 
     private function resetComposerState(): void
     {
-        $this->reset(['draftId', 'to', 'cc', 'bcc', 'showCc', 'showBcc', 'subject', 'bodyHtml', 'signatureId', 'attachments', 'savedAttachments', 'replyMode', 'sourceEmailId', 'inReplyToEmailId', 'quotedBodyHtml', 'linkRecordType', 'linkRecordId']);
+        $this->reset([
+            'draftId',
+            'to',
+            'cc',
+            'bcc',
+            'isMassSend',
+            'massRecipients',
+            'showCc',
+            'showBcc',
+            'subject',
+            'bodyHtml',
+            'signatureId',
+            'attachments',
+            'savedAttachments',
+            'replyMode',
+            'sourceEmailId',
+            'inReplyToEmailId',
+            'quotedBodyHtml',
+            'linkRecordType',
+            'linkRecordId',
+        ]);
         $this->resetErrorBag();
     }
 

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -59,6 +59,7 @@ use Relaticle\EmailIntegration\Models\Scopes\VisibleEmailScope;
 use Relaticle\EmailIntegration\Services\AllowedRecipientService;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
+use Relaticle\EmailIntegration\Services\MassSendRecipientResolver;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\PersonRecipientFormatter;
@@ -582,27 +583,29 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             return;
         }
 
-        /** @var list<array{person: People, email: string}> $recipients */
-        $recipients = [];
-        $peopleById = People::query()
+        /** @var list<string> $personIds */
+        $personIds = array_values(array_unique(array_column($this->massRecipients, 'personId')));
+
+        if ($personIds === []) {
+            $this->addError('massRecipients', __('filament/emails/composer.mass_send.no_recipients'));
+
+            return;
+        }
+
+        $people = People::query()
             ->with('company')
             ->where('team_id', $this->authUser()->current_team_id)
-            ->whereKey(array_column($this->massRecipients, 'personId'))
-            ->get()
-            ->keyBy(fn (People $person): string => (string) $person->getKey());
+            ->whereKey($personIds)
+            ->get();
 
-        foreach ($this->massRecipients as $massRecipient) {
-            $person = $peopleById->get($massRecipient['personId']);
+        $order = array_flip($personIds);
 
-            if (! $person instanceof People) {
-                continue;
-            }
+        $orderedPeople = $people
+            ->sortBy(fn (People $person): int => $order[(string) $person->getKey()] ?? PHP_INT_MAX)
+            ->values();
 
-            $recipients[] = [
-                'person' => $person,
-                'email' => $massRecipient['email'],
-            ];
-        }
+        $result = resolve(MassSendRecipientResolver::class)->resolveFromPeople($orderedPeople);
+        $recipients = $result->recipients;
 
         if ($recipients === []) {
             $this->addError('massRecipients', __('filament/emails/composer.mass_send.no_recipients'));
@@ -706,11 +709,11 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             return [];
         }
 
-        return $email->participants
+        return array_values($email->participants
             ->pluck('email_address')
             ->filter(fn (?string $address): bool => filled($address))
             ->map(fn (string $address): string => $address)
-            ->all();
+            ->all());
     }
 
     /**
@@ -884,11 +887,14 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
     private function syncMassRecipientsFromTo(): void
     {
         if ($this->to === []) {
+            $this->massRecipients = [];
+
             return;
         }
 
         $teamId = (string) $this->authUser()->current_team_id;
-        $existingPersonIds = array_column($this->massRecipients, 'personId');
+        $existingPersonIds = [];
+        $nextRecipients = [];
 
         foreach ($this->to as $address) {
             $email = PersonRecipientFormatter::primaryEmailFromValue($address);
@@ -910,12 +916,14 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             }
 
             $existingPersonIds[] = $personId;
-            $this->massRecipients[] = [
+            $nextRecipients[] = [
                 'personId' => $personId,
                 'email' => $email,
                 'name' => PersonRecipientFormatter::displayName($person, $email),
             ];
         }
+
+        $this->massRecipients = $nextRecipients;
     }
 
     private function personForEmail(string $emailAddress, string $teamId): ?People

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -513,13 +513,14 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         $attachmentNames = [...$pendingNames, ...$copiedNames, ...$forwardedNames, ...$inlineNames];
         $attachmentAttributes = [...$pendingAttributes, ...$copiedAttributes, ...$forwardedAttributes, ...$inlineAttributes];
 
+        $mergeTagRecord = $this->mergeTagRecord();
         $linkRecord = $this->linkRecord();
 
         $email = resolve(SendEmailAction::class)->execute(
             data: [
                 'connected_account_id' => (string) $this->accountId,
-                'subject' => $renderer->renderPlainText((string) $this->subject),
-                'body_html' => $this->withQuotedBody($renderer->renderForSending($bodyHtml)),
+                'subject' => $renderer->renderPlainText((string) $this->subject, $mergeTagRecord),
+                'body_html' => $this->withQuotedBody($renderer->renderForSending($bodyHtml, $mergeTagRecord)),
                 'to' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->to),
                 'cc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->cc),
                 'bcc' => array_map(fn (string $email): array => ['email' => $email, 'name' => null], $this->bcc),
@@ -949,7 +950,50 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
             ->whereHas('customFieldValues', fn (Builder $valueQuery): Builder => $valueQuery
                 ->where('custom_field_id', $emailField->getKey())
                 ->whereJsonContains('json_value', $emailAddress))
-            ->first(['id', 'name']);
+            ->first(['id', 'name', 'company_id']);
+    }
+
+    private function mergeTagRecord(): Company|Opportunity|People|null
+    {
+        $record = $this->linkRecord();
+
+        if ($record instanceof People) {
+            $record->loadMissing('company');
+
+            return $record;
+        }
+
+        if ($record instanceof Opportunity) {
+            $record->loadMissing('company');
+
+            return $record;
+        }
+
+        if ($record instanceof Company) {
+            return $record;
+        }
+
+        $firstTo = $this->to[0] ?? null;
+
+        if (! is_string($firstTo)) {
+            return null;
+        }
+
+        $email = PersonRecipientFormatter::primaryEmailFromValue($firstTo);
+
+        if ($email === null) {
+            return null;
+        }
+
+        $person = $this->personForEmail($email, (string) $this->authUser()->current_team_id);
+
+        if (! $person instanceof People) {
+            return null;
+        }
+
+        $person->loadMissing('company');
+
+        return $person;
     }
 
     /**

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -224,10 +224,15 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
         // A second `composer:open` while a draft is already in progress (e.g. the `c`
         // shortcut firing after a click landed on a button, not an input) must not
         // wipe what the user has typed. Just bring the composer back into view.
-        if ($this->isOpen) {
+        // Bulk mass send is different: it is a deliberate new session and must apply.
+        if ($this->isOpen && ! ($payload['massSend'] ?? false)) {
             $this->isMinimized = false;
 
             return;
+        }
+
+        if ($this->isOpen) {
+            $this->isMinimized = false;
         }
 
         $account = $this->sendableAccount() ?? $this->activeAccounts()->first();

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -1088,6 +1088,21 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
     }
 
     /**
+     * Every address the composer may commit or send to. Wider than {@see recipientOptions},
+     * which caps autocomplete rows for performance.
+     *
+     * @return list<string>
+     */
+    #[Computed]
+    public function allowedRecipientAddresses(): array
+    {
+        return resolve(AllowedRecipientService::class)->addressesFor(
+            $this->authUser(),
+            $this->threadRecipientAllowlist(),
+        );
+    }
+
+    /**
      * @return list<array{
      *     type: 'person'|'company_team',
      *     id: string,

--- a/packages/EmailIntegration/src/Services/AllowedRecipientService.php
+++ b/packages/EmailIntegration/src/Services/AllowedRecipientService.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Enums\CustomFields\PeopleField;
+use App\Models\CustomField;
+use App\Models\CustomFieldValue;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+final readonly class AllowedRecipientService
+{
+    public function __construct(
+        private RecipientSuggestionService $recipientSuggestions,
+    ) {}
+
+    /**
+     * @param  list<string>  $extraAddresses  Reply-thread participants the composer pre-filled.
+     */
+    public function isAllowed(User $user, string $email, array $extraAddresses = []): bool
+    {
+        $normalized = $this->normalize($email);
+
+        if ($normalized === '') {
+            return false;
+        }
+
+        return in_array($normalized, $this->addressesFor($user, $extraAddresses), true);
+    }
+
+    /**
+     * @param  list<string>  $to
+     * @param  list<string>  $cc
+     * @param  list<string>  $bcc
+     * @param  list<string>  $extraAddresses
+     * @return array<string, list<string>>
+     */
+    public function validationErrors(
+        User $user,
+        array $to,
+        array $cc,
+        array $bcc,
+        array $extraAddresses = [],
+    ): array {
+        $message = __('filament/emails/composer.validation.recipient_not_allowed');
+        $errors = [];
+
+        foreach (['to' => $to, 'cc' => $cc, 'bcc' => $bcc] as $field => $addresses) {
+            foreach ($addresses as $index => $address) {
+                if (! is_string($address) || ! $this->isAllowed($user, $address, $extraAddresses)) {
+                    $errors["{$field}.{$index}"] = [$message];
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  list<string>  $extraAddresses
+     * @return list<string>
+     */
+    public function addressesFor(User $user, array $extraAddresses = []): array
+    {
+        $addresses = [
+            ...$this->recipientSuggestions->addressesFor($user),
+            ...$this->crmPrimaryEmailsForTeam((string) $user->current_team_id),
+            ...array_map($this->normalize(...), $extraAddresses),
+        ];
+
+        return array_values(array_unique(array_filter($addresses)));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function crmPrimaryEmailsForTeam(string $teamId): array
+    {
+        $emailField = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $teamId)
+            ->where('entity_type', 'people')
+            ->where('code', PeopleField::EMAILS->value)
+            ->first();
+
+        if (! $emailField instanceof CustomField) {
+            return [];
+        }
+
+        $addresses = [];
+
+        foreach (CustomFieldValue::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $teamId)
+            ->where('entity_type', 'people')
+            ->where('custom_field_id', $emailField->getKey())
+            ->get(['json_value']) as $value) {
+            $email = $this->primaryEmailFromValue($value->json_value);
+
+            if ($email !== null) {
+                $addresses[] = $this->normalize($email);
+            }
+        }
+
+        return $addresses;
+    }
+
+    private function primaryEmailFromValue(mixed $value): ?string
+    {
+        $emails = $value instanceof Collection
+            ? $value
+            : collect(is_array($value) ? $value : []);
+
+        $email = $emails
+            ->filter(fn (mixed $item): bool => is_string($item) && trim($item) !== '')
+            ->first();
+
+        return is_string($email) ? $email : null;
+    }
+
+    private function normalize(string $email): string
+    {
+        return mb_strtolower(trim($email));
+    }
+}

--- a/packages/EmailIntegration/src/Services/AllowedRecipientService.php
+++ b/packages/EmailIntegration/src/Services/AllowedRecipientService.php
@@ -49,7 +49,7 @@ final readonly class AllowedRecipientService
 
         foreach (['to' => $to, 'cc' => $cc, 'bcc' => $bcc] as $field => $addresses) {
             foreach ($addresses as $index => $address) {
-                if (! is_string($address) || ! $this->isAllowed($user, $address, $extraAddresses)) {
+                if (! $this->isAllowed($user, $address, $extraAddresses)) {
                     $errors["{$field}.{$index}"] = [$message];
                 }
             }

--- a/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
+++ b/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
@@ -245,7 +245,7 @@ final readonly class EmailTemplateRenderService
             $value = $value->all();
         }
 
-        if ($value === null || $value === '' || $value === []) {
+        if (in_array($value, [null, '', []], true)) {
             return '';
         }
 

--- a/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
+++ b/packages/EmailIntegration/src/Services/EmailTemplateRenderService.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services;
 
+use App\Enums\CustomFields\PeopleField;
 use App\Models\Company;
+use App\Models\CustomField;
 use App\Models\Opportunity;
 use App\Models\People;
 use Filament\Forms\Components\RichEditor\RichContentRenderer;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Date;
 use Relaticle\EmailIntegration\Filament\RichContent\SignatureBlock;
 use Relaticle\EmailIntegration\Models\EmailAttachment;
@@ -24,8 +27,10 @@ final readonly class EmailTemplateRenderService
      */
     public const array MERGE_TAGS = [
         'name' => 'Full name',
-        'first_name' => 'First name',
         'company' => 'Company',
+        'phone_number' => 'Phone number',
+        'job_title' => 'Job title',
+        'linkedin' => 'LinkedIn',
         'today' => "Today's date",
     ];
 
@@ -96,13 +101,27 @@ final readonly class EmailTemplateRenderService
      */
     public function renderForSending(string $bodyHtml, ?Model $record = null): string
     {
+        $variables = $this->buildVariables($record);
+
         $html = RichContentRenderer::make($bodyHtml)
+            ->mergeTags($variables)
             ->customBlocks([SignatureBlock::class])
             ->fileAttachmentsDisk(EmailAttachment::DISK)
             ->fileAttachmentsVisibility('private')
             ->toHtml();
 
-        return $this->renderContent($html, $record);
+        return $this->renderContent($this->unwrapMergeTagSpans($html), $record);
+    }
+
+    /**
+     * RichEditor merge tags render as {@code span} nodes; once resolved, unwrap them
+     * so outbound HTML and the email preview sanitizer do not leave empty spans behind.
+     */
+    private function unwrapMergeTagSpans(string $html): string
+    {
+        $pattern = '#<span\b[^>]*\bdata-type="mergeTag"[^>]*>(.*?)</span>#is';
+
+        return preg_replace($pattern, '$1', $html) ?? $html;
     }
 
     /**
@@ -161,23 +180,97 @@ final readonly class EmailTemplateRenderService
         $recordVariables = match (true) {
             $record instanceof People => [
                 'name' => (string) $record->name,
-                'first_name' => explode(' ', trim((string) $record->name))[0],
                 'company' => $record->company !== null ? (string) $record->company->name : '',
+                ...$this->peopleCustomFieldValues($record),
             ],
             $record instanceof Company => [
                 'name' => (string) $record->name,
-                'first_name' => (string) $record->name,
                 'company' => (string) $record->name,
+                ...$this->emptyPeopleCustomFieldValues(),
             ],
             $record instanceof Opportunity => [
                 'name' => (string) $record->name,
-                'first_name' => explode(' ', trim((string) $record->name))[0],
                 'company' => $record->company !== null ? (string) $record->company->name : '',
+                ...$this->emptyPeopleCustomFieldValues(),
             ],
             default => [],
         };
 
         return [...$baseVariables, ...$recordVariables];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function peopleCustomFieldValues(People $person): array
+    {
+        $codes = [
+            'phone_number' => PeopleField::PHONE_NUMBER->value,
+            'job_title' => PeopleField::JOB_TITLE->value,
+            'linkedin' => PeopleField::LINKEDIN->value,
+        ];
+
+        $fields = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $person->team_id)
+            ->where('entity_type', 'people')
+            ->whereIn('code', array_values($codes))
+            ->get()
+            ->keyBy('code');
+
+        $person->loadMissing(['customFieldValues.customField']);
+
+        $values = [];
+
+        foreach ($codes as $key => $code) {
+            $field = $fields->get($code);
+
+            if (! $field instanceof CustomField) {
+                $values[$key] = '';
+
+                continue;
+            }
+
+            $value = $person->getCustomFieldValue($field);
+
+            $values[$key] = $this->customFieldMergeValue($value);
+        }
+
+        return $values;
+    }
+
+    private function customFieldMergeValue(mixed $value): string
+    {
+        if ($value instanceof Collection) {
+            $value = $value->all();
+        }
+
+        if ($value === null || $value === '' || $value === []) {
+            return '';
+        }
+
+        if (is_array($value)) {
+            $strings = array_values(array_filter(
+                array_map(static fn (mixed $item): string => (string) $item, $value),
+                static fn (string $item): bool => $item !== '',
+            ));
+
+            return implode(', ', $strings);
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function emptyPeopleCustomFieldValues(): array
+    {
+        return [
+            'phone_number' => '',
+            'job_title' => '',
+            'linkedin' => '',
+        ];
     }
 
     /**
@@ -201,20 +294,69 @@ final readonly class EmailTemplateRenderService
             : $value;
 
         $content = preg_replace_callback(
-            '/\{\{\s*(\w+)\s*\}\}/',
-            fn (array $matches): string => isset($variables[$matches[1]])
-                ? $resolve($variables[$matches[1]])
-                : $matches[0],
+            '/\{\{\s*([^}]+?)\s*\}\}/',
+            function (array $matches) use ($variables, $resolve): string {
+                $tagKey = $this->resolveMergeTagKey($matches[1]);
+
+                if ($tagKey === null || ! array_key_exists($tagKey, $variables)) {
+                    return $matches[0];
+                }
+
+                return $resolve($variables[$tagKey]);
+            },
             $content
         ) ?? $content;
 
         $legacyPairs = [];
         foreach ($variables as $key => $value) {
             $legacyPairs['{'.$key.'}'] = $resolve($value);
+
+            $label = self::MERGE_TAGS[$key] ?? null;
+
+            if ($label !== null) {
+                $legacyPairs['{'.$label.'}'] = $resolve($value);
+            }
         }
 
         // strtr replaces the longest keys first and never re-scans replacements,
         // so a value containing another `{tag}` is not recursively substituted.
         return strtr($content, $legacyPairs);
+    }
+
+    private function resolveMergeTagKey(string $raw): ?string
+    {
+        $normalized = strtolower(trim($raw));
+        $normalized = preg_replace('/\s+/', ' ', $normalized) ?? $normalized;
+
+        return $this->mergeTagKeyAliases()[$normalized] ?? null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function mergeTagKeyAliases(): array
+    {
+        static $aliases = null;
+
+        if (is_array($aliases)) {
+            return $aliases;
+        }
+
+        $aliases = [
+            'name' => 'name',
+            'full name' => 'name',
+            'full_name' => 'name',
+            'company' => 'company',
+            'today' => 'today',
+            "today's date" => 'today',
+            'todays date' => 'today',
+        ];
+
+        foreach (self::MERGE_TAGS as $key => $label) {
+            $aliases[strtolower($label)] = $key;
+            $aliases[str_replace(' ', '_', strtolower($label))] = $key;
+        }
+
+        return $aliases;
     }
 }

--- a/packages/EmailIntegration/src/Services/MassSendRecipientResolver.php
+++ b/packages/EmailIntegration/src/Services/MassSendRecipientResolver.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Enums\CustomFields\PeopleField;
+use App\Models\Company;
+use App\Models\CustomField;
+use App\Models\CustomFieldValue;
+use App\Models\People;
+use Illuminate\Database\Eloquent\Collection;
+use Relaticle\EmailIntegration\Support\PersonRecipientFormatter;
+
+final readonly class MassSendRecipientResolver
+{
+    /**
+     * @param  Collection<int, People>  $people
+     */
+    public function resolveFromPeople(Collection $people): MassSendRecipientResult
+    {
+        if ($people->isEmpty()) {
+            return new MassSendRecipientResult([], 0);
+        }
+
+        $teamId = (string) $people->first()->team_id;
+        /** @var list<string> $peopleIds */
+        $peopleIds = array_values($people
+            ->map(fn (People $person): string => (string) $person->getKey())
+            ->all());
+
+        $emailByPersonId = [];
+
+        foreach ($this->primaryEmailEntriesForPeople($peopleIds, $teamId) as $entry) {
+            $emailByPersonId[$entry['person_id']] = $entry['email'];
+        }
+
+        /** @var list<array{person: People, email: string}> $recipients */
+        $recipients = [];
+        $skipped = 0;
+        /** @var array<lowercase-string, true> $seenEmails */
+        $seenEmails = [];
+
+        foreach ($people as $person) {
+            $email = $emailByPersonId[(string) $person->getKey()] ?? null;
+
+            if ($email === null) {
+                $skipped++;
+
+                continue;
+            }
+
+            $normalizedEmail = strtolower($email);
+
+            if (isset($seenEmails[$normalizedEmail])) {
+                continue;
+            }
+
+            $seenEmails[$normalizedEmail] = true;
+            $recipients[] = ['person' => $person, 'email' => $email];
+        }
+
+        return new MassSendRecipientResult($recipients, $skipped);
+    }
+
+    /**
+     * @param  Collection<int, Company>  $companies
+     */
+    public function resolveFromCompanies(Collection $companies): MassSendRecipientResult
+    {
+        if ($companies->isEmpty()) {
+            return new MassSendRecipientResult([], 0);
+        }
+
+        $teamId = (string) $companies->first()->team_id;
+        $companyIds = $companies->pluck('id')->all();
+
+        $people = People::query()
+            ->where('team_id', $teamId)
+            ->whereIn('company_id', $companyIds)
+            ->get();
+
+        return $this->resolveFromPeople($people);
+    }
+
+    /**
+     * @param  list<string>  $peopleIds
+     * @return list<array{person_id: string, email: string}>
+     */
+    private function primaryEmailEntriesForPeople(array $peopleIds, string $teamId): array
+    {
+        if ($peopleIds === []) {
+            return [];
+        }
+
+        $emailField = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $teamId)
+            ->where('entity_type', 'people')
+            ->where('code', PeopleField::EMAILS->value)
+            ->first();
+
+        if (! $emailField instanceof CustomField) {
+            return [];
+        }
+
+        $entries = [];
+
+        foreach (CustomFieldValue::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $teamId)
+            ->where('entity_type', 'people')
+            ->where('custom_field_id', $emailField->getKey())
+            ->whereIn('entity_id', $peopleIds)
+            ->get(['entity_id', 'json_value']) as $value) {
+            $email = $this->primaryEmailFromValue($value->json_value);
+
+            if ($email !== null) {
+                $entries[] = [
+                    'person_id' => (string) $value->entity_id,
+                    'email' => $email,
+                ];
+            }
+        }
+
+        return $entries;
+    }
+
+    private function primaryEmailFromValue(mixed $value): ?string
+    {
+        return PersonRecipientFormatter::primaryEmailFromValue($value);
+    }
+}

--- a/packages/EmailIntegration/src/Services/MassSendRecipientResult.php
+++ b/packages/EmailIntegration/src/Services/MassSendRecipientResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Models\People;
+
+final readonly class MassSendRecipientResult
+{
+    /**
+     * @param  list<array{person: People, email: string}>  $recipients
+     */
+    public function __construct(
+        public array $recipients,
+        public int $skipped,
+    ) {}
+}

--- a/packages/EmailIntegration/src/Services/OpenMassSendComposer.php
+++ b/packages/EmailIntegration/src/Services/OpenMassSendComposer.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Models\Company;
+use App\Models\People;
+use Filament\Notifications\Notification;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Component;
+use Relaticle\EmailIntegration\Support\PersonRecipientFormatter;
+
+final readonly class OpenMassSendComposer
+{
+    public function __construct(
+        private MassSendRecipientResolver $resolver,
+    ) {}
+
+    /**
+     * @param  Collection<int, Model>  $records
+     */
+    public function execute(Component $page, Collection $records, bool $forCompanies): void
+    {
+        $result = $forCompanies
+            ? $this->resolver->resolveFromCompanies($this->companyRecords($records))
+            : $this->resolver->resolveFromPeople($this->peopleRecords($records));
+
+        if ($result->recipients === []) {
+            Notification::make()
+                ->title(__('filament/actions/mass-send.notifications.no_recipients.title'))
+                ->body(__('filament/actions/mass-send.notifications.no_recipients.body'))
+                ->warning()
+                ->send();
+
+            return;
+        }
+
+        if ($result->skipped > 0) {
+            Notification::make()
+                ->title(__('filament/actions/mass-send.notifications.skipped.title'))
+                ->body(__('filament/actions/mass-send.notifications.skipped.body', [
+                    'skipped' => $result->skipped,
+                ]))
+                ->warning()
+                ->send();
+        }
+
+        $linkRecordType = null;
+        $linkRecordId = null;
+
+        if ($forCompanies && $records->count() === 1) {
+            $company = $records->first();
+
+            if ($company instanceof Company) {
+                $linkRecordType = Company::class;
+                $linkRecordId = (string) $company->getKey();
+            }
+        }
+
+        /** @var list<array{personId: string, email: string, name: string}> $recipientPayload */
+        $recipientPayload = [];
+
+        foreach ($result->recipients as $recipient) {
+            $recipientPayload[] = [
+                'personId' => (string) $recipient['person']->getKey(),
+                'email' => $recipient['email'],
+                'name' => PersonRecipientFormatter::displayName($recipient['person'], $recipient['email']),
+            ];
+        }
+
+        $page->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => $recipientPayload,
+            'linkRecordType' => $linkRecordType,
+            'linkRecordId' => $linkRecordId,
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     * @return Collection<int, Company>
+     */
+    private function companyRecords(Collection $records): Collection
+    {
+        /** @var Collection<int, Company> $companies */
+        $companies = $records
+            ->filter(fn (Model $record): bool => $record instanceof Company)
+            ->values();
+
+        return $companies;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     * @return Collection<int, People>
+     */
+    private function peopleRecords(Collection $records): Collection
+    {
+        /** @var Collection<int, People> $people */
+        $people = $records
+            ->filter(fn (Model $record): bool => $record instanceof People)
+            ->values();
+
+        return $people;
+    }
+}

--- a/packages/EmailIntegration/src/Support/PersonRecipientFormatter.php
+++ b/packages/EmailIntegration/src/Support/PersonRecipientFormatter.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Support;
+
+use App\Models\People;
+use Illuminate\Support\Collection;
+
+final class PersonRecipientFormatter
+{
+    public static function displayName(People $person, ?string $email = null): string
+    {
+        $name = trim((string) $person->name);
+
+        if (self::isUsableDisplayName($name)) {
+            return $name;
+        }
+
+        if ($email !== null && self::validEmail($email) !== null) {
+            return $email;
+        }
+
+        return $name !== '' ? $name : ($email ?? '');
+    }
+
+    public static function primaryEmailFromValue(mixed $value): ?string
+    {
+        if (is_string($value)) {
+            $trimmed = trim($value);
+
+            if ($trimmed === '' || str_starts_with($trimmed, '[')) {
+                return null;
+            }
+
+            return self::validEmail($trimmed);
+        }
+
+        /** @var list<mixed> $items */
+        $items = $value instanceof Collection
+            ? $value->values()->all()
+            : (is_array($value) ? $value : []);
+
+        foreach ($items as $item) {
+            if (! is_string($item)) {
+                continue;
+            }
+
+            $email = self::validEmail(trim($item));
+
+            if ($email !== null) {
+                return $email;
+            }
+        }
+
+        return null;
+    }
+
+    private static function isUsableDisplayName(string $name): bool
+    {
+        if ($name === '' || $name === 'Array') {
+            return false;
+        }
+
+        if (str_starts_with($name, '[') && str_ends_with($name, ']')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function validEmail(string $candidate): ?string
+    {
+        return filter_var($candidate, FILTER_VALIDATE_EMAIL) !== false ? $candidate : null;
+    }
+}

--- a/packages/EmailIntegration/src/Support/PersonRecipientFormatter.php
+++ b/packages/EmailIntegration/src/Support/PersonRecipientFormatter.php
@@ -62,11 +62,7 @@ final class PersonRecipientFormatter
             return false;
         }
 
-        if (str_starts_with($name, '[') && str_ends_with($name, ']')) {
-            return false;
-        }
-
-        return true;
+        return ! str_starts_with($name, '[') || ! str_ends_with($name, ']');
     }
 
     private static function validEmail(string $candidate): ?string

--- a/resources/views/components/emails/composer-field.blade.php
+++ b/resources/views/components/emails/composer-field.blade.php
@@ -2,7 +2,7 @@
      `for` renders the row as a <label> so the caption focuses the control. --}}
 @props(['label', 'for' => false])
 
-<{{ $for ? 'label' : 'div' }} {{ $attributes->class(['flex items-center gap-3 py-2']) }}>
-    <span class="w-14 shrink-0 text-xs font-medium uppercase tracking-wide text-gray-400">{{ $label }}</span>
+<{{ $for ? 'label' : 'div' }} {{ $attributes->class(['flex min-h-10 items-center gap-3 py-2']) }}>
+    <span class="w-14 shrink-0 self-center text-xs font-medium uppercase tracking-wide text-gray-400">{{ $label }}</span>
     {{ $slot }}
 </{{ $for ? 'label' : 'div' }}>

--- a/resources/views/components/emails/composer-mass-recipient-list.blade.php
+++ b/resources/views/components/emails/composer-mass-recipient-list.blade.php
@@ -1,0 +1,43 @@
+@props([
+    'recipients' => [],
+])
+
+@php
+    use App\Services\AvatarService;
+
+    $removeLabel = __('filament/emails/composer.actions.remove_recipient');
+
+    $recipientTooltip = static function (string $name, string $email): string {
+        return $name === $email ? $email : "{$name} · {$email}";
+    };
+@endphp
+
+<ul {{ $attributes->class(['min-h-0 flex-1 overflow-y-auto divide-y divide-gray-100 dark:divide-white/5']) }}>
+    @forelse ($recipients as $recipient)
+        <li wire:key="mass-recipient-{{ $recipient['personId'] }}" class="flex items-center gap-3 px-3 py-2.5">
+            <x-filament::avatar
+                :src="resolve(AvatarService::class)->generate($recipient['name'])"
+                :alt="$recipient['name']"
+                size="h-8 w-8"
+                class="shrink-0"
+            />
+            <div
+                class="min-w-0 flex-1"
+                x-tooltip="{ content: @js($recipientTooltip($recipient['name'], $recipient['email'])), theme: $store.theme }"
+            >
+                <p class="truncate text-sm font-medium text-gray-900 dark:text-gray-100">{{ $recipient['name'] }}</p>
+                <p class="truncate text-xs text-gray-500 dark:text-gray-400">{{ $recipient['email'] }}</p>
+            </div>
+            <x-emails.composer-icon-button
+                icon="heroicon-m-x-mark"
+                :label="$removeLabel"
+                class="!p-1"
+                wire:click="removeMassRecipient('{{ $recipient['personId'] }}')"
+            />
+        </li>
+    @empty
+        <li class="px-3 py-6 text-center text-xs text-gray-400 dark:text-gray-500">
+            {{ __('filament/emails/composer.mass_send.add_recipients') }}
+        </li>
+    @endforelse
+</ul>

--- a/resources/views/components/emails/composer-mass-recipient-search.blade.php
+++ b/resources/views/components/emails/composer-mass-recipient-search.blade.php
@@ -1,0 +1,116 @@
+@props([
+    'options' => [],
+    'selectedPersonIds' => [],
+])
+
+@php
+    $companyTeamLabel = __('filament/emails/composer.fields.company_team_count');
+@endphp
+
+<div
+    wire:key="mass-recipient-search-{{ implode('-', $selectedPersonIds) }}"
+    x-data="{
+        query: '',
+        activeIndex: 0,
+        options: @js(array_values($options)),
+        selectedIds: @js($selectedPersonIds),
+        companyTeamLabel: @js($companyTeamLabel),
+
+        get matches() {
+            const q = this.query.trim().toLowerCase();
+
+            if (q === '') {
+                return [];
+            }
+
+            return this.options
+                .filter((option) => this.optionVisible(option))
+                .filter((option) => [option.label, option.description, option.email]
+                    .filter(Boolean)
+                    .some((value) => value.toLowerCase().includes(q)))
+                .slice(0, 8);
+        },
+
+        optionVisible(option) {
+            if (option.type === 'person') {
+                return ! this.selectedIds.includes(option.id);
+            }
+
+            return true;
+        },
+
+        async choose(option) {
+            if (option.type === 'company_team') {
+                await $wire.addMassCompanyTeamRecipients(option.id);
+            } else {
+                await $wire.addMassRecipient(option.id);
+            }
+
+            this.selectedIds = $wire.massRecipients.map((recipient) => recipient.personId);
+            this.query = '';
+            this.activeIndex = 0;
+        },
+
+        optionTooltip(option) {
+            if (option.type === 'company_team') {
+                return option.label + ' (' + this.companyTeamLabel + ' ' + option.count + ')';
+            }
+
+            if (option.email && option.label !== option.email) {
+                return option.label + ' · ' + option.email;
+            }
+
+            return option.label || option.email || '';
+        },
+    }"
+    {{ $attributes->class(['relative']) }}
+>
+    <label class="sr-only">{{ __('filament/emails/composer.mass_send.add_recipients') }}</label>
+
+    <div class="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 transition focus-within:border-primary-500 focus-within:ring-1 focus-within:ring-primary-500 dark:border-white/10 dark:bg-gray-900 dark:focus-within:border-primary-500">
+        <x-heroicon-o-plus class="h-4 w-4 shrink-0 text-gray-400" />
+        <input
+            type="text"
+            x-model="query"
+            placeholder="{{ __('filament/emails/composer.mass_send.add_recipients') }}"
+            class="min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-0 dark:text-gray-100"
+            x-on:keydown.arrow-down.prevent="activeIndex = Math.min(activeIndex + 1, matches.length - 1)"
+            x-on:keydown.arrow-up.prevent="activeIndex = Math.max(activeIndex - 1, 0)"
+            x-on:keydown.enter.prevent="matches[activeIndex] && choose(matches[activeIndex])"
+        />
+    </div>
+
+    <ul
+        x-show="matches.length > 0"
+        x-cloak
+        class="absolute left-0 right-0 top-full z-20 mt-1 max-h-56 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-white/10 dark:bg-gray-900"
+    >
+        <template x-for="(option, index) in matches" x-bind:key="option.type + ':' + option.id">
+            <li>
+                <button
+                    type="button"
+                    class="flex min-h-11 w-full items-center gap-2.5 px-2.5 py-2 text-left text-sm transition hover:bg-gray-50 dark:hover:bg-white/5"
+                    x-bind:class="index === activeIndex ? 'bg-gray-50 dark:bg-white/5' : ''"
+                    x-on:click="choose(option)"
+                >
+                    <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-500 dark:bg-white/10 dark:text-gray-300" aria-hidden="true">
+                        <x-heroicon-o-user x-show="option.type === 'person'" class="h-4 w-4" />
+                        <x-heroicon-o-building-office-2 x-show="option.type === 'company_team'" class="h-4 w-4" />
+                    </span>
+                    <span
+                        class="min-w-0 flex-1"
+                        x-bind:x-tooltip="optionTooltip(option) ? { content: optionTooltip(option), theme: $store.theme } : false"
+                    >
+                        <span class="block truncate font-medium text-gray-900 dark:text-gray-100" x-text="option.label"></span>
+                        <span class="block truncate text-xs text-gray-500 dark:text-gray-400" x-text="option.description"></span>
+                    </span>
+                    <span
+                        x-show="option.type === 'company_team'"
+                        class="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-white/10 dark:text-gray-300"
+                        x-text="companyTeamLabel + ' (' + option.count + ')'"
+                    ></span>
+                </button>
+            </li>
+        </template>
+    </ul>
+</div>

--- a/resources/views/components/emails/composer-mass-recipients.blade.php
+++ b/resources/views/components/emails/composer-mass-recipients.blade.php
@@ -1,0 +1,21 @@
+@props([
+    'recipients' => [],
+    'options' => [],
+])
+
+@php
+    $selectedPersonIds = collect($recipients)->pluck('personId')->sort()->values()->all();
+@endphp
+
+<aside {{ $attributes->class([
+    'flex w-72 shrink-0 flex-col border-l border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-white/5',
+]) }}>
+    <div class="border-b border-gray-200 p-3 dark:border-white/10">
+        <x-emails.composer-mass-recipient-search
+            :options="$options"
+            :selected-person-ids="$selectedPersonIds"
+        />
+    </div>
+
+    <x-emails.composer-mass-recipient-list :recipients="$recipients" />
+</aside>

--- a/resources/views/components/emails/composer-mass-send-footer-actions.blade.php
+++ b/resources/views/components/emails/composer-mass-send-footer-actions.blade.php
@@ -1,0 +1,19 @@
+@props([
+    'showToggle' => true,
+    'isMassSend' => false,
+    'recipientCount' => 0,
+])
+
+@if ($showToggle)
+    <div class="flex items-center gap-3">
+        <x-emails.composer-mass-send-toggle />
+
+        @if ($isMassSend && $recipientCount > 0)
+            <x-emails.composer-icon-button
+                icon="heroicon-o-trash"
+                :label="__('filament/emails/composer.actions.discard')"
+                wire:click="discard"
+            />
+        @endif
+    </div>
+@endif

--- a/resources/views/components/emails/composer-mass-send-outbox-hint.blade.php
+++ b/resources/views/components/emails/composer-mass-send-outbox-hint.blade.php
@@ -1,0 +1,9 @@
+<p {{ $attributes->class(['text-xs text-gray-500 dark:text-gray-400']) }}>
+    {{ __('filament/emails/composer.mass_send.outbox_hint') }}
+    <a
+        href="{{ \Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage::getUrl(['tab' => 'outbox'], tenant: filament()->getTenant()) }}"
+        class="font-medium text-primary-600 hover:underline dark:text-primary-400"
+    >
+        {{ __('filament/emails/composer.mass_send.view_outbox') }}
+    </a>
+</p>

--- a/resources/views/components/emails/composer-mass-send-to-summary.blade.php
+++ b/resources/views/components/emails/composer-mass-send-to-summary.blade.php
@@ -1,0 +1,9 @@
+@props([
+    'count',
+])
+
+<span {{ $attributes->class([
+    'inline-flex items-center rounded-md bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700 dark:bg-white/10 dark:text-gray-200',
+]) }}>
+    {{ __('filament/emails/composer.mass_send.summary', ['count' => $count]) }}
+</span>

--- a/resources/views/components/emails/composer-mass-send-toggle.blade.php
+++ b/resources/views/components/emails/composer-mass-send-toggle.blade.php
@@ -1,0 +1,10 @@
+@props([
+    'state' => '$wire.$entangle(\'isMassSend\').live',
+])
+
+<div {{ $attributes->class(['flex items-center gap-1.5']) }}>
+    <x-filament::toggle :state="$state" class="shrink-0 scale-75" />
+    <span class="text-xs text-gray-700 dark:text-gray-200">
+        {{ __('filament/emails/composer.mass_send.toggle') }}
+    </span>
+</div>

--- a/resources/views/components/emails/recipient-chips.blade.php
+++ b/resources/views/components/emails/recipient-chips.blade.php
@@ -1,6 +1,7 @@
 @props([
     'options' => [],
     'suggestions' => [],
+    'allowedAddresses' => [],
     'autofocus' => false,
 ])
 
@@ -29,6 +30,7 @@
         activeIndex: 0,
         popoverStyle: {},
         options: @js([...$options, ...$manualOptions]),
+        allowedAddresses: @js($allowedAddresses),
         removeLabel: @js($removeLabel),
         companyTeamLabel: @js($companyTeamLabel),
 
@@ -63,7 +65,23 @@
             };
         },
 
+        allowedEmail(raw = null) {
+            const value = (raw ?? this.newValue).trim().replace(/,$/, '');
+
+            if (! value) {
+                return null;
+            }
+
+            const normalized = value.toLowerCase();
+
+            return this.allowedAddresses.find((email) => email.toLowerCase() === normalized) ?? null;
+        },
+
         resolveEmail(raw = null) {
+            return this.resolveEmailFromOptions(raw) ?? this.allowedEmail(raw);
+        },
+
+        resolveEmailFromOptions(raw = null) {
             const value = (raw ?? this.newValue).trim().replace(/,$/, '');
 
             if (! value) {

--- a/resources/views/components/emails/recipient-chips.blade.php
+++ b/resources/views/components/emails/recipient-chips.blade.php
@@ -63,10 +63,40 @@
             };
         },
 
-        commit(raw = null) {
+        resolveEmail(raw = null) {
             const value = (raw ?? this.newValue).trim().replace(/,$/, '');
 
             if (! value) {
+                return null;
+            }
+
+            const normalized = value.toLowerCase();
+
+            const option = this.options.find((candidate) => {
+                if (candidate.type === 'company_team') {
+                    return (candidate.emails ?? []).some((email) => email.toLowerCase() === normalized);
+                }
+
+                return (candidate.email ?? '').toLowerCase() === normalized;
+            });
+
+            if (! option) {
+                return null;
+            }
+
+            if (option.type === 'company_team') {
+                return (option.emails ?? []).find((email) => email.toLowerCase() === normalized) ?? null;
+            }
+
+            return option.email;
+        },
+
+        commit(raw = null) {
+            const value = this.resolveEmail(raw);
+
+            if (! value) {
+                this.newValue = '';
+
                 return;
             }
 

--- a/resources/views/components/emails/recipient-chips.blade.php
+++ b/resources/views/components/emails/recipient-chips.blade.php
@@ -225,7 +225,7 @@
         x-init="$nextTick(() => $refs.input.focus())"
     @endif
     @if ($wireModel) wire:ignore @endif
-    {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => 'flex min-h-[1.75rem] min-w-0 flex-wrap items-center gap-1']) }}
+    {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => 'flex min-h-9 min-w-0 flex-wrap items-center gap-1']) }}
 >
     <template x-for="value in values" :key="value">
         <span class="inline-flex max-w-full items-center gap-1 rounded-full bg-primary-50 py-0.5 pl-2 pr-1 text-xs font-medium text-primary-700 ring-1 ring-primary-600/10 dark:bg-primary-400/10 dark:text-primary-300 dark:ring-primary-400/20">

--- a/resources/views/livewire/email-composer.blade.php
+++ b/resources/views/livewire/email-composer.blade.php
@@ -169,8 +169,8 @@
                         @if ($isMassSend)
                             <x-emails.composer-mass-send-to-summary :count="count($massRecipients)" />
                         @else
-                            <div class="min-w-0 flex-1">
-                                <x-emails.recipient-chips wire:model="to" :autofocus="true" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" />
+                            <div class="flex min-w-0 flex-1 items-center self-stretch">
+                                <x-emails.recipient-chips wire:model="to" :autofocus="true" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" class="w-full" />
                             </div>
                             <span class="shrink-0 space-x-2 text-xs font-medium text-gray-400">
                                 <button type="button" wire:click="toggleCc" @class(['transition hover:text-gray-700 dark:hover:text-gray-200', 'text-primary-600 dark:text-primary-400' => $showCc])>{{ __('filament/emails/composer.fields.cc') }}</button>
@@ -189,14 +189,14 @@
 
                     @if ($showCc && ! $isMassSend)
                         <x-emails.composer-field :label="__('filament/emails/composer.fields.cc')">
-                            <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="cc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" /></div>
+                            <div class="flex min-w-0 flex-1 items-center self-stretch"><x-emails.recipient-chips wire:model="cc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" class="w-full" /></div>
                         </x-emails.composer-field>
                         <x-emails.composer-error field="cc.*" />
                     @endif
 
                     @if ($showBcc && ! $isMassSend)
                         <x-emails.composer-field :label="__('filament/emails/composer.fields.bcc')">
-                            <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="bcc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" /></div>
+                            <div class="flex min-w-0 flex-1 items-center self-stretch"><x-emails.recipient-chips wire:model="bcc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" class="w-full" /></div>
                         </x-emails.composer-field>
                         <x-emails.composer-error field="bcc.*" />
                     @endif

--- a/resources/views/livewire/email-composer.blade.php
+++ b/resources/views/livewire/email-composer.blade.php
@@ -24,6 +24,9 @@
         // sits alongside. Shrinking drops back to the corner window.
         $isModal = $dock === 'floating' && $isExpanded && ! $isMinimized;
         $isFloating = $dock === 'floating';
+        $isFloatingExpanded = $isFloating && $isExpanded && ! $isMinimized;
+        $isMassSendLayout = $isFloatingExpanded && $isMassSend;
+        $showMassSendToggle = $isFloatingExpanded;
         $gutter = $isFloating ? 'px-4' : 'px-4 sm:px-6';
         $chromeButton = 'rounded-lg p-1.5 text-gray-400 transition hover:bg-gray-200/70 hover:text-gray-700 dark:hover:bg-white/10 dark:hover:text-gray-200';
     @endphp
@@ -47,7 +50,9 @@
                 'w-[38rem] h-[36rem]' => $isFloating && ! $isMinimized && ! $isExpanded,
                 'w-80' => $isFloating && $isMinimized,
                 // Matches the reader's panel: centred, same width and height.
-                'fi-email-reader-panel left-1/2 top-1/2 z-50 h-[85vh] w-[calc(100%-2rem)] max-w-5xl -translate-x-1/2 -translate-y-1/2' => $isModal,
+                'fi-email-reader-panel left-1/2 top-1/2 z-50 h-[85vh] w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2' => $isModal,
+                'max-w-5xl' => $isModal && ! $isMassSendLayout,
+                'max-w-6xl' => $isModal && $isMassSendLayout,
             ])
         >
             {{-- Title bar. The inline dock sits inside the message it answers, so it
@@ -65,7 +70,7 @@
                         class="flex min-w-0 flex-1 items-center gap-2 text-left text-sm font-medium text-gray-900 dark:text-gray-100"
                     >
                         <x-heroicon-m-envelope class="h-4 w-4 shrink-0 text-primary-500" />
-                        <span class="truncate">{{ filled($subject) ? $subject : __('filament/emails/composer.title') }}</span>
+                        <span class="truncate">{{ filled($subject) ? $subject : ($isMassSend ? __('filament/concerns/email-compose.actions.compose.label') : __('filament/emails/composer.title')) }}</span>
                     </button>
 
                     <div class="flex shrink-0 items-center gap-0.5">
@@ -129,6 +134,14 @@
                     <x-emails.composer-draft-bar class="h-10 px-4" />
                 @endif
 
+                @if ($isFloatingExpanded)
+                    <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+                @endif
+                @if ($isMassSendLayout)
+                    <div class="flex min-h-0 flex-1 overflow-hidden">
+                        <div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+                @endif
+
                 {{-- Field rows --}}
                 <div class="{{ $gutter }} shrink-0 divide-y divide-gray-100 text-sm dark:divide-white/5">
                     <x-emails.composer-field :label="__('filament/emails/composer.fields.from')" for>
@@ -153,42 +166,53 @@
                     <x-emails.composer-error field="accountId" />
 
                     <x-emails.composer-field :label="__('filament/emails/composer.fields.to')">
-                        <div class="min-w-0 flex-1">
-                            <x-emails.recipient-chips wire:model="to" :autofocus="true" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" />
-                        </div>
-                        <span class="shrink-0 space-x-2 text-xs font-medium text-gray-400">
-                            <button type="button" wire:click="toggleCc" @class(['transition hover:text-gray-700 dark:hover:text-gray-200', 'text-primary-600 dark:text-primary-400' => $showCc])>{{ __('filament/emails/composer.fields.cc') }}</button>
-                            <button type="button" wire:click="toggleBcc" @class(['transition hover:text-gray-700 dark:hover:text-gray-200', 'text-primary-600 dark:text-primary-400' => $showBcc])>{{ __('filament/emails/composer.fields.bcc') }}</button>
-                        </span>
+                        @if ($isMassSend)
+                            <x-emails.composer-mass-send-to-summary :count="count($massRecipients)" />
+                        @else
+                            <div class="min-w-0 flex-1">
+                                <x-emails.recipient-chips wire:model="to" :autofocus="true" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" />
+                            </div>
+                            <span class="shrink-0 space-x-2 text-xs font-medium text-gray-400">
+                                <button type="button" wire:click="toggleCc" @class(['transition hover:text-gray-700 dark:hover:text-gray-200', 'text-primary-600 dark:text-primary-400' => $showCc])>{{ __('filament/emails/composer.fields.cc') }}</button>
+                                <button type="button" wire:click="toggleBcc" @class(['transition hover:text-gray-700 dark:hover:text-gray-200', 'text-primary-600 dark:text-primary-400' => $showBcc])>{{ __('filament/emails/composer.fields.bcc') }}</button>
+                            </span>
+                        @endif
                     </x-emails.composer-field>
+                    @unless ($isMassSend)
                     <x-emails.composer-error field="to" />
                     {{-- The `to.*` => email rule keys its errors per array index (to.0,
                          to.1, ...), not the bare `to` key, so it needs its own line. --}}
                     <x-emails.composer-error field="to.*" />
+                    @else
+                    <x-emails.composer-error field="massRecipients" />
+                    @endunless
 
-                    @if ($showCc)
+                    @if ($showCc && ! $isMassSend)
                         <x-emails.composer-field :label="__('filament/emails/composer.fields.cc')">
                             <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="cc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" /></div>
                         </x-emails.composer-field>
                         <x-emails.composer-error field="cc.*" />
                     @endif
 
-                    @if ($showBcc)
+                    @if ($showBcc && ! $isMassSend)
                         <x-emails.composer-field :label="__('filament/emails/composer.fields.bcc')">
                             <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="bcc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" /></div>
                         </x-emails.composer-field>
                         <x-emails.composer-error field="bcc.*" />
                     @endif
 
-                    <x-emails.composer-field :label="__('filament/emails/composer.fields.subject')">
-                        <input
-                            type="text"
-                            wire:model="subject"
-                            placeholder="{{ __('filament/emails/composer.fields.subject_placeholder') }}"
-                            class="w-full border-0 bg-transparent p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:ring-0 dark:text-gray-100"
-                        />
-                    </x-emails.composer-field>
-                    <x-emails.composer-error field="subject" />
+                    <div class="border-b border-gray-100 dark:border-white/5">
+                        <x-emails.composer-field :label="__('filament/emails/composer.fields.subject')" for>
+                            <input
+                                id="email-composer-subject"
+                                type="text"
+                                wire:model="subject"
+                                placeholder="{{ __('filament/emails/composer.fields.subject_placeholder') }}"
+                                class="w-full min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-gray-900 shadow-none placeholder:text-gray-400 focus:border-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 dark:text-gray-100"
+                            />
+                        </x-emails.composer-field>
+                        <x-emails.composer-error field="subject" />
+                    </div>
                 </div>
 
                 {{-- Body: Filament RichEditor with floating toolbar only --}}
@@ -206,11 +230,27 @@
 
                 <x-emails.composer-attachments :saved="$savedAttachments" :pending="$attachments" />
 
+                @if ($isMassSendLayout)
+                        </div>
+                        <x-emails.composer-mass-recipients :recipients="$massRecipients" :options="$this->recipientOptions" />
+                    </div>
+                @endif
+                @if ($isFloatingExpanded)
+                    </div>
+                @endif
+
                 {{-- Bottom bar --}}
                 <div @class([
-                    'flex h-14 shrink-0 items-center justify-between border-t border-gray-200 px-3 dark:border-white/10',
-                    'sticky bottom-0 z-10 bg-white dark:bg-gray-900 sm:px-5' => ! $isFloating,
+                    'flex shrink-0 flex-col gap-2 border-t border-gray-200 px-3 dark:border-white/10 sm:px-5',
+                    'sticky bottom-0 z-10 bg-white dark:bg-gray-900' => ! $isFloating,
+                    'py-3' => $showMassSendToggle && $isMassSend,
+                    'h-14 justify-center' => ! ($showMassSendToggle && $isMassSend),
                 ])>
+                    @if ($showMassSendToggle && $isMassSend)
+                        <x-emails.composer-mass-send-outbox-hint />
+                    @endif
+
+                    <div class="flex items-center justify-between gap-3">
                     <div class="flex items-center gap-1">
                         <x-emails.composer-icon-button icon="heroicon-o-paper-clip" :label="__('filament/emails/composer.actions.attach')" x-on:click="$refs.attachments.click()" />
                         <input type="file" x-ref="attachments" wire:model="attachments" multiple class="hidden" />
@@ -239,14 +279,27 @@
                         <span wire:loading wire:target="attachments" class="pl-1 text-xs text-gray-400">{{ __('filament/emails/composer.actions.uploading') }}</span>
                     </div>
 
+                    <div class="flex items-center gap-3">
+                        <x-emails.composer-mass-send-footer-actions
+                            :show-toggle="$showMassSendToggle"
+                            :is-mass-send="$isMassSend"
+                            :recipient-count="count($massRecipients)"
+                        />
+
                     <x-filament::button
                         wire:click="send"
                         wire:loading.attr="disabled"
                         wire:target="send, attachments"
                         icon="heroicon-m-paper-airplane"
                     >
-                        {{ __('filament/emails/composer.actions.send') }}
+                        @if ($isMassSend)
+                            {{ __('filament/emails/composer.mass_send.send_button', ['count' => count($massRecipients)]) }}
+                        @else
+                            {{ __('filament/emails/composer.actions.send') }}
+                        @endif
                     </x-filament::button>
+                    </div>
+                    </div>
                 </div>
                 @endif
             @endunless

--- a/resources/views/livewire/email-composer.blade.php
+++ b/resources/views/livewire/email-composer.blade.php
@@ -170,7 +170,7 @@
                             <x-emails.composer-mass-send-to-summary :count="count($massRecipients)" />
                         @else
                             <div class="min-w-0 flex-1">
-                                <x-emails.recipient-chips wire:model="to" :autofocus="true" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" />
+                                <x-emails.recipient-chips wire:model="to" :autofocus="true" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" />
                             </div>
                             <span class="shrink-0 space-x-2 text-xs font-medium text-gray-400">
                                 <button type="button" wire:click="toggleCc" @class(['transition hover:text-gray-700 dark:hover:text-gray-200', 'text-primary-600 dark:text-primary-400' => $showCc])>{{ __('filament/emails/composer.fields.cc') }}</button>
@@ -189,14 +189,14 @@
 
                     @if ($showCc && ! $isMassSend)
                         <x-emails.composer-field :label="__('filament/emails/composer.fields.cc')">
-                            <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="cc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" /></div>
+                            <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="cc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" /></div>
                         </x-emails.composer-field>
                         <x-emails.composer-error field="cc.*" />
                     @endif
 
                     @if ($showBcc && ! $isMassSend)
                         <x-emails.composer-field :label="__('filament/emails/composer.fields.bcc')">
-                            <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="bcc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" /></div>
+                            <div class="min-w-0 flex-1"><x-emails.recipient-chips wire:model="bcc" :suggestions="$this->recipientSuggestions" :options="$this->recipientOptions" :allowed-addresses="$this->allowedRecipientAddresses" /></div>
                         </x-emails.composer-field>
                         <x-emails.composer-error field="bcc.*" />
                     @endif

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -442,6 +442,41 @@ it('rejects a recipient that is not on a record or in suggestions and sends noth
     expect(Email::query()->where('subject', 'Random recipient')->exists())->toBeFalse();
 });
 
+it('includes CRM addresses outside the autocomplete cap in the allowed recipient list', function (): void {
+    foreach (range(1, 300) as $i) {
+        $person = People::factory()->for($this->user->currentTeam)->create([
+            'name' => sprintf('Person %03d', $i),
+            'creator_id' => $this->user->getKey(),
+        ]);
+
+        AllowedComposerRecipient::seed($this->user, "cap{$i}@example.com");
+    }
+
+    AllowedComposerRecipient::seed($this->user, 'overflow@example.com');
+
+    $component = Livewire::test(EmailComposer::class)->dispatch('composer:open');
+
+    expect($component->instance()->allowedRecipientAddresses())
+        ->toContain('overflow@example.com');
+
+    $optionEmails = collect($component->instance()->recipientOptions())
+        ->pluck('email')
+        ->filter()
+        ->all();
+
+    expect($optionEmails)->not->toContain('overflow@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['overflow@example.com'])
+        ->set('subject', 'Overflow recipient')
+        ->set('bodyHtml', '<p>Body</p>')
+        ->call('send')
+        ->assertHasNoErrors();
+
+    expect(Email::query()->where('subject', 'Overflow recipient')->exists())->toBeTrue();
+});
+
 it('rejects an empty body with no signature block and sends nothing', function (): void {
     Livewire::test(EmailComposer::class)
         ->dispatch('composer:open')

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -32,14 +32,16 @@ use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
 use Relaticle\EmailIntegration\Models\TeamEmailBlocklist;
+use Relaticle\EmailIntegration\Services\AllowedRecipientService;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
+use Tests\Helpers\AllowedComposerRecipient;
 
 use function Pest\Laravel\actingAs;
 
-mutates(EmailComposer::class, SaveEmailDraftAction::class, DeleteEmailDraftAction::class, RecipientSuggestionService::class, ConnectedAccount::class, QueuedSendNotifier::class);
+mutates(EmailComposer::class, SaveEmailDraftAction::class, DeleteEmailDraftAction::class, RecipientSuggestionService::class, ConnectedAccount::class, QueuedSendNotifier::class, AllowedRecipientService::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -51,6 +53,18 @@ beforeEach(function (): void {
     actingAs($this->user);
     Filament::setCurrentPanel(Filament::getPanel('app'));
     Filament::setTenant($this->user->currentTeam);
+
+    AllowedComposerRecipient::seedMany($this->user, [
+        'lead@example.com',
+        'a@example.com',
+        'x@example.com',
+        'd@example.com',
+        'draft@example.com',
+        'victim@example.com',
+        'recipient@example.com',
+        'existing@example.com',
+        'forward-to@example.com',
+    ]);
 });
 
 it('opens via the composer:open event with the default account preselected', function (): void {
@@ -413,6 +427,19 @@ it('surfaces a validation error for a malformed recipient and sends nothing', fu
         ->assertSet('isOpen', true);
 
     expect(Email::query()->where('subject', 'Malformed recipient')->exists())->toBeFalse();
+});
+
+it('rejects a recipient that is not on a record or in suggestions and sends nothing', function (): void {
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['random@example.com'])
+        ->set('subject', 'Random recipient')
+        ->set('bodyHtml', '<p>Body</p>')
+        ->call('send')
+        ->assertHasErrors(['to.0'])
+        ->assertSet('isOpen', true);
+
+    expect(Email::query()->where('subject', 'Random recipient')->exists())->toBeFalse();
 });
 
 it('rejects an empty body with no signature block and sends nothing', function (): void {

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\CustomFields\PeopleField;
 use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\CustomFieldValue;
@@ -443,16 +444,31 @@ it('rejects a recipient that is not on a record or in suggestions and sends noth
 });
 
 it('includes CRM addresses outside the autocomplete cap in the allowed recipient list', function (): void {
+    $seedEmail = function (People $person, string $email): void {
+        $emailsField = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $person->team_id)
+            ->where('entity_type', 'people')
+            ->where('code', PeopleField::EMAILS->value)
+            ->firstOrFail();
+
+        $person->saveCustomFieldValue($emailsField, [$email], $person->team);
+    };
+
     foreach (range(1, 300) as $i) {
         $person = People::factory()->for($this->user->currentTeam)->create([
             'name' => sprintf('Person %03d', $i),
             'creator_id' => $this->user->getKey(),
         ]);
 
-        AllowedComposerRecipient::seed($this->user, "cap{$i}@example.com");
+        $seedEmail($person, "cap{$i}@example.com");
     }
 
-    AllowedComposerRecipient::seed($this->user, 'overflow@example.com');
+    $overflow = People::factory()->for($this->user->currentTeam)->create([
+        'name' => 'Z Overflow Contact',
+        'creator_id' => $this->user->getKey(),
+    ]);
+    $seedEmail($overflow, 'overflow@example.com');
 
     $component = Livewire::test(EmailComposer::class)->dispatch('composer:open');
 

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -268,6 +268,37 @@ it('queues an email through SendEmailAction on send with the persisted body and 
         ->and($email->scheduled_for)->not->toBeNull();
 });
 
+it('resolves merge tags from the primary To recipient when compose was not opened from a record', function (): void {
+    $person = People::factory()->for($this->user->currentTeam)->create([
+        'name' => 'Laravel Projects',
+        'creator_id' => $this->user->getKey(),
+    ]);
+
+    $emailsField = CustomField::query()
+        ->withoutGlobalScopes()
+        ->where('tenant_id', $person->team_id)
+        ->where('entity_type', 'people')
+        ->where('code', PeopleField::EMAILS->value)
+        ->firstOrFail();
+
+    $person->saveCustomFieldValue($emailsField, ['crm@example.com'], $person->team);
+
+    AllowedComposerRecipient::seed($this->user, 'crm@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['crm@example.com'])
+        ->set('subject', 'Hi {{ full name }}')
+        ->set('bodyHtml', '<p>Hello <span data-type="mergeTag" data-id="name">Full name</span></p>')
+        ->call('send')
+        ->assertHasNoErrors()
+        ->assertSet('isOpen', false);
+
+    $email = Email::query()->where('subject', 'Hi Laravel Projects')->sole();
+
+    expect($email->body?->body_html)->toContain('Hello Laravel Projects');
+});
+
 it('persists rich editor inline images when sending from the composer', function (): void {
     Storage::fake(EmailAttachment::DISK);
 

--- a/tests/Feature/EmailIntegration/EmailTemplateRenderTest.php
+++ b/tests/Feature/EmailIntegration/EmailTemplateRenderTest.php
@@ -2,10 +2,13 @@
 
 declare(strict_types=1);
 
+use App\Enums\CustomFields\PeopleField;
 use App\Models\Company;
+use App\Models\CustomField;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Date;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
@@ -85,6 +88,74 @@ it('substitutes merge tags in plain text without HTML-escaping', function (): vo
     $rendered = app(EmailTemplateRenderService::class)->renderPlainText('Hello {name}', $person);
 
     expect($rendered)->toBe('Hello Smith & Sons');
+});
+
+it('resolves RichEditor merge tag nodes when rendering for send', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Jane Doe',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $bodyHtml = '<p>Hello <span data-type="mergeTag" data-id="name">Full name</span></p>';
+
+    $rendered = app(EmailTemplateRenderService::class)->renderForSending($bodyHtml, $person);
+
+    expect($rendered)->toContain('Jane Doe')
+        ->and($rendered)->not->toContain('data-type="mergeTag"');
+});
+
+it('substitutes human-readable merge tag labels in plain text', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Jane Doe',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $rendered = app(EmailTemplateRenderService::class)->renderPlainText(
+        'Hi {{ full name }}, see you {{ today\'s date }}',
+        $person,
+    );
+
+    expect($rendered)
+        ->toContain('Hi Jane Doe,')
+        ->toContain('see you '.Date::now()->toFormattedDateString());
+});
+
+it('renders people custom field merge tags for phone number job title and linkedin', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Jane Doe',
+        'creator_id' => $this->user->id,
+    ]);
+
+    foreach ([
+        [PeopleField::PHONE_NUMBER, '+1 555 0100'],
+        [PeopleField::JOB_TITLE, 'Account Executive'],
+        [PeopleField::LINKEDIN, ['https://linkedin.com/in/jane-doe']],
+    ] as [$fieldCode, $value]) {
+        $customField = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $person->team_id)
+            ->where('entity_type', 'people')
+            ->where('code', $fieldCode->value)
+            ->firstOrFail();
+
+        $person->saveCustomFieldValue($customField, $value, $person->team);
+    }
+
+    $template = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->user->id,
+        'name' => 'People Fields Template',
+        'subject' => '{job_title} at {company}',
+        'body_html' => '<p>{name} | {phone_number} | {linkedin}</p>',
+    ]);
+
+    $result = app(EmailTemplateRenderService::class)->render($template, $person);
+
+    expect($result['subject'])->toBe('Account Executive at ')
+        ->and($result['body_html'])->toBe('<p>Jane Doe | +1 555 0100 | https://linkedin.com/in/jane-doe</p>');
 });
 
 it('renders {name} for a Company record', function (): void {

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -342,6 +342,15 @@ it('scopes the template dropdown to the current team', function (): void {
         'is_shared' => true,
     ]);
 
+    $teammatePrivate = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => User::factory()->create()->id,
+        'name' => 'Teammate private template',
+        'subject' => 'Private',
+        'body_html' => '<p>Private</p>',
+        'is_shared' => false,
+    ]);
+
     // A shared template owned by a different team must never appear here.
     $foreignUser = User::factory()->withTeam()->create();
     $foreignShared = EmailTemplate::create([
@@ -364,6 +373,7 @@ it('scopes the template dropdown to the current team', function (): void {
     expect(array_keys($options))
         ->toContain($ownPrivate->id)
         ->toContain($teammateShared->id)
+        ->not->toContain($teammatePrivate->id)
         ->not->toContain($foreignShared->id);
 });
 
@@ -402,4 +412,65 @@ it('rejects a cross-team template id submitted on send', function (): void {
         ->assertHasTableActionErrors(['template_id']);
 
     expect(EmailBatch::where('team_id', $this->team->id)->exists())->toBeFalse();
+});
+
+it('fills subject and body when an authorized template is selected', function (bool $own, bool $shared): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Recipient',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $template = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => $own ? $this->user->id : User::factory()->create()->id,
+        'name' => 'Authorized template',
+        'subject' => 'Authorized subject',
+        'body_html' => '<p>Authorized body</p>',
+        'is_shared' => $shared,
+    ]);
+
+    livewire(ListPeople::class)
+        ->mountTableBulkAction('massSend', records: [$person])
+        ->fillForm([
+            'template_id' => $template->id,
+        ])
+        ->assertSchemaStateSet([
+            'subject' => 'Authorized subject',
+            'body_html' => '<p>Authorized body</p>',
+        ]);
+})->with([
+    'own private' => [true, false],
+    'teammate shared' => [false, true],
+]);
+
+it('does not copy a teammate\'s private template into the editor', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Recipient',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $teammatePrivate = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => User::factory()->create()->id,
+        'name' => 'Teammate private template',
+        'subject' => 'SECRET SUBJECT',
+        'body_html' => '<p>SECRET BODY</p>',
+        'is_shared' => false,
+    ]);
+
+    livewire(ListPeople::class)
+        ->mountTableBulkAction('massSend', records: [$person])
+        ->fillForm([
+            'subject' => 'Original subject',
+            'body_html' => '<p>Original body</p>',
+        ])
+        ->fillForm([
+            'template_id' => $teammatePrivate->id,
+        ])
+        ->assertSchemaStateSet([
+            'subject' => 'Original subject',
+            'body_html' => '<p>Original body</p>',
+        ]);
 });

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -548,6 +548,32 @@ it('uses the email address when a person name looks like an empty json array', f
         ->assertSet('massRecipients.0.name', 'broken-name@example.com');
 });
 
+it('replaces an open compose session when bulk mass send opens the composer again', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($person, 'alice@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('subject', 'In progress')
+        ->set('to', ['alice@example.com'])
+        ->call('minimize')
+        ->assertSet('isMinimized', true)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => massRecipientPayload($person, 'alice@example.com'),
+        ])
+        ->assertSet('isMinimized', false)
+        ->assertSet('isMassSend', true)
+        ->assertSet('massRecipients', massRecipientPayload($person, 'alice@example.com'))
+        ->assertSet('to', [])
+        ->assertSet('subject', '');
+});
+
 it('expands signatures and resolves merge tags per recipient on mass send', function (): void {
     $signature = EmailSignature::withoutEvents(fn () => EmailSignature::factory()->create([
         'connected_account_id' => $this->account->id,

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -627,6 +627,32 @@ it('expands signatures and resolves merge tags per recipient on mass send', func
         ->and($aliceEmail->body->body_html)->not->toContain('data-id="signature"');
 });
 
+it('resolves RichEditor merge tag nodes per recipient on mass send', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($person, 'alice@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => massRecipientPayload($person, 'alice@example.com'),
+        ])
+        ->set('subject', 'Hi {name}')
+        ->set('bodyHtml', '<p>Hello <span data-type="mergeTag" data-id="name">Full name</span></p>')
+        ->call('send');
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+    $email = Email::where('batch_id', $batch->id)->firstOrFail();
+
+    expect($email->subject)->toBe('Hi Alice')
+        ->and($email->body->body_html)->toContain('Alice')
+        ->and($email->body->body_html)->not->toContain('data-type="mergeTag"');
+});
+
 it('ignores a tampered mass recipient email and sends to the CRM address', function (): void {
     $person = People::create([
         'team_id' => $this->team->id,

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -21,7 +21,9 @@ use Relaticle\EmailIntegration\Livewire\EmailComposer;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailBatch;
+use Relaticle\EmailIntegration\Models\EmailSignature;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
+use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\MassSendRecipientResolver;
 use Relaticle\EmailIntegration\Services\OpenMassSendComposer;
 use Relaticle\EmailIntegration\Support\PersonRecipientFormatter;
@@ -544,4 +546,139 @@ it('uses the email address when a person name looks like an empty json array', f
             ]],
         ])
         ->assertSet('massRecipients.0.name', 'broken-name@example.com');
+});
+
+it('expands signatures and resolves merge tags per recipient on mass send', function (): void {
+    $signature = EmailSignature::withoutEvents(fn () => EmailSignature::factory()->create([
+        'connected_account_id' => $this->account->id,
+        'content_html' => '<p>Best regards</p>',
+        'is_default' => true,
+    ]));
+
+    $personA = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $personB = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Bob',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($personA, 'alice@example.com');
+    setPersonEmail($personB, 'bob@example.com');
+
+    $bodyHtml = resolve(EmailTemplateRenderService::class)
+        ->applySignatureBlock('<p>Hello {name}</p>', $signature);
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => [
+                ...massRecipientPayload($personA, 'alice@example.com'),
+                ...massRecipientPayload($personB, 'bob@example.com'),
+            ],
+        ])
+        ->set('subject', 'Hi {name}')
+        ->set('bodyHtml', $bodyHtml)
+        ->call('send');
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+    $emails = Email::query()->where('batch_id', $batch->id)->with('body')->get();
+
+    $aliceEmail = $emails->first(fn (Email $email): bool => $email->subject === 'Hi Alice');
+    $bobEmail = $emails->first(fn (Email $email): bool => $email->subject === 'Hi Bob');
+
+    expect($emails)->toHaveCount(2)
+        ->and($aliceEmail)->not->toBeNull()
+        ->and($bobEmail)->not->toBeNull()
+        ->and($aliceEmail->body->body_html)->toContain('Hello Alice')
+        ->and($aliceEmail->body->body_html)->toContain('Best regards')
+        ->and($bobEmail->body->body_html)->toContain('Hello Bob')
+        ->and($bobEmail->body->body_html)->toContain('Best regards')
+        ->and($aliceEmail->body->body_html)->not->toContain('data-id="signature"');
+});
+
+it('ignores a tampered mass recipient email and sends to the CRM address', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Trusted Person',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($person, 'real@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => [[
+                'personId' => (string) $person->getKey(),
+                'email' => 'attacker@evil.com',
+                'name' => (string) $person->name,
+            ]],
+        ])
+        ->set('subject', 'Tampered address')
+        ->set('bodyHtml', '<p>Hi</p>')
+        ->call('send');
+
+    $email = Email::query()->where('subject', 'Tampered address')->firstOrFail();
+
+    $this->assertDatabaseHas('email_participants', [
+        'email_id' => $email->getKey(),
+        'email_address' => 'real@example.com',
+        'role' => 'to',
+    ]);
+
+    $this->assertDatabaseMissing('email_participants', [
+        'email_id' => $email->getKey(),
+        'email_address' => 'attacker@evil.com',
+    ]);
+});
+
+it('drops recipients removed from To when mass sending is toggled off and back on', function (): void {
+    $personA = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $personB = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Bob',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $personC = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Carol',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($personA, 'alice@example.com');
+    setPersonEmail($personB, 'bob@example.com');
+    setPersonEmail($personC, 'carol@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => [
+                ...massRecipientPayload($personA, 'alice@example.com'),
+                ...massRecipientPayload($personB, 'bob@example.com'),
+                ...massRecipientPayload($personC, 'carol@example.com'),
+            ],
+        ])
+        ->set('isMassSend', false)
+        ->set('to', ['alice@example.com'])
+        ->set('isMassSend', true)
+        ->assertCount('massRecipients', 1)
+        ->assertSet('massRecipients.0.personId', (string) $personA->getKey())
+        ->set('subject', 'Subset send')
+        ->set('bodyHtml', '<p>Hi</p>')
+        ->call('send');
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+
+    expect($batch->total_recipients)->toBe(1);
 });

--- a/tests/Feature/EmailIntegration/MassSendEmailTest.php
+++ b/tests/Feature/EmailIntegration/MassSendEmailTest.php
@@ -4,22 +4,34 @@ declare(strict_types=1);
 
 use App\Enums\CustomFields\PeopleField;
 use App\Features\EmailIntegration;
+use App\Filament\Resources\CompanyResource\Pages\ListCompanies;
 use App\Filament\Resources\PeopleResource\Pages\ListPeople;
+use App\Models\Company;
 use App\Models\CustomField;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Collection;
 use Laravel\Pennant\Feature;
+use Livewire\Livewire;
 use Relaticle\EmailIntegration\Actions\SendEmailBatchAction;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Filament\Actions\MassSendBulkAction;
+use Relaticle\EmailIntegration\Livewire\EmailComposer;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailBatch;
 use Relaticle\EmailIntegration\Models\EmailTemplate;
+use Relaticle\EmailIntegration\Services\MassSendRecipientResolver;
+use Relaticle\EmailIntegration\Services\OpenMassSendComposer;
+use Relaticle\EmailIntegration\Support\PersonRecipientFormatter;
 
 mutates(MassSendBulkAction::class);
 mutates(SendEmailBatchAction::class);
+mutates(MassSendRecipientResolver::class);
+mutates(OpenMassSendComposer::class);
+mutates(PersonRecipientFormatter::class);
+mutates(EmailComposer::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -36,10 +48,17 @@ beforeEach(function (): void {
 });
 
 /**
- * Set a person's canonical email on the EMAILS custom field — the same source
- * MassSendBulkAction resolves recipients from. A person can have this value with
- * NO prior EmailParticipant row (i.e. never emailed before).
+ * @return list<array{personId: string, email: string, name: string}>
  */
+function massRecipientPayload(People $person, string $email): array
+{
+    return [[
+        'personId' => (string) $person->getKey(),
+        'email' => $email,
+        'name' => (string) $person->name,
+    ]];
+}
+
 function setPersonEmail(People $person, string $emailAddress): void
 {
     $emailsField = CustomField::query()
@@ -77,7 +96,7 @@ it('hides mass send when no connected account can send', function (): void {
         ->assertTableBulkActionHidden('massSend');
 });
 
-it('creates an EmailBatch and persists one Email row per recipient', function (): void {
+it('opens the composer from people bulk send with resolved recipients', function (): void {
     $people = collect(range(1, 3))->map(fn (int $i): People => People::create([
         'team_id' => $this->team->id,
         'name' => "Person {$i}",
@@ -89,16 +108,38 @@ it('creates an EmailBatch and persists one Email row per recipient', function ()
     });
 
     livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: $people->all(),
-            data: [
-                'connected_account_id' => $this->account->id,
-                'subject' => 'Hello everyone',
-                'body_html' => '<p>Mass email body</p>',
-            ],
-        )
-        ->assertNotified();
+        ->callTableBulkAction('massSend', records: $people->all())
+        ->assertDispatched('composer:open');
+});
+
+it('creates an EmailBatch and persists one Email row per recipient from the composer', function (): void {
+    $people = collect(range(1, 3))->map(fn (int $i): People => People::create([
+        'team_id' => $this->team->id,
+        'name' => "Person {$i}",
+        'creator_id' => $this->user->id,
+    ]));
+
+    $people->each(function (People $person, int $index): void {
+        setPersonEmail($person, "person{$index}@example.com");
+    });
+
+    $recipients = $people->map(fn (People $person, int $index): array => [
+        'personId' => (string) $person->getKey(),
+        'email' => "person{$index}@example.com",
+        'name' => $person->name,
+    ])->values()->all();
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => $recipients,
+        ])
+        ->assertSet('isMassSend', true)
+        ->assertSet('massRecipients', $recipients)
+        ->set('subject', 'Hello everyone')
+        ->set('bodyHtml', '<p>Mass email body</p>')
+        ->call('send')
+        ->assertDispatched('outbox:changed');
 
     expect(EmailBatch::where('team_id', $this->team->id)->count())->toBe(1);
 
@@ -110,7 +151,7 @@ it('creates an EmailBatch and persists one Email row per recipient', function ()
         ->and(Email::where('batch_id', $batch->id)->where('status', EmailStatus::QUEUED)->count())->toBe(3);
 });
 
-it('skips people with no known email address', function (): void {
+it('warns when some selected people have no email but still opens the composer', function (): void {
     $withEmail = People::create([
         'team_id' => $this->team->id,
         'name' => 'Has Email',
@@ -126,36 +167,12 @@ it('skips people with no known email address', function (): void {
     ]);
 
     livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: [$withEmail, $withoutEmail],
-            data: [
-                'connected_account_id' => $this->account->id,
-                'subject' => 'Hello',
-                'body_html' => '<p>Hi</p>',
-            ],
-        )
-        // The undercount bug: when some are skipped the toast must say so,
-        // not silently report only the queued count.
-        ->assertNotified('Mass email queued');
-
-    $batch = EmailBatch::where('team_id', $this->team->id)->first();
-    expect($batch->total_recipients)->toBe(1)
-        ->and(Email::where('batch_id', $batch->id)->count())->toBe(1);
-
-    $email = Email::where('batch_id', $batch->id)->firstOrFail();
-
-    $this->assertDatabaseHas('emailables', [
-        'email_id' => $email->getKey(),
-        'emailable_type' => $withEmail->getMorphClass(),
-        'emailable_id' => $withEmail->id,
-    ]);
+        ->callTableBulkAction('massSend', records: [$withEmail, $withoutEmail])
+        ->assertNotified('Some recipients skipped')
+        ->assertDispatched('composer:open');
 });
 
 it('queues a person whose email is only in the custom field with no prior correspondence', function (): void {
-    // No EmailParticipant row exists for this person — the only place their
-    // address lives is the EMAILS custom field. The old participant-based
-    // resolution silently dropped them.
     $person = People::create([
         'team_id' => $this->team->id,
         'name' => 'Never Emailed',
@@ -164,17 +181,14 @@ it('queues a person whose email is only in the custom field with no prior corres
 
     setPersonEmail($person, 'never@example.com');
 
-    livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: [$person],
-            data: [
-                'connected_account_id' => $this->account->id,
-                'subject' => 'Hello',
-                'body_html' => '<p>Hi</p>',
-            ],
-        )
-        ->assertNotified('Mass email queued');
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => massRecipientPayload($person, 'never@example.com'),
+        ])
+        ->set('subject', 'Hello')
+        ->set('bodyHtml', '<p>Hi</p>')
+        ->call('send');
 
     $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
     expect($batch->total_recipients)->toBe(1);
@@ -196,15 +210,7 @@ it('shows warning notification when no valid recipients exist', function (): voi
     ]);
 
     livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: [$person],
-            data: [
-                'connected_account_id' => $this->account->id,
-                'subject' => 'Hello',
-                'body_html' => '<p>Hi</p>',
-            ],
-        )
+        ->callTableBulkAction('massSend', records: [$person])
         ->assertNotified('No valid recipients');
 
     expect(EmailBatch::count())->toBe(0);
@@ -219,17 +225,14 @@ it('sends a personalized subject as plain text when no template is saved', funct
 
     setPersonEmail($person, 'smith@example.com');
 
-    livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: [$person],
-            data: [
-                'connected_account_id' => $this->account->id,
-                'subject' => 'Hello {name}',
-                'body_html' => '<p>Hi {name}</p>',
-            ],
-        )
-        ->assertNotified();
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => massRecipientPayload($person, 'smith@example.com'),
+        ])
+        ->set('subject', 'Hello {name}')
+        ->set('bodyHtml', '<p>Hi {name}</p>')
+        ->call('send');
 
     $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
     $email = Email::where('batch_id', $batch->id)->firstOrFail();
@@ -254,25 +257,17 @@ it('applies template variables per recipient', function (): void {
     setPersonEmail($personA, 'alice@example.com');
     setPersonEmail($personB, 'bob@example.com');
 
-    $template = EmailTemplate::create([
-        'team_id' => $this->team->id,
-        'created_by' => $this->user->id,
-        'name' => 'Personalised',
-        'subject' => 'Hi {name}',
-        'body_html' => '<p>Hello {name}!</p>',
-    ]);
-
-    livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: [$personA, $personB],
-            data: [
-                'connected_account_id' => $this->account->id,
-                'template_id' => $template->id,
-                'subject' => 'Hi {name}',
-                'body_html' => '<p>Hello {name}!</p>',
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => [
+                ...massRecipientPayload($personA, 'alice@example.com'),
+                ...massRecipientPayload($personB, 'bob@example.com'),
             ],
-        );
+        ])
+        ->set('subject', 'Hi {name}')
+        ->set('bodyHtml', '<p>Hello {name}!</p>')
+        ->call('send');
 
     $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
 
@@ -280,7 +275,231 @@ it('applies template variables per recipient', function (): void {
         ->and(Email::where('batch_id', $batch->id)->where('subject', 'Hi Bob')->exists())->toBeTrue();
 });
 
-it('sends the edited subject and body when a template is selected', function (): void {
+it('removes a mass recipient from the sidebar', function (): void {
+    $personA = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $personB = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Bob',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($personA, 'alice@example.com');
+    setPersonEmail($personB, 'bob@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => [
+                ...massRecipientPayload($personA, 'alice@example.com'),
+                ...massRecipientPayload($personB, 'bob@example.com'),
+            ],
+        ])
+        ->call('removeMassRecipient', (string) $personB->getKey())
+        ->assertCount('massRecipients', 1)
+        ->set('subject', 'Hello')
+        ->set('bodyHtml', '<p>Hi</p>')
+        ->call('send');
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+    expect($batch->total_recipients)->toBe(1);
+});
+
+it('adds all company team members from the mass send sidebar search', function (): void {
+    $company = Company::create([
+        'team_id' => $this->team->id,
+        'name' => 'Acme Corp',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $personA = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'company_id' => $company->id,
+        'creator_id' => $this->user->id,
+    ]);
+
+    $personB = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Bob',
+        'company_id' => $company->id,
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($personA, 'alice@example.com');
+    setPersonEmail($personB, 'bob@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: ['massSend' => true, 'recipients' => []])
+        ->assertSet('isMassSend', true)
+        ->call('addMassCompanyTeamRecipients', (string) $company->getKey())
+        ->assertCount('massRecipients', 2)
+        ->call('addMassCompanyTeamRecipients', (string) $company->getKey())
+        ->assertCount('massRecipients', 2);
+});
+
+it('opens the composer for company bulk send with all linked people who have email', function (): void {
+    $company = Company::create([
+        'team_id' => $this->team->id,
+        'name' => 'Acme Corp',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $memberA = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'company_id' => $company->id,
+        'creator_id' => $this->user->id,
+    ]);
+
+    $memberB = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Bob',
+        'company_id' => $company->id,
+        'creator_id' => $this->user->id,
+    ]);
+
+    People::create([
+        'team_id' => $this->team->id,
+        'name' => 'No Email',
+        'company_id' => $company->id,
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($memberA, 'alice@example.com');
+    setPersonEmail($memberB, 'bob@example.com');
+
+    livewire(ListCompanies::class)
+        ->callTableBulkAction('massSend', records: [$company])
+        ->assertNotified('Some recipients skipped')
+        ->assertDispatched('composer:open');
+});
+
+it('queues one email per company member from the composer', function (): void {
+    $company = Company::create([
+        'team_id' => $this->team->id,
+        'name' => 'Acme Corp',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $memberA = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'company_id' => $company->id,
+        'creator_id' => $this->user->id,
+    ]);
+
+    $memberB = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Bob',
+        'company_id' => $company->id,
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($memberA, 'alice@example.com');
+    setPersonEmail($memberB, 'bob@example.com');
+
+    $result = resolve(MassSendRecipientResolver::class)->resolveFromCompanies(
+        Company::query()->whereKey($company->getKey())->get(),
+    );
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => array_map(
+                fn (array $recipient): array => [
+                    'personId' => (string) $recipient['person']->getKey(),
+                    'email' => $recipient['email'],
+                    'name' => (string) $recipient['person']->name,
+                ],
+                $result->recipients,
+            ),
+            'linkRecordType' => Company::class,
+            'linkRecordId' => (string) $company->getKey(),
+        ])
+        ->set('subject', 'Hello team')
+        ->set('bodyHtml', '<p>Hi</p>')
+        ->call('send');
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+    expect($batch->total_recipients)->toBe(2);
+});
+
+it('applies an authorized template through the composer picker', function (): void {
+    $person = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Recipient',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($person, 'recipient@example.com');
+
+    $template = EmailTemplate::create([
+        'team_id' => $this->team->id,
+        'created_by' => $this->user->id,
+        'name' => 'Authorized template',
+        'subject' => 'Authorized subject',
+        'body_html' => '<p>Authorized body</p>',
+        'is_shared' => false,
+    ]);
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => massRecipientPayload($person, 'recipient@example.com'),
+        ])
+        ->call('applyTemplate', (string) $template->getKey())
+        ->assertSet('subject', 'Authorized subject')
+        ->set('subject', 'Edited hello {name}')
+        ->set('bodyHtml', '<p>Edited body for {name}</p>')
+        ->call('send');
+
+    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
+    $email = Email::where('batch_id', $batch->id)->firstOrFail();
+
+    expect($email->subject)->toBe('Edited hello Recipient')
+        ->and($email->body->body_html)->toBe('<p>Edited body for Recipient</p>');
+});
+
+it('sends one email when mass sending is turned off', function (): void {
+    $personA = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Alice',
+        'creator_id' => $this->user->id,
+    ]);
+
+    $personB = People::create([
+        'team_id' => $this->team->id,
+        'name' => 'Bob',
+        'creator_id' => $this->user->id,
+    ]);
+
+    setPersonEmail($personA, 'alice@example.com');
+    setPersonEmail($personB, 'bob@example.com');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => [
+                ...massRecipientPayload($personA, 'alice@example.com'),
+                ...massRecipientPayload($personB, 'bob@example.com'),
+            ],
+        ])
+        ->set('isMassSend', false)
+        ->assertSet('to', ['alice@example.com', 'bob@example.com'])
+        ->set('subject', 'One email')
+        ->set('bodyHtml', '<p>Hello both</p>')
+        ->call('send');
+
+    expect(EmailBatch::count())->toBe(0);
+    expect(Email::where('subject', 'One email')->count())->toBe(1);
+});
+
+it('builds mass recipients when mass sending is enabled from normal compose', function (): void {
     $person = People::create([
         'team_id' => $this->team->id,
         'name' => 'Alice',
@@ -289,188 +508,40 @@ it('sends the edited subject and body when a template is selected', function ():
 
     setPersonEmail($person, 'alice@example.com');
 
-    $template = EmailTemplate::create([
-        'team_id' => $this->team->id,
-        'created_by' => $this->user->id,
-        'name' => 'Saved template',
-        'subject' => 'Saved subject for {name}',
-        'body_html' => '<p>Saved body for {name}</p>',
-    ]);
-
-    livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: [$person],
-            data: [
-                'connected_account_id' => $this->account->id,
-                'template_id' => $template->id,
-                'subject' => 'Edited hello {name}',
-                'body_html' => '<p>Edited body for {name}</p>',
-            ],
-        )
-        ->assertNotified();
-
-    $batch = EmailBatch::where('team_id', $this->team->id)->firstOrFail();
-    $email = Email::where('batch_id', $batch->id)->firstOrFail();
-
-    expect($email->subject)->toBe('Edited hello Alice')
-        ->and($email->body->body_html)->toBe('<p>Edited body for Alice</p>');
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['alice@example.com'])
+        ->set('isMassSend', true)
+        ->assertSet('to', [])
+        ->assertSet('massRecipients', massRecipientPayload($person, 'alice@example.com'));
 });
 
-it('scopes the template dropdown to the current team', function (): void {
+it('uses the email address when a person name looks like an empty json array', function (): void {
     $person = People::create([
         'team_id' => $this->team->id,
-        'name' => 'Recipient',
+        'name' => '[""]',
         'creator_id' => $this->user->id,
     ]);
 
-    $ownPrivate = EmailTemplate::create([
-        'team_id' => $this->team->id,
-        'created_by' => $this->user->id,
-        'name' => 'My private template',
-        'subject' => 'Mine',
-        'body_html' => '<p>Mine</p>',
-        'is_shared' => false,
-    ]);
+    setPersonEmail($person, 'broken-name@example.com');
 
-    $teammateShared = EmailTemplate::create([
-        'team_id' => $this->team->id,
-        'created_by' => User::factory()->create()->id,
-        'name' => 'Teammate shared template',
-        'subject' => 'Shared',
-        'body_html' => '<p>Shared</p>',
-        'is_shared' => true,
-    ]);
+    $result = resolve(MassSendRecipientResolver::class)->resolveFromPeople(new Collection([$person]));
 
-    $teammatePrivate = EmailTemplate::create([
-        'team_id' => $this->team->id,
-        'created_by' => User::factory()->create()->id,
-        'name' => 'Teammate private template',
-        'subject' => 'Private',
-        'body_html' => '<p>Private</p>',
-        'is_shared' => false,
-    ]);
-
-    // A shared template owned by a different team must never appear here.
-    $foreignUser = User::factory()->withTeam()->create();
-    $foreignShared = EmailTemplate::create([
-        'team_id' => $foreignUser->currentTeam->id,
-        'created_by' => $foreignUser->id,
-        'name' => 'Foreign shared template',
-        'subject' => 'Leaked',
-        'body_html' => '<p>Leaked</p>',
-        'is_shared' => true,
-    ]);
-
-    $component = livewire(ListPeople::class)
-        ->mountTableBulkAction('massSend', records: [$person]);
-
-    $options = $component->instance()
-        ->getMountedTableActionForm()
-        ->getComponent('template_id')
-        ->getOptions();
-
-    expect(array_keys($options))
-        ->toContain($ownPrivate->id)
-        ->toContain($teammateShared->id)
-        ->not->toContain($teammatePrivate->id)
-        ->not->toContain($foreignShared->id);
-});
-
-it('rejects a cross-team template id submitted on send', function (): void {
-    $person = People::create([
-        'team_id' => $this->team->id,
-        'name' => 'Recipient',
-        'creator_id' => $this->user->id,
-    ]);
-    setPersonEmail($person, 'recipient@example.com');
-
-    // A crafted submit could carry another team's template id even though the
-    // dropdown never offered it. The template select must reject it (its options
-    // are team-scoped) rather than render the foreign template into the send.
-    $foreignUser = User::factory()->withTeam()->create();
-    $foreignTemplate = EmailTemplate::create([
-        'team_id' => $foreignUser->currentTeam->id,
-        'created_by' => $foreignUser->id,
-        'name' => 'Foreign template',
-        'subject' => 'LEAKED SUBJECT',
-        'body_html' => '<p>LEAKED BODY</p>',
-        'is_shared' => true,
-    ]);
+    expect($result->recipients)->toHaveCount(1)
+        ->and($result->recipients[0]['email'])->toBe('broken-name@example.com');
 
     livewire(ListPeople::class)
-        ->callTableBulkAction(
-            'massSend',
-            records: [$person],
-            data: [
-                'connected_account_id' => $this->account->id,
-                'template_id' => $foreignTemplate->id,
-                'subject' => 'Plain subject',
-                'body_html' => '<p>Plain body</p>',
-            ],
-        )
-        ->assertHasTableActionErrors(['template_id']);
+        ->callTableBulkAction('massSend', records: [$person])
+        ->assertDispatched('composer:open');
 
-    expect(EmailBatch::where('team_id', $this->team->id)->exists())->toBeFalse();
-});
-
-it('fills subject and body when an authorized template is selected', function (bool $own, bool $shared): void {
-    $person = People::create([
-        'team_id' => $this->team->id,
-        'name' => 'Recipient',
-        'creator_id' => $this->user->id,
-    ]);
-
-    $template = EmailTemplate::create([
-        'team_id' => $this->team->id,
-        'created_by' => $own ? $this->user->id : User::factory()->create()->id,
-        'name' => 'Authorized template',
-        'subject' => 'Authorized subject',
-        'body_html' => '<p>Authorized body</p>',
-        'is_shared' => $shared,
-    ]);
-
-    livewire(ListPeople::class)
-        ->mountTableBulkAction('massSend', records: [$person])
-        ->fillForm([
-            'template_id' => $template->id,
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open', payload: [
+            'massSend' => true,
+            'recipients' => [[
+                'personId' => (string) $person->getKey(),
+                'email' => 'broken-name@example.com',
+                'name' => 'broken-name@example.com',
+            ]],
         ])
-        ->assertSchemaStateSet([
-            'subject' => 'Authorized subject',
-            'body_html' => '<p>Authorized body</p>',
-        ]);
-})->with([
-    'own private' => [true, false],
-    'teammate shared' => [false, true],
-]);
-
-it('does not copy a teammate\'s private template into the editor', function (): void {
-    $person = People::create([
-        'team_id' => $this->team->id,
-        'name' => 'Recipient',
-        'creator_id' => $this->user->id,
-    ]);
-
-    $teammatePrivate = EmailTemplate::create([
-        'team_id' => $this->team->id,
-        'created_by' => User::factory()->create()->id,
-        'name' => 'Teammate private template',
-        'subject' => 'SECRET SUBJECT',
-        'body_html' => '<p>SECRET BODY</p>',
-        'is_shared' => false,
-    ]);
-
-    livewire(ListPeople::class)
-        ->mountTableBulkAction('massSend', records: [$person])
-        ->fillForm([
-            'subject' => 'Original subject',
-            'body_html' => '<p>Original body</p>',
-        ])
-        ->fillForm([
-            'template_id' => $teammatePrivate->id,
-        ])
-        ->assertSchemaStateSet([
-            'subject' => 'Original subject',
-            'body_html' => '<p>Original body</p>',
-        ]);
+        ->assertSet('massRecipients.0.name', 'broken-name@example.com');
 });

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -28,6 +28,7 @@ use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailBody;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
+use Tests\Helpers\AllowedComposerRecipient;
 
 mutates(EmailsRelationManager::class, EmailInboxPage::class, EmailComposer::class, Email::class, HasEmailComposeActions::class, RedirectsToGrantSend::class, ConnectedAccount::class, QueuedSendNotifier::class, SendEmailAction::class, SaveEmailDraftAction::class);
 
@@ -83,6 +84,8 @@ beforeEach(function (): void {
         'name' => 'CC Person',
         'role' => EmailParticipantRole::CC,
     ]);
+
+    AllowedComposerRecipient::seed($this->user, 'forward-to@example.com');
 });
 
 it('reply persists a queued Email with REPLY creation_source', function (): void {

--- a/tests/Feature/Filament/App/Components/RecordChipTest.php
+++ b/tests/Feature/Filament/App/Components/RecordChipTest.php
@@ -78,7 +78,11 @@ function assigneesFilterField(ManageTasks $page): Select
 function pickerLabelText(array $options): array
 {
     return array_values(array_map(
-        fn (string $label): string => trim((string) preg_replace('/\s+/', ' ', strip_tags($label))),
+        fn (string $label): string => trim((string) preg_replace(
+            '/\s+/',
+            ' ',
+            html_entity_decode(strip_tags($label), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+        )),
         $options,
     ));
 }

--- a/tests/Helpers/AllowedComposerRecipient.php
+++ b/tests/Helpers/AllowedComposerRecipient.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helpers;
+
+use App\Enums\CustomFields\PeopleField;
+use App\Models\CustomField;
+use App\Models\People;
+use App\Models\User;
+
+final class AllowedComposerRecipient
+{
+    public static function seed(User $user, string $email): void
+    {
+        $team = $user->currentTeam;
+
+        $person = People::factory()->for($team)->create([
+            'creator_id' => $user->getKey(),
+        ]);
+
+        $emailsField = CustomField::query()
+            ->withoutGlobalScopes()
+            ->where('tenant_id', $team->getKey())
+            ->where('entity_type', 'people')
+            ->where('code', PeopleField::EMAILS->value)
+            ->firstOrFail();
+
+        $person->saveCustomFieldValue($emailsField, [$email], $team);
+    }
+
+    /**
+     * @param  list<string>  $emails
+     */
+    public static function seedMany(User $user, array $emails): void
+    {
+        foreach ($emails as $email) {
+            self::seed($user, $email);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Route People and Company bulk **Send Email** through the floating `EmailComposer` in mass-send mode instead of the Filament modal
- Add a recipient sidebar (search, add/remove, toggle back to single send) with Blade components built from Filament primitives
- Restore CRM-only To/Cc/Bcc entry via `AllowedRecipientService` and `recipient-chips` resolution so random addresses cannot become pills

## Test plan

- [x] Select people on People list, bulk Send Email: composer opens expanded with recipient sidebar and correct count
- [x] Select companies on Company list, bulk Send Email: expands to linked people with emails; warning when some are skipped
- [x] Toggle mass sending off: To field repopulates; layout stays stable
- [x] Type a random address in To and blur: input clears, no pill appears
- [x] Send mass email: queued notification, outbox updates, merge tags per recipient
- [x] `php artisan test --compact --filter=MassSend`
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailComposerTest.php`