### PR TITLE
fix(filament): scroll tables that are wider than their card

### DIFF
--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -472,14 +472,6 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
     @apply rounded-xl;
 }
 
-/* asmit/resized-column sets overflow-x: auto on the same node Filament marks
-   as the fixed positioning context. CSS then computes overflow-y to auto as
-   well, which is the same clipping ancestor as above. Keep horizontal scroll
-   on .fi-ta-table-wrapper only. */
-.fi-ta-content-ctn.fi-fixed-positioning-context {
-    overflow: visible;
-}
-
 .fi-ta-table thead {
     @apply bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900;
 }

--- a/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
+++ b/tests/Browser/AccessTokens/AccessTokenBrowserTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\App\AccessTokens\ManageAccessTokens;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+mutates(ManageAccessTokens::class);
+
+it('scrolls a table wider than its card so the row actions stay reachable', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $user->tokens()->create([
+        'name' => 'Deploy script',
+        'token' => Str::random(40),
+        'abilities' => ['create', 'read'],
+        'team_id' => $team->id,
+    ]);
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->navigate("/app/{$team->slug}/settings/access-tokens")
+        ->resize(1280, 900)
+        ->assertSee('Deploy script');
+
+    $rowActionReachable = $page->script(<<<'JS'
+        (() => {
+            const card = [...document.querySelectorAll('.fi-ta-ctn')].find((table) => table.textContent.includes('Deploy script'))
+            const scroller = card.querySelector('.fi-ta-content-ctn')
+
+            scroller.scrollLeft = scroller.scrollWidth
+
+            const action = card.querySelector('tbody tr td:last-child button')
+            const box = action.getBoundingClientRect()
+            const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2)
+
+            return box.right <= card.getBoundingClientRect().right && action.contains(hit)
+        })()
+        JS);
+
+    expect($rowActionReachable)->toBeTrue();
+});


### PR DESCRIPTION
## Problem

#660 set `overflow: visible` on `.fi-ta-content-ctn.fi-fixed-positioning-context`. That node is the only horizontal scroller a Filament table has: Filament's own `content.css` and `asmit/resized-column` both give it `overflow-x: auto`. #660 expected scroll to move to `.fi-ta-table-wrapper`, but Filament v5 renders no such node, so every table in the app panel lost its scroller.

A table wider than its card now spills past the border, and its last columns and row actions can't be reached. On Settings > Access Tokens at 1440px, the table is 768px wide inside a 696px card.

## Fix

Delete the override, so Filament's own `overflow-x: auto` applies again.

## Why #660 added it, and why it is safe to drop

#660 added the rule so row action menus on short relation-manager tables would stop flipping up over "+ New" and "Attach". On the current stack (Filament v5.8.1) the rule has no effect on that. The menu panel is `position: fixed`, so a scrolling ancestor never clips it.

I walked the one-row Notes relation manager on a company, with the row scrolled to the bottom of the viewport:

| CSS | Panel top at 1280x720 | Covers "New note" / "Attach" |
|---|---|---|
| before #660 | 564 | yes |
| `main` (#660's rule) | 574 | no |
| this PR | 574 | no |

At 1920x1080 all three open below the trigger. The menu still flips up when the viewport has no room below it, which is Floating UI's normal behavior. What keeps the buttons clear is #660's dropdown restyle (z-index 22, tighter items), and this PR keeps it.

## Evidence

`main`: the token table spills 73px past its card, and its row actions sit outside it.

![main spill](https://github.com/relaticle/relaticle/raw/refs/heads/gh-attach-assets/a1f0acb5-c8fc-4d80-bfb6-42bff24895fd/J3-base-spill-light.png)

This PR: the table scrolls inside its card, and the row actions are reachable.

![scrolled](https://github.com/relaticle/relaticle/raw/refs/heads/gh-attach-assets/23808124-815f-4429-8fa8-bdc59778ce89/J3-scrolled-light.png)

This PR at 1280x720: the row menu flips up for lack of room and stays clear of "New note" and "Attach".

![row menu at 1280x720](https://github.com/relaticle/relaticle/raw/refs/heads/gh-attach-assets/f76ed123-eff3-477c-aeb3-23607baa4d61/row-menu-1280x720.png)

## Tests

`tests/Browser/AccessTokens/AccessTokenBrowserTest.php` fails on `main`: at 1280px, the access token row action can't be reached inside its card. It passes with the fix.

Gate: pint, `composer test:lint`, `composer test:refactor`, PHPStan, type coverage 100%, `pest tests/Browser` (119 passed).
