### PR TITLE
fix(chat): keep closed panels closed when the browser goes back

### DIFF
--- a/packages/Chat/resources/views/livewire/app/chat/chat-all-chats-panel.blade.php
+++ b/packages/Chat/resources/views/livewire/app/chat/chat-all-chats-panel.blade.php
@@ -4,6 +4,13 @@
             open: @entangle('isOpen'),
             viewportWidth: window.innerWidth,
             init() {
+                {{-- Open at init only when Livewire restored this page from its
+                     back/forward cache; forward navigation always lands closed. --}}
+                if (this.open) {
+                    this.open = false;
+                    $wire.close();
+                }
+
                 this.keydownHandler = (e) => {
                     if (e.key === 'Escape' && this.open) {
                         e.preventDefault();

--- a/packages/Chat/resources/views/livewire/app/chat/chat-side-panel.blade.php
+++ b/packages/Chat/resources/views/livewire/app/chat/chat-side-panel.blade.php
@@ -2,7 +2,7 @@
     {{-- Side Panel --}}
     <div
         x-data="{
-            open: @entangle('isOpen'),
+            open: @entangle('isOpen').live,
             {{-- try/catch: storage access throws in Safari private mode, and an
                  exception here would kill the whole component's init. --}}
             width: (() => {
@@ -30,6 +30,12 @@
             copied: false,
 
             init() {
+                {{-- Open at init only when Livewire restored this page from its
+                     back/forward cache; forward navigation always lands closed. --}}
+                if (this.open) {
+                    this.open = false;
+                }
+
                 this.$watch('open', (newValue) => {
                     if (newValue === true) {
                         this.$nextTick(() => {

--- a/tests/Browser/Chat/SidePanelTest.php
+++ b/tests/Browser/Chat/SidePanelTest.php
@@ -15,3 +15,48 @@ it('renders the side panel on the dashboard', function (): void {
         ->assertPathIs("/app/{$team->slug}")
         ->assertSourceHas('data-chat-side-panel');
 });
+
+it('stays closed when the browser goes back to a page where it was closed', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+    $assistantName = config('chat.assistant_name');
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->click('a.fi-sidebar-item-btn[href$="/people"]')
+        ->waitForText('No people')
+        ->click("button[aria-label=\"Ask {$assistantName}\"]")
+        ->assertVisible('[data-chat-side-panel]')
+        ->click('[data-chat-side-panel] button[aria-label="Close chat panel"]')
+        ->wait(0.5)
+        ->assertMissing('[data-chat-side-panel]')
+        ->click('a.fi-sidebar-item-btn[href$="/companies"]')
+        ->waitForText('No companies')
+        ->back()
+        ->waitForText('No people')
+        ->wait(0.5);
+
+    $page->assertMissing('[data-chat-side-panel]');
+});
+
+it('does not restore an open panel when the browser goes back', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+    $assistantName = config('chat.assistant_name');
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->click('a.fi-sidebar-item-btn[href$="/people"]')
+        ->waitForText('No people')
+        ->click("button[aria-label=\"Ask {$assistantName}\"]")
+        ->assertVisible('[data-chat-side-panel]');
+
+    $page->script("window.Livewire.navigate('/app/{$team->slug}/companies')");
+
+    $page->waitForText('No companies')
+        ->back()
+        ->waitForText('No people')
+        ->wait(0.5);
+
+    $page->assertMissing('[data-chat-side-panel]');
+});

--- a/tests/Browser/Chat/SidebarAllChatsPanelTest.php
+++ b/tests/Browser/Chat/SidebarAllChatsPanelTest.php
@@ -82,3 +82,37 @@ it('navigates to a chat when clicked from the panel', function (): void {
     $page->click('[data-chat-all-chats-panel] a[href*="cnav1"]')
         ->assertPathIs("/app/{$team->slug}/chats/cnav1");
 });
+
+it('does not restore an open flyout when the browser goes back', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $team = $user->ownedTeams()->first();
+
+    $rows = [];
+    for ($i = 1; $i <= 8; $i++) {
+        $rows[] = [
+            'id' => "cback{$i}",
+            'participant_type' => 'user',
+            'participant_id' => $user->getKey(),
+            'team_id' => $team->getKey(),
+            'title' => "Filler {$i}",
+            'created_at' => now()->subMinutes(20 - $i),
+            'updated_at' => now()->subMinutes(20 - $i),
+        ];
+    }
+    DB::table('agent_conversations')->insert($rows);
+
+    $page = loginViaBrowser($user)
+        ->assertPathIs("/app/{$team->slug}")
+        ->click('button[aria-label="Open all chats"]')
+        ->wait(0.5)
+        ->assertVisible('[data-chat-all-chats-panel]');
+
+    $page->script("window.Livewire.navigate('/app/{$team->slug}/people')");
+
+    $page->waitForText('No people')
+        ->back()
+        ->waitForText('Get started')
+        ->wait(0.5);
+
+    $page->assertMissing('[data-chat-all-chats-panel]');
+});


### PR DESCRIPTION
Livewire restores a page from its back/forward cache with the component state it held when the user left, so the Rela panel (closed only client-side through a deferred entangle) and the all-chats panel (whose close request races the page swap when a nav link is clicked) both came back open on Back. The Rela panel now entangles `isOpen` live, and both panels close themselves in their Alpine `init()` when they are open at that point, which only happens on a cache restore. Back therefore never restores either panel open, matching forward navigation, which always lands closed. Three browser tests cover closed-then-Back for Rela and left-open-then-Back for both panels, and were confirmed failing before the fix. Reported by a user who saw both panels reopen on every page after closing them.