### PR TITLE
fix(docker): install pnpm without corepack so node 25+ images build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,11 @@ FROM node:22-alpine AS frontend
 
 WORKDIR /app
 
-# Copy package files and install (corepack reads the pinned pnpm version
-# from package.json's packageManager field)
+# Corepack is gone from Node 25+, and letting pnpm fetch its own pinned version
+# needs glibc, so install the exact version package.json already pins.
 COPY package.json pnpm-lock.yaml ./
-RUN corepack enable pnpm && pnpm install --frozen-lockfile --ignore-scripts
+RUN npm install -g "$(node -p 'require("./package.json").packageManager')" \
+    && pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy source files needed for build
 COPY vite.config.js ./


### PR DESCRIPTION
## Problem

The Docker build fails on any Node image newer than 24:

```
> [frontend 4/10] RUN corepack enable pnpm && pnpm install --frozen-lockfile --ignore-scripts:
0.045 /bin/sh: corepack: not found
ERROR: failed to solve: ... exit code: 127
```

Node's TSC voted to stop distributing corepack, and v25.0.0 dropped it. #721 (bump node 22-alpine to 26-alpine) fails both build jobs on exactly this line.

## Fix

Install the pnpm version `package.json` already pins, read straight from the `packageManager` field. One source of truth, no corepack, and it works on every Node major.

## Why not the obvious alternatives

`npm install -g pnpm` (unpinned) looks cleaner and does work in principle: pnpm's `pmOnFail` defaults to `download`, so it reads `packageManager` and switches to the pinned version. It fails on our bases, because the `@pnpm/exe` artifact it downloads is a native binary:

| base | `npm i -g pnpm` | this PR |
|---|---|---|
| `node:22-alpine` | exits 1, no output (musl) | works |
| `node:26-alpine` | exits 1, no output (musl) | works |
| `node:22-slim` | `libatomic.so.1: cannot open shared object file` | works |

`npm install -g pnpm@11.24.0` would also work, at the cost of a second copy of the version that drifts from `package.json`.

## Verification

Local `docker build`:

- `--target frontend` on `node:22-alpine`: passes, vite emits `public/build`
- `--target frontend` on `node:26-alpine`: passes
- full production image on `node:22-alpine`: passes

## Follow-up

With this merged, `@dependabot rebase` on #721 should go green, and its build job validates vite on Node 26 in CI. Node 26 reaches LTS on 2026-10-28.

CI itself is unaffected: `ci.yml` and `security-audit.yml` use `pnpm/action-setup`, which reads `packageManager` natively. The Dockerfile was the only corepack user in the repo.