### PR TITLE
Treat private teammate shares as no access

### DIFF
--- a/packages/EmailIntegration/src/Services/PrivacyService.php
+++ b/packages/EmailIntegration/src/Services/PrivacyService.php
@@ -45,7 +45,13 @@ final readonly class PrivacyService
         $share = $this->shareForViewer($email, $viewer);
 
         if ($share instanceof EmailShare) {
-            return EmailPrivacyTier::from($share->tier);
+            $tier = EmailPrivacyTier::from($share->tier);
+
+            if ($tier === EmailPrivacyTier::PRIVATE) {
+                return null;
+            }
+
+            return $tier;
         }
 
         // Email's own tier

--- a/tests/Feature/EmailIntegration/EmailPolicyTest.php
+++ b/tests/Feature/EmailIntegration/EmailPolicyTest.php
@@ -8,6 +8,7 @@ use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailShare;
 
 mutates(EmailPolicy::class);
 
@@ -46,6 +47,23 @@ it('denies every email ability to a user from another workspace', function (): v
         ->and($outsider->can('viewBody', $this->email))->toBeFalse()
         ->and($outsider->can('share', $this->email))->toBeFalse()
         ->and($outsider->can('requestAccess', $this->email))->toBeFalse();
+});
+
+it('denies every view ability to a teammate with a private share override', function (): void {
+    $teammate = User::factory()->create();
+    $teammate->teams()->attach($this->team);
+    $teammate->forceFill(['current_team_id' => $this->team->id])->save();
+
+    EmailShare::factory()->tier(EmailPrivacyTier::PRIVATE)->create([
+        'email_id' => $this->email->getKey(),
+        'shared_by' => $this->owner->id,
+        'shared_with' => $teammate->id,
+    ]);
+
+    expect($teammate->can('view', $this->email))->toBeFalse()
+        ->and($teammate->can('viewSubject', $this->email))->toBeFalse()
+        ->and($teammate->can('viewBody', $this->email))->toBeFalse()
+        ->and($teammate->can('requestAccess', $this->email))->toBeFalse();
 });
 
 it('still allows a teammate to view a shared-tier email in the same workspace', function (): void {

--- a/tests/Feature/EmailIntegration/PrivacyServiceTest.php
+++ b/tests/Feature/EmailIntegration/PrivacyServiceTest.php
@@ -204,6 +204,22 @@ it('effectiveTier uses per-email share tier when a share exists for the viewer',
     expect($tier)->toBe(EmailPrivacyTier::SUBJECT);
 });
 
+it('effectiveTier returns null when a per-viewer share tier is private', function (): void {
+    $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
+
+    $email = makePrivacyEmail(['privacy_tier' => EmailPrivacyTier::FULL]);
+
+    EmailShare::factory()->tier(EmailPrivacyTier::PRIVATE)->create([
+        'email_id' => $email->getKey(),
+        'shared_by' => $this->owner->id,
+        'shared_with' => $viewer->id,
+    ]);
+
+    $tier = $this->service->effectiveTier($email, $viewer);
+
+    expect($tier)->toBeNull();
+});
+
 it('effectiveTier falls back to the email privacy_tier when no share exists', function (): void {
     $viewer = User::factory()->create(['current_team_id' => $this->team->id]);
 


### PR DESCRIPTION
## Summary
- Map a per-viewer `EmailShare` with tier `private` to `null` in `PrivacyService::effectiveTier()`, matching the behavior for an email's own private default tier.
- Block `view`, `viewSubject`, `viewBody`, and `requestAccess` for teammates with a private share override.
- Add regression tests in `PrivacyServiceTest` and `EmailPolicyTest`.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/PrivacyServiceTest.php tests/Feature/EmailIntegration/EmailPolicyTest.php`