### PR TITLE
Hide access-request subjects until the viewer can see them

### DIFF
--- a/lang/en/filament/pages/email-access-requests.php
+++ b/lang/en/filament/pages/email-access-requests.php
@@ -31,6 +31,7 @@ return [
         'requested_outgoing' => 'you requested access',
         'unknown_user' => 'Unknown user',
         'no_subject' => '(No subject)',
+        'subject_hidden' => '(Subject hidden)',
         'email_unavailable' => 'The associated email is no longer available.',
     ],
     'empty' => [

--- a/packages/EmailIntegration/src/Livewire/Concerns/InteractsWithEmailAccessRequests.php
+++ b/packages/EmailIntegration/src/Livewire/Concerns/InteractsWithEmailAccessRequests.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Livewire\Concerns;
 
 use App\Models\User;
+use App\Support\LikePattern;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Support\Icons\Heroicon;
@@ -19,7 +20,9 @@ use Relaticle\EmailIntegration\Actions\DenyEmailAccessRequestAction;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Pages\EmailInboxPage;
+use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
+use Relaticle\EmailIntegration\Services\EmailSearchService;
 
 trait InteractsWithEmailAccessRequests
 {
@@ -49,7 +52,8 @@ trait InteractsWithEmailAccessRequests
                 TextColumn::make('email.subject')
                     ->label(__('filament/pages/email-access-requests.columns.email'))
                     ->placeholder(__('filament/pages/email-access-requests.request.no_subject'))
-                    ->searchable()
+                    ->searchable(query: $this->searchVisibleEmailSubject(...))
+                    ->getStateUsing($this->visibleEmailSubject(...))
                     ->limit(60),
                 TextColumn::make('tier_requested')
                     ->label(__('filament/pages/email-access-requests.columns.access'))
@@ -90,13 +94,43 @@ trait InteractsWithEmailAccessRequests
         $user = $this->authUser();
 
         return EmailAccessRequest::query()
-            ->with(['email', 'requester', 'owner'])
+            ->with(['email.shares', 'requester', 'owner'])
             ->whereHas('email', fn (Builder $query): Builder => $query->where('team_id', $user->current_team_id))
             ->when(
                 $this->tab === 'incoming',
                 fn (Builder $query): Builder => $query->where('owner_id', $user->getKey()),
                 fn (Builder $query): Builder => $query->where('requester_id', $user->getKey()),
             );
+    }
+
+    private function visibleEmailSubject(EmailAccessRequest $request): ?string
+    {
+        $email = $request->email;
+
+        if (! $email instanceof Email) {
+            return null;
+        }
+
+        if (! $this->authUser()->can('viewSubject', $email)) {
+            return __('filament/pages/email-access-requests.request.subject_hidden');
+        }
+
+        return $email->subject;
+    }
+
+    /**
+     * @param  Builder<EmailAccessRequest>  $query
+     * @return Builder<EmailAccessRequest>
+     */
+    private function searchVisibleEmailSubject(Builder $query, string $search): Builder
+    {
+        $viewer = $this->authUser();
+        $term = '%'.LikePattern::escape($search).'%';
+
+        return $query->whereHas('email', function (Builder $emailQuery) use ($term, $viewer): void {
+            $emailQuery->where('subject', 'ilike', $term);
+            resolve(EmailSearchService::class)->whereSubjectVisibleTo($emailQuery, $viewer);
+        });
     }
 
     private function openEmailAction(): Action

--- a/packages/EmailIntegration/src/Livewire/Concerns/InteractsWithEmailAccessRequests.php
+++ b/packages/EmailIntegration/src/Livewire/Concerns/InteractsWithEmailAccessRequests.php
@@ -128,6 +128,7 @@ trait InteractsWithEmailAccessRequests
         $term = '%'.LikePattern::escape($search).'%';
 
         return $query->whereHas('email', function (Builder $emailQuery) use ($term, $viewer): void {
+            /** @var Builder<Email> $emailQuery */
             $emailQuery->where('subject', 'ilike', $term);
             resolve(EmailSearchService::class)->whereSubjectVisibleTo($emailQuery, $viewer);
         });

--- a/packages/EmailIntegration/src/Services/EmailSearchService.php
+++ b/packages/EmailIntegration/src/Services/EmailSearchService.php
@@ -51,6 +51,15 @@ final readonly class EmailSearchService
      * @param  Builder<Email>  $query
      * @return Builder<Email>
      */
+    public function whereSubjectVisibleTo(Builder $query, User $viewer): Builder
+    {
+        return $this->whereViewerCanSeeSubject($query, $viewer->getKey());
+    }
+
+    /**
+     * @param  Builder<Email>  $query
+     * @return Builder<Email>
+     */
     private function whereViewerCanSeeSubject(Builder $query, string $viewerId): Builder
     {
         return $this->whereViewerHasAccessAtTiers($query, $viewerId, [

--- a/tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 use App\Models\User;
 use Filament\Facades\Filament;
 use Relaticle\EmailIntegration\Enums\EmailAccessRequestStatus;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccessRequestsPage;
 use Relaticle\EmailIntegration\Livewire\AccessRequestsTable;
+use Relaticle\EmailIntegration\Livewire\Concerns\InteractsWithEmailAccessRequests;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAccessRequest;
+use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Notifications\EmailAccessRequestedNotification;
+use Relaticle\EmailIntegration\Services\EmailSearchService;
 
-mutates(AccessRequestsTable::class, EmailAccessRequestsPage::class);
+mutates(AccessRequestsTable::class, EmailAccessRequestsPage::class, InteractsWithEmailAccessRequests::class, EmailSearchService::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -342,5 +346,199 @@ describe('getNavigationBadge', function (): void {
         ]);
 
         expect(EmailAccessRequestsPage::getNavigationBadge())->toBeNull();
+    });
+});
+
+describe('subject privacy', function (): void {
+    it('hides the email subject on outgoing requests when the viewer cannot see it', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+            'subject' => 'Confidential Thread XYZ',
+        ]);
+
+        $request = EmailAccessRequest::factory()->pending()->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $this->user->id,
+            'email_id' => $email->getKey(),
+        ]);
+
+        livewire(AccessRequestsTable::class)
+            ->call('setTab', 'outgoing')
+            ->assertCanSeeTableRecords([$request])
+            ->assertTableColumnStateSet('email.subject', __('filament/pages/email-access-requests.request.subject_hidden'), $request)
+            ->assertDontSee('Confidential Thread XYZ');
+    });
+
+    it('hides the email subject on outgoing requests after access is denied', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+            'subject' => 'Denied Thread Secret',
+        ]);
+
+        $request = EmailAccessRequest::factory()->denied()->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $this->user->id,
+            'email_id' => $email->getKey(),
+        ]);
+
+        livewire(AccessRequestsTable::class)
+            ->call('setTab', 'outgoing')
+            ->assertCanSeeTableRecords([$request])
+            ->assertTableColumnStateSet('email.subject', __('filament/pages/email-access-requests.request.subject_hidden'), $request)
+            ->assertDontSee('Denied Thread Secret');
+    });
+
+    it('shows the email subject on outgoing requests after access is approved', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+            'subject' => 'Approved Thread Subject',
+        ]);
+
+        $request = EmailAccessRequest::factory()->approved()->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $this->user->id,
+            'email_id' => $email->getKey(),
+        ]);
+
+        EmailShare::factory()->tier(EmailPrivacyTier::FULL)->create([
+            'email_id' => $email->getKey(),
+            'team_id' => $this->team->id,
+            'shared_by' => $owner->id,
+            'shared_with' => $this->user->id,
+        ]);
+
+        livewire(AccessRequestsTable::class)
+            ->call('setTab', 'outgoing')
+            ->assertTableColumnStateSet('email.subject', 'Approved Thread Subject', $request);
+    });
+
+    it('shows the email subject on outgoing requests when the viewer already has subject access', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+            'privacy_tier' => EmailPrivacyTier::SUBJECT,
+            'subject' => 'Visible Subject Line',
+        ]);
+
+        $request = EmailAccessRequest::factory()->pending()->forTier(EmailPrivacyTier::FULL)->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $this->user->id,
+            'email_id' => $email->getKey(),
+        ]);
+
+        livewire(AccessRequestsTable::class)
+            ->call('setTab', 'outgoing')
+            ->assertTableColumnStateSet('email.subject', 'Visible Subject Line', $request);
+    });
+
+    it('shows the email subject on incoming requests for the owner', function (): void {
+        $requester = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->user->id,
+            'connected_account_id' => $this->account->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+            'subject' => 'Owner Visible Subject',
+        ]);
+
+        $request = EmailAccessRequest::factory()->pending()->create([
+            'owner_id' => $this->user->id,
+            'requester_id' => $requester->id,
+            'email_id' => $email->getKey(),
+        ]);
+
+        livewire(AccessRequestsTable::class)
+            ->assertTableColumnStateSet('email.subject', 'Owner Visible Subject', $request);
+    });
+
+    it('does not match a hidden subject when searching outgoing requests', function (): void {
+        $owner = User::factory()->create(['current_team_id' => $this->team->id, 'name' => 'Pat Owner']);
+
+        $ownerAccount = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+        ]));
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $owner->id,
+            'connected_account_id' => $ownerAccount->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+            'subject' => 'Quarterly forecast secret',
+        ]);
+
+        $request = EmailAccessRequest::factory()->pending()->create([
+            'owner_id' => $owner->id,
+            'requester_id' => $this->user->id,
+            'email_id' => $email->getKey(),
+        ]);
+
+        livewire(AccessRequestsTable::class)
+            ->call('setTab', 'outgoing')
+            ->searchTable('Quarterly forecast secret')
+            ->assertCanNotSeeTableRecords([$request])
+            ->searchTable('Pat Owner')
+            ->assertCanSeeTableRecords([$request]);
+    });
+
+    it('matches the subject when searching incoming requests as the owner', function (): void {
+        $requester = User::factory()->create(['current_team_id' => $this->team->id]);
+
+        $email = Email::factory()->create([
+            'team_id' => $this->team->id,
+            'user_id' => $this->user->id,
+            'connected_account_id' => $this->account->getKey(),
+            'privacy_tier' => EmailPrivacyTier::METADATA_ONLY,
+            'subject' => 'Owner search subject',
+        ]);
+
+        $request = EmailAccessRequest::factory()->pending()->create([
+            'owner_id' => $this->user->id,
+            'requester_id' => $requester->id,
+            'email_id' => $email->getKey(),
+        ]);
+
+        livewire(AccessRequestsTable::class)
+            ->searchTable('Owner search subject')
+            ->assertCanSeeTableRecords([$request]);
     });
 });


### PR DESCRIPTION
## Summary
- The Sent access-requests table showed and searched `email.subject` with no `viewSubject` check.
- A metadata-only teammate could read a protected subject as soon as they filed a request, including while it was pending or after it was denied.
- Display now shows `(Subject hidden)` unless the viewer can see the subject. Search uses the same visibility rules as mailbox search.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailAccessRequestsPageTest.php`
- [x] Open Access Requests as a metadata-only teammate, switch to Sent: a pending row shows `(Subject hidden)`, not the real subject
- [x] Search the hidden subject: the row does not appear
- [x] After the owner approves: the subject is visible on Sent