### PR TITLE
Bind mailbox OAuth to the initiating workspace

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -5,6 +5,14 @@ paths:
 
 # Email integration
 
+## Bind mailbox OAuth to the initiating workspace
+
+`RedirectController` stores the current team id in the session before sending
+the user to Google or Microsoft. `CallbackController` connects the mailbox to
+that stored team, not `$user->currentTeam`. Switching workspaces in another tab
+during consent must not import history under the other workspace's sharing
+defaults. A missing or non-member binding fails closed: no account is created.
+
 ## Vanished provider messages must not fail the mailbox
 
 A listed Gmail or Graph id can be permanently deleted before `StoreEmailJob`

--- a/packages/EmailIntegration/src/Controllers/CallbackController.php
+++ b/packages/EmailIntegration/src/Controllers/CallbackController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Controllers;
 
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -64,11 +65,6 @@ final readonly class CallbackController
         /** @var User $user */
         $user = auth()->user();
 
-        // Without an active team we cannot scope or redirect; bail to the dashboard.
-        if ($user->currentTeam === null) {
-            return redirect('/')->with('error', 'Select a team before connecting an account.');
-        }
-
         if (! in_array($provider, self::SUPPORTED_PROVIDERS, true)) {
             return $this->redirectWithError($user, 'That email provider is not supported.');
         }
@@ -82,14 +78,20 @@ final readonly class CallbackController
         } catch (InvalidStateException) {
             Log::warning('OAuth callback state mismatch.', ['provider' => $provider, 'user_id' => $user->getKey()]);
 
-            return $this->redirectWithError($user, 'Your sign-in session expired. Please reconnect the account.');
+            return $this->redirectWithError($user, 'Your sign-in session expired. Please reconnect the account.', $this->boundWorkspace($request, $user));
         } catch (Throwable $e) {
             Log::error('OAuth callback failed.', ['provider' => $provider, 'user_id' => $user->getKey(), 'exception' => $e]);
 
-            return $this->redirectWithError($user, 'We could not connect that account. Please try again.');
+            return $this->redirectWithError($user, 'We could not connect that account. Please try again.', $this->boundWorkspace($request, $user));
         }
 
         throw_unless($socialUser instanceof TwoUser, RuntimeException::class, "Socialite driver [{$provider}] returned an unexpected user type.");
+
+        $team = $this->consumeBoundWorkspace($request, $user);
+
+        if (! $team instanceof Team) {
+            return $this->redirectWithError($user, 'Your sign-in session expired. Please reconnect the account.');
+        }
 
         /** @var array<int, string> $grantedScopes */
         $grantedScopes = $socialUser->approvedScopes;
@@ -98,7 +100,7 @@ final readonly class CallbackController
 
         resolve(ConnectAccountAction::class)->execute(new ConnectAccountData(
             userId: $user->getKey(),
-            teamId: $user->currentTeam->getKey(),
+            teamId: $team->getKey(),
             provider: $provider,
             emailAddress: $socialUser->getEmail(),
             displayName: $socialUser->getName(),
@@ -111,14 +113,41 @@ final readonly class CallbackController
         ));
 
         return redirect(EmailAccountsPage::getUrl([
-            'tenant' => $user->currentTeam->slug,
+            'tenant' => $team->slug,
         ]))->with('success', 'Account connected successfully.');
     }
 
-    private function redirectWithError(User $user, string $message): RedirectResponse
+    private function boundWorkspace(Request $request, User $user): ?Team
     {
+        return $this->workspaceIfMember($user, $request->session()->get(RedirectController::WORKSPACE_SESSION_KEY));
+    }
+
+    private function consumeBoundWorkspace(Request $request, User $user): ?Team
+    {
+        return $this->workspaceIfMember($user, $request->session()->pull(RedirectController::WORKSPACE_SESSION_KEY));
+    }
+
+    private function workspaceIfMember(User $user, mixed $teamId): ?Team
+    {
+        if (! is_string($teamId) || $teamId === '' || ! $user->belongsToTeamId($teamId)) {
+            return null;
+        }
+
+        $team = Team::query()->find($teamId);
+
+        return $team instanceof Team ? $team : null;
+    }
+
+    private function redirectWithError(User $user, string $message, ?Team $team = null): RedirectResponse
+    {
+        $team ??= $user->currentTeam;
+
+        if ($team === null) {
+            return redirect('/')->with('error', $message);
+        }
+
         return redirect(EmailAccountsPage::getUrl([
-            'tenant' => $user->currentTeam->slug,
+            'tenant' => $team->slug,
         ]))->with('error', $message);
     }
 

--- a/packages/EmailIntegration/src/Controllers/RedirectController.php
+++ b/packages/EmailIntegration/src/Controllers/RedirectController.php
@@ -4,28 +4,55 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Controllers;
 
+use App\Models\Team;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Laravel\Socialite\Socialite;
 use Laravel\Socialite\Two\AbstractProvider;
 use RuntimeException;
 
 final readonly class RedirectController
 {
-    public function __invoke(string $provider): RedirectResponse
-    {
-        return match ($provider) {
-            'gmail' => $this->driver('gmail')
-                ->scopes($this->gmailScopes())
-                ->with(['access_type' => 'offline', 'prompt' => 'consent'])
-                ->redirect(),
+    public const string WORKSPACE_SESSION_KEY = 'email_integration.oauth.team_id';
 
-            'azure' => $this->driver('azure')
-                ->setScopes($this->azureScopes())
-                ->with(['prompt' => 'consent'])
-                ->redirect(),
+    public function __invoke(Request $request, string $provider): RedirectResponse
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return match ($provider) {
+            'gmail' => $this->startOAuth(
+                $request,
+                $user,
+                $this->driver('gmail')
+                    ->scopes($this->gmailScopes())
+                    ->with(['access_type' => 'offline', 'prompt' => 'consent']),
+            ),
+
+            'azure' => $this->startOAuth(
+                $request,
+                $user,
+                $this->driver('azure')
+                    ->setScopes($this->azureScopes())
+                    ->with(['prompt' => 'consent']),
+            ),
 
             default => back(),
         };
+    }
+
+    private function startOAuth(Request $request, User $user, AbstractProvider $driver): RedirectResponse
+    {
+        $team = $user->currentTeam;
+
+        if (! $team instanceof Team) {
+            return redirect('/')->with('error', 'Select a team before connecting an account.');
+        }
+
+        $request->session()->put(self::WORKSPACE_SESSION_KEY, $team->getKey());
+
+        return $driver->redirect();
     }
 
     /** @return array<int, string> */

--- a/tests/Feature/CalendarIntegration/CalendarAccountConnectionTest.php
+++ b/tests/Feature/CalendarIntegration/CalendarAccountConnectionTest.php
@@ -34,6 +34,7 @@ it('flips calendar capability and dispatches InitialCalendarSyncJob on calendar 
     ];
 
     Socialite::fake('gmail', $social);
+    bindMailboxOAuthWorkspace($user);
 
     $this->get(route('email-accounts.callback', ['provider' => 'gmail']))
         ->assertRedirect();
@@ -63,6 +64,7 @@ it('enables calendar when Google grants calendar.events without calendar.readonl
     ];
 
     Socialite::fake('gmail', $social);
+    bindMailboxOAuthWorkspace($user);
 
     $this->get(route('email-accounts.callback', ['provider' => 'gmail']))
         ->assertRedirect();
@@ -92,6 +94,7 @@ it('connects mail without calendar when the user leaves both calendar scopes unc
     ];
 
     Socialite::fake('gmail', $social);
+    bindMailboxOAuthWorkspace($user);
 
     $this->get(route('email-accounts.callback', ['provider' => 'gmail']))
         ->assertRedirect();
@@ -121,6 +124,7 @@ it('records send as missing when Google does not grant gmail.send', function ():
     ];
 
     Socialite::fake('gmail', $social);
+    bindMailboxOAuthWorkspace($user);
 
     $this->get(route('email-accounts.callback', ['provider' => 'gmail']))
         ->assertRedirect();
@@ -150,6 +154,7 @@ it('turns send back on after reconnecting with gmail.send', function (): void {
         $social->approvedScopes = $scopes;
 
         Socialite::fake('gmail', $social);
+        bindMailboxOAuthWorkspace($user);
 
         $this->get(route('email-accounts.callback', ['provider' => 'gmail']))->assertRedirect();
 

--- a/tests/Feature/EmailIntegration/EmailCallbackControllerTest.php
+++ b/tests/Feature/EmailIntegration/EmailCallbackControllerTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Bus;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
+use Laravel\Socialite\Two\User as SocialiteUser;
 use Relaticle\EmailIntegration\Controllers\CallbackController;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
 
 mutates(CallbackController::class);
 
@@ -27,6 +30,34 @@ it('redirects with a flashed error when Socialite throws InvalidStateException',
         'tenant' => $this->user->currentTeam->slug,
     ], panel: 'app'));
     $response->assertSessionHas('error', 'Your sign-in session expired. Please reconnect the account.');
+});
+
+it('does not connect a mailbox when the authorizing workspace is missing from the session', function (): void {
+    Bus::fake();
+
+    $social = new SocialiteUser;
+    $social->id = 'gmail-missing-workspace';
+    $social->email = 'missing-workspace@example.com';
+    $social->name = 'Demo';
+    $social->token = 'access-token';
+    $social->refreshToken = 'refresh-token';
+    $social->expiresIn = 3600;
+    $social->approvedScopes = [
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.send',
+    ];
+
+    Socialite::fake('gmail', $social);
+
+    $this->get(route('email-accounts.callback', ['provider' => 'gmail']))
+        ->assertRedirect(EmailAccountsPage::getUrl([
+            'tenant' => $this->user->currentTeam->slug,
+        ], panel: 'app'))
+        ->assertSessionHas('error', 'Your sign-in session expired. Please reconnect the account.');
+
+    $this->assertDatabaseMissing(ConnectedAccount::class, [
+        'email_address' => 'missing-workspace@example.com',
+    ]);
 });
 
 it('redirects with a generic error when Socialite throws any other exception', function (): void {

--- a/tests/Feature/EmailIntegration/GmailOAuthRedirectTest.php
+++ b/tests/Feature/EmailIntegration/GmailOAuthRedirectTest.php
@@ -31,6 +31,8 @@ it('redirects to Google using the Gmail OAuth client and the email-account callb
         ->and(urldecode((string) ($query['scope'] ?? '')))->toContain('https://www.googleapis.com/auth/calendar.readonly')
         ->and($query['access_type'] ?? null)->toBe('offline')
         ->and($query['prompt'] ?? null)->toBe('consent');
+
+    expect(session(RedirectController::WORKSPACE_SESSION_KEY))->toBe($user->currentTeam->getKey());
 });
 
 it('includes calendar.readonly even when the leftover capability query is sent', function (): void {
@@ -44,4 +46,15 @@ it('includes calendar.readonly even when the leftover capability query is sent',
     expect(urldecode((string) ($query['scope'] ?? '')))
         ->toContain('https://www.googleapis.com/auth/calendar.events')
         ->toContain('https://www.googleapis.com/auth/calendar.readonly');
+});
+
+it('does not start Google consent when the user has no workspace', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $this->get(route('email-accounts.redirect', ['provider' => 'gmail']))
+        ->assertRedirect('/')
+        ->assertSessionHas('error', 'Select a team before connecting an account.');
+
+    expect(session()->has(RedirectController::WORKSPACE_SESSION_KEY))->toBeFalse();
 });

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -10,8 +10,10 @@ use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\User as SocialiteUser;
 use Relaticle\EmailIntegration\Actions\ConnectAccountAction;
 use Relaticle\EmailIntegration\Controllers\CallbackController;
+use Relaticle\EmailIntegration\Controllers\RedirectController;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\RelinkMailboxHistoryJob;
@@ -20,6 +22,7 @@ use Relaticle\EmailIntegration\Models\ConnectedAccount;
 mutates(AppServiceProvider::class);
 mutates(CallbackController::class);
 mutates(ConnectAccountAction::class);
+mutates(RedirectController::class);
 
 it('resolves the azure socialite driver', function (): void {
     expect(fn () => Socialite::driver('azure'))->not->toThrow(Throwable::class);
@@ -46,6 +49,7 @@ it('stores an azure connected account and flips calendar capability when Graph c
     ];
 
     Socialite::fake('azure', $social);
+    bindMailboxOAuthWorkspace($user);
 
     $this->get(route('email-accounts.callback', ['provider' => 'azure']))
         ->assertRedirect();
@@ -85,6 +89,7 @@ it('flips calendar capability when Graph grants Calendars.ReadWrite without Cale
     ];
 
     Socialite::fake('azure', $social);
+    bindMailboxOAuthWorkspace($user);
 
     $this->get(route('email-accounts.callback', ['provider' => 'azure']))
         ->assertRedirect();
@@ -119,6 +124,7 @@ it('records send as missing when Graph does not grant Mail.Send', function (): v
     ];
 
     Socialite::fake('azure', $social);
+    bindMailboxOAuthWorkspace($user);
 
     $this->get(route('email-accounts.callback', ['provider' => 'azure']))
         ->assertRedirect();
@@ -152,6 +158,7 @@ it('preserves the stored refresh token when a reconnect returns none', function 
         ];
 
         Socialite::fake('gmail', $social);
+        bindMailboxOAuthWorkspace($user);
 
         $this->get(route('email-accounts.callback', ['provider' => 'gmail']))->assertRedirect();
 
@@ -194,12 +201,108 @@ it('dispatches history import when a disconnected account is reconnected', funct
     ];
 
     Socialite::fake('gmail', $social);
+    bindMailboxOAuthWorkspace($user);
     $this->get(route('email-accounts.callback', ['provider' => 'gmail']))->assertRedirect();
 
     expect($account->refresh()->trashed())->toBeFalse();
 
     Bus::assertDispatched(InitialEmailSyncJob::class, fn (InitialEmailSyncJob $job): bool => $job->connectedAccount->is($account));
     Bus::assertDispatched(RelinkMailboxHistoryJob::class, fn (RelinkMailboxHistoryJob $job): bool => $job->connectedAccount->is($account));
+});
+
+it('connects the mailbox to the workspace where authorization started after the current workspace changes', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $initiatingTeam = $user->currentTeam;
+    $otherTeam = Team::factory()->create(['user_id' => $user->getKey()]);
+    $user->teams()->attach($otherTeam, ['role' => 'admin']);
+
+    $this->actingAs($user);
+
+    config()->set('services.gmail.client_id', 'gmail-client-id');
+    config()->set('services.gmail.client_secret', 'gmail-client-secret');
+    config()->set('services.gmail.redirect', 'http://localhost/email-accounts/callback/gmail');
+
+    $this->get(route('email-accounts.redirect', ['provider' => 'gmail']))
+        ->assertRedirect();
+
+    $user->forceFill(['current_team_id' => $otherTeam->getKey()])->save();
+    $user->unsetRelation('currentTeam');
+
+    $social = new SocialiteUser;
+    $social->id = 'gmail-workspace-bind';
+    $social->email = 'bind@example.com';
+    $social->name = 'Demo';
+    $social->token = 'access-token';
+    $social->refreshToken = 'refresh-token';
+    $social->expiresIn = 3600;
+    $social->approvedScopes = [
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.send',
+    ];
+
+    Socialite::fake('gmail', $social);
+
+    $this->get(route('email-accounts.callback', ['provider' => 'gmail']))
+        ->assertRedirect(EmailAccountsPage::getUrl([
+            'tenant' => $initiatingTeam->slug,
+        ], panel: 'app'));
+
+    $this->assertDatabaseHas(ConnectedAccount::class, [
+        'email_address' => 'bind@example.com',
+        'team_id' => $initiatingTeam->getKey(),
+    ]);
+    $this->assertDatabaseMissing(ConnectedAccount::class, [
+        'email_address' => 'bind@example.com',
+        'team_id' => $otherTeam->getKey(),
+    ]);
+});
+
+it('does not connect a mailbox when the user left the authorizing workspace', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withTeam()->create();
+    $foreignTeam = Team::factory()->create();
+    $user->teams()->attach($foreignTeam, ['role' => 'admin']);
+    $user->forceFill(['current_team_id' => $foreignTeam->getKey()])->save();
+    $user->unsetRelation('currentTeam');
+
+    $this->actingAs($user);
+
+    config()->set('services.gmail.client_id', 'gmail-client-id');
+    config()->set('services.gmail.client_secret', 'gmail-client-secret');
+    config()->set('services.gmail.redirect', 'http://localhost/email-accounts/callback/gmail');
+
+    $this->get(route('email-accounts.redirect', ['provider' => 'gmail']))
+        ->assertRedirect();
+
+    $user->teams()->detach($foreignTeam);
+    $user->forceFill(['current_team_id' => $user->ownedTeams()->first()?->getKey()])->save();
+    $user->unsetRelation('currentTeam');
+    $user->unsetRelation('teams');
+
+    $social = new SocialiteUser;
+    $social->id = 'gmail-left-workspace';
+    $social->email = 'left@example.com';
+    $social->name = 'Demo';
+    $social->token = 'access-token';
+    $social->refreshToken = 'refresh-token';
+    $social->expiresIn = 3600;
+    $social->approvedScopes = [
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.send',
+    ];
+
+    Socialite::fake('gmail', $social);
+
+    $this->get(route('email-accounts.callback', ['provider' => 'gmail']))
+        ->assertRedirect()
+        ->assertSessionHas('error', 'Your sign-in session expired. Please reconnect the account.');
+
+    $this->assertDatabaseMissing(ConnectedAccount::class, [
+        'email_address' => 'left@example.com',
+    ]);
 });
 
 it('stores a separate connected account when the same mailbox is connected in a second workspace', function (): void {
@@ -224,6 +327,7 @@ it('stores a separate connected account when the same mailbox is connected in a 
         ];
 
         Socialite::fake('gmail', $social);
+        bindMailboxOAuthWorkspace($user);
 
         $this->actingAs($user)
             ->get(route('email-accounts.callback', ['provider' => 'gmail']))
@@ -268,6 +372,7 @@ it('makes the first connected account the default and leaves later connections n
         ];
 
         Socialite::fake('gmail', $social);
+        bindMailboxOAuthWorkspace($user);
 
         $this->get(route('email-accounts.callback', ['provider' => 'gmail']))->assertRedirect();
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,6 +21,7 @@ use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
 use Pest\Browser\Api\AwaitableWebpage;
 use Pest\Browser\Playwright\Playwright;
+use Relaticle\EmailIntegration\Controllers\RedirectController;
 use Tests\Helpers\PestTiaRuntime;
 use Tests\TestCase;
 
@@ -94,6 +95,15 @@ function userChannelAuth(User $user, string $id): bool
     }
 
     return (bool) $callback($user, $id);
+}
+
+function bindMailboxOAuthWorkspace(User $user): void
+{
+    $teamId = $user->current_team_id;
+
+    throw_unless(is_string($teamId) && $teamId !== '', RuntimeException::class, 'bindMailboxOAuthWorkspace requires a current workspace.');
+
+    session()->put(RedirectController::WORKSPACE_SESSION_KEY, $teamId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Store the workspace that starts Gmail or Microsoft consent in the session, then connect the mailbox to that team on callback instead of `$user->currentTeam`.
- Switching workspaces in another tab during consent no longer imports mailbox history under the other workspace's sharing defaults.
- Fail closed when the binding is missing or the user no longer belongs to that workspace.

## Test plan
- [x] Start Gmail or Microsoft connect in workspace A, switch to workspace B in another tab, complete consent: mailbox lands in A and the success redirect stays on A.
- [x] Connect the same mailbox from workspace B on purpose (start OAuth while B is current): a second connected account is created on B.
- [x] Complete a callback with no prior redirect: no account is created and the expired-session error is shown.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php tests/Feature/EmailIntegration/EmailCallbackControllerTest.php tests/Feature/EmailIntegration/GmailOAuthRedirectTest.php tests/Feature/CalendarIntegration/CalendarAccountConnectionTest.php`