### PR TITLE
Authorize composer inline images before attaching them

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -71,3 +71,11 @@ that calendar date. Do not convert them through the viewer's timezone: a
 Los Angeles day window starts at 07:00 UTC, so a September 10 all-day event
 would otherwise appear on the 9th. Timed meetings still use local-day UTC
 bounds.
+
+## Authorize composer inline images
+
+`EmailInlineImageEmbedder` copies files named in composer HTML (`data-id` or
+`src`). Those attributes are client-controlled. Only embed files on
+`EmailAttachment::DISK` under `email-attachments/{current_team_id}/` with an
+`image/` MIME type, plus `data:image/` URIs. Do not treat `/storage/...` URLs
+as arbitrary disk paths.

--- a/packages/EmailIntegration/src/Actions/SendEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/SendEmailAction.php
@@ -77,6 +77,7 @@ final readonly class SendEmailAction
         $scheduledFor = $this->resolveScheduledFor($data, $priority);
 
         $embedded = $this->inlineImageEmbedder->embed(
+            $user,
             (string) $data['body_html'],
             array_values($data['attachments'] ?? []),
             $data['attachment_file_names'] ?? [],

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -1106,7 +1106,7 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                 ->hiddenLabel()
                 ->resizableImages()
                 ->fileAttachmentsDisk(EmailAttachment::DISK)
-                ->fileAttachmentsDirectory('email-attachments')
+                ->fileAttachmentsDirectory(fn (): string => EmailAttachment::composeImagesDirectory((string) $this->authUser()->current_team_id))
                 ->fileAttachmentsVisibility('private')
                 ->statePath('bodyHtml')
                 ->mergeTags(EmailTemplateRenderService::MERGE_TAGS)

--- a/packages/EmailIntegration/src/Models/EmailAttachment.php
+++ b/packages/EmailIntegration/src/Models/EmailAttachment.php
@@ -30,6 +30,15 @@ final class EmailAttachment extends Model
      */
     use HasFactory, HasUlids;
 
+    /**
+     * Directory on {@see DISK} for RichEditor inline images. Tenant-scoped so
+     * composer HTML cannot name another workspace's files.
+     */
+    public static function composeImagesDirectory(string $teamId): string
+    {
+        return 'email-attachments/'.$teamId;
+    }
+
     protected static function newFactory(): EmailAttachmentFactory
     {
         return EmailAttachmentFactory::new();

--- a/packages/EmailIntegration/src/Services/EmailInlineImageEmbedder.php
+++ b/packages/EmailIntegration/src/Services/EmailInlineImageEmbedder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services;
 
+use App\Models\User;
 use DOMDocument;
 use DOMElement;
 use Illuminate\Support\Facades\Storage;
@@ -18,6 +19,9 @@ final readonly class EmailInlineImageEmbedder
      * serve through {@see EmailHtmlSanitizer}. Composer images are stored on disk
      * with a `data-id` path while the HTML still references a transient URL.
      *
+     * Image `src` and `data-id` are client-controlled, so disk files are copied
+     * only when they live in the sender's tenant compose directory and are images.
+     *
      * @param  array<int, string>  $attachmentPaths
      * @param  array<string, string>  $attachmentFileNames
      * @param  array<string, array{is_inline?: bool, content_id?: ?string}>  $attachmentAttributes
@@ -29,6 +33,7 @@ final readonly class EmailInlineImageEmbedder
      * }
      */
     public function embed(
+        User $user,
         string $bodyHtml,
         array $attachmentPaths = [],
         array $attachmentFileNames = [],
@@ -78,7 +83,7 @@ final readonly class EmailInlineImageEmbedder
             }
 
             if (! isset($contentIdsBySourcePath[$sourcePath])) {
-                $embedded = $this->copyToEmailAttachmentDisk($sourcePath);
+                $embedded = $this->copyToEmailAttachmentDisk($user, $sourcePath);
 
                 if ($embedded === null) {
                     continue;
@@ -154,71 +159,111 @@ final readonly class EmailInlineImageEmbedder
             return $src;
         }
 
-        $path = parse_url($src, PHP_URL_PATH);
-
-        if (! is_string($path) || $path === '') {
-            return null;
-        }
-
-        if (str_starts_with($path, '/storage/')) {
-            return ltrim(mb_substr($path, mb_strlen('/storage/')), '/');
-        }
-
-        return ltrim($path, '/');
+        return null;
     }
 
     /**
      * @return array{path: string, filename: string, content_id: string}|null
      */
-    private function copyToEmailAttachmentDisk(string $sourcePath): ?array
+    private function copyToEmailAttachmentDisk(User $user, string $sourcePath): ?array
     {
         if (str_starts_with(mb_strtolower($sourcePath), 'data:image/')) {
             return $this->copyDataUri($sourcePath);
         }
 
-        foreach ($this->candidateDisks() as $diskName) {
-            $disk = Storage::disk($diskName);
+        $path = $this->authorizedStoragePath($user, $sourcePath);
 
-            foreach ($this->candidateStoragePaths($sourcePath) as $path) {
-                if (! $disk->exists($path)) {
-                    continue;
-                }
-
-                $mimeType = $disk->mimeType($path) ?: 'application/octet-stream';
-                $extension = $this->extensionFromMimeType($mimeType);
-                $destination = 'email-attachments/'.Str::ulid().'.'.$extension;
-
-                Storage::disk(EmailAttachment::DISK)->put($destination, $disk->get($path) ?? '');
-
-                if (! Storage::disk(EmailAttachment::DISK)->exists($destination)) {
-                    continue;
-                }
-
-                return [
-                    'path' => $destination,
-                    'filename' => basename($path) !== '' && basename($path) !== '.'
-                        ? basename($path)
-                        : "inline.{$extension}",
-                    'content_id' => $this->makeContentId(),
-                ];
-            }
+        if ($path === null) {
+            return null;
         }
 
-        return null;
+        $disk = Storage::disk(EmailAttachment::DISK);
+
+        if (! $disk->exists($path)) {
+            return null;
+        }
+
+        $mimeType = $disk->mimeType($path);
+
+        if (! is_string($mimeType) || ! str_starts_with(mb_strtolower($mimeType), 'image/')) {
+            return null;
+        }
+
+        $extension = $this->extensionFromMimeType($mimeType);
+        $destination = 'email-attachments/'.Str::ulid().'.'.$extension;
+
+        Storage::disk(EmailAttachment::DISK)->put($destination, $disk->get($path) ?? '');
+
+        if (! Storage::disk(EmailAttachment::DISK)->exists($destination)) {
+            return null;
+        }
+
+        return [
+            'path' => $destination,
+            'filename' => basename($path) !== '' && basename($path) !== '.'
+                ? basename($path)
+                : "inline.{$extension}",
+            'content_id' => $this->makeContentId(),
+        ];
     }
 
-    /**
-     * @return list<string>
-     */
-    private function candidateStoragePaths(string $sourcePath): array
+    private function authorizedStoragePath(User $user, string $sourcePath): ?string
     {
-        $paths = [$sourcePath];
+        $path = $this->normalizeStoragePath($sourcePath);
 
-        if (! str_contains($sourcePath, '/')) {
-            $paths[] = 'email-attachments/'.$sourcePath;
+        if ($path === null) {
+            return null;
         }
 
-        return array_values(array_unique($paths));
+        $teamId = $user->current_team_id;
+
+        if (blank($teamId)) {
+            return null;
+        }
+
+        $directory = EmailAttachment::composeImagesDirectory((string) $teamId).'/';
+
+        if (! str_starts_with($path, $directory)) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function normalizeStoragePath(string $sourcePath): ?string
+    {
+        $path = str_replace('\\', '/', $sourcePath);
+        $path = ltrim($path, '/');
+
+        if ($path === '' || str_contains($path, "\0")) {
+            return null;
+        }
+
+        $segments = [];
+
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+
+            if ($segment === '..') {
+                if ($segments === []) {
+                    return null;
+                }
+
+                array_pop($segments);
+
+                continue;
+            }
+
+            $segments[] = $segment;
+        }
+
+        if ($segments === []) {
+            return null;
+        }
+
+        return implode('/', $segments);
     }
 
     /**
@@ -247,21 +292,6 @@ final readonly class EmailInlineImageEmbedder
             'filename' => "inline.{$extension}",
             'content_id' => $this->makeContentId(),
         ];
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function candidateDisks(): array
-    {
-        $defaultDisk = (string) config('filament.default_filesystem_disk', 'local');
-
-        return array_values(array_unique([
-            EmailAttachment::DISK,
-            'public',
-            $defaultDisk,
-            $defaultDisk === 'local' ? 'public' : 'local',
-        ]));
     }
 
     private function makeContentId(): string

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -322,6 +322,28 @@ it('persists rich editor inline images when sending from the composer', function
         ->and($email->body?->body_html)->not->toContain($uploadId);
 });
 
+it('does not attach a storage file referenced by a composer image url', function (): void {
+    Storage::fake(EmailAttachment::DISK);
+    Storage::fake('public');
+    Storage::disk('public')->put('private.csv', 'secret,tenant,data');
+    Storage::disk(EmailAttachment::DISK)->put('private.csv', 'secret,tenant,data');
+
+    Livewire::test(EmailComposer::class)
+        ->dispatch('composer:open')
+        ->set('to', ['lead@example.com'])
+        ->set('subject', 'Composer image leak')
+        ->set('bodyHtml', '<p><img src="/storage/private.csv"></p><p>Hello</p>')
+        ->call('send')
+        ->assertHasNoErrors()
+        ->assertSet('isOpen', false);
+
+    $email = Email::query()->where('subject', 'Composer image leak')->sole();
+
+    expect($email->attachments)->toHaveCount(0)
+        ->and($email->body?->body_html)->not->toContain('cid:')
+        ->and(Storage::disk('public')->get('private.csv'))->toBe('secret,tenant,data');
+});
+
 it('links a queued send to the record the composer was opened from', function (): void {
     $person = People::factory()->recycle([$this->user, $this->user->currentTeam])->create();
 

--- a/tests/Feature/EmailIntegration/SendEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/SendEmailActionTest.php
@@ -17,6 +17,7 @@ use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailThread;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceFactoryInterface;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
@@ -25,7 +26,7 @@ use Relaticle\EmailIntegration\Services\EmailSendingService;
 use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-mutates(SendEmailAction::class, LinkEmailAction::class, EmailSendingService::class, ConnectedAccount::class, EmailInlineImageEmbedder::class);
+mutates(SendEmailAction::class, LinkEmailAction::class, EmailSendingService::class, ConnectedAccount::class, EmailInlineImageEmbedder::class, EmailAttachment::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->withTeam()->create();
@@ -534,7 +535,7 @@ it('embeds rich editor inline images from data-id paths when queuing send', func
     Storage::fake('local');
     Storage::fake('public');
 
-    $editorPath = 'email-attachments/editor-image.png';
+    $editorPath = EmailAttachment::composeImagesDirectory((string) $this->user->current_team_id).'/editor-image.png';
     Storage::disk('local')->put($editorPath, 'png-bytes');
 
     $email = app(SendEmailAction::class)->execute([
@@ -563,4 +564,99 @@ it('embeds rich editor inline images from data-id paths when queuing send', func
     expect($sanitized)
         ->toContain(route('email-attachments.inline', ['attachment' => $attachment->getKey()]))
         ->not->toContain('cid:'.$attachment->content_id);
+});
+
+it('does not attach a storage file referenced by a composer image url', function (): void {
+    Storage::fake('local');
+    Storage::fake('public');
+    Storage::disk('public')->put('private.csv', 'secret,tenant,data');
+    Storage::disk('local')->put('private.csv', 'secret,tenant,data');
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Inline image',
+        'body_html' => '<p>See below</p><img src="/storage/private.csv">',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]);
+
+    expect($email->attachments)->toHaveCount(0)
+        ->and($email->body?->body_html)->toContain('/storage/private.csv')
+        ->and($email->body?->body_html)->not->toContain('cid:');
+});
+
+it('does not attach another tenant image named in composer html', function (): void {
+    Storage::fake('local');
+
+    $otherUser = User::factory()->withTeam()->create();
+    $foreignPath = EmailAttachment::composeImagesDirectory((string) $otherUser->current_team_id).'/secret.png';
+    Storage::disk('local')->put($foreignPath, 'png-bytes-from-other-tenant');
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Inline image',
+        'body_html' => '<p>See below</p><img data-id="'.$foreignPath.'" src="">',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]);
+
+    expect($email->attachments)->toHaveCount(0)
+        ->and($email->body?->body_html)->toContain($foreignPath)
+        ->and(Storage::disk('local')->get($foreignPath))->toBe('png-bytes-from-other-tenant');
+});
+
+it('does not attach a non-image file from the tenant compose directory', function (): void {
+    Storage::fake('local');
+
+    $path = EmailAttachment::composeImagesDirectory((string) $this->user->current_team_id).'/notes.csv';
+    Storage::disk('local')->put($path, 'secret,csv,contents');
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Inline image',
+        'body_html' => '<p>See below</p><img data-id="'.$path.'" src="">',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]);
+
+    expect($email->attachments)->toHaveCount(0)
+        ->and($email->body?->body_html)->toContain($path);
+});
+
+it('does not follow path traversal in composer image data-id', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('private.csv', 'secret,tenant,data');
+
+    $path = EmailAttachment::composeImagesDirectory((string) $this->user->current_team_id).'/../../private.csv';
+
+    $email = app(SendEmailAction::class)->execute([
+        'connected_account_id' => $this->account->id,
+        'subject' => 'Inline image',
+        'body_html' => '<p>See below</p><img data-id="'.$path.'" src="">',
+        'to' => [['email' => 'recipient@example.com', 'name' => null]],
+        'cc' => [],
+        'bcc' => [],
+        'in_reply_to_email_id' => null,
+        'creation_source' => EmailCreationSource::COMPOSE,
+        'privacy_tier' => EmailPrivacyTier::FULL,
+        'batch_id' => null,
+    ]);
+
+    expect($email->attachments)->toHaveCount(0)
+        ->and(Storage::disk('local')->get('private.csv'))->toBe('secret,tenant,data');
 });


### PR DESCRIPTION
## Summary
- Composer HTML could name an arbitrary storage path in an image tag, and the embedder copied that file into outbound attachments with no tenant or MIME check.
- Inline images now embed only from `email-attachments/{current_team_id}/` on the attachment disk, and only when the file is an `image/` type. `/storage/...` URLs are no longer treated as disk paths.
- `data:image/` URIs and quoted `cid:` images are unchanged.

## Test plan
- [x] Send a message with a real RichEditor inline image and confirm it still embeds as a CID attachment.
- [x] Confirm `<img src="/storage/private.csv">` does not attach the file.
- [x] Confirm a known path into another workspace's compose directory is not copied.
- [x] `php artisan test --compact tests/Feature/EmailIntegration/SendEmailActionTest.php tests/Feature/EmailIntegration/EmailComposerTest.php`