### PR TITLE
Remove inbox and sent folders from record email lists

### DIFF
--- a/lang/en/filament/pages/record-emails.php
+++ b/lang/en/filament/pages/record-emails.php
@@ -45,6 +45,7 @@ return [
         ],
     ],
     'empty' => [
+        'heading' => 'No emails',
         'description' => 'This record doesn\'t have any emails, or they may be hidden due to permissions.',
         'compose' => 'Compose email',
     ],

--- a/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/BaseRecordEmailsPage.php
@@ -42,8 +42,6 @@ abstract class BaseRecordEmailsPage extends Page
 
     protected string $view = 'filament.pages.record-emails';
 
-    public EmailFolder $folder = EmailFolder::All;
-
     public ?string $selectedEmailId = null;
 
     public string $search = '';
@@ -53,13 +51,8 @@ abstract class BaseRecordEmailsPage extends Page
         $this->record = $this->resolveRecord($record);
     }
 
-    /**
-     * A send from this record belongs on All, not Inbox. Inbox is inbound only
-     * and would hide the just-queued outbound copy.
-     */
     public function showQueuedSendOnRecord(?string $emailId = null): void
     {
-        $this->folder = EmailFolder::All;
         $this->search = '';
 
         if (filled($emailId)) {
@@ -136,12 +129,6 @@ abstract class BaseRecordEmailsPage extends Page
                     ->where('status', EmailAccessRequestStatus::PENDING),
             ])
             ->withGlobalScope('visible', new VisibleEmailScope($user));
-
-        if ($this->folder === EmailFolder::Sent) {
-            $query->sent();
-        } elseif ($this->folder === EmailFolder::Inbox) {
-            $query->inbox();
-        }
 
         if (filled($this->search)) {
             resolve(EmailSearchService::class)->applyToQuery($query, $user, $this->search);
@@ -254,16 +241,6 @@ abstract class BaseRecordEmailsPage extends Page
         unset($this->inboxUnreadCount);
     }
 
-    public function setFolder(string $folder): void
-    {
-        $this->folder = EmailFolder::from($folder);
-        $this->search = '';
-        $this->selectedEmailId = null;
-        $this->resetPage();
-        unset($this->emails);
-        $this->dispatch('composer:dismiss-inline');
-    }
-
     public function deselectEmail(): void
     {
         $this->selectedEmailId = null;
@@ -324,7 +301,7 @@ abstract class BaseRecordEmailsPage extends Page
         /** @var Company|Opportunity|People $record */
         $record = $this->getRecord();
 
-        $count = resolve(MarkAllEmailsAsReadAction::class)->execute($this->authUser(), $this->folder, $record);
+        $count = resolve(MarkAllEmailsAsReadAction::class)->execute($this->authUser(), EmailFolder::All, $record);
 
         unset($this->inboxUnreadCount, $this->emails);
 

--- a/resources/views/components/emails/list-empty.blade.php
+++ b/resources/views/components/emails/list-empty.blade.php
@@ -1,6 +1,5 @@
 @props([
     'search',
-    'folder',
     'canCompose' => false,
 ])
 
@@ -14,7 +13,7 @@
         />
     @else
         <x-filament::empty-state
-            :heading="__('filament/pages/email-inbox.list_empty.'.$folder->value)"
+            :heading="__('filament/pages/record-emails.empty.heading')"
             :description="__('filament/pages/record-emails.empty.description')"
             icon="heroicon-o-envelope"
             icon-color="gray"

--- a/resources/views/filament/pages/record-emails.blade.php
+++ b/resources/views/filament/pages/record-emails.blade.php
@@ -35,16 +35,8 @@
              which opens the global floating composer. --}}
         <div class="flex shrink-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b border-gray-200 bg-gray-50/80 px-4 py-3 dark:border-gray-800 dark:bg-gray-900 sm:px-6">
 
-            <div class="flex min-w-0 flex-1 items-center gap-3">
-                <div class="flex shrink-0 items-center gap-1 rounded-lg bg-gray-100 p-1 ring-1 ring-gray-950/5 dark:bg-gray-950 dark:ring-white/10">
-                    <x-emails.folder-tab :grow="false" folder="all"   :active="$folder->value === 'all'"   icon="heroicon-o-squares-2x2"   :label="__('filament/pages/email-inbox.folders.all')" />
-                    <x-emails.folder-tab :grow="false" folder="inbox" :active="$folder->value === 'inbox'" icon="heroicon-o-inbox"          :label="__('filament/pages/email-inbox.folders.inbox')" />
-                    <x-emails.folder-tab :grow="false" folder="sent"  :active="$folder->value === 'sent'"  icon="heroicon-o-paper-airplane" :label="__('filament/pages/email-inbox.folders.sent')" />
-                </div>
-
-                <div class="min-w-[10rem] max-w-sm flex-1">
-                    <x-emails.search-bar :search="$search" :framed="false" />
-                </div>
+            <div class="min-w-[10rem] max-w-sm flex-1">
+                <x-emails.search-bar :search="$search" :framed="false" />
             </div>
         </div>
 
@@ -55,7 +47,6 @@
                 <x-emails.list-empty
                     class="flex-1"
                     :search="$search"
-                    :folder="$folder"
                     :can-compose="$this->hasActiveConnectedAccount"
                 />
             @endforelse

--- a/tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php
+++ b/tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php
@@ -9,7 +9,6 @@ use App\Models\People;
 use App\Models\Team;
 use App\Models\User;
 use Filament\Facades\Filament;
-use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Pages\BaseRecordEmailsPage;
 use Relaticle\EmailIntegration\Filament\RelationManagers\BaseEmailsRelationManager;
@@ -187,13 +186,11 @@ it('hides the duplicate table row from the emails relation manager', function ()
         ->assertTableActionHidden('requestAccess', $this->ownerCopy);
 });
 
-it('moves the record mailbox to All after a compose send', function (): void {
+it('opens the sent email on the record mailbox after compose', function (): void {
     $this->actingAs($this->owner);
     Filament::setTenant($this->team);
 
     livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
-        ->set('folder', EmailFolder::Inbox)
         ->dispatch('composer:sent', emailId: $this->ownerCopy->getKey())
-        ->assertSet('folder', EmailFolder::All)
         ->assertSet('selectedEmailId', $this->ownerCopy->getKey());
 });

--- a/tests/Feature/EmailIntegration/RecordEmailsMarkAllReadTest.php
+++ b/tests/Feature/EmailIntegration/RecordEmailsMarkAllReadTest.php
@@ -6,7 +6,6 @@ use App\Filament\Resources\PeopleResource\Pages\PeopleEmailsPage;
 use App\Models\People;
 use App\Models\User;
 use Filament\Facades\Filament;
-use Relaticle\EmailIntegration\Enums\EmailFolder;
 use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
@@ -77,7 +76,6 @@ it('marks all of the record\'s unread emails as read', function (): void {
 
 it('opens with the list only, and reads an email into the overlay until it is closed', function (): void {
     $page = livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
-        ->assertSet('folder', EmailFolder::All)
         ->assertSet('selectedEmailId', null);
 
     expect($page->instance()->selectedEmail())->toBeNull();


### PR DESCRIPTION
## Summary
- Drop All / Inbox / Sent folder tabs on Person, Company, and Opportunity email pages
- Show one chronological list with search only, matching Attio-style CRM context
- Simplify empty state copy and remove folder-specific query filtering

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/RecordEmailsMarkAllReadTest.php tests/Feature/EmailIntegration/DuplicateSyncedEmailAccessTest.php tests/Feature/EmailIntegration/RecordEmailsEmptyStateTest.php`
- [x] Open a Person / Company / Opportunity → Emails and confirm folder tabs are gone
- [x] Confirm shared teammate mail appears in the list without folder ambiguity
- [x] Compose from a record and confirm the sent email opens in the reader