### PR TITLE
Add workspace email forwarding address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,11 @@ EMAIL_SUMMARY_MODEL=gpt-4o-mini
 # the whole mailbox. Self-hosters can set this to keep the first sync small.
 # EMAIL_SYNC_INITIAL_DAYS=90
 
+# Workspace email forwarding (Postmark inbound). Point MX for EMAIL_INBOUND_DOMAIN
+# at Postmark and set the webhook URL to /webhooks/inbound/postmark/{token}.
+# EMAIL_INBOUND_DOMAIN=inbound.example.com
+# POSTMARK_INBOUND_WEBHOOK_SECRET=
+
 # Self-hosted AI via Ollama. Set OLLAMA_MODEL to a tool-calling-capable model
 # tag (e.g. qwen3:14b) to add it to the chat model picker.
 # OLLAMA_BASE_URL=http://localhost:11434

--- a/config/email-integration.php
+++ b/config/email-integration.php
@@ -76,6 +76,11 @@ return [
      * Outbox & deliverability defaults. Per-account values on
      * connected_accounts.{hourly,daily}_send_limit override these.
      */
+    'inbound' => [
+        'domain' => env('EMAIL_INBOUND_DOMAIN', 'inbound.relaticle.test'),
+        'webhook_secret' => env('POSTMARK_INBOUND_WEBHOOK_SECRET', ''),
+    ],
+
     'outbox' => [
         'defaults' => [
             'hourly_send_limit' => (int) env('EMAIL_DEFAULT_HOURLY_LIMIT', 12),

--- a/database/factories/TeamForwardingAddressFactory.php
+++ b/database/factories/TeamForwardingAddressFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
+
+/**
+ * @extends Factory<TeamForwardingAddress>
+ */
+final class TeamForwardingAddressFactory extends Factory
+{
+    protected $model = TeamForwardingAddress::class;
+
+    public function definition(): array
+    {
+        return [
+            'team_id' => Team::factory(),
+            'local_part' => fake()->unique()->slug(2),
+        ];
+    }
+}

--- a/database/factories/UserForwardingBlocklistFactory.php
+++ b/database/factories/UserForwardingBlocklistFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
+use Relaticle\EmailIntegration\Models\UserForwardingBlocklist;
+
+/**
+ * @extends Factory<UserForwardingBlocklist>
+ */
+final class UserForwardingBlocklistFactory extends Factory
+{
+    protected $model = UserForwardingBlocklist::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'team_id' => Team::factory(),
+            'type' => EmailBlocklistType::EMAIL,
+            'value' => fake()->unique()->safeEmail(),
+        ];
+    }
+}

--- a/database/factories/UserForwardingFullAccessGrantFactory.php
+++ b/database/factories/UserForwardingFullAccessGrantFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Relaticle\EmailIntegration\Models\UserForwardingFullAccessGrant;
+
+/**
+ * @extends Factory<UserForwardingFullAccessGrant>
+ */
+final class UserForwardingFullAccessGrantFactory extends Factory
+{
+    protected $model = UserForwardingFullAccessGrant::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'team_id' => Team::factory(),
+            'granted_user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/UserForwardingSettingsFactory.php
+++ b/database/factories/UserForwardingSettingsFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\UserForwardingSettings;
+
+/**
+ * @extends Factory<UserForwardingSettings>
+ */
+final class UserForwardingSettingsFactory extends Factory
+{
+    protected $model = UserForwardingSettings::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'team_id' => Team::factory(),
+            'sharing_tier' => EmailPrivacyTier::METADATA_ONLY,
+        ];
+    }
+}

--- a/database/migrations/2026_09_12_082957_create_forwarding_address_tables_and_nullable_connected_account_on_emails.php
+++ b/database/migrations/2026_09_12_082957_create_forwarding_address_tables_and_nullable_connected_account_on_emails.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('team_forwarding_addresses', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->teams();
+            $table->string('local_part', 100);
+            $table->timestamps();
+
+            $table->unique('team_id');
+            $table->unique('local_part');
+        });
+
+        Schema::create('user_forwarding_settings', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+            $table->teams();
+            $table->string('sharing_tier', 30)->default('metadata_only');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'team_id']);
+        });
+
+        Schema::create('user_forwarding_full_access_grants', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+            $table->teams();
+            $table->foreignUlid('granted_user_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'team_id', 'granted_user_id'], 'user_forwarding_grants_unique');
+        });
+
+        Schema::create('user_forwarding_blocklists', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+            $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+            $table->teams();
+            $table->string('type', 20);
+            $table->string('value');
+            $table->timestamps();
+
+            $table->index(['user_id', 'team_id', 'type', 'value']);
+        });
+
+        Schema::table('emails', function (Blueprint $table): void {
+            $table->dropForeign(['connected_account_id']);
+            $table->dropUnique('idx_emails_account_msgid');
+        });
+
+        Schema::table('emails', function (Blueprint $table): void {
+            $table->ulid('connected_account_id')->nullable()->change();
+        });
+
+        Schema::table('emails', function (Blueprint $table): void {
+            $table->foreign('connected_account_id')
+                ->references('id')
+                ->on('connected_accounts')
+                ->nullOnDelete();
+
+            $table->unique(['connected_account_id', 'rfc_message_id'], 'idx_emails_account_msgid');
+        });
+
+        DB::statement(
+            'CREATE UNIQUE INDEX emails_inbound_message_id_unique ON emails (team_id, user_id, rfc_message_id) WHERE connected_account_id IS NULL AND rfc_message_id IS NOT NULL'
+        );
+    }
+};

--- a/lang/en/filament/pages/email-accounts.php
+++ b/lang/en/filament/pages/email-accounts.php
@@ -75,6 +75,10 @@ return [
             'heading' => 'Connected accounts',
             'description' => 'We take your privacy very seriously. Read our <a href=":url" target="_blank" class="underline">Privacy Policy</a>.',
         ],
+        'forwarding' => [
+            'heading' => 'Forwarding address',
+            'description' => 'Forward or BCC specific emails into your workspace without syncing your whole inbox.',
+        ],
     ],
     'synced_at' => 'Synced :time',
     'in_sync' => 'In Sync',

--- a/lang/en/filament/pages/forwarding-address-settings.php
+++ b/lang/en/filament/pages/forwarding-address-settings.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Forwarding address',
+    'subheading' => 'Update your forwarding permissions and settings.',
+    'learn_more' => 'Learn more about forwarding email',
+    'tabs' => [
+        'general' => 'General',
+        'blocklist' => 'Mailbox-only blocklist',
+    ],
+    'visibility' => [
+        'label' => 'Email visibility',
+        'hint' => 'Choose how much of your forwarded email your workspace can see by default. You will always see everything in your own mailbox.',
+    ],
+    'full_access' => [
+        'label' => 'Individuals with full access',
+        'hint' => 'They see all your forwarded email, including attachments, even if your workspace default is more restrictive.',
+        'add' => 'Add person',
+        'only_when_restricted' => 'Only applicable if metadata only or subject line and metadata is selected.',
+        'empty' => 'No teammates added yet.',
+        'notifications' => [
+            'added' => 'Teammate added.',
+            'removed' => 'Teammate removed.',
+        ],
+    ],
+    'blocklist' => [
+        'label' => 'Blocklist',
+        'hint' => 'Emails from blocklisted domains and addresses will not appear in Relaticle.',
+        'empty_heading' => 'No emails or domains yet',
+        'empty_description' => 'Emails from blocklisted domains and addresses will not appear in Relaticle.',
+        'add' => 'Add to blocklist',
+        'emails_label' => 'Email addresses',
+        'emails_placeholder' => 'Add an email address',
+        'emails_after_label' => 'Separate multiple addresses with commas.',
+        'domains_label' => 'Domains',
+        'domains_placeholder' => 'Add a domain',
+        'domains_after_label' => 'Separate multiple domains with commas.',
+        'notifications' => [
+            'added' => 'Blocklist updated.',
+            'deleted' => 'Entry removed.',
+        ],
+    ],
+    'notifications' => [
+        'saved' => 'Forwarding settings saved.',
+    ],
+];

--- a/lang/en/filament/pages/forwarding-address.php
+++ b/lang/en/filament/pages/forwarding-address.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'section_heading' => 'Forwarding address',
+    'learn_more' => 'Learn more about forwarding email',
+    'sublabel' => 'Email',
+    'status_ready' => 'Ready',
+    'options' => 'Options',
+    'copied' => 'Address copied.',
+];

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -74,5 +74,34 @@
         </div>
     </x-filament::section>
 
+    <x-filament::section
+        class="mt-8"
+        :heading="__('filament/pages/email-accounts.sections.forwarding.heading')"
+        :description="__('filament/pages/email-accounts.sections.forwarding.description')"
+    >
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 px-4 py-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10">
+            <div class="flex min-w-0 flex-1 items-center gap-3">
+                <x-brand.logomark size="sm" class="shrink-0 text-gray-950 dark:text-white" />
+
+                <div class="min-w-0">
+                    <p class="truncate text-sm font-medium text-gray-950 dark:text-white">
+                        {{ $this->forwardingAddress->fullAddress() }}
+                    </p>
+                    <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                        {{ __('filament/pages/forwarding-address.sublabel') }}
+                    </p>
+                </div>
+            </div>
+
+            <div class="flex shrink-0 items-center gap-3">
+                <x-filament::badge color="success" icon="heroicon-m-bolt">
+                    {{ __('filament/pages/email-accounts.in_sync') }}
+                </x-filament::badge>
+
+                {{ $this->forwardingActions() }}
+            </div>
+        </div>
+    </x-filament::section>
+
     <x-filament-actions::modals />
 </x-filament-panels::page>

--- a/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/email-accounts.blade.php
@@ -8,24 +8,18 @@
         </p>
     </div>
 
-    <x-filament::section
-        :heading="__('filament/pages/email-accounts.sections.connected.heading')"
-        :description="$this->connectedSectionDescription()"
-    >
-        <div
-            class="space-y-3"
-            @if ($this->isImportingAnyAccount())
-                wire:poll.5s="refreshAccounts"
-            @endif
-        >
+    <x-filament::section :heading="__('filament/pages/email-accounts.sections.connected.heading')" :description="$this->connectedSectionDescription()">
+        <div class="space-y-3" @if ($this->isImportingAnyAccount()) wire:poll.5s="refreshAccounts" @endif>
             @foreach ($this->connectedAccounts as $account)
-                <div wire:key="email-account-{{ $account->getKey() }}" class="flex flex-col gap-3 rounded-lg border border-gray-200 px-4 py-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10">
+                <div wire:key="email-account-{{ $account->getKey() }}"
+                    class="flex flex-col gap-3 rounded-lg border border-gray-200 px-4 py-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10">
                     <div class="flex min-w-0 flex-1 items-center gap-3">
                         <x-filament::icon :icon="$account->provider->getIcon()" class="h-5 w-5 shrink-0 text-gray-400" />
 
                         <div class="min-w-0">
                             <div class="flex items-center gap-2">
-                                <p class="truncate text-sm font-medium text-gray-950 dark:text-white">{{ $account->email_address }}</p>
+                                <p class="truncate text-sm font-medium text-gray-950 dark:text-white">
+                                    {{ $account->email_address }}</p>
                                 @if ($account->is_default)
                                     <x-filament::badge color="info" class="shrink-0">
                                         {{ __('filament/pages/email-accounts.default_badge') }}
@@ -42,21 +36,17 @@
                         @if ($account->showsSyncProgress())
                             <x-email-integration::importing-badge :account="$account" :icon="$this->syncingIcon()" />
                         @else
-                            <x-filament::badge
-                                :color="$account->status->getColor()"
-                                :icon="$account->isActive() ? 'heroicon-m-bolt' : 'heroicon-m-exclamation-triangle'"
-                                :title="$account->last_synced_at ? __('filament/pages/email-accounts.synced_at', ['time' => $account->last_synced_at->diffForHumans()]) : null"
-                            >
+                            <x-filament::badge :color="$account->status->getColor()" :icon="$account->isActive() ? 'heroicon-m-bolt' : 'heroicon-m-exclamation-triangle'" :title="$account->last_synced_at
+                                ? __('filament/pages/email-accounts.synced_at', [
+                                    'time' => $account->last_synced_at->diffForHumans(),
+                                ])
+                                : null">
                                 {{ $account->isActive() ? __('filament/pages/email-accounts.in_sync') : $account->status->getLabel() }}
                             </x-filament::badge>
                         @endif
-                        @if (! $account->hasSend())
-                            <x-filament::badge
-                                color="warning"
-                                icon="heroicon-m-exclamation-triangle"
-                                :tooltip="__('filament/pages/email-accounts.send_missing_tooltip')"
-                                :aria-label="__('filament/pages/email-accounts.send_missing_tooltip')"
-                            />
+                        @if (!$account->hasSend())
+                            <x-filament::badge color="warning" icon="heroicon-m-exclamation-triangle" :tooltip="__('filament/pages/email-accounts.send_missing_tooltip')"
+                                :aria-label="__('filament/pages/email-accounts.send_missing_tooltip')" />
                         @endif
 
                         {{ $this->accountActions($account->getKey()) }}
@@ -64,7 +54,8 @@
                 </div>
             @endforeach
 
-            <div class="flex flex-wrap items-center justify-center gap-3 rounded-xl border border-dashed border-gray-300 p-4 dark:border-white/20">
+            <div
+                class="flex flex-wrap items-center justify-center gap-3 rounded-xl border border-dashed border-gray-300 p-4 dark:border-white/20">
                 {{ $this->connectGmailAction }}
 
                 @if ($this->connectAzureAction->isVisible())
@@ -74,12 +65,9 @@
         </div>
     </x-filament::section>
 
-    <x-filament::section
-        class="mt-8"
-        :heading="__('filament/pages/email-accounts.sections.forwarding.heading')"
-        :description="__('filament/pages/email-accounts.sections.forwarding.description')"
-    >
-        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 px-4 py-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10">
+    <x-filament::section class="mt-8" :heading="__('filament/pages/email-accounts.sections.forwarding.heading')" :description="__('filament/pages/email-accounts.sections.forwarding.description')">
+        <div
+            class="flex flex-col gap-3 rounded-lg border border-gray-200 px-4 py-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10">
             <div class="flex min-w-0 flex-1 items-center gap-3">
                 <x-brand.logomark size="sm" class="shrink-0 text-gray-950 dark:text-white" />
 

--- a/packages/EmailIntegration/resources/views/filament/pages/forwarding-address-settings.blade.php
+++ b/packages/EmailIntegration/resources/views/filament/pages/forwarding-address-settings.blade.php
@@ -1,0 +1,28 @@
+<x-filament-panels::page>
+    <x-filament::breadcrumbs :breadcrumbs="$this->getBreadcrumbs()" />
+
+    <x-filament::section class="-mt-2">
+        <x-slot name="heading">
+            <div class="flex items-start gap-3">
+                <x-brand.logomark size="sm" class="mt-0.5 shrink-0 text-gray-950 dark:text-white" />
+
+                <div class="min-w-0">
+                    <p class="truncate text-base font-semibold text-gray-950 dark:text-white">
+                        {{ $this->forwardingAddress->fullAddress() }}
+                    </p>
+                    <p class="mt-1 text-sm font-normal text-gray-500 dark:text-gray-400">
+                        {{ __('filament/pages/forwarding-address-settings.subheading') }}
+                    </p>
+                </div>
+            </div>
+        </x-slot>
+
+        {{ $this->form }}
+
+        <div class="mt-6 flex justify-end">
+            {{ $this->saveAction }}
+        </div>
+    </x-filament::section>
+
+    <x-filament-actions::modals />
+</x-filament-panels::page>

--- a/packages/EmailIntegration/resources/views/forms/forwarding-blocklist-entries.blade.php
+++ b/packages/EmailIntegration/resources/views/forms/forwarding-blocklist-entries.blade.php
@@ -1,0 +1,49 @@
+<div class="space-y-3">
+    @if ($this->blocklistEntries->isNotEmpty())
+        <div class="overflow-hidden rounded-xl border border-gray-200 dark:border-white/10">
+            <table class="w-full table-auto divide-y divide-gray-200 text-sm dark:divide-white/10">
+                <thead class="bg-gray-50 dark:bg-white/5">
+                    <tr>
+                        <th class="px-4 py-3 text-start font-medium text-gray-950 dark:text-white">
+                            {{ __('filament/pages/email-privacy-settings.blocklist.table.address') }}
+                        </th>
+                        <th class="px-4 py-3 text-start font-medium text-gray-950 dark:text-white">
+                            {{ __('filament/pages/email-privacy-settings.blocklist.table.type') }}
+                        </th>
+                        <th class="px-4 py-3 text-end font-medium text-gray-950 dark:text-white">
+                            <span class="sr-only">{{ __('filament/pages/email-privacy-settings.blocklist.table.actions') }}</span>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-white/10">
+                    @foreach ($this->blocklistEntries as $entry)
+                        <tr wire:key="forwarding-blocklist-entry-{{ $entry->getKey() }}">
+                            <td class="px-4 py-3 font-medium text-gray-950 dark:text-white">
+                                {{ $entry->value }}
+                            </td>
+                            <td class="px-4 py-3 text-gray-600 dark:text-gray-300">
+                                {{ $entry->type->getLabel() }}
+                            </td>
+                            <td class="px-4 py-3 text-end">
+                                {{ ($this->deleteBlocklistEntryAction)(['entry_id' => $entry->getKey()]) }}
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @else
+        <div class="rounded-xl border border-dashed border-gray-300 px-6 py-10 text-center dark:border-white/20">
+            <p class="text-sm font-medium text-gray-950 dark:text-white">
+                {{ $emptyHeading }}
+            </p>
+            <p class="mx-auto mt-1 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+                {{ $emptyDescription }}
+            </p>
+
+            <div class="mt-4 flex justify-center">
+                {{ $this->addBlocklistAction }}
+            </div>
+        </div>
+    @endif
+</div>

--- a/packages/EmailIntegration/resources/views/forms/forwarding-full-access-hint.blade.php
+++ b/packages/EmailIntegration/resources/views/forms/forwarding-full-access-hint.blade.php
@@ -1,0 +1,3 @@
+<div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600 dark:border-white/10 dark:bg-white/5 dark:text-gray-300">
+    {{ __('filament/pages/forwarding-address-settings.full_access.only_when_restricted') }}
+</div>

--- a/packages/EmailIntegration/routes/web.php
+++ b/packages/EmailIntegration/routes/web.php
@@ -14,7 +14,7 @@ Route::middleware(['web'])->group(function (): void {
         ->whereIn('provider', ['gmail', 'azure'])
         ->middleware('throttle:120,1');
 
-    Route::post('webhooks/inbound/postmark', InboundEmailWebhookController::class)
+    Route::post('webhooks/inbound/postmark/{token}', InboundEmailWebhookController::class)
         ->name('inbound-email.webhook')
         ->middleware('throttle:120,1');
 });

--- a/packages/EmailIntegration/routes/web.php
+++ b/packages/EmailIntegration/routes/web.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Route;
 use Relaticle\EmailIntegration\Controllers\CalendarPushWebhookController;
 use Relaticle\EmailIntegration\Controllers\CallbackController as EmailCallbackController;
+use Relaticle\EmailIntegration\Controllers\InboundEmailWebhookController;
 use Relaticle\EmailIntegration\Controllers\RedirectController as EmailRedirectController;
 
 Route::middleware(['web'])->group(function (): void {
     Route::post('webhooks/calendar/{provider}', CalendarPushWebhookController::class)
         ->name('calendar-push.webhook')
         ->whereIn('provider', ['gmail', 'azure'])
+        ->middleware('throttle:120,1');
+
+    Route::post('webhooks/inbound/postmark', InboundEmailWebhookController::class)
+        ->name('inbound-email.webhook')
         ->middleware('throttle:120,1');
 });
 

--- a/packages/EmailIntegration/src/Actions/DeleteUserForwardingBlocklistEntryAction.php
+++ b/packages/EmailIntegration/src/Actions/DeleteUserForwardingBlocklistEntryAction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Models\UserForwardingBlocklist;
+
+final readonly class DeleteUserForwardingBlocklistEntryAction
+{
+    public function execute(User $user, Team $team, string $entryId): void
+    {
+        UserForwardingBlocklist::query()
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $team->getKey())
+            ->whereKey($entryId)
+            ->firstOrFail()
+            ->delete();
+    }
+}

--- a/packages/EmailIntegration/src/Actions/EnsureTeamForwardingAddressAction.php
+++ b/packages/EmailIntegration/src/Actions/EnsureTeamForwardingAddressAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
+
+final readonly class EnsureTeamForwardingAddressAction
+{
+    public function execute(Team $team): TeamForwardingAddress
+    {
+        $existing = TeamForwardingAddress::query()
+            ->where('team_id', $team->getKey())
+            ->first();
+
+        if ($existing instanceof TeamForwardingAddress) {
+            return $existing;
+        }
+
+        $localPart = $this->uniqueLocalPart((string) $team->slug);
+
+        return TeamForwardingAddress::query()->create([
+            'team_id' => $team->getKey(),
+            'local_part' => $localPart,
+        ]);
+    }
+
+    private function uniqueLocalPart(string $base): string
+    {
+        $candidate = Str::lower(Str::slug($base));
+
+        if ($candidate === '') {
+            $candidate = 'workspace';
+        }
+
+        if (! TeamForwardingAddress::query()->where('local_part', $candidate)->exists()) {
+            return $candidate;
+        }
+
+        $suffix = 2;
+
+        while (TeamForwardingAddress::query()->where('local_part', "{$candidate}-{$suffix}")->exists()) {
+            $suffix++;
+        }
+
+        return "{$candidate}-{$suffix}";
+    }
+}

--- a/packages/EmailIntegration/src/Actions/LinkEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/LinkEmailAction.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Relaticle\EmailIntegration\Enums\ContactCreationMode;
+use Relaticle\EmailIntegration\Enums\EmailCreationSource;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\PublicEmailDomain;
@@ -126,11 +127,14 @@ final readonly class LinkEmailAction
                 )
                 ->first();
 
+            $canAutoCreateRecords = $connectedAccount !== null
+                || $email->creation_source === EmailCreationSource::BCC_INBOUND;
+
             $wouldCreatePerson = ! $person
                 && ! $email->is_internal
                 && ! $isAutomatedSender
                 && ! $suppressCreate
-                && $connectedAccount
+                && $canAutoCreateRecords
                 && $team
                 && $this->shouldCreatePerson($team, $participant->email_address, $email);
 

--- a/packages/EmailIntegration/src/Actions/ResolveForwardingSenderAction.php
+++ b/packages/EmailIntegration/src/Actions/ResolveForwardingSenderAction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
+
+final readonly class ResolveForwardingSenderAction
+{
+    public function execute(Team $team, string $fromAddress): ?User
+    {
+        $normalized = strtolower(trim($fromAddress));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        $member = $team->allUsers()
+            ->first(fn (User $user): bool => strtolower($user->email) === $normalized);
+
+        if ($member instanceof User) {
+            return $member;
+        }
+
+        $accountOwnerId = ConnectedAccount::query()
+            ->where('team_id', $team->getKey())
+            ->whereRaw('lower(email_address) = ?', [$normalized])
+            ->value('user_id');
+
+        if (! is_string($accountOwnerId) || $accountOwnerId === '') {
+            return null;
+        }
+
+        return $team->allUsers()->firstWhere('id', $accountOwnerId);
+    }
+}

--- a/packages/EmailIntegration/src/Actions/SeedForwardingFullAccessSharesAction.php
+++ b/packages/EmailIntegration/src/Actions/SeedForwardingFullAccessSharesAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\UserForwardingFullAccessGrant;
+use Relaticle\EmailIntegration\Services\EmailSharingService;
+
+final readonly class SeedForwardingFullAccessSharesAction
+{
+    public function __construct(private EmailSharingService $sharing) {}
+
+    public function execute(Email $email, User $owner, Team $team): void
+    {
+        $granteeIds = UserForwardingFullAccessGrant::query()
+            ->where('user_id', $owner->getKey())
+            ->where('team_id', $team->getKey())
+            ->pluck('granted_user_id');
+
+        foreach ($granteeIds as $granteeId) {
+            $grantee = $team->allUsers()->firstWhere('id', $granteeId);
+
+            if (! $grantee instanceof User) {
+                continue;
+            }
+
+            $this->sharing->shareEmail($email, $owner, $grantee, EmailPrivacyTier::FULL);
+        }
+    }
+}

--- a/packages/EmailIntegration/src/Actions/StoreInboundEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreInboundEmailAction.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Data\InboundEmailData;
+use Relaticle\EmailIntegration\Enums\EmailCategory;
+use Relaticle\EmailIntegration\Enums\EmailCreationSource;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Enums\EmailStatus;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailAttachment;
+use Relaticle\EmailIntegration\Models\EmailLabel;
+use Relaticle\EmailIntegration\Models\EmailParticipant;
+use Relaticle\EmailIntegration\Services\ForwardingBlocklistMatcher;
+use Relaticle\EmailIntegration\Services\ForwardingPrivacyService;
+use Symfony\Component\Mime\MimeTypes;
+use Throwable;
+
+final readonly class StoreInboundEmailAction
+{
+    public function __construct(
+        private ForwardingBlocklistMatcher $blocklist,
+        private ForwardingPrivacyService $privacy,
+        private SeedForwardingFullAccessSharesAction $seedShares,
+    ) {}
+
+    public function execute(User $user, Team $team, InboundEmailData $data): ?Email
+    {
+        $participantAddresses = array_map(
+            fn (array $participant): string => strtolower($participant['email_address']),
+            $data->participants,
+        );
+
+        if ($this->blocklist->isBlocked($user->getKey(), $team->getKey(), $participantAddresses)) {
+            return null;
+        }
+
+        if ($data->rfcMessageId !== '' && Email::query()
+            ->withoutGlobalScopes()
+            ->where('team_id', $team->getKey())
+            ->where('user_id', $user->getKey())
+            ->whereNull('connected_account_id')
+            ->where('rfc_message_id', $data->rfcMessageId)
+            ->exists()) {
+            return null;
+        }
+
+        $storedPaths = [];
+
+        try {
+            return DB::transaction(function () use ($user, $team, $data, $participantAddresses, &$storedPaths): Email {
+                $email = Email::query()->create([
+                    'team_id' => $team->getKey(),
+                    'user_id' => $user->getKey(),
+                    'connected_account_id' => null,
+                    'rfc_message_id' => $data->rfcMessageId,
+                    'provider_message_id' => null,
+                    'thread_id' => null,
+                    'in_reply_to' => $data->inReplyTo,
+                    'subject' => $data->subject,
+                    'snippet' => $data->snippet,
+                    'sent_at' => $data->sentAt,
+                    'direction' => EmailDirection::INBOUND,
+                    'folder' => EmailFolder::Inbox,
+                    'status' => EmailStatus::SYNCED,
+                    'privacy_tier' => $this->privacy->defaultSharingTier($user, $team),
+                    'has_attachments' => $data->attachments !== [],
+                    'creation_source' => EmailCreationSource::BCC_INBOUND,
+                ]);
+
+                $email->body()->create([
+                    'body_text' => $data->bodyText,
+                    'body_html' => $data->bodyHtml,
+                ]);
+
+                foreach ($data->participants as $participant) {
+                    EmailParticipant::query()->create([
+                        'email_id' => $email->getKey(),
+                        'email_address' => strtolower($participant['email_address']),
+                        'name' => $participant['name'],
+                        'role' => $participant['role'],
+                    ]);
+                }
+
+                foreach ($data->attachments as $attachment) {
+                    $path = $this->storeAttachment($email, $attachment, $storedPaths);
+
+                    EmailAttachment::query()->create([
+                        'email_id' => $email->getKey(),
+                        'filename' => $this->filename($attachment),
+                        'mime_type' => $attachment['mime_type'],
+                        'size' => $attachment['size'],
+                        'content_id' => $attachment['content_id'],
+                        'is_inline' => filled($attachment['content_id']),
+                        'provider_attachment_id' => null,
+                        'storage_path' => $path,
+                    ]);
+                }
+
+                $teamUserEmails = $team->allUsers()
+                    ->pluck('email')
+                    ->map(fn (string $address): string => strtolower($address));
+
+                $isInternal = $participantAddresses !== []
+                    && collect($participantAddresses)->every(
+                        fn (string $address): bool => $teamUserEmails->contains($address),
+                    );
+
+                $email->updateQuietly(['is_internal' => $isInternal]);
+
+                EmailLabel::query()->create([
+                    'email_id' => $email->getKey(),
+                    'label' => ($isInternal ? EmailCategory::Personal : EmailCategory::Other)->value,
+                    'source' => 'system',
+                    'created_at' => now(),
+                ]);
+
+                $this->seedShares->execute($email, $user, $team);
+                resolve(LinkEmailAction::class)->execute($email);
+
+                return $email;
+            });
+        } catch (Throwable $exception) {
+            Storage::disk(EmailAttachment::DISK)->delete($storedPaths);
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @param  array{filename: string|null, mime_type: string|null, size: int, content_id: string|null, content: string}  $attachment
+     * @param  list<string>  $storedPaths
+     */
+    private function storeAttachment(Email $email, array $attachment, array &$storedPaths): ?string
+    {
+        if ($attachment['content'] === '') {
+            return null;
+        }
+
+        $binary = base64_decode($attachment['content'], true);
+
+        if ($binary === false) {
+            return null;
+        }
+
+        $path = "email-attachments/{$email->team_id}/".Str::ulid();
+
+        Storage::disk(EmailAttachment::DISK)->put($path, $binary);
+        $storedPaths[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * @param  array{filename: string|null, mime_type: string|null, size: int, content_id: string|null, content: string}  $attachment
+     */
+    private function filename(array $attachment): string
+    {
+        if (filled($attachment['filename'])) {
+            return (string) $attachment['filename'];
+        }
+
+        $extensions = MimeTypes::getDefault()->getExtensions((string) ($attachment['mime_type'] ?? 'application/octet-stream'));
+
+        return 'attachment.'.($extensions[0] ?? 'bin');
+    }
+}

--- a/packages/EmailIntegration/src/Actions/StoreInboundEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreInboundEmailAction.php
@@ -6,6 +6,7 @@ namespace Relaticle\EmailIntegration\Actions;
 
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -128,6 +129,10 @@ final readonly class StoreInboundEmailAction
 
                 return $email;
             });
+        } catch (UniqueConstraintViolationException) {
+            Storage::disk(EmailAttachment::DISK)->delete($storedPaths);
+
+            return null;
         } catch (Throwable $exception) {
             Storage::disk(EmailAttachment::DISK)->delete($storedPaths);
 

--- a/packages/EmailIntegration/src/Actions/UpdateUserForwardingBlocklistAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateUserForwardingBlocklistAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Models\UserForwardingBlocklist;
+
+final readonly class UpdateUserForwardingBlocklistAction
+{
+    /**
+     * @param  list<array{type: string, value: string}>  $blocklist
+     */
+    public function execute(User $user, Team $team, array $blocklist): void
+    {
+        UserForwardingBlocklist::query()
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $team->getKey())
+            ->delete();
+
+        foreach ($blocklist as $entry) {
+            $value = strtolower(trim((string) $entry['value']));
+
+            if ($value === '') {
+                continue;
+            }
+
+            UserForwardingBlocklist::query()->create([
+                'user_id' => $user->getKey(),
+                'team_id' => $team->getKey(),
+                'type' => $entry['type'],
+                'value' => $value,
+            ]);
+        }
+    }
+}

--- a/packages/EmailIntegration/src/Actions/UpdateUserForwardingFullAccessGrantsAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateUserForwardingFullAccessGrantsAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Models\UserForwardingFullAccessGrant;
+
+final readonly class UpdateUserForwardingFullAccessGrantsAction
+{
+    /**
+     * @param  list<string>  $grantedUserIds
+     */
+    public function execute(User $user, Team $team, array $grantedUserIds): void
+    {
+        $memberIds = $team->allUsers()->modelKeys();
+        $validIds = array_values(array_intersect($grantedUserIds, $memberIds));
+        $validIds = array_values(array_filter(
+            $validIds,
+            fn (string $id): bool => $id !== $user->getKey(),
+        ));
+
+        UserForwardingFullAccessGrant::query()
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $team->getKey())
+            ->delete();
+
+        foreach ($validIds as $granteeId) {
+            UserForwardingFullAccessGrant::query()->create([
+                'user_id' => $user->getKey(),
+                'team_id' => $team->getKey(),
+                'granted_user_id' => $granteeId,
+            ]);
+        }
+    }
+}

--- a/packages/EmailIntegration/src/Actions/UpdateUserForwardingFullAccessGrantsAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateUserForwardingFullAccessGrantsAction.php
@@ -15,7 +15,10 @@ final readonly class UpdateUserForwardingFullAccessGrantsAction
      */
     public function execute(User $user, Team $team, array $grantedUserIds): void
     {
-        $memberIds = $team->allUsers()->modelKeys();
+        $memberIds = $team->allUsers()
+            ->pluck('id')
+            ->map(fn (mixed $id): string => (string) $id)
+            ->all();
         $validIds = array_values(array_intersect($grantedUserIds, $memberIds));
         $validIds = array_values(array_filter(
             $validIds,

--- a/packages/EmailIntegration/src/Actions/UpdateUserForwardingSettingsAction.php
+++ b/packages/EmailIntegration/src/Actions/UpdateUserForwardingSettingsAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Actions;
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\UserForwardingSettings;
+
+final readonly class UpdateUserForwardingSettingsAction
+{
+    public function execute(User $user, Team $team, EmailPrivacyTier $sharingTier): UserForwardingSettings
+    {
+        return UserForwardingSettings::query()->updateOrCreate([
+            'user_id' => $user->getKey(),
+            'team_id' => $team->getKey(),
+        ], [
+            'sharing_tier' => $sharingTier->value,
+        ]);
+    }
+}

--- a/packages/EmailIntegration/src/Controllers/InboundEmailWebhookController.php
+++ b/packages/EmailIntegration/src/Controllers/InboundEmailWebhookController.php
@@ -6,25 +6,30 @@ namespace Relaticle\EmailIntegration\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Jobs\ProcessInboundEmailJob;
 
 final readonly class InboundEmailWebhookController
 {
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, string $token): Response
     {
-        if (! $this->authorized($request)) {
+        if (! $this->authorized($token)) {
             return response('', Response::HTTP_FORBIDDEN);
         }
 
         /** @var array<string, mixed> $payload */
         $payload = $request->json()->all();
 
-        dispatch(new ProcessInboundEmailJob($payload));
+        $path = 'inbound-webhooks/'.Str::ulid().'.json';
+        Storage::disk('local')->put($path, json_encode($payload, JSON_THROW_ON_ERROR));
+
+        dispatch(new ProcessInboundEmailJob($path));
 
         return response('', Response::HTTP_OK);
     }
 
-    private function authorized(Request $request): bool
+    private function authorized(string $token): bool
     {
         $secret = (string) config('email-integration.inbound.webhook_secret');
 
@@ -32,8 +37,6 @@ final readonly class InboundEmailWebhookController
             return app()->environment('local', 'testing');
         }
 
-        $provided = $request->header('X-Relaticle-Inbound-Secret');
-
-        return is_string($provided) && hash_equals($secret, $provided);
+        return hash_equals($secret, $token);
     }
 }

--- a/packages/EmailIntegration/src/Controllers/InboundEmailWebhookController.php
+++ b/packages/EmailIntegration/src/Controllers/InboundEmailWebhookController.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Relaticle\EmailIntegration\Jobs\ProcessInboundEmailJob;
+
+final readonly class InboundEmailWebhookController
+{
+    public function __invoke(Request $request): Response
+    {
+        if (! $this->authorized($request)) {
+            return response('', Response::HTTP_FORBIDDEN);
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $request->json()->all();
+
+        dispatch(new ProcessInboundEmailJob($payload));
+
+        return response('', Response::HTTP_OK);
+    }
+
+    private function authorized(Request $request): bool
+    {
+        $secret = (string) config('email-integration.inbound.webhook_secret');
+
+        if ($secret === '') {
+            return app()->environment('local', 'testing');
+        }
+
+        $provided = $request->header('X-Relaticle-Inbound-Secret');
+
+        return is_string($provided) && hash_equals($secret, $provided);
+    }
+}

--- a/packages/EmailIntegration/src/Data/InboundEmailData.php
+++ b/packages/EmailIntegration/src/Data/InboundEmailData.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Data;
+
+use Carbon\CarbonInterface;
+
+final readonly class InboundEmailData
+{
+    /**
+     * @param  list<array{email_address: string, name: string|null, role: string}>  $participants
+     * @param  list<array{filename: string|null, mime_type: string|null, size: int, content_id: string|null, content: string}>  $attachments
+     */
+    public function __construct(
+        public string $rfcMessageId,
+        public ?string $inReplyTo,
+        public string $subject,
+        public ?string $snippet,
+        public ?CarbonInterface $sentAt,
+        public ?string $bodyText,
+        public ?string $bodyHtml,
+        public array $participants,
+        public array $attachments,
+    ) {}
+}

--- a/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/EmailAccountsPage.php
@@ -4,18 +4,24 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Pages;
 
+use App\Models\Team;
+use App\Models\User;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Support\Enums\Size;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\HtmlString;
+use Relaticle\EmailIntegration\Actions\EnsureTeamForwardingAddressAction;
 use Relaticle\EmailIntegration\Filament\Clusters\EmailSettings;
 use Relaticle\EmailIntegration\Filament\Concerns\HasConnectedAccountActions;
 use Relaticle\EmailIntegration\Filament\Concerns\HasConnectMailboxActions;
 use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
 
 final class EmailAccountsPage extends Page
 {
@@ -69,6 +75,7 @@ final class EmailAccountsPage extends Page
         return [
             self::getRouteName(),
             EmailAccountSettingsPage::getRouteName(),
+            ForwardingAddressSettingsPage::getRouteName(),
         ];
     }
 
@@ -77,11 +84,21 @@ final class EmailAccountsPage extends Page
      */
     public Collection $connectedAccounts;
 
-    public function mount(): void
+    public TeamForwardingAddress $forwardingAddress;
+
+    public function mount(EnsureTeamForwardingAddressAction $ensureForwardingAddress): void
     {
         $this->sendSuccessNotification();
         $this->sendErrorNotification();
         $this->connectedAccounts = $this->getAccounts();
+
+        /** @var User $user */
+        $user = auth()->user();
+        $team = $user->currentTeam;
+
+        abort_unless($team instanceof Team, 404);
+
+        $this->forwardingAddress = $ensureForwardingAddress->execute($team);
     }
 
     /**
@@ -90,6 +107,23 @@ final class EmailAccountsPage extends Page
     private function getAccounts(): Collection
     {
         return $this->ownedAccountsQuery()->defaultFirst()->get();
+    }
+
+    public function forwardingActions(): ActionGroup
+    {
+        return ActionGroup::make([
+            Action::make('forwardingSettings')
+                ->label(__('filament/pages/email-accounts.actions.manage'))
+                ->icon('heroicon-o-cog-6-tooth')
+                ->color('gray')
+                ->size(Size::Small)
+                ->url(fn (): string => ForwardingAddressSettingsPage::getUrl()),
+        ])
+            ->label(__('filament/pages/email-accounts.actions.manage'))
+            ->icon(Heroicon::EllipsisVertical)
+            ->color('gray')
+            ->size(Size::Small)
+            ->iconButton();
     }
 
     public function editSettingsAction(): Action

--- a/packages/EmailIntegration/src/Filament/Pages/ForwardingAddressSettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/ForwardingAddressSettingsPage.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Filament\Pages;
+
+use App\Models\Team;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\ViewField;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Components\View;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
+use Filament\Support\Enums\Size;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
+use Relaticle\EmailIntegration\Actions\EnsureTeamForwardingAddressAction;
+use Relaticle\EmailIntegration\Actions\UpdateUserForwardingBlocklistAction;
+use Relaticle\EmailIntegration\Actions\UpdateUserForwardingFullAccessGrantsAction;
+use Relaticle\EmailIntegration\Actions\UpdateUserForwardingSettingsAction;
+use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Clusters\EmailSettings;
+use Relaticle\EmailIntegration\Filament\Concerns\HasEmailFeatureFlag;
+use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
+use Relaticle\EmailIntegration\Models\UserForwardingBlocklist;
+use Relaticle\EmailIntegration\Models\UserForwardingFullAccessGrant;
+use Relaticle\EmailIntegration\Models\UserForwardingSettings;
+
+/**
+ * @property-read Schema $form
+ * @property-read Collection<int, UserForwardingBlocklist> $blocklistEntries
+ */
+final class ForwardingAddressSettingsPage extends Page implements HasSchemas
+{
+    use HasEmailFeatureFlag, InteractsWithSchemas;
+
+    protected string $view = 'email-integration::filament.pages.forwarding-address-settings';
+
+    protected static ?string $cluster = EmailSettings::class;
+
+    protected static ?string $slug = 'forwarding';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected ?string $heading = '';
+
+    protected ?string $subheading = null;
+
+    public TeamForwardingAddress $forwardingAddress;
+
+    /** @var array<string, mixed>|null */
+    public ?array $data = [];
+
+    public function mount(EnsureTeamForwardingAddressAction $ensureForwardingAddress): void
+    {
+        /** @var User $user */
+        $user = auth()->user();
+        $team = $user->currentTeam;
+
+        abort_unless($team instanceof Team, 404);
+
+        $this->forwardingAddress = $ensureForwardingAddress->execute($team);
+
+        $settings = UserForwardingSettings::query()
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $team->getKey())
+            ->first();
+
+        $this->form->fill([
+            'sharing_tier' => $settings?->sharing_tier->value ?? EmailPrivacyTier::METADATA_ONLY->value,
+            'full_access_user_ids' => UserForwardingFullAccessGrant::query()
+                ->where('user_id', $user->getKey())
+                ->where('team_id', $team->getKey())
+                ->pluck('granted_user_id')
+                ->all(),
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getBreadcrumbs(): array
+    {
+        return [
+            EmailAccountsPage::getUrl() => (string) __('filament/pages/email-accounts.navigation_label'),
+            '' => $this->forwardingAddress->fullAddress(),
+        ];
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Tabs::make()
+                    ->tabs([
+                        Tab::make(__('filament/pages/forwarding-address-settings.tabs.general'))
+                            ->icon(Heroicon::OutlinedCog6Tooth)
+                            ->schema([
+                                Section::make(__('filament/pages/forwarding-address-settings.visibility.label'))
+                                    ->description(__('filament/pages/forwarding-address-settings.visibility.hint'))
+                                    ->compact()
+                                    ->schema([$this->sharingTierField()]),
+                                Section::make(__('filament/pages/forwarding-address-settings.full_access.label'))
+                                    ->description(__('filament/pages/forwarding-address-settings.full_access.hint'))
+                                    ->compact()
+                                    ->schema([
+                                        Select::make('full_access_user_ids')
+                                            ->label(__('filament/pages/forwarding-address-settings.full_access.add'))
+                                            ->multiple()
+                                            ->searchable()
+                                            ->options(fn (): array => $this->teammateOptions())
+                                            ->native(false),
+                                        View::make('email-integration::forms.forwarding-full-access-hint'),
+                                    ]),
+                            ]),
+                        Tab::make(__('filament/pages/forwarding-address-settings.tabs.blocklist'))
+                            ->icon(Heroicon::OutlinedNoSymbol)
+                            ->schema([
+                                Section::make(__('filament/pages/forwarding-address-settings.blocklist.label'))
+                                    ->description(__('filament/pages/forwarding-address-settings.blocklist.hint'))
+                                    ->compact()
+                                    ->headerActions([
+                                        fn (): Action => $this->addBlocklistAction()
+                                            ->visible(fn (): bool => $this->blocklistEntries->isNotEmpty()),
+                                    ])
+                                    ->schema([$this->blocklistField()]),
+                            ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    private function sharingTierField(): ViewField
+    {
+        return ViewField::make('sharing_tier')
+            ->view('email-integration::forms.sharing-tier-cards')
+            ->viewData([
+                'ariaLabel' => __('filament/pages/forwarding-address-settings.visibility.label'),
+            ]);
+    }
+
+    private function blocklistField(): View
+    {
+        return View::make('email-integration::forms.forwarding-blocklist-entries')
+            ->viewData([
+                'emptyHeading' => __('filament/pages/forwarding-address-settings.blocklist.empty_heading'),
+                'emptyDescription' => __('filament/pages/forwarding-address-settings.blocklist.empty_description'),
+            ]);
+    }
+
+    /**
+     * @return array<int, TagsInput>
+     */
+    private function blocklistFormSchema(): array
+    {
+        return [
+            TagsInput::make('blocklist_emails')
+                ->label(__('filament/pages/forwarding-address-settings.blocklist.emails_label'))
+                ->placeholder(__('filament/pages/forwarding-address-settings.blocklist.emails_placeholder'))
+                ->afterLabel(__('filament/pages/forwarding-address-settings.blocklist.emails_after_label'))
+                ->nestedRecursiveRules(['email', 'max:255']),
+            TagsInput::make('blocklist_domains')
+                ->label(__('filament/pages/forwarding-address-settings.blocklist.domains_label'))
+                ->placeholder(__('filament/pages/forwarding-address-settings.blocklist.domains_placeholder'))
+                ->afterLabel(__('filament/pages/forwarding-address-settings.blocklist.domains_after_label'))
+                ->nestedRecursiveRules(['regex:/^[a-z0-9.-]+\.[a-z]{2,}$/i', 'max:255']),
+        ];
+    }
+
+    public function addBlocklistAction(): Action
+    {
+        return Action::make('addBlocklist')
+            ->label(__('filament/pages/forwarding-address-settings.blocklist.add'))
+            ->icon(Heroicon::OutlinedPlus)
+            ->size(Size::Small)
+            ->modalHeading(__('filament/pages/forwarding-address-settings.blocklist.add'))
+            ->schema($this->blocklistFormSchema())
+            ->action(function (array $data, UpdateUserForwardingBlocklistAction $updateBlocklist): void {
+                [$emails, $domains] = $this->mergedBlocklistValues(
+                    $data['blocklist_emails'] ?? [],
+                    $data['blocklist_domains'] ?? [],
+                );
+
+                $updateBlocklist->execute($this->authUser(), $this->team(), $this->blocklistRowsFromValues($emails, $domains));
+
+                unset($this->blocklistEntries);
+
+                Notification::make()
+                    ->success()
+                    ->title(__('filament/pages/forwarding-address-settings.blocklist.notifications.added'))
+                    ->send();
+            });
+    }
+
+    public function deleteBlocklistEntryAction(): Action
+    {
+        return Action::make('deleteBlocklistEntry')
+            ->label(__('filament/pages/email-signatures.actions.delete'))
+            ->icon(Heroicon::OutlinedTrash)
+            ->color('danger')
+            ->size(Size::Small)
+            ->iconButton()
+            ->requiresConfirmation()
+            ->action(function (array $arguments): void {
+                UserForwardingBlocklist::query()
+                    ->where('user_id', $this->authUser()->getKey())
+                    ->where('team_id', $this->team()->getKey())
+                    ->whereKey((string) $arguments['entry_id'])
+                    ->firstOrFail()
+                    ->delete();
+
+                unset($this->blocklistEntries);
+
+                Notification::make()
+                    ->success()
+                    ->title(__('filament/pages/forwarding-address-settings.blocklist.notifications.deleted'))
+                    ->send();
+            });
+    }
+
+    public function saveAction(): Action
+    {
+        return Action::make('save')
+            ->label(__('filament/pages/email-accounts.settings.submit_label'))
+            ->action(function (
+                UpdateUserForwardingSettingsAction $updateSettings,
+                UpdateUserForwardingFullAccessGrantsAction $updateGrants,
+            ): void {
+                $data = $this->form->getState();
+                $tier = EmailPrivacyTier::from((string) ($data['sharing_tier'] ?? EmailPrivacyTier::METADATA_ONLY->value));
+
+                $updateSettings->execute($this->authUser(), $this->team(), $tier);
+                $granteeIds = array_values(array_map(strval(...), $data['full_access_user_ids'] ?? []));
+
+                $updateGrants->execute(
+                    $this->authUser(),
+                    $this->team(),
+                    $granteeIds,
+                );
+
+                Notification::make()
+                    ->success()
+                    ->title(__('filament/pages/forwarding-address-settings.notifications.saved'))
+                    ->send();
+            });
+    }
+
+    /**
+     * @return Collection<int, UserForwardingBlocklist>
+     */
+    #[Computed]
+    public function blocklistEntries(): Collection
+    {
+        return UserForwardingBlocklist::query()
+            ->where('user_id', $this->authUser()->getKey())
+            ->where('team_id', $this->team()->getKey())
+            ->latest()
+            ->get();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function teammateOptions(): array
+    {
+        return $this->team()
+            ->allUsers()
+            ->reject(fn (User $member): bool => $member->getKey() === $this->authUser()->getKey())
+            ->mapWithKeys(fn (User $member): array => [$member->getKey() => $member->name])
+            ->all();
+    }
+
+    /**
+     * @param  array<int, string>  $newEmails
+     * @param  array<int, string>  $newDomains
+     * @return array{0: array<int, string>, 1: array<int, string>}
+     */
+    private function mergedBlocklistValues(array $newEmails, array $newDomains): array
+    {
+        $emails = $this->blocklistEntries
+            ->where('type', EmailBlocklistType::EMAIL)
+            ->pluck('value')
+            ->merge($newEmails)
+            ->map(fn (mixed $value): string => strtolower(trim((string) $value)))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $domains = $this->blocklistEntries
+            ->where('type', EmailBlocklistType::DOMAIN)
+            ->pluck('value')
+            ->merge($newDomains)
+            ->map(fn (mixed $value): string => strtolower(trim((string) $value)))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        return [$emails, $domains];
+    }
+
+    /**
+     * @param  array<int, string>  $emails
+     * @param  array<int, string>  $domains
+     * @return list<array{type: string, value: string}>
+     */
+    private function blocklistRowsFromValues(array $emails, array $domains): array
+    {
+        return array_values(collect([
+            EmailBlocklistType::EMAIL->value => $emails,
+            EmailBlocklistType::DOMAIN->value => $domains,
+        ])
+            ->flatMap(fn (array $values, string $type): array => array_map(
+                fn (string $value): array => ['type' => $type, 'value' => $value],
+                $values,
+            ))
+            ->all());
+    }
+
+    private function authUser(): User
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user;
+    }
+
+    private function team(): Team
+    {
+        $team = $this->authUser()->currentTeam;
+
+        abort_unless($team instanceof Team, 404);
+
+        return $team;
+    }
+}

--- a/packages/EmailIntegration/src/Filament/Pages/ForwardingAddressSettingsPage.php
+++ b/packages/EmailIntegration/src/Filament/Pages/ForwardingAddressSettingsPage.php
@@ -23,6 +23,7 @@ use Filament\Support\Enums\Size;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
+use Relaticle\EmailIntegration\Actions\DeleteUserForwardingBlocklistEntryAction;
 use Relaticle\EmailIntegration\Actions\EnsureTeamForwardingAddressAction;
 use Relaticle\EmailIntegration\Actions\UpdateUserForwardingBlocklistAction;
 use Relaticle\EmailIntegration\Actions\UpdateUserForwardingFullAccessGrantsAction;
@@ -211,13 +212,12 @@ final class ForwardingAddressSettingsPage extends Page implements HasSchemas
             ->size(Size::Small)
             ->iconButton()
             ->requiresConfirmation()
-            ->action(function (array $arguments): void {
-                UserForwardingBlocklist::query()
-                    ->where('user_id', $this->authUser()->getKey())
-                    ->where('team_id', $this->team()->getKey())
-                    ->whereKey((string) $arguments['entry_id'])
-                    ->firstOrFail()
-                    ->delete();
+            ->action(function (array $arguments, DeleteUserForwardingBlocklistEntryAction $deleteEntry): void {
+                $deleteEntry->execute(
+                    $this->authUser(),
+                    $this->team(),
+                    (string) $arguments['entry_id'],
+                );
 
                 unset($this->blocklistEntries);
 

--- a/packages/EmailIntegration/src/Jobs/ProcessInboundEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/ProcessInboundEmailJob.php
@@ -8,27 +8,33 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Storage;
 use Relaticle\EmailIntegration\Actions\ResolveForwardingSenderAction;
 use Relaticle\EmailIntegration\Actions\StoreInboundEmailAction;
 use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
+use Relaticle\EmailIntegration\Services\PostmarkInboundAuthenticationValidator;
 use Relaticle\EmailIntegration\Services\PostmarkInboundParser;
+use Throwable;
 
 final class ProcessInboundEmailJob implements ShouldQueue
 {
     use Queueable;
 
-    /**
-     * @param  array<string, mixed>  $payload
-     */
-    public function __construct(private readonly array $payload) {}
+    public function __construct(private readonly string $payloadPath) {}
 
     public function handle(
         PostmarkInboundParser $parser,
+        PostmarkInboundAuthenticationValidator $authenticator,
         ResolveForwardingSenderAction $resolveSender,
         StoreInboundEmailAction $store,
     ): void {
-        /** @var list<string> $recipientAddresses */
-        $recipientAddresses = array_values($parser->recipientAddresses($this->payload));
+        $payload = $this->payload();
+
+        if ($payload === null) {
+            return;
+        }
+
+        $recipientAddresses = $parser->recipientAddresses($payload);
 
         if ($recipientAddresses === []) {
             return;
@@ -46,10 +52,14 @@ final class ProcessInboundEmailJob implements ShouldQueue
             return;
         }
 
-        $data = $parser->parse($this->payload);
+        $data = $parser->parse($payload);
         $fromAddress = collect($data->participants)->firstWhere('role', 'from')['email_address'] ?? null;
 
         if (! is_string($fromAddress) || $fromAddress === '') {
+            return;
+        }
+
+        if (! $authenticator->passes($payload, $fromAddress)) {
             return;
         }
 
@@ -60,6 +70,34 @@ final class ProcessInboundEmailJob implements ShouldQueue
         }
 
         $store->execute($sender, $team, $data);
+
+        Storage::disk('local')->delete($this->payloadPath);
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        Storage::disk('local')->delete($this->payloadPath);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function payload(): ?array
+    {
+        if (! Storage::disk('local')->exists($this->payloadPath)) {
+            return null;
+        }
+
+        $contents = Storage::disk('local')->get($this->payloadPath);
+
+        if (! is_string($contents) || $contents === '') {
+            return null;
+        }
+
+        /** @var array<string, mixed>|null $payload */
+        $payload = json_decode($contents, true);
+
+        return is_array($payload) ? $payload : null;
     }
 
     /**

--- a/packages/EmailIntegration/src/Jobs/ProcessInboundEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/ProcessInboundEmailJob.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Relaticle\EmailIntegration\Jobs;
 
 use App\Models\Team;
+use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Relaticle\EmailIntegration\Actions\ResolveForwardingSenderAction;
@@ -54,7 +55,7 @@ final class ProcessInboundEmailJob implements ShouldQueue
 
         $sender = $resolveSender->execute($team, $fromAddress);
 
-        if ($sender === null) {
+        if (! $sender instanceof User) {
             return;
         }
 

--- a/packages/EmailIntegration/src/Jobs/ProcessInboundEmailJob.php
+++ b/packages/EmailIntegration/src/Jobs/ProcessInboundEmailJob.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Jobs;
+
+use App\Models\Team;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Relaticle\EmailIntegration\Actions\ResolveForwardingSenderAction;
+use Relaticle\EmailIntegration\Actions\StoreInboundEmailAction;
+use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
+use Relaticle\EmailIntegration\Services\PostmarkInboundParser;
+
+final class ProcessInboundEmailJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(private readonly array $payload) {}
+
+    public function handle(
+        PostmarkInboundParser $parser,
+        ResolveForwardingSenderAction $resolveSender,
+        StoreInboundEmailAction $store,
+    ): void {
+        /** @var list<string> $recipientAddresses */
+        $recipientAddresses = array_values($parser->recipientAddresses($this->payload));
+
+        if ($recipientAddresses === []) {
+            return;
+        }
+
+        $forwardingAddress = $this->resolveForwardingAddress($recipientAddresses);
+
+        if (! $forwardingAddress instanceof TeamForwardingAddress) {
+            return;
+        }
+
+        $team = Team::query()->find($forwardingAddress->team_id);
+
+        if (! $team instanceof Team) {
+            return;
+        }
+
+        $data = $parser->parse($this->payload);
+        $fromAddress = collect($data->participants)->firstWhere('role', 'from')['email_address'] ?? null;
+
+        if (! is_string($fromAddress) || $fromAddress === '') {
+            return;
+        }
+
+        $sender = $resolveSender->execute($team, $fromAddress);
+
+        if ($sender === null) {
+            return;
+        }
+
+        $store->execute($sender, $team, $data);
+    }
+
+    /**
+     * @param  list<string>  $recipientAddresses
+     */
+    private function resolveForwardingAddress(array $recipientAddresses): ?TeamForwardingAddress
+    {
+        $domain = strtolower((string) config('email-integration.inbound.domain'));
+
+        foreach ($recipientAddresses as $address) {
+            $localPart = $this->localPart($address, $domain);
+
+            if ($localPart === null) {
+                continue;
+            }
+
+            $match = TeamForwardingAddress::query()
+                ->where('local_part', $localPart)
+                ->first();
+
+            if ($match instanceof TeamForwardingAddress) {
+                return $match;
+            }
+        }
+
+        return null;
+    }
+
+    private function localPart(string $address, string $domain): ?string
+    {
+        $normalized = strtolower(trim($address));
+        $suffix = '@'.$domain;
+
+        if (! str_ends_with($normalized, $suffix)) {
+            return null;
+        }
+
+        $localPart = substr($normalized, 0, -strlen($suffix));
+
+        return $localPart !== '' ? $localPart : null;
+    }
+}

--- a/packages/EmailIntegration/src/Models/Email.php
+++ b/packages/EmailIntegration/src/Models/Email.php
@@ -41,7 +41,7 @@ use Relaticle\EmailIntegration\Support\EmailHtmlSanitizer;
  * @property string $id
  * @property string $team_id
  * @property string $user_id
- * @property string $connected_account_id
+ * @property string|null $connected_account_id
  * @property string|null $rfc_message_id
  * @property string|null $provider_message_id
  * @property string|null $thread_id

--- a/packages/EmailIntegration/src/Models/Scopes/ActiveAccountScope.php
+++ b/packages/EmailIntegration/src/Models/Scopes/ActiveAccountScope.php
@@ -27,6 +27,9 @@ final readonly class ActiveAccountScope implements Scope
      */
     public function apply(Builder $builder, Model $model): void
     {
-        $builder->whereHas('connectedAccount');
+        $builder->where(function (Builder $query): void {
+            $query->whereNull('connected_account_id')
+                ->orWhereHas('connectedAccount');
+        });
     }
 }

--- a/packages/EmailIntegration/src/Models/Scopes/VisibleEmailScope.php
+++ b/packages/EmailIntegration/src/Models/Scopes/VisibleEmailScope.php
@@ -99,6 +99,20 @@ final readonly class VisibleEmailScope implements Scope
                         ->whereColumn('email_blocklists.connected_account_id', 'emails.connected_account_id')
                         ->where('email_blocklists.type', EmailBlocklistType::DOMAIN->value)
                         ->whereRaw("lower(email_participants.email_address) like '%@' || lower(email_blocklists.value)");
+                })->orWhereExists(function (BaseBuilder $blockedEmail): void {
+                    $blockedEmail->from('user_forwarding_blocklists')
+                        ->whereNull('emails.connected_account_id')
+                        ->whereColumn('user_forwarding_blocklists.user_id', 'emails.user_id')
+                        ->whereColumn('user_forwarding_blocklists.team_id', 'emails.team_id')
+                        ->where('user_forwarding_blocklists.type', EmailBlocklistType::EMAIL->value)
+                        ->whereRaw('lower(user_forwarding_blocklists.value) = lower(email_participants.email_address)');
+                })->orWhereExists(function (BaseBuilder $blockedDomain): void {
+                    $blockedDomain->from('user_forwarding_blocklists')
+                        ->whereNull('emails.connected_account_id')
+                        ->whereColumn('user_forwarding_blocklists.user_id', 'emails.user_id')
+                        ->whereColumn('user_forwarding_blocklists.team_id', 'emails.team_id')
+                        ->where('user_forwarding_blocklists.type', EmailBlocklistType::DOMAIN->value)
+                        ->whereRaw("lower(email_participants.email_address) like '%@' || lower(user_forwarding_blocklists.value)");
                 });
             });
         });

--- a/packages/EmailIntegration/src/Models/TeamForwardingAddress.php
+++ b/packages/EmailIntegration/src/Models/TeamForwardingAddress.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Models;
+
+use App\Models\Concerns\HasTeam;
+use App\Models\Team;
+use Database\Factories\TeamForwardingAddressFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $team_id
+ * @property string $local_part
+ */
+final class TeamForwardingAddress extends Model
+{
+    /**
+     * @use HasFactory<TeamForwardingAddressFactory>
+     */
+    use HasFactory, HasTeam, HasUlids;
+
+    protected static function newFactory(): TeamForwardingAddressFactory
+    {
+        return TeamForwardingAddressFactory::new();
+    }
+
+    protected $fillable = [
+        'team_id',
+        'local_part',
+    ];
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function fullAddress(): string
+    {
+        $domain = (string) config('email-integration.inbound.domain');
+
+        return "{$this->local_part}@{$domain}";
+    }
+}

--- a/packages/EmailIntegration/src/Models/UserForwardingBlocklist.php
+++ b/packages/EmailIntegration/src/Models/UserForwardingBlocklist.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Models;
+
+use App\Models\Concerns\HasTeam;
+use App\Models\User;
+use Database\Factories\UserForwardingBlocklistFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
+
+/**
+ * @property EmailBlocklistType $type
+ * @property string $value
+ */
+final class UserForwardingBlocklist extends Model
+{
+    /**
+     * @use HasFactory<UserForwardingBlocklistFactory>
+     */
+    use HasFactory, HasTeam, HasUlids;
+
+    protected static function newFactory(): UserForwardingBlocklistFactory
+    {
+        return UserForwardingBlocklistFactory::new();
+    }
+
+    protected $fillable = [
+        'user_id',
+        'team_id',
+        'type',
+        'value',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'type' => EmailBlocklistType::class,
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/packages/EmailIntegration/src/Models/UserForwardingFullAccessGrant.php
+++ b/packages/EmailIntegration/src/Models/UserForwardingFullAccessGrant.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Models;
+
+use App\Models\Concerns\HasTeam;
+use App\Models\User;
+use Database\Factories\UserForwardingFullAccessGrantFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class UserForwardingFullAccessGrant extends Model
+{
+    /**
+     * @use HasFactory<UserForwardingFullAccessGrantFactory>
+     */
+    use HasFactory, HasTeam, HasUlids;
+
+    protected static function newFactory(): UserForwardingFullAccessGrantFactory
+    {
+        return UserForwardingFullAccessGrantFactory::new();
+    }
+
+    protected $fillable = [
+        'user_id',
+        'team_id',
+        'granted_user_id',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function grantedUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'granted_user_id');
+    }
+}

--- a/packages/EmailIntegration/src/Models/UserForwardingSettings.php
+++ b/packages/EmailIntegration/src/Models/UserForwardingSettings.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Models;
+
+use App\Models\Concerns\HasTeam;
+use App\Models\User;
+use Database\Factories\UserForwardingSettingsFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+
+/**
+ * @property EmailPrivacyTier $sharing_tier
+ */
+final class UserForwardingSettings extends Model
+{
+    /**
+     * @use HasFactory<UserForwardingSettingsFactory>
+     */
+    use HasFactory, HasTeam, HasUlids;
+
+    protected static function newFactory(): UserForwardingSettingsFactory
+    {
+        return UserForwardingSettingsFactory::new();
+    }
+
+    protected $fillable = [
+        'user_id',
+        'team_id',
+        'sharing_tier',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'sharing_tier' => EmailPrivacyTier::class,
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -60,10 +60,22 @@ final class EmailVisibilityService
     {
         $email->loadMissing('participants');
 
+        $addresses = $email->participants->pluck('email_address')->all();
+
+        if ($email->connected_account_id === null) {
+            if (resolve(ForwardingBlocklistMatcher::class)->isBlocked(
+                (string) $email->user_id,
+                (string) $email->team_id,
+                $addresses,
+            )) {
+                return true;
+            }
+        }
+
         return $this->isHiddenFromOwnerFor(
             (string) $email->team_id,
             $email->connected_account_id,
-            $email->participants->pluck('email_address')->all(),
+            $addresses,
         );
     }
 

--- a/packages/EmailIntegration/src/Services/EmailVisibilityService.php
+++ b/packages/EmailIntegration/src/Services/EmailVisibilityService.php
@@ -60,7 +60,11 @@ final class EmailVisibilityService
     {
         $email->loadMissing('participants');
 
-        $addresses = $email->participants->pluck('email_address')->all();
+        $addresses = array_values($email->participants
+            ->pluck('email_address')
+            ->filter(fn (?string $address): bool => filled($address))
+            ->map(fn (string $address): string => $address)
+            ->all());
 
         if ($email->connected_account_id === null) {
             if (resolve(ForwardingBlocklistMatcher::class)->isBlocked(

--- a/packages/EmailIntegration/src/Services/ForwardingBlocklistMatcher.php
+++ b/packages/EmailIntegration/src/Services/ForwardingBlocklistMatcher.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use Illuminate\Support\Collection;
+use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
+use Relaticle\EmailIntegration\Models\UserForwardingBlocklist;
+
+final readonly class ForwardingBlocklistMatcher
+{
+    /**
+     * @param  list<string>  $addresses
+     */
+    public function isBlocked(string $userId, string $teamId, array $addresses): bool
+    {
+        if ($addresses === []) {
+            return false;
+        }
+
+        $rows = UserForwardingBlocklist::query()
+            ->where('user_id', $userId)
+            ->where('team_id', $teamId)
+            ->get();
+
+        if ($rows->isEmpty()) {
+            return false;
+        }
+
+        return Collection::make($addresses)
+            ->contains(fn (string $address): bool => $this->matchesAny($address, $rows));
+    }
+
+    /**
+     * @param  Collection<int, UserForwardingBlocklist>  $rows
+     */
+    private function matchesAny(string $address, Collection $rows): bool
+    {
+        $normalized = strtolower(trim($address));
+
+        foreach ($rows as $row) {
+            if ($row->type === EmailBlocklistType::EMAIL && $row->value === $normalized) {
+                return true;
+            }
+
+            if ($row->type === EmailBlocklistType::DOMAIN) {
+                $domain = $this->domainFromEmail($normalized);
+
+                if ($domain !== null && $domain === $row->value) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function domainFromEmail(string $email): ?string
+    {
+        $at = strrpos($email, '@');
+
+        if ($at === false) {
+            return null;
+        }
+
+        $domain = strtolower(substr($email, $at + 1));
+
+        return $domain !== '' ? $domain : null;
+    }
+}

--- a/packages/EmailIntegration/src/Services/ForwardingPrivacyService.php
+++ b/packages/EmailIntegration/src/Services/ForwardingPrivacyService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use App\Models\Team;
+use App\Models\User;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Models\UserForwardingSettings;
+
+final readonly class ForwardingPrivacyService
+{
+    public function defaultSharingTier(User $user, Team $team): EmailPrivacyTier
+    {
+        $settings = UserForwardingSettings::query()
+            ->where('user_id', $user->getKey())
+            ->where('team_id', $team->getKey())
+            ->first();
+
+        if ($settings instanceof UserForwardingSettings) {
+            return $settings->sharing_tier;
+        }
+
+        if ($user->default_email_sharing_tier instanceof EmailPrivacyTier) {
+            return $user->default_email_sharing_tier;
+        }
+
+        return $team->default_email_sharing_tier ?? EmailPrivacyTier::METADATA_ONLY;
+    }
+}

--- a/packages/EmailIntegration/src/Services/PostmarkInboundAuthenticationValidator.php
+++ b/packages/EmailIntegration/src/Services/PostmarkInboundAuthenticationValidator.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+final readonly class PostmarkInboundAuthenticationValidator
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function passes(array $payload, string $fromAddress): bool
+    {
+        $spf = $this->headerValue($payload, 'Received-SPF');
+
+        if ($spf === null) {
+            return app()->environment('local', 'testing');
+        }
+
+        if (! str_starts_with(strtolower($spf), 'pass')) {
+            return false;
+        }
+
+        $envelopeFrom = $this->envelopeFrom($spf);
+
+        if ($envelopeFrom === null) {
+            return true;
+        }
+
+        return $this->domainsAlign($fromAddress, $envelopeFrom);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function headerValue(array $payload, string $name): ?string
+    {
+        $headers = $payload['Headers'] ?? [];
+
+        if (! is_array($headers)) {
+            return null;
+        }
+
+        foreach ($headers as $header) {
+            if (! is_array($header)) {
+                continue;
+            }
+
+            if (($header['Name'] ?? null) === $name) {
+                $value = $header['Value'] ?? null;
+
+                return is_string($value) && $value !== '' ? $value : null;
+            }
+        }
+
+        return null;
+    }
+
+    private function envelopeFrom(string $receivedSpf): ?string
+    {
+        if (preg_match('/envelope-from=([^;\s]+)/i', $receivedSpf, $matches) !== 1) {
+            return null;
+        }
+
+        $address = strtolower(trim($matches[1], '<>'));
+
+        return $address !== '' ? $address : null;
+    }
+
+    private function domainsAlign(string $fromAddress, string $envelopeFrom): bool
+    {
+        $fromDomain = $this->domainFromEmail($fromAddress);
+        $envelopeDomain = $this->domainFromEmail($envelopeFrom);
+
+        if ($fromDomain === null || $envelopeDomain === null) {
+            return false;
+        }
+
+        return $fromDomain === $envelopeDomain;
+    }
+
+    private function domainFromEmail(string $email): ?string
+    {
+        $at = strrpos(strtolower(trim($email)), '@');
+
+        if ($at === false) {
+            return null;
+        }
+
+        $domain = substr($email, $at + 1);
+
+        return $domain !== '' ? strtolower($domain) : null;
+    }
+}

--- a/packages/EmailIntegration/src/Services/PostmarkInboundParser.php
+++ b/packages/EmailIntegration/src/Services/PostmarkInboundParser.php
@@ -38,6 +38,7 @@ final readonly class PostmarkInboundParser
 
     /**
      * @param  array<string, mixed>  $payload
+     * @return list<string>
      */
     public function recipientAddresses(array $payload): array
     {

--- a/packages/EmailIntegration/src/Services/PostmarkInboundParser.php
+++ b/packages/EmailIntegration/src/Services/PostmarkInboundParser.php
@@ -41,12 +41,7 @@ final readonly class PostmarkInboundParser
      */
     public function recipientAddresses(array $payload): array
     {
-        $addresses = [];
-
-        foreach ($this->addressList($payload, 'ToFull') as $entry) {
-            $addresses[] = $entry;
-        }
-
+        $addresses = $this->addressList($payload, 'ToFull');
         foreach ($this->addressList($payload, 'CcFull') as $entry) {
             $addresses[] = $entry;
         }
@@ -63,7 +58,7 @@ final readonly class PostmarkInboundParser
             }
         }
 
-        return array_values(array_unique(array_map('strtolower', $addresses)));
+        return array_values(array_unique(array_map(strtolower(...), $addresses)));
     }
 
     /**
@@ -89,7 +84,7 @@ final readonly class PostmarkInboundParser
     /**
      * @param  array<string, mixed>  $payload
      */
-    private function sentAt(array $payload): ?CarbonImmutable
+    private function sentAt(array $payload): CarbonImmutable
     {
         $date = $this->string($payload, 'Date');
 

--- a/packages/EmailIntegration/src/Services/PostmarkInboundParser.php
+++ b/packages/EmailIntegration/src/Services/PostmarkInboundParser.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Services;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+use Relaticle\EmailIntegration\Data\InboundEmailData;
+
+final readonly class PostmarkInboundParser
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function parse(array $payload): InboundEmailData
+    {
+        $messageId = $this->messageId($payload);
+        $participants = $this->participants($payload);
+        $attachments = $this->attachments($payload);
+        $textBody = $this->string($payload, 'TextBody');
+        $htmlBody = $this->string($payload, 'HtmlBody');
+        $subject = $this->string($payload, 'Subject') ?? '';
+        $snippet = Str::limit(strip_tags($textBody ?: $htmlBody ?: ''), 255, '');
+
+        return new InboundEmailData(
+            rfcMessageId: $messageId,
+            inReplyTo: $this->headerValue($payload, 'In-Reply-To'),
+            subject: $subject,
+            snippet: $snippet !== '' ? $snippet : null,
+            sentAt: $this->sentAt($payload),
+            bodyText: $textBody,
+            bodyHtml: $htmlBody,
+            participants: $participants,
+            attachments: $attachments,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function recipientAddresses(array $payload): array
+    {
+        $addresses = [];
+
+        foreach ($this->addressList($payload, 'ToFull') as $entry) {
+            $addresses[] = $entry;
+        }
+
+        foreach ($this->addressList($payload, 'CcFull') as $entry) {
+            $addresses[] = $entry;
+        }
+
+        $to = $this->string($payload, 'To');
+
+        if ($to !== null) {
+            foreach (explode(',', $to) as $part) {
+                $email = $this->extractEmail(trim($part));
+
+                if ($email !== null) {
+                    $addresses[] = $email;
+                }
+            }
+        }
+
+        return array_values(array_unique(array_map('strtolower', $addresses)));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function messageId(array $payload): string
+    {
+        $header = $this->headerValue($payload, 'Message-ID');
+
+        if ($header !== null && $header !== '') {
+            return $header;
+        }
+
+        $postmarkId = $this->string($payload, 'MessageID');
+
+        if ($postmarkId !== null && $postmarkId !== '') {
+            return "<{$postmarkId}@postmark>";
+        }
+
+        return '<'.Str::uuid().'@inbound>';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function sentAt(array $payload): ?CarbonImmutable
+    {
+        $date = $this->string($payload, 'Date');
+
+        if ($date === null) {
+            return now();
+        }
+
+        try {
+            return CarbonImmutable::parse($date);
+        } catch (\Throwable) {
+            return now();
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array{email_address: string, name: string|null, role: string}>
+     */
+    private function participants(array $payload): array
+    {
+        $participants = [];
+
+        $from = $this->fullAddress($payload, 'FromFull', 'From');
+
+        if ($from !== null) {
+            $participants[] = ['email_address' => $from['email'], 'name' => $from['name'], 'role' => 'from'];
+        }
+
+        foreach ($this->fullAddresses($payload, 'ToFull', 'To') as $entry) {
+            $participants[] = ['email_address' => $entry['email'], 'name' => $entry['name'], 'role' => 'to'];
+        }
+
+        foreach ($this->fullAddresses($payload, 'CcFull', 'Cc') as $entry) {
+            $participants[] = ['email_address' => $entry['email'], 'name' => $entry['name'], 'role' => 'cc'];
+        }
+
+        return $participants;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array{filename: string|null, mime_type: string|null, size: int, content_id: string|null, content: string}>
+     */
+    private function attachments(array $payload): array
+    {
+        $attachments = $payload['Attachments'] ?? [];
+
+        if (! is_array($attachments)) {
+            return [];
+        }
+
+        $parsed = [];
+
+        foreach ($attachments as $attachment) {
+            if (! is_array($attachment)) {
+                continue;
+            }
+
+            $content = $attachment['Content'] ?? '';
+
+            if (! is_string($content) || $content === '') {
+                continue;
+            }
+
+            $parsed[] = [
+                'filename' => isset($attachment['Name']) && is_string($attachment['Name']) ? $attachment['Name'] : null,
+                'mime_type' => isset($attachment['ContentType']) && is_string($attachment['ContentType']) ? $attachment['ContentType'] : null,
+                'size' => (int) ($attachment['ContentLength'] ?? strlen(base64_decode($content, true) ?: '')),
+                'content_id' => isset($attachment['ContentID']) && is_string($attachment['ContentID']) ? $attachment['ContentID'] : null,
+                'content' => $content,
+            ];
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<string>
+     */
+    private function addressList(array $payload, string $fullKey): array
+    {
+        $entries = $payload[$fullKey] ?? [];
+
+        if (! is_array($entries)) {
+            return [];
+        }
+
+        $addresses = [];
+
+        foreach ($entries as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $email = $entry['Email'] ?? null;
+
+            if (is_string($email) && $email !== '') {
+                $addresses[] = strtolower($email);
+            }
+        }
+
+        return $addresses;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{email: string, name: string|null}|null
+     */
+    private function fullAddress(array $payload, string $fullKey, string $fallbackKey): ?array
+    {
+        $full = $payload[$fullKey] ?? null;
+
+        if (is_array($full)) {
+            $email = $full['Email'] ?? null;
+
+            if (is_string($email) && $email !== '') {
+                $name = $full['Name'] ?? null;
+
+                return [
+                    'email' => strtolower($email),
+                    'name' => is_string($name) && $name !== '' ? $name : null,
+                ];
+            }
+        }
+
+        $raw = $this->string($payload, $fallbackKey);
+        $email = $raw !== null ? $this->extractEmail($raw) : null;
+
+        if ($email === null) {
+            return null;
+        }
+
+        return ['email' => $email, 'name' => null];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<array{email: string, name: string|null}>
+     */
+    private function fullAddresses(array $payload, string $fullKey, string $fallbackKey): array
+    {
+        $entries = $payload[$fullKey] ?? [];
+
+        if (is_array($entries) && $entries !== []) {
+            $parsed = [];
+
+            foreach ($entries as $entry) {
+                if (! is_array($entry)) {
+                    continue;
+                }
+
+                $email = $entry['Email'] ?? null;
+
+                if (! is_string($email) || $email === '') {
+                    continue;
+                }
+
+                $name = $entry['Name'] ?? null;
+                $parsed[] = [
+                    'email' => strtolower($email),
+                    'name' => is_string($name) && $name !== '' ? $name : null,
+                ];
+            }
+
+            if ($parsed !== []) {
+                return $parsed;
+            }
+        }
+
+        $raw = $this->string($payload, $fallbackKey);
+
+        if ($raw === null) {
+            return [];
+        }
+
+        $parsed = [];
+
+        foreach (explode(',', $raw) as $part) {
+            $email = $this->extractEmail(trim($part));
+
+            if ($email !== null) {
+                $parsed[] = ['email' => $email, 'name' => null];
+            }
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function headerValue(array $payload, string $name): ?string
+    {
+        $headers = $payload['Headers'] ?? [];
+
+        if (! is_array($headers)) {
+            return null;
+        }
+
+        foreach ($headers as $header) {
+            if (! is_array($header)) {
+                continue;
+            }
+
+            if (($header['Name'] ?? null) === $name) {
+                $value = $header['Value'] ?? null;
+
+                return is_string($value) ? trim($value) : null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function string(array $payload, string $key): ?string
+    {
+        $value = $payload[$key] ?? null;
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+
+    private function extractEmail(string $value): ?string
+    {
+        if (preg_match('/<([^>]+)>/', $value, $matches) === 1) {
+            return strtolower(trim($matches[1]));
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            return strtolower($value);
+        }
+
+        return null;
+    }
+}

--- a/tests/Feature/EmailIntegration/ForwardingAddressTest.php
+++ b/tests/Feature/EmailIntegration/ForwardingAddressTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Bus;
+use Relaticle\EmailIntegration\Actions\EnsureTeamForwardingAddressAction;
+use Relaticle\EmailIntegration\Actions\ResolveForwardingSenderAction;
+use Relaticle\EmailIntegration\Actions\StoreInboundEmailAction;
+use Relaticle\EmailIntegration\Enums\EmailBlocklistType;
+use Relaticle\EmailIntegration\Enums\EmailCreationSource;
+use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
+use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
+use Relaticle\EmailIntegration\Filament\Pages\ForwardingAddressSettingsPage;
+use Relaticle\EmailIntegration\Jobs\ProcessInboundEmailJob;
+use Relaticle\EmailIntegration\Models\Email;
+use Relaticle\EmailIntegration\Models\EmailShare;
+use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
+use Relaticle\EmailIntegration\Models\UserForwardingBlocklist;
+use Relaticle\EmailIntegration\Models\UserForwardingFullAccessGrant;
+use Relaticle\EmailIntegration\Models\UserForwardingSettings;
+use Relaticle\EmailIntegration\Services\PostmarkInboundParser;
+
+mutates(
+    EnsureTeamForwardingAddressAction::class,
+    ProcessInboundEmailJob::class,
+    EmailAccountsPage::class,
+    ForwardingAddressSettingsPage::class,
+);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    $this->team = $this->user->currentTeam;
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+    Filament::setTenant($this->team);
+
+    config()->set('email-integration.inbound.domain', 'inbound.relaticle.test');
+});
+
+it('creates a stable team forwarding address from the workspace slug', function (): void {
+    $address = resolve(EnsureTeamForwardingAddressAction::class)->execute($this->team);
+
+    expect($address->local_part)->toBe($this->team->slug)
+        ->and($address->fullAddress())->toBe("{$this->team->slug}@inbound.relaticle.test");
+});
+
+it('shows the forwarding address on the accounts page', function (): void {
+    livewire(EmailAccountsPage::class)
+        ->assertSee("{$this->team->slug}@inbound.relaticle.test")
+        ->assertSee(__('filament/pages/email-accounts.in_sync'));
+});
+
+it('dispatches inbound email processing from the webhook', function (): void {
+    Bus::fake([ProcessInboundEmailJob::class]);
+
+    $this->postJson(route('inbound-email.webhook'), ['Subject' => 'Hello'])
+        ->assertOk();
+
+    Bus::assertDispatched(ProcessInboundEmailJob::class);
+});
+
+it('stores forwarded mail for a verified workspace sender', function (): void {
+    $address = TeamForwardingAddress::factory()->create([
+        'team_id' => $this->team->id,
+        'local_part' => 'acme',
+    ]);
+
+    UserForwardingSettings::factory()->create([
+        'user_id' => $this->user->id,
+        'team_id' => $this->team->id,
+        'sharing_tier' => EmailPrivacyTier::SUBJECT,
+    ]);
+
+    $payload = [
+        'From' => $this->user->email,
+        'FromFull' => ['Email' => $this->user->email, 'Name' => $this->user->name],
+        'To' => "{$address->local_part}@inbound.relaticle.test",
+        'ToFull' => [['Email' => "{$address->local_part}@inbound.relaticle.test", 'Name' => '']],
+        'Subject' => 'Forwarded deal thread',
+        'TextBody' => 'Body copy',
+        'Headers' => [
+            ['Name' => 'Message-ID', 'Value' => '<forwarded-1@example.com>'],
+        ],
+    ];
+
+    (new ProcessInboundEmailJob($payload))->handle(
+        resolve(PostmarkInboundParser::class),
+        resolve(ResolveForwardingSenderAction::class),
+        resolve(StoreInboundEmailAction::class),
+    );
+
+    $email = Email::query()->where('user_id', $this->user->id)->first();
+
+    expect($email)->not->toBeNull()
+        ->and($email->connected_account_id)->toBeNull()
+        ->and($email->creation_source)->toBe(EmailCreationSource::BCC_INBOUND)
+        ->and($email->privacy_tier)->toBe(EmailPrivacyTier::SUBJECT)
+        ->and($email->subject)->toBe('Forwarded deal thread');
+});
+
+it('rejects forwarded mail from an unknown sender', function (): void {
+    TeamForwardingAddress::factory()->create([
+        'team_id' => $this->team->id,
+        'local_part' => 'acme',
+    ]);
+
+    $payload = [
+        'From' => 'stranger@example.com',
+        'FromFull' => ['Email' => 'stranger@example.com', 'Name' => 'Stranger'],
+        'To' => 'acme@inbound.relaticle.test',
+        'ToFull' => [['Email' => 'acme@inbound.relaticle.test', 'Name' => '']],
+        'Subject' => 'Should not store',
+        'TextBody' => 'Body',
+        'Headers' => [
+            ['Name' => 'Message-ID', 'Value' => '<forwarded-2@example.com>'],
+        ],
+    ];
+
+    (new ProcessInboundEmailJob($payload))->handle(
+        resolve(PostmarkInboundParser::class),
+        resolve(ResolveForwardingSenderAction::class),
+        resolve(StoreInboundEmailAction::class),
+    );
+
+    expect(Email::query()->count())->toBe(0);
+});
+
+it('skips storing mail that matches the forwarding blocklist', function (): void {
+    $address = TeamForwardingAddress::factory()->create([
+        'team_id' => $this->team->id,
+        'local_part' => 'acme',
+    ]);
+
+    UserForwardingBlocklist::factory()->create([
+        'user_id' => $this->user->id,
+        'team_id' => $this->team->id,
+        'type' => EmailBlocklistType::EMAIL,
+        'value' => 'blocked@contact.com',
+    ]);
+
+    $payload = [
+        'From' => $this->user->email,
+        'FromFull' => ['Email' => $this->user->email, 'Name' => $this->user->name],
+        'To' => "{$address->local_part}@inbound.relaticle.test",
+        'ToFull' => [['Email' => "{$address->local_part}@inbound.relaticle.test", 'Name' => '']],
+        'Subject' => 'Blocked participant',
+        'TextBody' => 'Body',
+        'Headers' => [
+            ['Name' => 'Message-ID', 'Value' => '<forwarded-3@example.com>'],
+        ],
+        'CcFull' => [['Email' => 'blocked@contact.com', 'Name' => 'Blocked']],
+    ];
+
+    (new ProcessInboundEmailJob($payload))->handle(
+        resolve(PostmarkInboundParser::class),
+        resolve(ResolveForwardingSenderAction::class),
+        resolve(StoreInboundEmailAction::class),
+    );
+
+    expect(Email::query()->count())->toBe(0);
+});
+
+it('seeds full access shares for granted teammates', function (): void {
+    $teammate = User::factory()->create();
+    $this->team->users()->attach($teammate, ['role' => 'member']);
+
+    TeamForwardingAddress::factory()->create([
+        'team_id' => $this->team->id,
+        'local_part' => 'acme',
+    ]);
+
+    UserForwardingFullAccessGrant::factory()->create([
+        'user_id' => $this->user->id,
+        'team_id' => $this->team->id,
+        'granted_user_id' => $teammate->id,
+    ]);
+
+    $payload = [
+        'From' => $this->user->email,
+        'FromFull' => ['Email' => $this->user->email, 'Name' => $this->user->name],
+        'To' => 'acme@inbound.relaticle.test',
+        'ToFull' => [['Email' => 'acme@inbound.relaticle.test', 'Name' => '']],
+        'Subject' => 'Shared forward',
+        'TextBody' => 'Body',
+        'Headers' => [
+            ['Name' => 'Message-ID', 'Value' => '<forwarded-4@example.com>'],
+        ],
+    ];
+
+    (new ProcessInboundEmailJob($payload))->handle(
+        resolve(PostmarkInboundParser::class),
+        resolve(ResolveForwardingSenderAction::class),
+        resolve(StoreInboundEmailAction::class),
+    );
+
+    $email = Email::query()->first();
+
+    expect($email)->not->toBeNull();
+
+    $this->assertDatabaseHas(EmailShare::class, [
+        'email_id' => $email->id,
+        'shared_with' => $teammate->id,
+        'tier' => EmailPrivacyTier::FULL->value,
+    ]);
+});
+
+it('opens the forwarding settings page without a pre-existing address row', function (): void {
+    livewire(ForwardingAddressSettingsPage::class)
+        ->assertSuccessful()
+        ->assertSee(__('filament/pages/forwarding-address-settings.tabs.general'))
+        ->assertSee(__('filament/pages/forwarding-address-settings.tabs.blocklist'));
+
+    $this->assertDatabaseHas(TeamForwardingAddress::class, [
+        'team_id' => $this->team->id,
+    ]);
+});
+
+it('loads the forwarding settings page over http', function (): void {
+    $this->get(ForwardingAddressSettingsPage::getUrl())
+        ->assertOk()
+        ->assertSee(__('filament/pages/forwarding-address-settings.visibility.label'));
+});
+
+it('saves forwarding visibility settings from the settings page', function (): void {
+    livewire(ForwardingAddressSettingsPage::class)
+        ->fillForm(['sharing_tier' => EmailPrivacyTier::FULL->value])
+        ->callAction('save')
+        ->assertNotified();
+
+    $this->assertDatabaseHas(UserForwardingSettings::class, [
+        'user_id' => $this->user->id,
+        'team_id' => $this->team->id,
+        'sharing_tier' => EmailPrivacyTier::FULL->value,
+    ]);
+});

--- a/tests/Feature/EmailIntegration/ForwardingAddressTest.php
+++ b/tests/Feature/EmailIntegration/ForwardingAddressTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Actions\EnsureTeamForwardingAddressAction;
 use Relaticle\EmailIntegration\Actions\ResolveForwardingSenderAction;
 use Relaticle\EmailIntegration\Actions\StoreInboundEmailAction;
@@ -14,12 +16,14 @@ use Relaticle\EmailIntegration\Enums\EmailPrivacyTier;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Filament\Pages\ForwardingAddressSettingsPage;
 use Relaticle\EmailIntegration\Jobs\ProcessInboundEmailJob;
+use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailShare;
 use Relaticle\EmailIntegration\Models\TeamForwardingAddress;
 use Relaticle\EmailIntegration\Models\UserForwardingBlocklist;
 use Relaticle\EmailIntegration\Models\UserForwardingFullAccessGrant;
 use Relaticle\EmailIntegration\Models\UserForwardingSettings;
+use Relaticle\EmailIntegration\Services\PostmarkInboundAuthenticationValidator;
 use Relaticle\EmailIntegration\Services\PostmarkInboundParser;
 
 mutates(
@@ -29,7 +33,37 @@ mutates(
     ForwardingAddressSettingsPage::class,
 );
 
+/**
+ * @param  array<string, mixed>  $payload
+ */
+function processInboundPayload(array $payload): void
+{
+    $path = 'inbound-webhooks/test-'.Str::ulid().'.json';
+    Storage::disk('local')->put($path, json_encode($payload, JSON_THROW_ON_ERROR));
+
+    (new ProcessInboundEmailJob($path))->handle(
+        resolve(PostmarkInboundParser::class),
+        resolve(PostmarkInboundAuthenticationValidator::class),
+        resolve(ResolveForwardingSenderAction::class),
+        resolve(StoreInboundEmailAction::class),
+    );
+}
+
+/**
+ * @param  array<int, array{Name: string, Value: string}>  $headers
+ * @return array<int, array{Name: string, Value: string}>
+ */
+function forwardingAuthHeaders(string $envelopeFrom, array $headers = []): array
+{
+    return array_merge($headers, [
+        ['Name' => 'Received-SPF', 'Value' => "Pass (sender SPF authorized) identity=mailfrom; envelope-from={$envelopeFrom}"],
+        ['Name' => 'X-Spam-Tests', 'Value' => 'DKIM_SIGNED,DKIM_VALID,SPF_PASS'],
+    ]);
+}
+
 beforeEach(function (): void {
+    Storage::fake('local');
+
     $this->user = User::factory()->withTeam()->create();
     $this->actingAs($this->user);
     $this->team = $this->user->currentTeam;
@@ -37,6 +71,7 @@ beforeEach(function (): void {
     Filament::setTenant($this->team);
 
     config()->set('email-integration.inbound.domain', 'inbound.relaticle.test');
+    config()->set('email-integration.inbound.webhook_secret', 'test-secret');
 });
 
 it('creates a stable team forwarding address from the workspace slug', function (): void {
@@ -55,10 +90,30 @@ it('shows the forwarding address on the accounts page', function (): void {
 it('dispatches inbound email processing from the webhook', function (): void {
     Bus::fake([ProcessInboundEmailJob::class]);
 
-    $this->postJson(route('inbound-email.webhook'), ['Subject' => 'Hello'])
+    $this->postJson(route('inbound-email.webhook', ['token' => 'test-secret']), ['Subject' => 'Hello'])
         ->assertOk();
 
     Bus::assertDispatched(ProcessInboundEmailJob::class);
+});
+
+it('rejects inbound webhooks with an invalid token', function (): void {
+    Bus::fake([ProcessInboundEmailJob::class]);
+
+    $this->postJson(route('inbound-email.webhook', ['token' => 'wrong-secret']), ['Subject' => 'Hello'])
+        ->assertForbidden();
+
+    Bus::assertNotDispatched(ProcessInboundEmailJob::class);
+});
+
+it('rejects inbound webhooks in production when the secret is unset', function (): void {
+    Bus::fake([ProcessInboundEmailJob::class]);
+    config()->set('email-integration.inbound.webhook_secret', '');
+    $this->app->detectEnvironment(fn (): string => 'production');
+
+    $this->postJson(route('inbound-email.webhook', ['token' => 'any-token']), ['Subject' => 'Hello'])
+        ->assertForbidden();
+
+    Bus::assertNotDispatched(ProcessInboundEmailJob::class);
 });
 
 it('stores forwarded mail for a verified workspace sender', function (): void {
@@ -80,16 +135,12 @@ it('stores forwarded mail for a verified workspace sender', function (): void {
         'ToFull' => [['Email' => "{$address->local_part}@inbound.relaticle.test", 'Name' => '']],
         'Subject' => 'Forwarded deal thread',
         'TextBody' => 'Body copy',
-        'Headers' => [
+        'Headers' => forwardingAuthHeaders($this->user->email, [
             ['Name' => 'Message-ID', 'Value' => '<forwarded-1@example.com>'],
-        ],
+        ]),
     ];
 
-    (new ProcessInboundEmailJob($payload))->handle(
-        resolve(PostmarkInboundParser::class),
-        resolve(ResolveForwardingSenderAction::class),
-        resolve(StoreInboundEmailAction::class),
-    );
+    processInboundPayload($payload);
 
     $email = Email::query()->where('user_id', $this->user->id)->first();
 
@@ -98,6 +149,38 @@ it('stores forwarded mail for a verified workspace sender', function (): void {
         ->and($email->creation_source)->toBe(EmailCreationSource::BCC_INBOUND)
         ->and($email->privacy_tier)->toBe(EmailPrivacyTier::SUBJECT)
         ->and($email->subject)->toBe('Forwarded deal thread');
+});
+
+it('stores forwarded mail for a sender matched by connected account email', function (): void {
+    $address = TeamForwardingAddress::factory()->create([
+        'team_id' => $this->team->id,
+        'local_part' => 'acme',
+    ]);
+
+    $connectedEmail = 'sales@workspace.example';
+
+    ConnectedAccount::factory()->create([
+        'user_id' => $this->user->id,
+        'team_id' => $this->team->id,
+        'email_address' => $connectedEmail,
+    ]);
+
+    $payload = [
+        'From' => $connectedEmail,
+        'FromFull' => ['Email' => $connectedEmail, 'Name' => 'Sales'],
+        'To' => "{$address->local_part}@inbound.relaticle.test",
+        'ToFull' => [['Email' => "{$address->local_part}@inbound.relaticle.test", 'Name' => '']],
+        'Subject' => 'Connected mailbox forward',
+        'TextBody' => 'Body copy',
+        'Headers' => forwardingAuthHeaders($connectedEmail, [
+            ['Name' => 'Message-ID', 'Value' => '<forwarded-connected@example.com>'],
+        ]),
+    ];
+
+    processInboundPayload($payload);
+
+    expect(Email::query()->where('user_id', $this->user->id)->value('subject'))
+        ->toBe('Connected mailbox forward');
 });
 
 it('rejects forwarded mail from an unknown sender', function (): void {
@@ -113,16 +196,36 @@ it('rejects forwarded mail from an unknown sender', function (): void {
         'ToFull' => [['Email' => 'acme@inbound.relaticle.test', 'Name' => '']],
         'Subject' => 'Should not store',
         'TextBody' => 'Body',
-        'Headers' => [
+        'Headers' => forwardingAuthHeaders('stranger@example.com', [
             ['Name' => 'Message-ID', 'Value' => '<forwarded-2@example.com>'],
+        ]),
+    ];
+
+    processInboundPayload($payload);
+
+    expect(Email::query()->count())->toBe(0);
+});
+
+it('rejects forwarded mail that fails sender authentication', function (): void {
+    TeamForwardingAddress::factory()->create([
+        'team_id' => $this->team->id,
+        'local_part' => 'acme',
+    ]);
+
+    $payload = [
+        'From' => $this->user->email,
+        'FromFull' => ['Email' => $this->user->email, 'Name' => $this->user->name],
+        'To' => 'acme@inbound.relaticle.test',
+        'ToFull' => [['Email' => 'acme@inbound.relaticle.test', 'Name' => '']],
+        'Subject' => 'Spoofed forward',
+        'TextBody' => 'Body',
+        'Headers' => [
+            ['Name' => 'Message-ID', 'Value' => '<forwarded-spoof@example.com>'],
+            ['Name' => 'Received-SPF', 'Value' => 'Fail (sender SPF unauthorized) identity=mailfrom; envelope-from=attacker@evil.example'],
         ],
     ];
 
-    (new ProcessInboundEmailJob($payload))->handle(
-        resolve(PostmarkInboundParser::class),
-        resolve(ResolveForwardingSenderAction::class),
-        resolve(StoreInboundEmailAction::class),
-    );
+    processInboundPayload($payload);
 
     expect(Email::query()->count())->toBe(0);
 });
@@ -147,17 +250,13 @@ it('skips storing mail that matches the forwarding blocklist', function (): void
         'ToFull' => [['Email' => "{$address->local_part}@inbound.relaticle.test", 'Name' => '']],
         'Subject' => 'Blocked participant',
         'TextBody' => 'Body',
-        'Headers' => [
+        'Headers' => forwardingAuthHeaders($this->user->email, [
             ['Name' => 'Message-ID', 'Value' => '<forwarded-3@example.com>'],
-        ],
+        ]),
         'CcFull' => [['Email' => 'blocked@contact.com', 'Name' => 'Blocked']],
     ];
 
-    (new ProcessInboundEmailJob($payload))->handle(
-        resolve(PostmarkInboundParser::class),
-        resolve(ResolveForwardingSenderAction::class),
-        resolve(StoreInboundEmailAction::class),
-    );
+    processInboundPayload($payload);
 
     expect(Email::query()->count())->toBe(0);
 });
@@ -184,16 +283,12 @@ it('seeds full access shares for granted teammates', function (): void {
         'ToFull' => [['Email' => 'acme@inbound.relaticle.test', 'Name' => '']],
         'Subject' => 'Shared forward',
         'TextBody' => 'Body',
-        'Headers' => [
+        'Headers' => forwardingAuthHeaders($this->user->email, [
             ['Name' => 'Message-ID', 'Value' => '<forwarded-4@example.com>'],
-        ],
+        ]),
     ];
 
-    (new ProcessInboundEmailJob($payload))->handle(
-        resolve(PostmarkInboundParser::class),
-        resolve(ResolveForwardingSenderAction::class),
-        resolve(StoreInboundEmailAction::class),
-    );
+    processInboundPayload($payload);
 
     $email = Email::query()->first();
 


### PR DESCRIPTION
## Summary

- Adds a per-workspace forwarding address (`{slug}@inbound.domain`) so users can forward or BCC specific emails without syncing a full mailbox.
- Postmark inbound webhook ingests mail, attributes it to the verified workspace sender, and stores it with `bcc_inbound` creation source.
- Per-user settings page covers email visibility, full-access teammates, and a mailbox-only blocklist.
- Accounts page row matches connected mailbox styling (Relaticle logomark, In Sync badge, Manage menu).

## Test plan

- [x] `php artisan test --filter=ForwardingAddressTest`
- [x] Open Email settings → Accounts → forwarding row → Manage → General + Blocklist tabs
- [ ] POST sample Postmark payload to `/webhooks/inbound/postmark` and confirm email links to CRM records
- [ ] Set `EMAIL_INBOUND_DOMAIN` and verify displayed address updates