### PR TITLE
feat(settings): appearance settings and a dedicated settings shell

### DIFF
--- a/app/Enums/AccentColor.php
+++ b/app/Enums/AccentColor.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
-/**
- * Accent seeds a member can pick for their own view of the app. Filament
- * expands the hex into a full 50-950 ramp via Color::hex(), so one seed is
- * enough. `null` means the brand default (BrandColors::primary()).
- */
 enum AccentColor: string
 {
     case Blue = '#2563EB';

--- a/app/Enums/AccentColor.php
+++ b/app/Enums/AccentColor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Accent seeds a member can pick for their own view of the app. Filament
+ * expands the hex into a full 50-950 ramp via Color::hex(), so one seed is
+ * enough. `null` means the brand default (BrandColors::primary()).
+ */
+enum AccentColor: string
+{
+    case Blue = '#2563EB';
+    case Cyan = '#0891B2';
+    case Amber = '#D97706';
+    case Orange = '#EA580C';
+    case Pink = '#DB2777';
+    case Purple = '#9333EA';
+    case Green = '#059669';
+    case Slate = '#475569';
+
+    public function label(): string
+    {
+        return __("appearance.accent_colors.{$this->name}");
+    }
+}

--- a/app/Filament/Clusters/Settings.php
+++ b/app/Filament/Clusters/Settings.php
@@ -11,7 +11,7 @@ final class Settings extends Cluster
 {
     protected static ?string $slug = 'settings';
 
-    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
+    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Start;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
 

--- a/app/Filament/Pages/AccessTokens.php
+++ b/app/Filament/Pages/AccessTokens.php
@@ -19,6 +19,8 @@ final class AccessTokens extends Page
 {
     protected string $view = 'filament.pages.access-tokens';
 
+    protected static string $layout = 'filament.layouts.settings';
+
     protected static ?string $slug = 'access-tokens';
 
     protected static ?int $navigationSort = 4;

--- a/app/Filament/Pages/Appearance.php
+++ b/app/Filament/Pages/Appearance.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use App\Enums\AccentColor;
+use App\Filament\Clusters\Settings;
+use App\Support\BrandColors;
+use Filament\Clusters\Cluster;
+use Filament\Enums\ThemeMode;
+use Filament\Pages\Page;
+
+final class Appearance extends Page
+{
+    protected string $view = 'filament.pages.appearance';
+
+    protected static string $layout = 'filament.layouts.settings';
+
+    protected static ?string $slug = 'appearance';
+
+    protected static ?int $navigationSort = 5;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-swatch';
+
+    /** @var class-string<Cluster>|null */
+    protected static ?string $cluster = Settings::class;
+
+    public static function getNavigationLabel(): string
+    {
+        return __('appearance.title');
+    }
+
+    public function getHeading(): string
+    {
+        return __('appearance.title');
+    }
+
+    public static function getLabel(): string
+    {
+        return __('appearance.title');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getViewData(): array
+    {
+        return [
+            'accents' => AccentColor::cases(),
+            'brandColor' => BrandColors::primary()['DEFAULT'],
+            'themes' => ThemeMode::cases(),
+        ];
+    }
+}

--- a/app/Filament/Pages/CreateTeam.php
+++ b/app/Filament/Pages/CreateTeam.php
@@ -13,6 +13,7 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 use App\Rules\ValidTeamSlug;
+use App\Support\WorkspaceUrlPrefix;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Facades\Filament;
@@ -438,8 +439,6 @@ final class CreateTeam extends RegisterTenant
      */
     private function getWorkspaceFormComponents(): array
     {
-        $appHost = parse_url(url()->getAppUrl(), PHP_URL_HOST);
-
         return [
             TextInput::make('user_name')
                 ->label(__('filament/pages/teams.create_team.form.your_name.label'))
@@ -479,7 +478,7 @@ final class CreateTeam extends RegisterTenant
                     column: 'slug',
                     ignorable: fn (): ?Team => $this->tenant instanceof Team ? $this->tenant : null,
                 )
-                ->prefix("{$appHost}/")
+                ->prefix(WorkspaceUrlPrefix::get())
                 ->helperText(__('filament/pages/teams.create_team.form.workspace_handle.helper_text'))
                 ->live(onBlur: true)
                 ->afterStateUpdated(function (Set $set): void {

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -18,6 +18,8 @@ final class EditProfile extends Page
 {
     protected string $view = 'filament.pages.edit-profile';
 
+    protected static string $layout = 'filament.layouts.settings';
+
     protected static ?string $slug = 'profile';
 
     protected static ?int $navigationSort = 1;

--- a/app/Filament/Pages/EditTeam.php
+++ b/app/Filament/Pages/EditTeam.php
@@ -6,6 +6,7 @@ namespace App\Filament\Pages;
 
 use App\Filament\Pages\Concerns\HasWorkspaceSettingsNavigation;
 use App\Livewire\App\Teams\DeleteTeam;
+use App\Livewire\App\Teams\UpdateTeamLogo;
 use App\Livewire\App\Teams\UpdateTeamName;
 use App\Models\Team;
 use Filament\Pages\Tenancy\EditTenantProfile;
@@ -29,6 +30,8 @@ final class EditTeam extends EditTenantProfile
 
         return $schema->components([
             Livewire::make(UpdateTeamName::class)
+                ->data(['team' => $tenant]),
+            Livewire::make(UpdateTeamLogo::class)
                 ->data(['team' => $tenant]),
             Livewire::make(DeleteTeam::class)
                 ->visible(fn (): bool => $tenant->isPersonalTeam() === false)

--- a/app/Filament/Pages/NotificationPreferences.php
+++ b/app/Filament/Pages/NotificationPreferences.php
@@ -12,6 +12,8 @@ final class NotificationPreferences extends Page
 {
     protected string $view = 'filament.pages.notification-preferences';
 
+    protected static string $layout = 'filament.layouts.settings';
+
     protected static ?string $slug = 'notifications';
 
     protected static ?int $navigationSort = 3;

--- a/app/Filament/Pages/Security.php
+++ b/app/Filament/Pages/Security.php
@@ -18,6 +18,8 @@ final class Security extends Page
 {
     protected string $view = 'filament.pages.security';
 
+    protected static string $layout = 'filament.layouts.settings';
+
     protected static ?string $slug = 'security';
 
     protected static ?int $navigationSort = 2;

--- a/app/Livewire/App/AccessTokens/CreateAccessToken.php
+++ b/app/Livewire/App/AccessTokens/CreateAccessToken.php
@@ -27,12 +27,23 @@ final class CreateAccessToken extends BaseLivewireComponent
 
     public ?string $plainTextToken = null;
 
+    private const string DEFAULT_EXPIRATION_DAYS = '180';
+
     public function mount(): void
     {
-        $this->form->fill([
+        $this->form->fill($this->initialFormState());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function initialFormState(): array
+    {
+        return [
             'team_id' => $this->authUser()->currentTeam?->getKey(),
             'permissions' => Jetstream::$defaultPermissions,
-        ]);
+            'expiration' => self::DEFAULT_EXPIRATION_DAYS,
+        ];
     }
 
     public function form(Schema $schema): Schema
@@ -40,7 +51,6 @@ final class CreateAccessToken extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('access-tokens.sections.create.title'))
-                    ->aside()
                     ->description(
                         __('access-tokens.sections.create.description'),
                     )
@@ -161,10 +171,7 @@ final class CreateAccessToken extends BaseLivewireComponent
 
         $this->plainTextToken = explode('|', $token->plainTextToken, 2)[1];
 
-        $this->form->fill([
-            'team_id' => $user->currentTeam?->getKey(),
-            'permissions' => Jetstream::$defaultPermissions,
-        ]);
+        $this->form->fill($this->initialFormState());
 
         $this->dispatch('tokenCreated');
 

--- a/app/Livewire/App/AccessTokens/ManageAccessTokens.php
+++ b/app/Livewire/App/AccessTokens/ManageAccessTokens.php
@@ -33,6 +33,8 @@ final class ManageAccessTokens extends BaseLivewireComponent implements HasTable
         $user = $this->authUser();
 
         return $table
+            ->heading(__('access-tokens.sections.manage.title'))
+            ->description(__('access-tokens.sections.manage.description'))
             ->query(
                 fn (): Builder => PersonalAccessToken::query()
                     ->with('team')

--- a/app/Livewire/App/AccessTokens/ManageOAuthConnectors.php
+++ b/app/Livewire/App/AccessTokens/ManageOAuthConnectors.php
@@ -33,6 +33,8 @@ final class ManageOAuthConnectors extends BaseLivewireComponent implements HasTa
         $userId = $this->authUser()->getKey();
 
         return $table
+            ->heading(__('access-tokens.connectors.title'))
+            ->description(__('access-tokens.connectors.description'))
             ->query(fn (): Builder => Passport::client()->newQuery()
                 ->whereIn('id', fn (QueryBuilder $query) => $query
                     ->select('client_id')

--- a/app/Livewire/App/Profile/DeleteAccount.php
+++ b/app/Livewire/App/Profile/DeleteAccount.php
@@ -35,7 +35,6 @@ final class DeleteAccount extends BaseLivewireComponent
             ->schema([
                 Section::make(__('profile.sections.delete_account.title'))
                     ->description(__('profile.sections.delete_account.description'))
-                    ->aside()
                     ->schema([
                         TextEntry::make('deleteAccountNotice')
                             ->hiddenLabel()

--- a/app/Livewire/App/Profile/LogoutOtherBrowserSessions.php
+++ b/app/Livewire/App/Profile/LogoutOtherBrowserSessions.php
@@ -28,7 +28,6 @@ final class LogoutOtherBrowserSessions extends BaseLivewireComponent
             ->schema([
                 Section::make(__('profile.sections.browser_sessions.title'))
                     ->description(__('profile.sections.browser_sessions.description'))
-                    ->aside()
                     ->schema([
                         ViewField::make('browserSessions')
                             ->hiddenLabel()

--- a/app/Livewire/App/Profile/ManageMfa.php
+++ b/app/Livewire/App/Profile/ManageMfa.php
@@ -54,7 +54,6 @@ final class ManageMfa extends BaseLivewireComponent
             ->schema([
                 Section::make(__('profile.sections.mfa.title'))
                     ->description(__('profile.sections.mfa.description'))
-                    ->aside()
                     ->schema([
                         ViewField::make('mfa')
                             ->hiddenLabel()

--- a/app/Livewire/App/Profile/ManagePasskeys.php
+++ b/app/Livewire/App/Profile/ManagePasskeys.php
@@ -40,7 +40,6 @@ final class ManagePasskeys extends BaseLivewireComponent
             ->schema([
                 Section::make(__('profile.sections.passkeys.title'))
                     ->description(__('profile.sections.passkeys.description'))
-                    ->aside()
                     ->schema([
                         ViewField::make('passkeys')
                             ->hiddenLabel()

--- a/app/Livewire/App/Profile/UpdatePassword.php
+++ b/app/Livewire/App/Profile/UpdatePassword.php
@@ -29,7 +29,6 @@ final class UpdatePassword extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make($hasPassword ? __('profile.sections.update_password.title') : __('profile.sections.set_password.title'))
-                    ->aside()
                     ->description($hasPassword ? __('profile.sections.update_password.description') : __('profile.sections.set_password.description'))
                     ->schema([
                         TextInput::make('password')

--- a/app/Livewire/App/Profile/UpdateProfileInformation.php
+++ b/app/Livewire/App/Profile/UpdateProfileInformation.php
@@ -68,7 +68,6 @@ final class UpdateProfileInformation extends BaseLivewireComponent
         return $schema
             ->schema([
                 Section::make(__('profile.sections.update_profile_information.title'))
-                    ->aside()
                     ->description(__('profile.sections.update_profile_information.description'))
                     ->schema([
                         FileUpload::make('profile_photo_path')

--- a/app/Livewire/App/Teams/UpdateTeamLogo.php
+++ b/app/Livewire/App/Teams/UpdateTeamLogo.php
@@ -49,7 +49,8 @@ final class UpdateTeamLogo extends BaseLivewireComponent
                             ->avatar()
                             // Last in the chain on purpose: avatar() calls image(),
                             // which resets the allowlist back to `image/*`.
-                            ->acceptedFileTypes(Team::LOGO_MIME_TYPES),
+                            ->acceptedFileTypes(Team::LOGO_MIME_TYPES)
+                            ->maxSize(Team::LOGO_MAX_KILOBYTES),
                         Actions::make([
                             Action::make('save')
                                 ->label(__('profile.actions.save'))

--- a/app/Livewire/App/Teams/UpdateTeamLogo.php
+++ b/app/Livewire/App/Teams/UpdateTeamLogo.php
@@ -28,6 +28,9 @@ final class UpdateTeamLogo extends BaseLivewireComponent
         $this->team = $team;
 
         $this->form->fill();
+
+        // fill() hydrates defaults only; the media collection needs its own load.
+        $this->form->loadStateFromRelationships(shouldHydrate: true);
     }
 
     public function form(Schema $schema): Schema

--- a/app/Livewire/App/Teams/UpdateTeamLogo.php
+++ b/app/Livewire/App/Teams/UpdateTeamLogo.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\App\Teams;
+
+use App\Livewire\BaseLivewireComponent;
+use App\Models\Team;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Filament\Actions\Action;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Livewire\Attributes\Locked;
+
+final class UpdateTeamLogo extends BaseLivewireComponent
+{
+    /** @var array<string, mixed>|null */
+    public ?array $data = [];
+
+    #[Locked]
+    public Team $team;
+
+    public function mount(Team $team): void
+    {
+        $this->team = $team;
+
+        $this->form->fill();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->model($this->team)
+            ->schema([
+                Section::make(__('teams.sections.update_team_logo.title'))
+                    ->aside()
+                    ->description(__('teams.sections.update_team_logo.description'))
+                    ->schema([
+                        SpatieMediaLibraryFileUpload::make('logo')
+                            ->label(__('teams.form.team_logo.label'))
+                            ->collection(Team::LOGO_MEDIA_COLLECTION)
+                            ->image()
+                            ->acceptedFileTypes(Team::LOGO_MIME_TYPES)
+                            ->imageEditor()
+                            ->avatar(),
+                        Actions::make([
+                            Action::make('save')
+                                ->label(__('profile.actions.save'))
+                                ->submit('updateLogo'),
+                        ]),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function updateLogo(): void
+    {
+        try {
+            $this->rateLimit(5);
+        } catch (TooManyRequestsException $exception) {
+            $this->sendRateLimitedNotification($exception);
+
+            return;
+        }
+
+        $this->form->getState();
+        $this->form->saveRelationships();
+
+        $this->sendNotification();
+    }
+}

--- a/app/Livewire/App/Teams/UpdateTeamLogo.php
+++ b/app/Livewire/App/Teams/UpdateTeamLogo.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Locked;
 
 final class UpdateTeamLogo extends BaseLivewireComponent
@@ -57,6 +58,8 @@ final class UpdateTeamLogo extends BaseLivewireComponent
 
     public function updateLogo(): void
     {
+        Gate::authorize('update', $this->team);
+
         try {
             $this->rateLimit(5);
         } catch (TooManyRequestsException $exception) {

--- a/app/Livewire/App/Teams/UpdateTeamLogo.php
+++ b/app/Livewire/App/Teams/UpdateTeamLogo.php
@@ -42,10 +42,11 @@ final class UpdateTeamLogo extends BaseLivewireComponent
                         SpatieMediaLibraryFileUpload::make('logo')
                             ->label(__('teams.form.team_logo.label'))
                             ->collection(Team::LOGO_MEDIA_COLLECTION)
-                            ->image()
-                            ->acceptedFileTypes(Team::LOGO_MIME_TYPES)
                             ->imageEditor()
-                            ->avatar(),
+                            ->avatar()
+                            // Last in the chain on purpose: avatar() calls image(),
+                            // which resets the allowlist back to `image/*`.
+                            ->acceptedFileTypes(Team::LOGO_MIME_TYPES),
                         Actions::make([
                             Action::make('save')
                                 ->label(__('profile.actions.save'))

--- a/app/Livewire/App/Teams/UpdateTeamLogo.php
+++ b/app/Livewire/App/Teams/UpdateTeamLogo.php
@@ -74,7 +74,6 @@ final class UpdateTeamLogo extends BaseLivewireComponent
         }
 
         $this->form->getState();
-        $this->form->saveRelationships();
 
         $this->sendNotification();
     }

--- a/app/Livewire/App/Teams/UpdateTeamName.php
+++ b/app/Livewire/App/Teams/UpdateTeamName.php
@@ -11,6 +11,7 @@ use App\Models\Team;
 use App\Rules\ValidTeamSlug;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use Filament\Actions\Action;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
@@ -37,6 +38,24 @@ final class UpdateTeamName extends BaseLivewireComponent
         $this->form->fill($team->only(['name', 'slug']));
     }
 
+    /**
+     * The part of the workspace address that precedes the slug, so the field
+     * reads as the URL members will actually visit.
+     */
+    private function slugPrefix(): string
+    {
+        $panel = Filament::getPanel('app');
+        $domains = $panel->getDomains();
+
+        if ($domains !== []) {
+            return reset($domains).'/';
+        }
+
+        $host = parse_url((string) config('app.url'), PHP_URL_HOST);
+
+        return (is_string($host) ? $host : '').'/'.$panel->getPath().'/';
+    }
+
     public function form(Schema $schema): Schema
     {
         return $schema
@@ -60,6 +79,7 @@ final class UpdateTeamName extends BaseLivewireComponent
                             }),
                         TextInput::make('slug')
                             ->label(__('teams.form.team_slug.label'))
+                            ->prefix($this->slugPrefix())
                             ->helperText(__('teams.form.team_slug.helper_text'))
                             ->string()
                             ->maxLength(255)

--- a/app/Livewire/App/Teams/UpdateTeamName.php
+++ b/app/Livewire/App/Teams/UpdateTeamName.php
@@ -9,9 +9,9 @@ use App\Filament\Pages\EditTeam;
 use App\Livewire\BaseLivewireComponent;
 use App\Models\Team;
 use App\Rules\ValidTeamSlug;
+use App\Support\WorkspaceUrlPrefix;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
 use Filament\Actions\Action;
-use Filament\Facades\Filament;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
@@ -38,24 +38,6 @@ final class UpdateTeamName extends BaseLivewireComponent
         $this->form->fill($team->only(['name', 'slug']));
     }
 
-    /**
-     * The part of the workspace address that precedes the slug, so the field
-     * reads as the URL members will actually visit.
-     */
-    private function slugPrefix(): string
-    {
-        $panel = Filament::getPanel('app');
-        $domains = $panel->getDomains();
-
-        if ($domains !== []) {
-            return reset($domains).'/';
-        }
-
-        $host = parse_url((string) config('app.url'), PHP_URL_HOST);
-
-        return (is_string($host) ? $host : '').'/'.$panel->getPath().'/';
-    }
-
     public function form(Schema $schema): Schema
     {
         return $schema
@@ -79,7 +61,7 @@ final class UpdateTeamName extends BaseLivewireComponent
                             }),
                         TextInput::make('slug')
                             ->label(__('teams.form.team_slug.label'))
-                            ->prefix($this->slugPrefix())
+                            ->prefix(WorkspaceUrlPrefix::get())
                             ->helperText(__('teams.form.team_slug.helper_text'))
                             ->string()
                             ->maxLength(255)

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -87,12 +87,9 @@ final class Team extends JetstreamTeam implements HasAvatar, HasMedia, Onboardab
 
     public const string LOGO_MEDIA_COLLECTION = 'logo';
 
-    /**
-     * SVG is excluded on purpose: it carries script, and a workspace logo is the
-     * one image members upload to the public disk on our own origin.
-     *
-     * @var list<string>
-     */
+    // SVG is excluded on purpose: it carries script, and a workspace logo is the
+    // one image members upload to the public disk on our own origin.
+    /** @var list<string> */
     public const array LOGO_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
     public const int LOGO_MAX_KILOBYTES = 2048;

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -95,6 +95,8 @@ final class Team extends JetstreamTeam implements HasAvatar, HasMedia, Onboardab
      */
     public const array LOGO_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
+    public const int LOGO_MAX_KILOBYTES = 2048;
+
     public const string SLUG_REGEX = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
 
     /**

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -34,6 +34,8 @@ use Laravel\Jetstream\Team as JetstreamTeam;
 use Relaticle\Chat\Models\AgentConversation;
 use Relaticle\Chat\Models\AiCreditBalance;
 use Relaticle\ImportWizard\Models\Import;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Onboard\Concerns\GetsOnboarded;
 use Spatie\Onboard\Concerns\Onboardable;
 use Spatie\Sluggable\HasSlug;
@@ -71,7 +73,7 @@ use Spatie\Sluggable\SlugOptions;
 #[Hidden([
     'invite_link_token',
 ])]
-final class Team extends JetstreamTeam implements HasAvatar, Onboardable
+final class Team extends JetstreamTeam implements HasAvatar, HasMedia, Onboardable
 {
     use Billable;
     use GetsOnboarded;
@@ -81,6 +83,17 @@ final class Team extends JetstreamTeam implements HasAvatar, Onboardable
 
     use HasSlug;
     use HasUlids;
+    use InteractsWithMedia;
+
+    public const string LOGO_MEDIA_COLLECTION = 'logo';
+
+    /**
+     * SVG is excluded on purpose: it carries script, and a workspace logo is the
+     * one image members upload to the public disk on our own origin.
+     *
+     * @var list<string>
+     */
+    public const array LOGO_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
     public const string SLUG_REGEX = '/^[a-z0-9]+(?:-[a-z0-9]+)*$/';
 
@@ -343,7 +356,20 @@ final class Team extends JetstreamTeam implements HasAvatar, Onboardable
 
     public function getFilamentAvatarUrl(): string
     {
+        $logo = $this->getFirstMediaUrl(self::LOGO_MEDIA_COLLECTION);
+
+        if ($logo !== '') {
+            return $logo;
+        }
+
         return resolve(AvatarService::class)->generate(name: $this->name, bgColor: '#000000', textColor: '#ffffff');
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection(self::LOGO_MEDIA_COLLECTION)
+            ->acceptsMimeTypes(self::LOGO_MIME_TYPES)
+            ->singleFile();
     }
 
     /**

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -361,13 +361,8 @@ final class AppPanelProvider extends PanelProvider
                 PanelsRenderHook::TENANT_MENU_AFTER,
                 fn (): View|Factory => view('filament.app.sidebar-toggle')
             )
-            /**
-             * Appearance is a device preference held in localStorage, so the accent
-             * ramps ship as CSS and the browser picks one. STYLES_AFTER renders past
-             *
-             * @filamentStyles, which is what makes the `html[data-accent]` block win
-             * over the `:root` defaults it emits.
-             */
+            // STYLES_AFTER renders past the panel stylesheet, which is what lets the
+            // `html[data-accent]` ramps outrank the `:root` defaults it emits.
             ->renderHook(
                 PanelsRenderHook::STYLES_AFTER,
                 fn (): View|Factory => view('filament.app.accent-palettes', [

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers\Filament;
 
+use App\Enums\AccentColor;
 use App\Enums\SupportFormType;
 use App\Features\Billing as BillingFeature;
 use App\Features\SupportMenu;
@@ -359,6 +360,23 @@ final class AppPanelProvider extends PanelProvider
             ->renderHook(
                 PanelsRenderHook::TENANT_MENU_AFTER,
                 fn (): View|Factory => view('filament.app.sidebar-toggle')
+            )
+            /**
+             * Appearance is a device preference held in localStorage, so the accent
+             * ramps ship as CSS and the browser picks one. STYLES_AFTER renders past
+             *
+             * @filamentStyles, which is what makes the `html[data-accent]` block win
+             * over the `:root` defaults it emits.
+             */
+            ->renderHook(
+                PanelsRenderHook::STYLES_AFTER,
+                fn (): View|Factory => view('filament.app.accent-palettes', [
+                    'accents' => AccentColor::cases(),
+                ])
+            )
+            ->renderHook(
+                PanelsRenderHook::HEAD_START,
+                fn (): View|Factory => view('filament.app.appearance-preference')
             )
             /**
              * The activation checklist lives here rather than on the dashboard

--- a/app/Support/WorkspaceUrlPrefix.php
+++ b/app/Support/WorkspaceUrlPrefix.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Uri;
+
+final readonly class WorkspaceUrlPrefix
+{
+    public static function get(): string
+    {
+        $panel = Filament::getPanel('app');
+        $domains = $panel->getDomains();
+
+        if ($domains !== []) {
+            return reset($domains).'/';
+        }
+
+        return Uri::of((string) config('app.url'))->host().'/'.$panel->getPath().'/';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "blade-ui-kit/blade-icons": "^1.8",
         "doctrine/dbal": "^4.4",
         "filament/filament": "^5.0",
+        "filament/spatie-laravel-media-library-plugin": "^5.7",
         "knuckleswtf/scribe": "^5.8",
         "laravel/ai": "~0.11.0",
         "laravel/cashier": "^16.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7037543fdc2e53d0dca61afa117b216e",
+    "content-hash": "1958783b507c2fcf3de326f8be900ed6",
     "packages": [
         {
             "name": "andreiio/blade-remix-icon",
@@ -2316,6 +2316,43 @@
                 "source": "https://github.com/filamentphp/filament"
             },
             "time": "2026-09-08T10:21:40+00:00"
+        },
+        {
+            "name": "filament/spatie-laravel-media-library-plugin",
+            "version": "v5.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
+                "reference": "16d3c2b0a4a47fd03dfe5f448f6b3bb5a53b0587"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-media-library-plugin/zipball/16d3c2b0a4a47fd03dfe5f448f6b3bb5a53b0587",
+                "reference": "16d3c2b0a4a47fd03dfe5f448f6b3bb5a53b0587",
+                "shasum": ""
+            },
+            "require": {
+                "filament/support": "self.version",
+                "php": "^8.2",
+                "spatie/laravel-medialibrary": "^11.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Filament\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Filament support for `spatie/laravel-medialibrary`.",
+            "homepage": "https://github.com/filamentphp/filament",
+            "support": {
+                "issues": "https://github.com/filamentphp/filament/issues",
+                "source": "https://github.com/filamentphp/filament"
+            },
+            "time": "2026-07-17T11:47:27+00:00"
         },
         {
             "name": "filament/support",

--- a/lang/en/appearance.php
+++ b/lang/en/appearance.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Appearance',
+    'theme' => [
+        'heading' => 'Theme',
+        'description' => 'Choose the color scheme for this browser.',
+        'modes' => [
+            'light' => 'Light',
+            'dark' => 'Dark',
+            'system' => 'System',
+        ],
+    ],
+
+    'accent' => [
+        'heading' => 'Accent color',
+        'description' => 'The color the app highlights with, saved on this browser.',
+        'brand_default' => 'Relaticle default',
+    ],
+
+    'accent_colors' => [
+        'Blue' => 'Blue',
+        'Cyan' => 'Cyan',
+        'Amber' => 'Amber',
+        'Orange' => 'Orange',
+        'Pink' => 'Pink',
+        'Purple' => 'Purple',
+        'Green' => 'Green',
+        'Slate' => 'Slate',
+    ],
+];

--- a/lang/en/filament/panel.php
+++ b/lang/en/filament/panel.php
@@ -12,6 +12,10 @@ return [
         'settings' => 'Settings',
     ],
 
+    'settings_layout' => [
+        'back_to_app' => 'Back to app',
+    ],
+
     'navigation_groups' => [
         'tasks' => 'Tasks',
     ],

--- a/lang/en/teams.php
+++ b/lang/en/teams.php
@@ -9,7 +9,7 @@ return [
         ],
         'team_slug' => [
             'label' => 'Workspace Slug',
-            'helper_text' => 'Only lowercase letters, numbers, and hyphens. This appears in your workspace URL.',
+            'helper_text' => 'Only lowercase letters, numbers, and hyphens.',
         ],
         'emails' => [
             'label' => 'Send invite to',
@@ -19,12 +19,19 @@ return [
         'invite_as' => [
             'label' => 'Invite as',
         ],
+        'team_logo' => [
+            'label' => 'Workspace logo',
+        ],
     ],
 
     'sections' => [
         'update_team_name' => [
             'title' => 'Workspace Name',
             'description' => 'The workspace\'s name and owner information.',
+        ],
+        'update_team_logo' => [
+            'title' => 'Workspace Logo',
+            'description' => 'Your logo appears in the workspace switcher, on invitations, and on the join page.',
         ],
         'add_team_member' => [
             'title' => 'Invite people',

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -926,7 +926,7 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
 /* Account settings shell: personal settings render without the panel's
    workspace chrome, so the frame is defined here rather than by fi-layout. */
 .fi-settings-layout {
-    @apply flex h-screen flex-col bg-white dark:bg-gray-900;
+    @apply flex h-full flex-col bg-white dark:bg-gray-900;
 }
 
 .fi-settings-topbar {
@@ -935,27 +935,24 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
 
 /* The topbar and the page share one container so the back link, the page
    heading and the content below all sit on the same left edge. */
+.fi-settings-container,
+.fi-settings-main .fi-page {
+    @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8;
+}
+
 .fi-settings-container {
-    @apply mx-auto flex w-full max-w-6xl items-center gap-x-3 px-4 sm:px-6 lg:px-8;
+    @apply flex items-center gap-x-3;
 }
 
 .fi-settings-back-link {
     @apply inline-flex items-center gap-x-1.5 rounded-lg px-2 py-1 text-sm font-medium text-gray-600 transition hover:bg-gray-100 hover:text-gray-950 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white;
 }
 
-.fi-settings-topbar-heading {
-    @apply text-sm font-semibold text-gray-950 dark:text-white;
-}
-
 .fi-settings-main {
     @apply flex-1 overflow-y-auto;
 
     .fi-page {
-        @apply mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 lg:px-8;
-    }
-
-    .fi-settings-back-link {
-        @apply -ml-2;
+        @apply py-8;
     }
 
     .fi-page-sub-navigation-sidebar-ctn {

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -922,3 +922,43 @@ body:has([data-sidebar-workspace-toggle]) .fi-topbar-collapse-sidebar-btn-ctn {
 
 /* Chat record chips moved to resources/css/theme.css: the marketing hero
    mock renders the same chips and only loads that shared bundle. */
+
+/* Account settings shell: personal settings render without the panel's
+   workspace chrome, so the frame is defined here rather than by fi-layout. */
+.fi-settings-layout {
+    @apply flex h-screen flex-col bg-white dark:bg-gray-900;
+}
+
+.fi-settings-topbar {
+    @apply shrink-0 border-b border-gray-200 py-3 dark:border-white/10;
+}
+
+/* The topbar and the page share one container so the back link, the page
+   heading and the content below all sit on the same left edge. */
+.fi-settings-container {
+    @apply mx-auto flex w-full max-w-6xl items-center gap-x-3 px-4 sm:px-6 lg:px-8;
+}
+
+.fi-settings-back-link {
+    @apply inline-flex items-center gap-x-1.5 rounded-lg px-2 py-1 text-sm font-medium text-gray-600 transition hover:bg-gray-100 hover:text-gray-950 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white;
+}
+
+.fi-settings-topbar-heading {
+    @apply text-sm font-semibold text-gray-950 dark:text-white;
+}
+
+.fi-settings-main {
+    @apply flex-1 overflow-y-auto;
+
+    .fi-page {
+        @apply mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 lg:px-8;
+    }
+
+    .fi-settings-back-link {
+        @apply -ml-2;
+    }
+
+    .fi-page-sub-navigation-sidebar-ctn {
+        @apply md:sticky md:top-8 md:self-start;
+    }
+}

--- a/resources/views/components/app/theme-preview.blade.php
+++ b/resources/views/components/app/theme-preview.blade.php
@@ -1,0 +1,43 @@
+@props(['mode'])
+
+@php
+    $panes = $mode === 'system' ? ['light', 'dark'] : [$mode];
+@endphp
+
+<span class="flex h-24 w-full overflow-hidden rounded-lg border border-gray-200 dark:border-white/10">
+    @foreach($panes as $pane)
+        <span @class([
+            'flex flex-1 gap-1.5 p-2',
+            'bg-gray-50' => $pane === 'light',
+            'bg-gray-900' => $pane === 'dark',
+        ])>
+            <span class="flex w-1/3 flex-col gap-1">
+                @for($i = 0; $i < 4; $i++)
+                    <span @class([
+                        'h-1.5 rounded-full',
+                        'w-full' => $i === 0,
+                        'w-3/4' => $i !== 0,
+                        'bg-gray-300' => $pane === 'light',
+                        'bg-gray-700' => $pane === 'dark',
+                    ])></span>
+                @endfor
+            </span>
+
+            <span @class([
+                'flex flex-1 flex-col gap-1 rounded p-1.5',
+                'bg-white' => $pane === 'light',
+                'bg-gray-800' => $pane === 'dark',
+            ])>
+                @for($i = 0; $i < 5; $i++)
+                    <span @class([
+                        'h-1.5 rounded-full',
+                        'w-full' => $i % 2 === 0,
+                        'w-2/3' => $i % 2 !== 0,
+                        'bg-gray-200' => $pane === 'light',
+                        'bg-gray-700' => $pane === 'dark',
+                    ])></span>
+                @endfor
+            </span>
+        </span>
+    @endforeach
+</span>

--- a/resources/views/components/mfa-section.blade.php
+++ b/resources/views/components/mfa-section.blade.php
@@ -1,5 +1,5 @@
 <div class="space-y-4">
-    <div class="flex items-start justify-between gap-4 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+    <div class="flex items-start justify-between gap-4">
         <div class="space-y-1">
             <div class="flex items-center gap-2 font-medium text-gray-900 dark:text-white">
                 <x-filament::icon

--- a/resources/views/filament/app/accent-palettes.blade.php
+++ b/resources/views/filament/app/accent-palettes.blade.php
@@ -1,0 +1,20 @@
+@props(['accents'])
+
+{{--
+    The brand ramp is baked into the `@theme` block in resources/css/theme.css, so
+    overriding Filament's `--primary-*` alone changes nothing: components read the
+    `--color-primary-*` tokens. Both are set here, and the attribute selector is
+    what outranks the `:root` defaults.
+--}}
+<style>
+    @foreach($accents as $accent)
+        @php($ramp = \Filament\Support\Colors\Color::hex($accent->value))
+        html[data-accent="{{ $accent->name }}"] {
+            @foreach($ramp as $shade => $value)
+                --primary-{{ $shade }}: {{ $value }};
+                --color-primary-{{ $shade }}: {{ $value }};
+            @endforeach
+            --color-primary: {{ $ramp[600] }};
+        }
+    @endforeach
+</style>

--- a/resources/views/filament/app/appearance-preference.blade.php
+++ b/resources/views/filament/app/appearance-preference.blade.php
@@ -1,0 +1,15 @@
+<script>
+    const loadAccent = () => {
+        const accent = localStorage.getItem('accent')
+
+        if (accent) {
+            document.documentElement.dataset.accent = accent
+        } else {
+            delete document.documentElement.dataset.accent
+        }
+    }
+
+    loadAccent()
+
+    document.addEventListener('livewire:navigated', loadAccent)
+</script>

--- a/resources/views/filament/layouts/settings.blade.php
+++ b/resources/views/filament/layouts/settings.blade.php
@@ -1,0 +1,34 @@
+@php
+    $livewire ??= null;
+@endphp
+
+{{-- Account settings drop the panel shell, so the topbar is rebuilt here. It
+     keeps a .fi-topbar-start: the app panel teleports every page heading there
+     (see filament.app.topbar-page-heading), and without the target Alpine
+     aborts the teleport and the page renders with no heading at all. --}}
+<x-filament-panels::layout.base :livewire="$livewire">
+    <a href="#fi-main-content" class="fi-skip-link fi-sr-only">
+        {{ __('filament-panels::layout.skip_to_content.label') }}
+    </a>
+
+    <div class="fi-settings-layout">
+        <header class="fi-settings-topbar">
+            <div class="fi-settings-container">
+                <a
+                    href="{{ \App\Filament\Pages\Dashboard::getUrl() }}"
+                    wire:navigate
+                    class="fi-settings-back-link"
+                >
+                    <x-filament::icon icon="ri-arrow-left-line" class="size-4" />
+                    {{ __('filament/panel.settings_layout.back_to_app') }}
+                </a>
+
+                <div class="fi-topbar-start"></div>
+            </div>
+        </header>
+
+        <main id="fi-main-content" class="fi-settings-main">
+            {{ $slot }}
+        </main>
+    </div>
+</x-filament-panels::layout.base>

--- a/resources/views/filament/pages/appearance.blade.php
+++ b/resources/views/filament/pages/appearance.blade.php
@@ -1,0 +1,105 @@
+@php
+    $themeIcons = [
+        'light' => 'ri-sun-line',
+        'dark' => 'ri-moon-line',
+        'system' => 'ri-computer-line',
+    ];
+@endphp
+
+<x-filament-panels::page>
+    <div
+        x-cloak
+        x-data="{
+            theme: localStorage.getItem('theme') ?? @js(\Filament\Facades\Filament::getDefaultThemeMode()->value),
+            accent: localStorage.getItem('accent'),
+
+            selectTheme(theme) {
+                this.theme = theme
+                localStorage.setItem('theme', theme)
+
+                document.documentElement.classList.toggle(
+                    'dark',
+                    theme === 'dark' ||
+                        (theme === 'system' &&
+                            window.matchMedia('(prefers-color-scheme: dark)').matches),
+                )
+            },
+
+            selectAccent(accent) {
+                this.accent = accent
+
+                if (accent) {
+                    localStorage.setItem('accent', accent)
+                    document.documentElement.dataset.accent = accent
+                } else {
+                    localStorage.removeItem('accent')
+                    delete document.documentElement.dataset.accent
+                }
+            },
+        }"
+        class="space-y-6"
+    >
+        <x-filament::section
+            :heading="__('appearance.theme.heading')"
+            :description="__('appearance.theme.description')"
+        >
+            <div class="grid gap-4 sm:grid-cols-3">
+                @foreach($themes as $themeOption)
+                    <button
+                        type="button"
+                        @click="selectTheme(@js($themeOption->value))"
+                        :aria-pressed="theme === @js($themeOption->value)"
+                        class="group flex flex-col gap-3 rounded-xl border p-3 text-left transition"
+                        :class="theme === @js($themeOption->value)
+                            ? 'border-primary-600 ring-1 ring-primary-600'
+                            : 'border-gray-200 hover:border-gray-300 dark:border-white/10 dark:hover:border-white/20'"
+                    >
+                        <x-app.theme-preview :mode="$themeOption->value" />
+
+                        <span class="flex items-center gap-2 px-1 pb-1 text-sm font-medium text-gray-950 dark:text-white">
+                            <x-filament::icon :icon="$themeIcons[$themeOption->value]" class="size-4" />
+                            {{ __('appearance.theme.modes.'.$themeOption->value) }}
+                        </span>
+                    </button>
+                @endforeach
+            </div>
+        </x-filament::section>
+
+        <x-filament::section
+            :heading="__('appearance.accent.heading')"
+            :description="__('appearance.accent.description')"
+        >
+            <div class="flex flex-wrap items-center gap-3">
+                <button
+                    type="button"
+                    @click="selectAccent(null)"
+                    :aria-pressed="accent === null"
+                    title="{{ __('appearance.accent.brand_default') }}"
+                    class="size-7 rounded-full transition"
+                    style="background-color: {{ $brandColor }}; --tw-ring-color: {{ $brandColor }};"
+                    :class="accent === null
+                        ? 'ring-2 ring-offset-2 ring-offset-white dark:ring-offset-gray-900'
+                        : 'hover:scale-110'"
+                >
+                    <span class="sr-only">{{ __('appearance.accent.brand_default') }}</span>
+                </button>
+
+                @foreach($accents as $accent)
+                    <button
+                        type="button"
+                        @click="selectAccent(@js($accent->name))"
+                        :aria-pressed="accent === @js($accent->name)"
+                        title="{{ $accent->label() }}"
+                        class="size-7 rounded-full transition"
+                        style="background-color: {{ $accent->value }}; --tw-ring-color: {{ $accent->value }};"
+                        :class="accent === @js($accent->name)
+                            ? 'ring-2 ring-offset-2 ring-offset-white dark:ring-offset-gray-900'
+                            : 'hover:scale-110'"
+                    >
+                        <span class="sr-only">{{ $accent->label() }}</span>
+                    </button>
+                @endforeach
+            </div>
+        </x-filament::section>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/appearance.blade.php
+++ b/resources/views/filament/pages/appearance.blade.php
@@ -15,14 +15,8 @@
 
             selectTheme(theme) {
                 this.theme = theme
-                localStorage.setItem('theme', theme)
 
-                document.documentElement.classList.toggle(
-                    'dark',
-                    theme === 'dark' ||
-                        (theme === 'system' &&
-                            window.matchMedia('(prefers-color-scheme: dark)').matches),
-                )
+                this.$dispatch('theme-changed', theme)
             },
 
             selectAccent(accent) {

--- a/resources/views/livewire/app/access-tokens/manage-access-tokens.blade.php
+++ b/resources/views/livewire/app/access-tokens/manage-access-tokens.blade.php
@@ -1,12 +1,5 @@
-<x-filament::section aside :contained="false">
-    <x-slot name="heading">
-        {{ __('access-tokens.sections.manage.title') }}
-    </x-slot>
-    <x-slot name="description">
-        {{ __('access-tokens.sections.manage.description') }}
-    </x-slot>
-
+<div>
     {{ $this->table }}
 
     <x-filament-actions::modals />
-</x-filament::section>
+</div>

--- a/resources/views/livewire/app/access-tokens/manage-oauth-connectors.blade.php
+++ b/resources/views/livewire/app/access-tokens/manage-oauth-connectors.blade.php
@@ -1,12 +1,5 @@
-<x-filament::section aside :contained="false">
-    <x-slot name="heading">
-        {{ __('access-tokens.connectors.title') }}
-    </x-slot>
-    <x-slot name="description">
-        {{ __('access-tokens.connectors.description') }}
-    </x-slot>
-
+<div>
     {{ $this->table }}
 
     <x-filament-actions::modals />
-</x-filament::section>
+</div>

--- a/resources/views/livewire/app/teams/update-team-logo.blade.php
+++ b/resources/views/livewire/app/teams/update-team-logo.blade.php
@@ -1,0 +1,7 @@
+<div>
+    <form wire:submit="updateLogo">
+        {{ $this->form }}
+    </form>
+
+    <x-filament-actions::modals/>
+</div>

--- a/tests/Feature/AccessTokens/CreateAccessTokenTest.php
+++ b/tests/Feature/AccessTokens/CreateAccessTokenTest.php
@@ -10,6 +10,24 @@ use Laravel\Jetstream\Features;
 
 mutates(User::class);
 
+test('the expiration field defaults to 180 days', function () {
+    $this->actingAs($user = User::factory()->withTeam()->create());
+
+    livewire(CreateAccessToken::class)
+        ->assertFormSet(['expiration' => '180'])
+        ->fillForm([
+            'name' => 'Default Expiry Token',
+            'team_id' => $user->currentTeam->id,
+            'permissions' => ['read'],
+        ])
+        ->call('createToken')
+        ->assertHasNoFormErrors();
+
+    $token = $user->fresh()->tokens->first();
+
+    expect($token->expires_at->startOfDay()->equalTo(now()->addDays(180)->startOfDay()))->toBeTrue();
+})->skip(fn () => ! Features::hasApiFeatures(), 'API support is not enabled.');
+
 test('api tokens can be created with team and expiration', function () {
     $this->actingAs($user = User::factory()->withTeam()->create());
 

--- a/tests/Feature/Profile/AppearanceTest.php
+++ b/tests/Feature/Profile/AppearanceTest.php
@@ -28,6 +28,14 @@ it('renders every theme mode and accent swatch', function (): void {
     }
 });
 
+it('renders accent labels through the translation layer', function (): void {
+    app('translator')->addLines(['appearance.accent_colors.Blue' => 'Azure'], 'en');
+
+    Livewire::test(Appearance::class)
+        ->assertSuccessful()
+        ->assertSee('Azure');
+});
+
 it('ships a primary ramp for every accent', function (): void {
     $this->get(Appearance::getUrl())
         ->assertSuccessful()

--- a/tests/Feature/Profile/AppearanceTest.php
+++ b/tests/Feature/Profile/AppearanceTest.php
@@ -34,3 +34,10 @@ it('ships a primary ramp for every accent', function (): void {
         ->assertSee('html[data-accent="'.AccentColor::Blue->name.'"]', false)
         ->assertSee('--primary-500', false);
 });
+
+it('restores the stored accent on every page load', function (): void {
+    $this->get(Appearance::getUrl())
+        ->assertSuccessful()
+        ->assertSee('const loadAccent', false)
+        ->assertSee("document.addEventListener('livewire:navigated', loadAccent)", false);
+});

--- a/tests/Feature/Profile/AppearanceTest.php
+++ b/tests/Feature/Profile/AppearanceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AccentColor;
+use App\Filament\Pages\Appearance;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+mutates(Appearance::class, AccentColor::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->withTeam()->create();
+    $this->actingAs($this->user);
+    Filament::setTenant($this->user->currentTeam);
+});
+
+it('renders every theme mode and accent swatch', function (): void {
+    $page = Livewire::test(Appearance::class)
+        ->assertSuccessful()
+        ->assertSee('Light')
+        ->assertSee('Dark')
+        ->assertSee('System');
+
+    foreach (AccentColor::cases() as $accent) {
+        $page->assertSee($accent->label());
+    }
+});
+
+it('ships a primary ramp for every accent', function (): void {
+    $this->get(Appearance::getUrl())
+        ->assertSuccessful()
+        ->assertSee('html[data-accent="'.AccentColor::Blue->name.'"]', false)
+        ->assertSee('--primary-500', false);
+});

--- a/tests/Feature/Teams/UpdateTeamLogoTest.php
+++ b/tests/Feature/Teams/UpdateTeamLogoTest.php
@@ -97,6 +97,15 @@ it('keeps the existing logo when the form is saved untouched', function (): void
     expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(1);
 });
 
+it('rejects a logo larger than the size cap', function (): void {
+    Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->fillForm(['logo' => UploadedFile::fake()->image('huge.png', 4000, 4000)->size(Team::LOGO_MAX_KILOBYTES + 1)])
+        ->call('updateLogo')
+        ->assertHasFormErrors(['logo']);
+
+    expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(0);
+});
+
 it('holds a single logo even when media is added outside the form', function (): void {
     $this->team->addMedia(UploadedFile::fake()->image('first.png', 120, 120))
         ->toMediaCollection(Team::LOGO_MEDIA_COLLECTION);

--- a/tests/Feature/Teams/UpdateTeamLogoTest.php
+++ b/tests/Feature/Teams/UpdateTeamLogoTest.php
@@ -59,6 +59,34 @@ it('keeps only the latest logo when a new one replaces it', function (): void {
     expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(1);
 });
 
+it('clears the logo when the upload is emptied', function (): void {
+    $component = Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->fillForm(['logo' => UploadedFile::fake()->image('logo.png', 200, 200)])
+        ->call('updateLogo');
+
+    expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(1);
+
+    $component
+        ->fillForm(['logo' => []])
+        ->call('updateLogo')
+        ->assertHasNoFormErrors();
+
+    $team = $this->team->fresh();
+
+    expect($team->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(0)
+        ->and($team->getFilamentAvatarUrl())->toContain('data:image/svg+xml');
+});
+
+it('holds a single logo even when media is added outside the form', function (): void {
+    $this->team->addMedia(UploadedFile::fake()->image('first.png', 120, 120))
+        ->toMediaCollection(Team::LOGO_MEDIA_COLLECTION);
+
+    $this->team->addMedia(UploadedFile::fake()->image('second.png', 120, 120))
+        ->toMediaCollection(Team::LOGO_MEDIA_COLLECTION);
+
+    expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(1);
+});
+
 it('replaces the workspace initials avatar with the logo url', function (): void {
     $this->team
         ->addMedia(UploadedFile::fake()->image('logo.png', 200, 200))

--- a/tests/Feature/Teams/UpdateTeamLogoTest.php
+++ b/tests/Feature/Teams/UpdateTeamLogoTest.php
@@ -77,6 +77,15 @@ it('clears the logo when the upload is emptied', function (): void {
         ->and($team->getFilamentAvatarUrl())->toContain('data:image/svg+xml');
 });
 
+it('rejects an image type outside the logo allowlist', function (): void {
+    Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->fillForm(['logo' => UploadedFile::fake()->image('logo.gif', 120, 120)])
+        ->call('updateLogo')
+        ->assertHasFormErrors(['logo']);
+
+    expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(0);
+});
+
 it('holds a single logo even when media is added outside the form', function (): void {
     $this->team->addMedia(UploadedFile::fake()->image('first.png', 120, 120))
         ->toMediaCollection(Team::LOGO_MEDIA_COLLECTION);

--- a/tests/Feature/Teams/UpdateTeamLogoTest.php
+++ b/tests/Feature/Teams/UpdateTeamLogoTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\EditTeam;
+use App\Livewire\App\Teams\UpdateTeamLogo;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+mutates(UpdateTeamLogo::class);
+
+beforeEach(function (): void {
+    Storage::fake('public');
+
+    $this->user = User::factory()->create([
+        'email' => 'branding@example.com',
+        'email_verified_at' => now(),
+    ]);
+
+    $this->team = Team::factory()->create([
+        'user_id' => $this->user->id,
+        'personal_team' => false,
+    ]);
+
+    $this->actingAs($this->user);
+    Filament::setTenant($this->team);
+});
+
+it('renders the workspace logo section', function (): void {
+    Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->assertSuccessful()
+        ->assertSee('Workspace Logo');
+});
+
+it('stores an uploaded logo in the media collection', function (): void {
+    Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->fillForm(['logo' => UploadedFile::fake()->image('logo.png', 200, 200)])
+        ->call('updateLogo')
+        ->assertHasNoFormErrors()
+        ->assertNotified();
+
+    expect($this->team->fresh()->getFirstMedia(Team::LOGO_MEDIA_COLLECTION))->not->toBeNull();
+});
+
+it('keeps only the latest logo when a new one replaces it', function (): void {
+    $component = Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->fillForm(['logo' => UploadedFile::fake()->image('first.png', 200, 200)])
+        ->call('updateLogo');
+
+    $component
+        ->fillForm(['logo' => UploadedFile::fake()->image('second.png', 200, 200)])
+        ->call('updateLogo')
+        ->assertHasNoFormErrors();
+
+    expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(1);
+});
+
+it('replaces the workspace initials avatar with the logo url', function (): void {
+    $this->team
+        ->addMedia(UploadedFile::fake()->image('logo.png', 200, 200))
+        ->toMediaCollection(Team::LOGO_MEDIA_COLLECTION);
+
+    expect($this->team->fresh()->getFilamentAvatarUrl())->toContain('logo.png');
+});
+
+it('falls back to the generated initials avatar without a logo', function (): void {
+    expect($this->team->getFilamentAvatarUrl())->toContain('data:image/svg+xml');
+});
+
+it('offers the logo section on a personal workspace', function (): void {
+    $this->team->forceFill(['personal_team' => true])->save();
+
+    Livewire::test(EditTeam::class)
+        ->assertSuccessful()
+        ->assertSeeLivewire(UpdateTeamLogo::class);
+});

--- a/tests/Feature/Teams/UpdateTeamLogoTest.php
+++ b/tests/Feature/Teams/UpdateTeamLogoTest.php
@@ -99,6 +99,20 @@ it('falls back to the generated initials avatar without a logo', function (): vo
     expect($this->team->getFilamentAvatarUrl())->toContain('data:image/svg+xml');
 });
 
+it('refuses a logo change from a member who does not own the workspace', function (): void {
+    $member = User::factory()->create();
+    $this->team->users()->attach($member, ['role' => 'editor']);
+
+    $this->actingAs($member);
+
+    Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->fillForm(['logo' => UploadedFile::fake()->image('sneaky.png', 120, 120)])
+        ->call('updateLogo')
+        ->assertForbidden();
+
+    expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(0);
+});
+
 it('offers the logo section on a personal workspace', function (): void {
     $this->team->forceFill(['personal_team' => true])->save();
 

--- a/tests/Feature/Teams/UpdateTeamLogoTest.php
+++ b/tests/Feature/Teams/UpdateTeamLogoTest.php
@@ -86,6 +86,17 @@ it('rejects an image type outside the logo allowlist', function (): void {
     expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(0);
 });
 
+it('keeps the existing logo when the form is saved untouched', function (): void {
+    $this->team->addMedia(UploadedFile::fake()->image('existing.png', 120, 120))
+        ->toMediaCollection(Team::LOGO_MEDIA_COLLECTION);
+
+    Livewire::test(UpdateTeamLogo::class, ['team' => $this->team])
+        ->call('updateLogo')
+        ->assertHasNoFormErrors();
+
+    expect($this->team->fresh()->getMedia(Team::LOGO_MEDIA_COLLECTION))->toHaveCount(1);
+});
+
 it('holds a single logo even when media is added outside the form', function (): void {
     $this->team->addMedia(UploadedFile::fake()->image('first.png', 120, 120))
         ->toMediaCollection(Team::LOGO_MEDIA_COLLECTION);

--- a/tests/Feature/Teams/UpdateTeamNameTest.php
+++ b/tests/Feature/Teams/UpdateTeamNameTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Livewire\App\Teams\UpdateTeamName;
 use App\Models\Team;
 use App\Models\User;
+use Filament\Facades\Filament;
 use Livewire\Livewire;
 
 mutates(UpdateTeamName::class);
@@ -104,4 +105,15 @@ test('same slug does not trigger redirect', function () {
         ->assertHasNoFormErrors()
         ->assertNotified()
         ->assertNoRedirect();
+});
+
+test('the slug field is prefixed with the workspace address', function () {
+    $this->actingAs($user = User::factory()->withTeam()->create());
+
+    $panel = Filament::getPanel('app');
+    $host = parse_url((string) config('app.url'), PHP_URL_HOST);
+
+    Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
+        ->assertSuccessful()
+        ->assertSee($host.'/'.$panel->getPath().'/');
 });

--- a/tests/Feature/Teams/UpdateTeamNameTest.php
+++ b/tests/Feature/Teams/UpdateTeamNameTest.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
+use App\Filament\Pages\CreateTeam;
 use App\Livewire\App\Teams\UpdateTeamName;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\WorkspaceUrlPrefix;
 use Filament\Facades\Filament;
+use Illuminate\Support\Uri;
 use Livewire\Livewire;
 
-mutates(UpdateTeamName::class);
+mutates(UpdateTeamName::class, WorkspaceUrlPrefix::class);
 
 test('team name and slug can be updated', function () {
     $this->actingAs($user = User::factory()->withTeam()->create());
@@ -111,9 +114,19 @@ test('the slug field is prefixed with the workspace address', function () {
     $this->actingAs($user = User::factory()->withTeam()->create());
 
     $panel = Filament::getPanel('app');
-    $host = parse_url((string) config('app.url'), PHP_URL_HOST);
+    $host = Uri::of((string) config('app.url'))->host();
+
+    expect(WorkspaceUrlPrefix::get())->toBe($host.'/'.$panel->getPath().'/');
 
     Livewire::test(UpdateTeamName::class, ['team' => $user->currentTeam])
         ->assertSuccessful()
-        ->assertSee($host.'/'.$panel->getPath().'/');
+        ->assertSee(WorkspaceUrlPrefix::get());
+});
+
+test('the create workspace wizard shows the same slug prefix', function () {
+    $this->actingAs(User::factory()->withTeam()->create());
+
+    Livewire::test(CreateTeam::class)
+        ->assertSuccessful()
+        ->assertSee(WorkspaceUrlPrefix::get());
 });


### PR DESCRIPTION
Account settings rendered inside the workspace panel, so a page of personal preferences carried the main sidebar, the workspace switcher and the rest of the tenant chrome with it. Theme could only be flipped from the user menu, and there was no accent choice at all.

## Appearance

New page under Settings with Light/Dark/System cards and eight accent swatches. Both apply immediately, no page reload.

It is a device preference: held in localStorage, never written to the database, so clearing site data resets it. Each accent ships as a CSS block and the browser picks one by setting `html[data-accent]`, which outranks the `:root` defaults `@filamentStyles` emits. Both `--primary-*` and `--color-primary-*` are written, because the brand ramp is baked into the `@theme` block in `resources/css/theme.css` and components read the latter. With no accent chosen nothing is overridden, so the default stays the brand violet exactly as before.

## Settings shell

Profile, Security, Notifications, Access Tokens and Appearance render in `filament.layouts.settings`: nav on the left and sticky, no sidebar, no workspace switcher, back link to the app. The shell keeps a `.fi-topbar-start`, without which the panel's page-heading teleport has no target and every settings page renders untitled.

Section layout is now consistent across all five: heading and description sit on top of the card rather than in a left column. `Manage Access Tokens` and `AI Connectors` moved their heading onto the table itself, which removes a card nested inside a card.

## Workspace logo

Uploaded through spatie/laravel-medialibrary, mirroring Company's `logo` collection, feeding `Team::getFilamentAvatarUrl()` for the switcher, invitation emails and join pages. SVG is excluded: it carries script, and this is the first image members upload to the public disk on our own origin.

## Also here

- Workspace Slug shows the address prefix it belongs to, derived from the panel rather than hardcoded, so it reads as the URL members will visit
- Access token expiration defaults to 180 days

## Verified

pint, rector, phpstan, 100% type coverage, full Pest suite (4682 tests). Browser: all five settings pages, `wire:navigate` between them and back to the app, accent and theme surviving navigation, light and dark, 390px viewport.

## Follow-up

`Team::getFilamentAvatarUrl()` reads the media relation per team in the switcher. Fine at the handful of workspaces a member belongs to; worth eager-loading if that list grows.

Supersedes #606.
