### PR TITLE
Fix Microsoft mail import to use per-folder Graph delta

### DIFF
--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Services;
 
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use JsonException;
 use Relaticle\EmailIntegration\Data\FetchedEmailData;
 use Relaticle\EmailIntegration\Data\MailBackfillPage;
 use Relaticle\EmailIntegration\Data\MailDeltaResult;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Contracts\MailServiceInterface;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphClientFactory;
@@ -18,10 +22,8 @@ use RuntimeException;
 
 final class MicrosoftGraphMailService implements MailServiceInterface
 {
-    // All-folder delta stream. Unlike a per-folder endpoint (/me/mailFolders/Inbox/...),
-    // this spans Inbox, SentItems, etc. in a single cursor, so Sent mail syncs too.
-    // Folder/direction is derived per message from parentFolderId in fetchMessage().
-    private const string MESSAGES_DELTA = '/me/messages/delta';
+    /** Graph message delta is per-folder. These two cover inbound and outbound sync. */
+    private const array DELTA_FOLDERS = ['inbox', 'sentitems'];
 
     private const string RECONCILIATION_PROPERTY_ID = 'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId';
 
@@ -37,6 +39,7 @@ final class MicrosoftGraphMailService implements MailServiceInterface
 
     public function fetchDelta(string $cursor): MailDeltaResult
     {
+        $cursors = $this->decodeCursor($cursor);
         $http = $this->clientFactory->make($this->account);
 
         $messageIds = [];
@@ -45,30 +48,38 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         // lands in both the read and unread lists (which the sync job would then apply
         // in an order-dependent way).
         $readState = [];
-        $nextUrl = $cursor;
-        $deltaLink = $cursor;
+        $newCursors = [];
 
-        do {
-            $response = $http->get($nextUrl)->throw()->json();
+        foreach (self::DELTA_FOLDERS as $folder) {
+            $folderCursor = $cursors[$folder];
+            $url = $folderCursor;
+            $deltaLink = $folderCursor;
 
-            foreach ($response['value'] ?? [] as $message) {
-                // Graph delta includes tombstones for deleted messages; they carry no
-                // fetchable payload, so dispatching a StoreEmailJob would just 404.
-                if (isset($message['@removed'])) {
-                    continue;
+            do {
+                $response = $this->getDeltaPage($http, $url);
+
+                foreach ($response['value'] ?? [] as $message) {
+                    // Graph delta includes tombstones for deleted messages; they carry no
+                    // fetchable payload, so dispatching a StoreEmailJob would just 404.
+                    if (isset($message['@removed'])) {
+                        continue;
+                    }
+
+                    $id = (string) $message['id'];
+                    $messageIds[] = $id;
+
+                    if (array_key_exists('isRead', $message)) {
+                        $readState[$id] = $message['isRead'] === true;
+                    }
                 }
 
-                $id = (string) $message['id'];
-                $messageIds[] = $id;
+                $nextLink = $response['@odata.nextLink'] ?? null;
+                $deltaLink = $response['@odata.deltaLink'] ?? $deltaLink;
+                $url = is_string($nextLink) && $nextLink !== '' ? $nextLink : null;
+            } while ($url !== null);
 
-                if (array_key_exists('isRead', $message)) {
-                    $readState[$id] = $message['isRead'] === true;
-                }
-            }
-
-            $nextUrl = $response['@odata.nextLink'] ?? null;
-            $deltaLink = $response['@odata.deltaLink'] ?? $deltaLink;
-        } while ($nextUrl !== null);
+            $newCursors[$folder] = (string) $deltaLink;
+        }
 
         $readMessageIds = [];
         $unreadMessageIds = [];
@@ -83,7 +94,7 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         return new MailDeltaResult(
             messageIds: collect($messageIds)->unique()->values(),
             readMessageIds: collect($readMessageIds)->values(),
-            newCursor: (string) $deltaLink,
+            newCursor: $this->encodeCursor($newCursors),
             unreadMessageIds: collect($unreadMessageIds)->values(),
         );
     }
@@ -155,11 +166,9 @@ final class MicrosoftGraphMailService implements MailServiceInterface
 
     public function initialBackfill(?int $daysBack = null, ?string $pageToken = null): MailBackfillPage
     {
+        $state = $this->backfillState($pageToken, $daysBack);
         $http = $this->clientFactory->make($this->account);
-
-        $nextUrl = $pageToken ?? $this->initialDeltaUrl($daysBack);
-
-        $response = $http->get($nextUrl)->throw()->json();
+        $response = $this->getDeltaPage($http, $state['url']);
 
         $messageIds = [];
 
@@ -171,25 +180,49 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             $messageIds[] = (string) $message['id'];
         }
 
+        $ids = collect($messageIds)->unique()->values();
         $nextLink = $response['@odata.nextLink'] ?? null;
         $deltaLink = $response['@odata.deltaLink'] ?? null;
 
-        return new MailBackfillPage(
-            messageIds: collect($messageIds)->unique()->values(),
-            nextPageToken: is_string($nextLink) && $nextLink !== '' ? $nextLink : null,
-            cursor: is_string($deltaLink) && $deltaLink !== '' ? $deltaLink : null,
-        );
-    }
-
-    private function initialDeltaUrl(?int $daysBack): string
-    {
-        if ($daysBack === null || $daysBack <= 0) {
-            return self::MESSAGES_DELTA;
+        if (is_string($nextLink) && $nextLink !== '') {
+            return new MailBackfillPage(
+                messageIds: $ids,
+                nextPageToken: $this->encodeBackfillState([
+                    ...$state,
+                    'url' => $nextLink,
+                ]),
+                cursor: null,
+            );
         }
 
-        $afterIso = now()->subDays($daysBack)->toIso8601String();
+        throw_unless(
+            is_string($deltaLink) && $deltaLink !== '',
+            RuntimeException::class,
+            'Microsoft Graph delta page included neither nextLink nor deltaLink.',
+        );
 
-        return self::MESSAGES_DELTA.'?$filter='.rawurlencode("receivedDateTime ge {$afterIso}");
+        $cursors = $state['cursors'];
+        $cursors[$state['folder']] = $deltaLink;
+        $nextFolder = $this->nextDeltaFolder($state['folder']);
+
+        if ($nextFolder !== null) {
+            return new MailBackfillPage(
+                messageIds: $ids,
+                nextPageToken: $this->encodeBackfillState([
+                    'folder' => $nextFolder,
+                    'url' => $this->folderDeltaUrl($nextFolder, $state['daysBack']),
+                    'cursors' => $cursors,
+                    'daysBack' => $state['daysBack'],
+                ]),
+                cursor: null,
+            );
+        }
+
+        return new MailBackfillPage(
+            messageIds: $ids,
+            nextPageToken: null,
+            cursor: $this->encodeCursor($cursors),
+        );
     }
 
     public function sendMessage(array $data): array
@@ -350,5 +383,169 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             'inbox' => EmailFolder::Inbox,
             default => EmailFolder::Archive,
         };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getDeltaPage(PendingRequest $http, string $url): array
+    {
+        try {
+            $response = $http->get($url)->throw()->json();
+        } catch (RequestException $e) {
+            if ($e->response->status() === 410) {
+                throw MailHistoryExpired::forAccount((string) $this->account->getKey());
+            }
+
+            throw $e;
+        }
+
+        return is_array($response) ? $response : [];
+    }
+
+    /**
+     * @return array{folder: string, url: string, cursors: array<string, string>, daysBack: int|null}
+     */
+    private function backfillState(?string $pageToken, ?int $daysBack): array
+    {
+        if ($pageToken === null || $pageToken === '') {
+            $folder = self::DELTA_FOLDERS[0];
+
+            return [
+                'folder' => $folder,
+                'url' => $this->folderDeltaUrl($folder, $daysBack),
+                'cursors' => [],
+                'daysBack' => $daysBack,
+            ];
+        }
+
+        try {
+            $decoded = json_decode($pageToken, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new RuntimeException('Microsoft Graph mail backfill page token is invalid.');
+        }
+
+        throw_unless(is_array($decoded), RuntimeException::class, 'Microsoft Graph mail backfill page token is invalid.');
+
+        $folder = $decoded['folder'] ?? null;
+        $url = $decoded['url'] ?? null;
+        $cursors = $decoded['cursors'] ?? null;
+        $tokenDaysBack = $decoded['daysBack'] ?? null;
+
+        throw_if(! is_string($folder) || ! in_array($folder, self::DELTA_FOLDERS, true), RuntimeException::class, 'Microsoft Graph mail backfill page token is invalid.');
+        throw_if(! is_string($url) || $url === '', RuntimeException::class, 'Microsoft Graph mail backfill page token is invalid.');
+        throw_unless(is_array($cursors), RuntimeException::class, 'Microsoft Graph mail backfill page token is invalid.');
+        throw_if($tokenDaysBack !== null && ! is_int($tokenDaysBack), RuntimeException::class, 'Microsoft Graph mail backfill page token is invalid.');
+
+        $stringCursors = [];
+
+        foreach ($cursors as $key => $value) {
+            throw_if(! is_string($key) || ! is_string($value) || $value === '', RuntimeException::class, 'Microsoft Graph mail backfill page token is invalid.');
+
+            $stringCursors[$key] = $value;
+        }
+
+        return [
+            'folder' => $folder,
+            'url' => $url,
+            'cursors' => $stringCursors,
+            'daysBack' => $tokenDaysBack,
+        ];
+    }
+
+    /**
+     * @param  array{folder: string, url: string, cursors: array<string, string>, daysBack: int|null}  $state
+     */
+    private function encodeBackfillState(array $state): string
+    {
+        return json_encode([
+            'v' => 1,
+            ...$state,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @param  array<string, string>  $cursors
+     */
+    private function encodeCursor(array $cursors): string
+    {
+        $ordered = [];
+
+        foreach (self::DELTA_FOLDERS as $folder) {
+            $folderCursor = $cursors[$folder] ?? null;
+
+            throw_unless(
+                is_string($folderCursor) && $folderCursor !== '',
+                RuntimeException::class,
+                'Microsoft Graph mail backfill finished without a delta cursor for every folder.',
+            );
+
+            $ordered[$folder] = $folderCursor;
+        }
+
+        return json_encode([
+            'v' => 1,
+            'cursors' => $ordered,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function decodeCursor(string $cursor): array
+    {
+        try {
+            $decoded = json_decode($cursor, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw MailHistoryExpired::forAccount((string) $this->account->getKey());
+        }
+
+        if (! is_array($decoded)) {
+            throw MailHistoryExpired::forAccount((string) $this->account->getKey());
+        }
+
+        $cursors = $decoded['cursors'] ?? null;
+
+        if (! is_array($cursors)) {
+            throw MailHistoryExpired::forAccount((string) $this->account->getKey());
+        }
+
+        $decodedCursors = [];
+
+        foreach (self::DELTA_FOLDERS as $folder) {
+            $folderCursor = $cursors[$folder] ?? null;
+
+            if (! is_string($folderCursor) || $folderCursor === '') {
+                throw MailHistoryExpired::forAccount((string) $this->account->getKey());
+            }
+
+            $decodedCursors[$folder] = $folderCursor;
+        }
+
+        return $decodedCursors;
+    }
+
+    private function folderDeltaUrl(string $folder, ?int $daysBack): string
+    {
+        $path = "/me/mailFolders/{$folder}/messages/delta";
+
+        if ($daysBack === null || $daysBack <= 0) {
+            return $path;
+        }
+
+        $afterIso = now()->subDays($daysBack)->toIso8601String();
+
+        return $path.'?$filter='.rawurlencode("receivedDateTime ge {$afterIso}");
+    }
+
+    private function nextDeltaFolder(string $current): ?string
+    {
+        $index = array_search($current, self::DELTA_FOLDERS, true);
+
+        if ($index === false) {
+            return null;
+        }
+
+        return self::DELTA_FOLDERS[$index + 1] ?? null;
     }
 }

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -6,8 +6,10 @@ use App\Models\User;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
+use Relaticle\EmailIntegration\Data\MailDeltaResult;
 use Relaticle\EmailIntegration\Enums\EmailDirection;
 use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Exceptions\MailHistoryExpired;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\Factories\MicrosoftGraphServiceFactory;
 use Relaticle\EmailIntegration\Services\MicrosoftGraphMailService;
@@ -40,44 +42,67 @@ function makeAzureAccount(): ConnectedAccount
         ]);
 }
 
-it('backfills from the all-folder /me/messages/delta stream and returns the Graph deltaLink', function (): void {
+/**
+ * @param  array<string, string>  $cursors
+ */
+function microsoftMailCursor(array $cursors = []): string
+{
+    return json_encode([
+        'v' => 1,
+        'cursors' => [
+            'inbox' => $cursors['inbox'] ?? 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=INBOX',
+            'sentitems' => $cursors['sentitems'] ?? 'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta?$deltatoken=SENT',
+        ],
+    ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+}
+
+it('backfills Inbox then SentItems and returns per-folder delta cursors', function (): void {
+    Http::preventStrayRequests();
     Http::fake([
-        'https://graph.microsoft.com/v1.0/me/messages/delta*' => Http::response([
+        'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta' => Http::response([
             'value' => [
-                ['id' => 'AAA1', 'isRead' => false],
-                ['id' => 'AAA2', 'isRead' => true],
+                ['id' => 'IN1', 'isRead' => false],
             ],
-            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/messages/delta?$deltatoken=TKN',
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=INBOX',
+        ]),
+        'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta' => Http::response([
+            'value' => [
+                ['id' => 'SE1', 'isRead' => true],
+            ],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta?$deltatoken=SENT',
         ]),
     ]);
 
     $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
 
-    $result = $service->initialBackfill();
+    $inboxPage = $service->initialBackfill();
 
-    expect($result->cursor)->toContain('$deltatoken=TKN')
-        ->and($result->messageIds->all())->toEqual(['AAA1', 'AAA2'])
-        ->and($result->nextPageToken)->toBeNull();
+    expect($inboxPage->cursor)->toBeNull()
+        ->and($inboxPage->messageIds->all())->toEqual(['IN1'])
+        ->and($inboxPage->nextPageToken)->not->toBeNull();
 
-    // Must hit the all-folder endpoint, not the Inbox-only one, so Sent mail syncs.
-    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/messages/delta')
-        && ! str_contains((string) $r->url(), 'mailFolders')
-        && ! str_contains((string) $r->url(), 'receivedDateTime'));
+    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/mailFolders/inbox/messages/delta'));
+    Http::assertNotSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/mailFolders/sentitems/messages/delta'));
+    Http::assertNotSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/messages/delta'));
+
+    $sentPage = $service->initialBackfill(null, $inboxPage->nextPageToken);
+
+    expect($sentPage->nextPageToken)->toBeNull()
+        ->and($sentPage->messageIds->all())->toEqual(['SE1'])
+        ->and($sentPage->cursor)->toBe(microsoftMailCursor());
+
+    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/mailFolders/sentitems/messages/delta'));
+    Http::assertNotSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/mailFolders/drafts/'));
 });
 
 it('returns one backfill page and does not follow @odata.nextLink', function (): void {
+    Http::preventStrayRequests();
     Http::fake([
-        'https://graph.microsoft.com/v1.0/me/messages/delta' => Http::response([
+        'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta' => Http::response([
             'value' => [
                 ['id' => 'AAA1'],
             ],
-            '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/messages/delta?$skiptoken=NEXT',
-        ]),
-        'https://graph.microsoft.com/v1.0/me/messages/delta?$skiptoken=NEXT' => Http::response([
-            'value' => [
-                ['id' => 'AAA2'],
-            ],
-            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/messages/delta?$deltatoken=TKN',
+            '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$skiptoken=NEXT',
         ]),
     ]);
 
@@ -91,41 +116,100 @@ it('returns one backfill page and does not follow @odata.nextLink', function ():
 });
 
 it('applies the optional initial_days cap as a receivedDateTime filter', function (): void {
+    Http::preventStrayRequests();
     Http::fake([
-        'https://graph.microsoft.com/v1.0/me/messages/delta*' => Http::response([
+        'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta*' => Http::response([
             'value' => [],
-            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/messages/delta?$deltatoken=TKN',
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=INBOX',
         ]),
     ]);
 
     resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->initialBackfill(90);
 
-    Http::assertSent(fn (Request $r): bool => str_contains(urldecode((string) $r->url()), 'receivedDateTime ge'));
+    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/mailFolders/inbox/messages/delta')
+        && str_contains(urldecode((string) $r->url()), 'receivedDateTime ge'));
+});
+
+it('applies the same receivedDateTime filter when SentItems backfill starts', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta*' => Http::response([
+            'value' => [],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=INBOX',
+        ]),
+        'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta*' => Http::response([
+            'value' => [],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta?$deltatoken=SENT',
+        ]),
+    ]);
+
+    $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
+    $inboxPage = $service->initialBackfill(90);
+
+    $service->initialBackfill(90, $inboxPage->nextPageToken);
+
+    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/mailFolders/sentitems/messages/delta')
+        && str_contains(urldecode((string) $r->url()), 'receivedDateTime ge'));
 });
 
 it('paginates delta with @odata.nextLink and surfaces new + read ids + new cursor', function (): void {
+    Http::preventStrayRequests();
     Http::fake([
-        'https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$deltatoken=OLD' => Http::response([
+        'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=OLD' => Http::response([
             'value' => [
                 ['id' => 'AAA1', 'isRead' => false],
             ],
-            '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$skiptoken=NEXT',
+            '@odata.nextLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$skiptoken=NEXT',
         ]),
-        'https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$skiptoken=NEXT' => Http::response([
+        'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$skiptoken=NEXT' => Http::response([
             'value' => [
                 ['id' => 'AAA2', 'isRead' => true],
             ],
-            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$deltatoken=FRESH',
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=FRESH',
+        ]),
+        'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta?$deltatoken=SENT-OLD' => Http::response([
+            'value' => [
+                ['id' => 'SE1', 'isRead' => true],
+            ],
+            '@odata.deltaLink' => 'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta?$deltatoken=SENT-FRESH',
         ]),
     ]);
 
     $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
 
-    $delta = $service->fetchDelta('https://graph.microsoft.com/v1.0/me/mailFolders/Inbox/messages/delta?$deltatoken=OLD');
+    $delta = $service->fetchDelta(microsoftMailCursor([
+        'inbox' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=OLD',
+        'sentitems' => 'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta?$deltatoken=SENT-OLD',
+    ]));
 
-    expect($delta->messageIds->all())->toEqual(['AAA1', 'AAA2'])
-        ->and($delta->readMessageIds->all())->toEqual(['AAA2'])
-        ->and($delta->newCursor)->toContain('$deltatoken=FRESH');
+    expect($delta->messageIds->all())->toEqual(['AAA1', 'AAA2', 'SE1'])
+        ->and($delta->readMessageIds->all())->toEqual(['AAA2', 'SE1'])
+        ->and($delta->newCursor)->toBe(microsoftMailCursor([
+            'inbox' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=FRESH',
+            'sentitems' => 'https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages/delta?$deltatoken=SENT-FRESH',
+        ]));
+});
+
+it('throws MailHistoryExpired when Graph returns 410 for a folder delta', function (): void {
+    Http::preventStrayRequests();
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=EXPIRED' => Http::response('', 410),
+    ]);
+
+    $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
+
+    expect(fn (): MailDeltaResult => $service->fetchDelta(microsoftMailCursor([
+        'inbox' => 'https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages/delta?$deltatoken=EXPIRED',
+    ])))->toThrow(MailHistoryExpired::class);
+});
+
+it('throws MailHistoryExpired for a legacy all-folder /me/messages/delta cursor', function (): void {
+    Http::preventStrayRequests();
+
+    $service = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount());
+
+    expect(fn (): MailDeltaResult => $service->fetchDelta('https://graph.microsoft.com/v1.0/me/messages/delta?$deltatoken=TKN'))
+        ->toThrow(MailHistoryExpired::class);
 });
 
 it('maps a Graph drafts-folder message as an inbound draft', function (): void {


### PR DESCRIPTION
## Summary
- Microsoft Graph does not support `/me/messages/delta`. Initial mailbox import now tracks Inbox and Sent Items with the supported per-folder delta endpoints.
- `sync_cursor` stores both folder `deltaLink`s as one JSON cursor so incremental sync still uses a single opaque token.
- A legacy `/me/messages/delta` cursor or a Graph 410 now expires history and starts a full import. Tests fake the real folder endpoints instead of the invalid one.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php`
- [ ] Confirm the first Microsoft import requests `/me/mailFolders/inbox/messages/delta`, then Sent Items, and never `/me/messages/delta`
- [ ] Confirm incremental sync advances both folder cursors after new Inbox and Sent mail
- [ ] Confirm a 410 from Graph clears the cursor and re-runs the initial import