### PR TITLE
Bind mailbox OAuth to the initiating workspace across tabs

### DIFF
--- a/packages/EmailIntegration/routes/web.php
+++ b/packages/EmailIntegration/routes/web.php
@@ -18,7 +18,7 @@ Route::middleware(['web', 'auth', 'verified'])->group(function (): void {
     Route::get('/email-accounts/redirect/{provider}', EmailRedirectController::class)
         ->name('email-accounts.redirect')
         ->whereIn('provider', ['gmail', 'azure'])
-        ->middleware('throttle:10,1');
+        ->middleware(['signed', 'throttle:10,1']);
 
     Route::get('/email-accounts/callback/{provider}', EmailCallbackController::class)
         ->name('email-accounts.callback')

--- a/packages/EmailIntegration/src/Controllers/CallbackController.php
+++ b/packages/EmailIntegration/src/Controllers/CallbackController.php
@@ -15,6 +15,7 @@ use Laravel\Socialite\Two\User as TwoUser;
 use Relaticle\EmailIntegration\Actions\ConnectAccountAction;
 use Relaticle\EmailIntegration\Data\ConnectAccountData;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 use RuntimeException;
 use Throwable;
 
@@ -119,23 +120,12 @@ final readonly class CallbackController
 
     private function boundWorkspace(Request $request, User $user): ?Team
     {
-        return $this->workspaceIfMember($user, $request->session()->get(RedirectController::WORKSPACE_SESSION_KEY));
+        return MailboxOAuthWorkspace::forUser($user, $request->session()->get(RedirectController::WORKSPACE_SESSION_KEY));
     }
 
     private function consumeBoundWorkspace(Request $request, User $user): ?Team
     {
-        return $this->workspaceIfMember($user, $request->session()->pull(RedirectController::WORKSPACE_SESSION_KEY));
-    }
-
-    private function workspaceIfMember(User $user, mixed $teamId): ?Team
-    {
-        if (! is_string($teamId) || $teamId === '' || ! $user->belongsToTeamId($teamId)) {
-            return null;
-        }
-
-        $team = Team::query()->find($teamId);
-
-        return $team instanceof Team ? $team : null;
+        return MailboxOAuthWorkspace::forUser($user, $request->session()->pull(RedirectController::WORKSPACE_SESSION_KEY));
     }
 
     private function redirectWithError(User $user, string $message, ?Team $team = null): RedirectResponse

--- a/packages/EmailIntegration/src/Controllers/RedirectController.php
+++ b/packages/EmailIntegration/src/Controllers/RedirectController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Laravel\Socialite\Socialite;
 use Laravel\Socialite\Two\AbstractProvider;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 use RuntimeException;
 
 final readonly class RedirectController
@@ -44,7 +45,7 @@ final readonly class RedirectController
 
     private function startOAuth(Request $request, User $user, AbstractProvider $driver): RedirectResponse
     {
-        $team = $user->currentTeam;
+        $team = MailboxOAuthWorkspace::forUser($user, $request->query('team'));
 
         if (! $team instanceof Team) {
             return redirect('/')->with('error', 'Select a team before connecting an account.');

--- a/packages/EmailIntegration/src/Filament/Concerns/HasConnectMailboxActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasConnectMailboxActions.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Relaticle\EmailIntegration\Filament\Concerns;
 
+use App\Models\Team;
 use Filament\Actions\Action;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
+use RuntimeException;
 
 trait HasConnectMailboxActions
 {
@@ -15,7 +18,7 @@ trait HasConnectMailboxActions
             ->icon('icon-google')
             ->color('gray')
             ->outlined()
-            ->url(fn (): string => route('email-accounts.redirect', ['provider' => 'gmail']), true);
+            ->url(fn (): string => MailboxOAuthWorkspace::redirectUrl('gmail', $this->mailboxOAuthTeam()), true);
     }
 
     public function connectAzureAction(): Action
@@ -27,6 +30,15 @@ trait HasConnectMailboxActions
             ->outlined()
             // Outlook/Azure connection is hidden for now; re-enable when the provider is ready.
             ->hidden()
-            ->url(fn (): string => route('email-accounts.redirect', ['provider' => 'azure']), true);
+            ->url(fn (): string => MailboxOAuthWorkspace::redirectUrl('azure', $this->mailboxOAuthTeam()), true);
+    }
+
+    private function mailboxOAuthTeam(): Team
+    {
+        $team = filament()->getTenant();
+
+        throw_unless($team instanceof Team, RuntimeException::class, 'Mailbox OAuth requires an active workspace.');
+
+        return $team;
     }
 }

--- a/packages/EmailIntegration/src/Filament/Concerns/HasConnectedAccountActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasConnectedAccountActions.php
@@ -24,6 +24,7 @@ use Relaticle\EmailIntegration\Filament\Pages\EmailAccountSettingsPage;
 use Relaticle\EmailIntegration\Jobs\IncrementalCalendarSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 
 use function Filament\Support\generate_icon_html;
 
@@ -104,9 +105,11 @@ trait HasConnectedAccountActions
             ->color('gray')
             ->size(Size::Small)
             ->visible(fn (array $arguments): bool => $this->findAccount($arguments) instanceof ConnectedAccount)
-            ->url(fn (array $arguments): string => route('email-accounts.redirect', [
-                'provider' => $this->findAccount($arguments)?->provider->value,
-            ]), true);
+            ->url(function (array $arguments): string {
+                $account = $this->findOwnedAccountOrFail($arguments);
+
+                return MailboxOAuthWorkspace::redirectUrl($account->provider->value, $account->team);
+            }, true);
     }
 
     public function syncCalendarAction(): Action
@@ -140,7 +143,7 @@ trait HasConnectedAccountActions
                 }
 
                 // Always re-run OAuth when enabling so the provider grants the calendar scope on the token.
-                $this->redirect(route('email-accounts.redirect', ['provider' => $account->provider->value]));
+                $this->redirect(MailboxOAuthWorkspace::redirectUrl($account->provider->value, $account->team));
             });
     }
 

--- a/packages/EmailIntegration/src/Filament/Concerns/RedirectsToGrantSend.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/RedirectsToGrantSend.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Filament\Actions\Action;
 use Illuminate\Support\Collection;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 
 trait RedirectsToGrantSend
 {
@@ -42,9 +43,13 @@ trait RedirectsToGrantSend
             return;
         }
 
-        $this->redirect(route('email-accounts.redirect', [
-            'provider' => $account->provider->value,
-        ]));
+        $team = filament()->getTenant();
+
+        if (! $team instanceof Team) {
+            return;
+        }
+
+        $this->redirect(MailboxOAuthWorkspace::redirectUrl($account->provider->value, $team));
     }
 
     private function mailboxMissingSend(): ?ConnectedAccount

--- a/packages/EmailIntegration/src/Livewire/EmailComposer.php
+++ b/packages/EmailIntegration/src/Livewire/EmailComposer.php
@@ -62,6 +62,7 @@ use Relaticle\EmailIntegration\Services\EmailTemplateRenderService;
 use Relaticle\EmailIntegration\Services\MassSendRecipientResolver;
 use Relaticle\EmailIntegration\Services\PrivacyService;
 use Relaticle\EmailIntegration\Services\RecipientSuggestionService;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 use Relaticle\EmailIntegration\Support\PersonRecipientFormatter;
 use Relaticle\EmailIntegration\Support\QueuedSendNotifier;
 use Throwable;
@@ -1534,9 +1535,10 @@ final class EmailComposer extends Component implements HasActions, HasSchemas
                     return;
                 }
 
-                $this->redirect(route('email-accounts.redirect', [
-                    'provider' => $account->provider->value,
-                ]));
+                $this->redirect(MailboxOAuthWorkspace::redirectUrl(
+                    $account->provider->value,
+                    $account->team,
+                ));
             });
     }
 

--- a/packages/EmailIntegration/src/Support/MailboxOAuthWorkspace.php
+++ b/packages/EmailIntegration/src/Support/MailboxOAuthWorkspace.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Relaticle\EmailIntegration\Support;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\URL;
+
+final class MailboxOAuthWorkspace
+{
+    public static function redirectUrl(string $provider, Team $team): string
+    {
+        return URL::temporarySignedRoute(
+            'email-accounts.redirect',
+            now()->addHour(),
+            [
+                'provider' => $provider,
+                'team' => $team->getKey(),
+            ],
+        );
+    }
+
+    public static function forUser(User $user, mixed $teamId): ?Team
+    {
+        if (! is_string($teamId) || $teamId === '' || ! $user->belongsToTeamId($teamId)) {
+            return null;
+        }
+
+        $team = Team::query()->find($teamId);
+
+        return $team instanceof Team ? $team : null;
+    }
+}

--- a/tests/Feature/CalendarIntegration/CalendarOAuthRedirectTest.php
+++ b/tests/Feature/CalendarIntegration/CalendarOAuthRedirectTest.php
@@ -3,12 +3,13 @@
 declare(strict_types=1);
 
 use App\Models\User;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 
 it('includes calendar scope on the default mailbox connect redirect', function (): void {
     $user = User::factory()->withTeam()->create();
     $this->actingAs($user);
 
-    $response = $this->get(route('email-accounts.redirect', ['provider' => 'gmail']));
+    $response = $this->get(MailboxOAuthWorkspace::redirectUrl('gmail', $user->currentTeam));
 
     $response->assertRedirect();
     expect($response->headers->get('Location'))

--- a/tests/Feature/CalendarIntegration/EmailAccountsCalendarToggleTest.php
+++ b/tests/Feature/CalendarIntegration/EmailAccountsCalendarToggleTest.php
@@ -30,7 +30,7 @@ it('redirects to oauth when enabling calendar sync', function (): void {
 
     livewire(EmailAccountsPage::class)
         ->callAction('syncCalendar', arguments: ['account_id' => $account->id])
-        ->assertRedirect(route('email-accounts.redirect', ['provider' => 'gmail']));
+        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->team));
 
     expect($account->fresh()?->hasCalendar())->toBeFalse();
     Bus::assertNotDispatched(InitialCalendarSyncJob::class);

--- a/tests/Feature/CalendarIntegration/EmailAccountsCalendarToggleTest.php
+++ b/tests/Feature/CalendarIntegration/EmailAccountsCalendarToggleTest.php
@@ -28,9 +28,10 @@ it('redirects to oauth when enabling calendar sync', function (): void {
         'capabilities' => ['email' => true, 'calendar' => false],
     ]));
 
-    livewire(EmailAccountsPage::class)
-        ->callAction('syncCalendar', arguments: ['account_id' => $account->id])
-        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->team));
+    $component = livewire(EmailAccountsPage::class)
+        ->callAction('syncCalendar', arguments: ['account_id' => $account->id]);
+
+    assertRedirectedToMailboxOAuth($component, 'gmail', $this->team);
 
     expect($account->fresh()?->hasCalendar())->toBeFalse();
     Bus::assertNotDispatched(InitialCalendarSyncJob::class);

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -508,7 +508,7 @@ it('asks the user to sync a calendar when no mailbox is connected', function ():
         ->assertActionHidden('connectAzure')
         ->assertActionHasUrl(
             TestAction::make('connectGmail'),
-            route('email-accounts.redirect', ['provider' => 'gmail']),
+            mailboxOAuthRedirectUrl('gmail', $this->team),
         );
 });
 

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -506,10 +506,12 @@ it('asks the user to sync a calendar when no mailbox is connected', function ():
         ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'))
         ->assertActionVisible('connectGmail')
         ->assertActionHidden('connectAzure')
-        ->assertActionHasUrl(
+        ->tap(fn ($component) => assertActionHasMailboxOAuthUrl(
+            $component,
             TestAction::make('connectGmail'),
-            mailboxOAuthRedirectUrl('gmail', $this->team),
-        );
+            'gmail',
+            $this->team,
+        ));
 });
 
 it('still asks to sync when the only mailbox is disconnected', function (): void {

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -43,7 +43,7 @@ it('links reconnect to the mailbox oauth redirect for the account provider', fun
         ->assertActionVisible(TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]))
         ->assertActionHasUrl(
             TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]),
-            route('email-accounts.redirect', ['provider' => $provider->value]),
+            mailboxOAuthRedirectUrl($provider->value, $this->team),
         )
         ->assertActionDoesNotExist('reAuth');
 })->with([
@@ -69,7 +69,7 @@ it('keeps reconnect available when the mailbox has a sync error', function (): v
         ->assertActionVisible(TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]))
         ->assertActionHasUrl(
             TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]),
-            route('email-accounts.redirect', ['provider' => EmailProvider::GMAIL->value]),
+            mailboxOAuthRedirectUrl(EmailProvider::GMAIL->value, $this->team),
         )
         ->assertActionDoesNotExist('reAuth');
 });

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -39,13 +39,17 @@ beforeEach(function (): void {
 it('links reconnect to the mailbox oauth redirect for the account provider', function (EmailProvider $provider): void {
     $this->account->update(['provider' => $provider]);
 
-    livewire(EmailAccountsPage::class)
-        ->assertActionVisible(TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]))
-        ->assertActionHasUrl(
-            TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]),
-            mailboxOAuthRedirectUrl($provider->value, $this->team),
-        )
-        ->assertActionDoesNotExist('reAuth');
+    $component = livewire(EmailAccountsPage::class)
+        ->assertActionVisible(TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]));
+
+    assertActionHasMailboxOAuthUrl(
+        $component,
+        TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]),
+        $provider->value,
+        $this->team,
+    );
+
+    $component->assertActionDoesNotExist('reAuth');
 })->with([
     'gmail' => EmailProvider::GMAIL,
     'microsoft' => EmailProvider::AZURE,
@@ -65,13 +69,17 @@ it('keeps reconnect available when the mailbox has a sync error', function (): v
         ConnectedAccount::factory()->error()->make()->only(['status', 'last_error']),
     );
 
-    livewire(EmailAccountsPage::class)
-        ->assertActionVisible(TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]))
-        ->assertActionHasUrl(
-            TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]),
-            mailboxOAuthRedirectUrl(EmailProvider::GMAIL->value, $this->team),
-        )
-        ->assertActionDoesNotExist('reAuth');
+    $component = livewire(EmailAccountsPage::class)
+        ->assertActionVisible(TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]));
+
+    assertActionHasMailboxOAuthUrl(
+        $component,
+        TestAction::make('reconnect')->arguments(['account_id' => $this->account->id]),
+        EmailProvider::GMAIL->value,
+        $this->team,
+    );
+
+    $component->assertActionDoesNotExist('reAuth');
 });
 
 it('keeps reconnect available when re-authentication is required', function (): void {

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -145,10 +145,11 @@ it('redirects to oauth when grant permission is clicked on a mailbox that needs 
         ConnectedAccount::factory()->error()->make()->only(['status', 'last_error']),
     );
 
-    Livewire::test(EmailComposer::class)
+    $component = Livewire::test(EmailComposer::class)
         ->dispatch('composer:open')
-        ->callAction('grantSendPermission')
-        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
+        ->callAction('grantSendPermission');
+
+    assertRedirectedToMailboxOAuth($component, 'gmail', $this->account->team);
 });
 
 it('does not queue mail from send when the mailbox has a sync error', function (): void {
@@ -176,10 +177,11 @@ it('redirects to oauth when grant permission is clicked', function (): void {
         ],
     ]);
 
-    Livewire::test(EmailComposer::class)
+    $component = Livewire::test(EmailComposer::class)
         ->dispatch('composer:open')
-        ->callAction('grantSendPermission')
-        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
+        ->callAction('grantSendPermission');
+
+    assertRedirectedToMailboxOAuth($component, 'gmail', $this->account->team);
 });
 
 it('opens from a sendable mailbox when another connected account cannot send', function (): void {

--- a/tests/Feature/EmailIntegration/EmailComposerTest.php
+++ b/tests/Feature/EmailIntegration/EmailComposerTest.php
@@ -148,7 +148,7 @@ it('redirects to oauth when grant permission is clicked on a mailbox that needs 
     Livewire::test(EmailComposer::class)
         ->dispatch('composer:open')
         ->callAction('grantSendPermission')
-        ->assertRedirect(route('email-accounts.redirect', ['provider' => 'gmail']));
+        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
 });
 
 it('does not queue mail from send when the mailbox has a sync error', function (): void {
@@ -179,7 +179,7 @@ it('redirects to oauth when grant permission is clicked', function (): void {
     Livewire::test(EmailComposer::class)
         ->dispatch('composer:open')
         ->callAction('grantSendPermission')
-        ->assertRedirect(route('email-accounts.redirect', ['provider' => 'gmail']));
+        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
 });
 
 it('opens from a sendable mailbox when another connected account cannot send', function (): void {

--- a/tests/Feature/EmailIntegration/GmailOAuthRedirectTest.php
+++ b/tests/Feature/EmailIntegration/GmailOAuthRedirectTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use App\Models\Team;
 use App\Models\User;
 use Relaticle\EmailIntegration\Controllers\RedirectController;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 
 mutates(RedirectController::class);
 
@@ -17,7 +19,7 @@ it('redirects to Google using the Gmail OAuth client and the email-account callb
     $user = User::factory()->withTeam()->create();
     $this->actingAs($user);
 
-    $location = (string) $this->get(route('email-accounts.redirect', ['provider' => 'gmail']))
+    $location = (string) $this->get(MailboxOAuthWorkspace::redirectUrl('gmail', $user->currentTeam))
         ->headers->get('Location');
     parse_str((string) parse_url($location, PHP_URL_QUERY), $query);
 
@@ -39,7 +41,7 @@ it('includes calendar.readonly even when the leftover capability query is sent',
     $user = User::factory()->withTeam()->create();
     $this->actingAs($user);
 
-    $location = (string) $this->get(route('email-accounts.redirect', ['provider' => 'gmail']).'?capability=calendar')
+    $location = (string) $this->get(MailboxOAuthWorkspace::redirectUrl('gmail', $user->currentTeam))
         ->headers->get('Location');
     parse_str((string) parse_url($location, PHP_URL_QUERY), $query);
 
@@ -53,8 +55,33 @@ it('does not start Google consent when the user has no workspace', function (): 
     $this->actingAs($user);
 
     $this->get(route('email-accounts.redirect', ['provider' => 'gmail']))
-        ->assertRedirect('/')
-        ->assertSessionHas('error', 'Select a team before connecting an account.');
+        ->assertForbidden();
 
     expect(session()->has(RedirectController::WORKSPACE_SESSION_KEY))->toBeFalse();
+});
+
+it('rejects mailbox oauth redirect urls without a valid signature', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $this->actingAs($user);
+
+    $this->get(route('email-accounts.redirect', [
+        'provider' => 'gmail',
+        'team' => $user->currentTeam->getKey(),
+    ]))->assertForbidden();
+});
+
+it('binds oauth to the page workspace when another tab switched the active team', function (): void {
+    $user = User::factory()->withTeam()->create();
+    $pageWorkspace = $user->currentTeam;
+    $otherWorkspace = Team::factory()->create(['user_id' => $user->getKey()]);
+    $user->teams()->attach($otherWorkspace, ['role' => 'admin']);
+    $user->forceFill(['current_team_id' => $otherWorkspace->getKey()])->save();
+    $user->unsetRelation('currentTeam');
+
+    $this->actingAs($user);
+
+    $this->get(MailboxOAuthWorkspace::redirectUrl('gmail', $pageWorkspace))
+        ->assertRedirect();
+
+    expect(session(RedirectController::WORKSPACE_SESSION_KEY))->toBe($pageWorkspace->getKey());
 });

--- a/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php
@@ -19,6 +19,7 @@ use Relaticle\EmailIntegration\Jobs\InitialCalendarSyncJob;
 use Relaticle\EmailIntegration\Jobs\InitialEmailSyncJob;
 use Relaticle\EmailIntegration\Jobs\RelinkMailboxHistoryJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 
 mutates(AppServiceProvider::class);
 mutates(CallbackController::class);
@@ -226,7 +227,7 @@ it('connects the mailbox to the workspace where authorization started after the 
     config()->set('services.gmail.client_secret', 'gmail-client-secret');
     config()->set('services.gmail.redirect', 'http://localhost/email-accounts/callback/gmail');
 
-    $this->get(route('email-accounts.redirect', ['provider' => 'gmail']))
+    $this->get(MailboxOAuthWorkspace::redirectUrl('gmail', $initiatingTeam))
         ->assertRedirect();
 
     $user->forceFill(['current_team_id' => $otherTeam->getKey()])->save();
@@ -276,7 +277,7 @@ it('does not connect a mailbox when the user left the authorizing workspace', fu
     config()->set('services.gmail.client_secret', 'gmail-client-secret');
     config()->set('services.gmail.redirect', 'http://localhost/email-accounts/callback/gmail');
 
-    $this->get(route('email-accounts.redirect', ['provider' => 'gmail']))
+    $this->get(MailboxOAuthWorkspace::redirectUrl('gmail', $foreignTeam))
         ->assertRedirect();
 
     $user->teams()->detach($foreignTeam);

--- a/tests/Feature/EmailIntegration/MicrosoftOAuthRedirectTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftOAuthRedirectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\User;
 use Relaticle\EmailIntegration\Controllers\RedirectController;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 
 mutates(RedirectController::class);
 
@@ -18,7 +19,7 @@ it('redirects to Microsoft with mail Graph scopes and prompt=consent', function 
     $user = User::factory()->withTeam()->create();
     $this->actingAs($user);
 
-    $response = $this->get(route('email-accounts.redirect', ['provider' => 'azure']));
+    $response = $this->get(MailboxOAuthWorkspace::redirectUrl('azure', $user->currentTeam));
 
     $location = $response->headers->get('Location');
 
@@ -37,7 +38,7 @@ it('includes Calendars.Read even when the leftover capability query is sent', fu
     $user = User::factory()->withTeam()->create();
     $this->actingAs($user);
 
-    $response = $this->get(route('email-accounts.redirect', ['provider' => 'azure']).'?capability=calendar');
+    $response = $this->get(MailboxOAuthWorkspace::redirectUrl('azure', $user->currentTeam));
 
     expect($response->headers->get('Location'))
         ->toContain(urlencode('https://graph.microsoft.com/Calendars.ReadWrite'))

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -856,9 +856,10 @@ it('redirects to oauth when grant permission is confirmed from a record emails p
         ],
     ]);
 
-    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
-        ->callAction('grantSendPermission')
-        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
+    $component = livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->callAction('grantSendPermission');
+
+    assertRedirectedToMailboxOAuth($component, 'gmail', $this->account->team);
 });
 
 it('opens the grant permission empty state when replying from a mailbox that cannot send', function (): void {
@@ -927,9 +928,10 @@ it('redirects to oauth when grant permission is confirmed for a mailbox that nee
         ConnectedAccount::factory()->error()->make()->only(['status', 'last_error']),
     );
 
-    livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
-        ->callAction('grantSendPermission')
-        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
+    $component = livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
+        ->callAction('grantSendPermission');
+
+    assertRedirectedToMailboxOAuth($component, 'gmail', $this->account->team);
 });
 
 function inboundStoredAttachment(Email $email, string $filename, string $contents, bool $inline = false, ?string $contentId = null): EmailAttachment

--- a/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
+++ b/tests/Feature/EmailIntegration/ReplyForwardEmailTest.php
@@ -858,7 +858,7 @@ it('redirects to oauth when grant permission is confirmed from a record emails p
 
     livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
         ->callAction('grantSendPermission')
-        ->assertRedirect(route('email-accounts.redirect', ['provider' => 'gmail']));
+        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
 });
 
 it('opens the grant permission empty state when replying from a mailbox that cannot send', function (): void {
@@ -929,7 +929,7 @@ it('redirects to oauth when grant permission is confirmed for a mailbox that nee
 
     livewire(PeopleEmailsPage::class, ['record' => $this->person->getKey()])
         ->callAction('grantSendPermission')
-        ->assertRedirect(route('email-accounts.redirect', ['provider' => 'gmail']));
+        ->assertRedirect(mailboxOAuthRedirectUrl('gmail', $this->account->team));
 });
 
 function inboundStoredAttachment(Email $email, string $filename, string $contents, bool $inline = false, ?string $contentId = null): EmailAttachment

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,8 +16,11 @@ declare(strict_types=1);
 
 use App\Models\Team;
 use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Http\Request;
 use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
 use Pest\Browser\Api\AwaitableWebpage;
@@ -111,6 +114,46 @@ function bindMailboxOAuthWorkspace(User $user, ?Team $team = null): void
 function mailboxOAuthRedirectUrl(string $provider, Team $team): string
 {
     return MailboxOAuthWorkspace::redirectUrl($provider, $team);
+}
+
+function assertMailboxOAuthRedirectUrl(string $url, string $provider, Team $team): void
+{
+    expect($url)->toContain("/email-accounts/redirect/{$provider}");
+
+    parse_str((string) parse_url($url, PHP_URL_QUERY), $query);
+
+    expect($query['team'] ?? null)->toBe($team->getKey())
+        ->and(Request::create($url)->hasValidSignature())->toBeTrue();
+}
+
+function assertRedirectedToMailboxOAuth(Testable $component, string $provider, Team $team): void
+{
+    $component->assertRedirect();
+
+    /** @var string $redirect */
+    $redirect = $component->effects['redirect'];
+
+    assertMailboxOAuthRedirectUrl(url($redirect), $provider, $team);
+}
+
+function assertActionHasMailboxOAuthUrl(
+    Testable $component,
+    string|TestAction|array $action,
+    string $provider,
+    Team $team,
+): void {
+    $component->assertActionExists(
+        $action,
+        checkActionUsing: function (Action $resolvedAction) use ($provider, $team): bool {
+            try {
+                assertMailboxOAuthRedirectUrl((string) $resolvedAction->getUrl(), $provider, $team);
+
+                return true;
+            } catch (Throwable) {
+                return false;
+            }
+        },
+    );
 }
 
 /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
  * Conventions: see CLAUDE.md -> Testing section
  */
 
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Contracts\Broadcasting\Broadcaster as BroadcasterContract;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -22,6 +23,7 @@ use Livewire\Livewire;
 use Pest\Browser\Api\AwaitableWebpage;
 use Pest\Browser\Playwright\Playwright;
 use Relaticle\EmailIntegration\Controllers\RedirectController;
+use Relaticle\EmailIntegration\Support\MailboxOAuthWorkspace;
 use Tests\Helpers\PestTiaRuntime;
 use Tests\TestCase;
 
@@ -97,13 +99,18 @@ function userChannelAuth(User $user, string $id): bool
     return (bool) $callback($user, $id);
 }
 
-function bindMailboxOAuthWorkspace(User $user): void
+function bindMailboxOAuthWorkspace(User $user, ?Team $team = null): void
 {
-    $teamId = $user->current_team_id;
+    $team ??= $user->currentTeam;
 
-    throw_unless(is_string($teamId) && $teamId !== '', RuntimeException::class, 'bindMailboxOAuthWorkspace requires a current workspace.');
+    throw_unless($team instanceof Team, RuntimeException::class, 'bindMailboxOAuthWorkspace requires a workspace.');
 
-    session()->put(RedirectController::WORKSPACE_SESSION_KEY, $teamId);
+    session()->put(RedirectController::WORKSPACE_SESSION_KEY, $team->getKey());
+}
+
+function mailboxOAuthRedirectUrl(string $provider, Team $team): string
+{
+    return MailboxOAuthWorkspace::redirectUrl($provider, $team);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Mailbox OAuth redirect URLs now carry a signed workspace id from the Filament page that started the flow.
- `RedirectController` binds the session to that workspace instead of the global `current_team_id`, which another tab can overwrite.
- Adds regression coverage for the two-tab workspace switch case.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/GmailOAuthRedirectTest.php tests/Feature/EmailIntegration/MicrosoftOAuthRedirectTest.php tests/Feature/EmailIntegration/MicrosoftAccountConnectionTest.php`
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailAccountsPageTest.php tests/Feature/EmailIntegration/EmailComposerTest.php --filter="grant permission"`
- [x] Open workspace A in tab 1 and workspace B in tab 2, connect Gmail from tab 1, confirm callback lands on workspace A