### PR TITLE
Thread Microsoft replies through Graph /reply

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -5,6 +5,13 @@ paths:
 
 # Email integration
 
+## Microsoft Graph replies
+
+`sendMail` always starts a new conversation. Reply with
+`POST /me/messages/{id}/reply` after resolving the original Graph message
+by `internetMessageId` (`in_reply_to`) or `conversationId` (`thread_id`).
+Fall back to `sendMail` only when this mailbox has no matching message.
+
 ## Bind mailbox OAuth to the initiating workspace
 
 `RedirectController` stores the current team id in the session before sending

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -234,7 +234,68 @@ final class MicrosoftGraphMailService implements MailServiceInterface
         );
     }
 
+    /**
+     * Send a new email, or reply when `in_reply_to` / `thread_id` resolve to a
+     * message in this mailbox. Graph conversation ids are mailbox-local.
+     *
+     * @param array{
+     *     subject: string,
+     *     body_html: string,
+     *     body_text?: string,
+     *     to: array<int, array{email: string, name: ?string}>,
+     *     cc?: array<int, array{email: string, name: ?string}>,
+     *     bcc?: array<int, array{email: string, name: ?string}>,
+     *     from_name?: string,
+     *     in_reply_to?: string,
+     *     thread_id?: string,
+     *     rfc_message_id?: string,
+     *     attachments?: array<int, array{filename: string, mime_type: string, content: string, is_inline?: bool, content_id?: ?string}>,
+     * } $data
+     * @return array{provider_message_id: string, thread_id: string, rfc_message_id: string}
+     */
     public function sendMessage(array $data): array
+    {
+        $message = $this->graphMessagePayload($data);
+        $http = $this->clientFactory->make($this->account);
+        $replyTo = $this->resolveReplyTarget($data);
+        $synthetic = (string) Str::ulid();
+        $threadId = "ms-pending-thread-{$synthetic}";
+
+        if ($replyTo === null) {
+            $http->post('/me/sendMail', ['message' => $message, 'saveToSentItems' => true])
+                ->throw();
+        } else {
+            // /reply stamps In-Reply-To, References, and conversationId. sendMail cannot.
+            $http->post('/me/messages/'.rawurlencode($replyTo['id']).'/reply', ['message' => $message])
+                ->throw();
+
+            $threadId = $replyTo['conversationId'] !== ''
+                ? $replyTo['conversationId']
+                : $threadId;
+        }
+
+        // Graph send/reply returns 202 with no body. Synthesize the message id;
+        // the next delta sync picks up the canonical Graph id + internetMessageId.
+        return [
+            'provider_message_id' => "ms-pending-{$synthetic}",
+            'thread_id' => $threadId,
+            'rfc_message_id' => $data['rfc_message_id'] ?? "<{$synthetic}@graph.microsoft.com>",
+        ];
+    }
+
+    /**
+     * @param array{
+     *     subject: string,
+     *     body_html: string,
+     *     to: array<int, array{email: string, name: ?string}>,
+     *     cc?: array<int, array{email: string, name: ?string}>,
+     *     bcc?: array<int, array{email: string, name: ?string}>,
+     *     rfc_message_id?: string,
+     *     attachments?: array<int, array{filename: string, mime_type: string, content: string, is_inline?: bool, content_id?: ?string}>,
+     * } $data
+     * @return array<string, mixed>
+     */
+    private function graphMessagePayload(array $data): array
     {
         $message = [
             'subject' => $data['subject'],
@@ -275,24 +336,66 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             ]];
         }
 
-        $this->clientFactory->make($this->account)
-            ->post('/me/sendMail', ['message' => $message, 'saveToSentItems' => true])
-            ->throw();
+        return $message;
+    }
 
-        // Graph /me/sendMail returns 202 with no body. Synthesize ids; the next
-        // delta sync will pick up the canonical Graph id + internetMessageId.
-        $synthetic = (string) Str::ulid();
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array{id: string, conversationId: string}|null
+     */
+    private function resolveReplyTarget(array $data): ?array
+    {
+        $inReplyTo = $data['in_reply_to'] ?? null;
+
+        if (is_string($inReplyTo) && $inReplyTo !== '') {
+            $match = $this->findMessageByFilter("internetMessageId eq '{$this->escapeODataString($inReplyTo)}'");
+
+            if ($match !== null) {
+                return $match;
+            }
+        }
+
+        $threadId = $data['thread_id'] ?? null;
+
+        if (! is_string($threadId) || $threadId === '' || str_starts_with($threadId, 'ms-pending-')) {
+            return null;
+        }
+
+        return $this->findMessageByFilter("conversationId eq '{$this->escapeODataString($threadId)}'");
+    }
+
+    /**
+     * @return array{id: string, conversationId: string}|null
+     */
+    private function findMessageByFilter(string $filter): ?array
+    {
+        $message = $this->clientFactory->make($this->account)
+            ->get('/me/messages', [
+                '$filter' => $filter,
+                '$select' => 'id,conversationId',
+                '$top' => 1,
+            ])
+            ->throw()
+            ->json('value.0');
+
+        if (! is_array($message) || ! isset($message['id'])) {
+            return null;
+        }
 
         return [
-            'provider_message_id' => "ms-pending-{$synthetic}",
-            'thread_id' => "ms-pending-thread-{$synthetic}",
-            'rfc_message_id' => $data['rfc_message_id'] ?? "<{$synthetic}@graph.microsoft.com>",
+            'id' => (string) $message['id'],
+            'conversationId' => (string) ($message['conversationId'] ?? ''),
         ];
+    }
+
+    private function escapeODataString(string $value): string
+    {
+        return str_replace("'", "''", $value);
     }
 
     public function findSentMessage(string $rfcMessageId): ?array
     {
-        $escaped = str_replace("'", "''", $rfcMessageId);
+        $escaped = $this->escapeODataString($rfcMessageId);
 
         $message = $this->clientFactory->make($this->account)
             ->get('/me/messages', [

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -392,6 +392,152 @@ it('maps a Graph message payload to FetchedEmailData', function (): void {
         ->and($email->isRead)->toBeFalse();
 });
 
+it('replies through Graph /reply when in_reply_to matches a mailbox message', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/messages/*/reply' => Http::response('', 202),
+        'https://graph.microsoft.com/v1.0/me/messages*' => Http::response([
+            'value' => [[
+                'id' => 'ORIG1',
+                'conversationId' => 'conv-1',
+            ]],
+        ]),
+        'https://graph.microsoft.com/v1.0/me/sendMail' => Http::response('should not sendMail', 500),
+    ]);
+
+    $result = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->sendMessage([
+        'subject' => 'Re: Hello',
+        'body_html' => '<p>Reply</p>',
+        'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'in_reply_to' => '<orig@example.com>',
+        'thread_id' => 'conv-1',
+        'rfc_message_id' => '<reply@example.com>',
+    ]);
+
+    expect($result['thread_id'])->toBe('conv-1');
+
+    Http::assertSent(fn (Request $r): bool => $r->method() === 'GET'
+        && str_contains(urldecode((string) $r->url()), "internetMessageId eq '<orig@example.com>'"));
+
+    Http::assertSent(function (Request $r): bool {
+        $message = $r->data()['message'] ?? [];
+
+        return $r->method() === 'POST'
+            && str_contains((string) $r->url(), '/me/messages/ORIG1/reply')
+            && ($message['body']['content'] ?? null) === '<p>Reply</p>'
+            && $message['singleValueExtendedProperties'] === [[
+                'id' => 'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId',
+                'value' => '<reply@example.com>',
+            ]];
+    });
+
+    Http::assertNotSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/sendMail'));
+});
+
+it('falls back to the conversation when the in-reply-to message is not in this mailbox', function (): void {
+    Http::fake(function (Request $request) {
+        if ($request->method() === 'GET') {
+            if (str_contains(urldecode((string) $request->url()), 'internetMessageId')) {
+                return Http::response(['value' => []]);
+            }
+
+            return Http::response([
+                'value' => [[
+                    'id' => 'LATEST1',
+                    'conversationId' => 'conv-3',
+                ]],
+            ]);
+        }
+
+        if (str_contains((string) $request->url(), '/reply')) {
+            return Http::response('', 202);
+        }
+
+        return Http::response('unexpected', 500);
+    });
+
+    $result = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->sendMessage([
+        'subject' => 'Re: Hello',
+        'body_html' => '<p>Reply</p>',
+        'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'in_reply_to' => '<missing@example.com>',
+        'thread_id' => 'conv-3',
+    ]);
+
+    expect($result['thread_id'])->toBe('conv-3');
+
+    Http::assertSent(fn (Request $r): bool => $r->method() === 'GET'
+        && str_contains(urldecode((string) $r->url()), "internetMessageId eq '<missing@example.com>'"));
+    Http::assertSent(fn (Request $r): bool => $r->method() === 'GET'
+        && str_contains(urldecode((string) $r->url()), "conversationId eq 'conv-3'"));
+    Http::assertSent(fn (Request $r): bool => $r->method() === 'POST'
+        && str_contains((string) $r->url(), '/me/messages/LATEST1/reply'));
+    Http::assertNotSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/sendMail'));
+});
+
+it('replies through the conversation when only thread_id is in this mailbox', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/messages/*/reply' => Http::response('', 202),
+        'https://graph.microsoft.com/v1.0/me/messages*' => Http::response([
+            'value' => [[
+                'id' => 'LATEST1',
+                'conversationId' => 'conv-2',
+            ]],
+        ]),
+        'https://graph.microsoft.com/v1.0/me/sendMail' => Http::response('should not sendMail', 500),
+    ]);
+
+    $result = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->sendMessage([
+        'subject' => 'Re: Hello',
+        'body_html' => '<p>Reply</p>',
+        'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'thread_id' => 'conv-2',
+    ]);
+
+    expect($result['thread_id'])->toBe('conv-2');
+
+    Http::assertSent(fn (Request $r): bool => $r->method() === 'GET'
+        && str_contains(urldecode((string) $r->url()), "conversationId eq 'conv-2'"));
+
+    Http::assertSent(fn (Request $r): bool => $r->method() === 'POST'
+        && str_contains((string) $r->url(), '/me/messages/LATEST1/reply'));
+});
+
+it('sends a new message when the in-reply-to original is not in this mailbox', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/messages*' => Http::response(['value' => []]),
+        'https://graph.microsoft.com/v1.0/me/sendMail' => Http::response('', 202),
+    ]);
+
+    $result = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->sendMessage([
+        'subject' => 'Re: Hello',
+        'body_html' => '<p>Reply from another mailbox</p>',
+        'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'in_reply_to' => '<orig@example.com>',
+    ]);
+
+    expect($result['thread_id'])->toStartWith('ms-pending-thread-');
+
+    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/sendMail'));
+    Http::assertNotSent(fn (Request $r): bool => str_contains((string) $r->url(), '/reply'));
+});
+
+it('does not treat a pending synthetic thread id as a Graph conversation', function (): void {
+    Http::fake([
+        'https://graph.microsoft.com/v1.0/me/sendMail' => Http::response('', 202),
+        'https://graph.microsoft.com/v1.0/me/messages*' => Http::response('should not look up', 500),
+    ]);
+
+    resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->sendMessage([
+        'subject' => 'Hi',
+        'body_html' => '<p>Hi</p>',
+        'to' => [['email' => 'b@example.com', 'name' => 'B']],
+        'thread_id' => 'ms-pending-thread-01JABC',
+    ]);
+
+    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/sendMail'));
+    Http::assertNotSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/messages'));
+});
+
 it('POSTs to /me/sendMail and returns provider ids', function (): void {
     Http::fake([
         'https://graph.microsoft.com/v1.0/me/sendMail' => Http::response('', 202),


### PR DESCRIPTION
## Summary
- Microsoft replies now use `POST /me/messages/{id}/reply` instead of `/me/sendMail`, so Outlook keeps `In-Reply-To`, `References`, and `conversationId`.
- The original Graph message is resolved by RFC `internetMessageId`, then by `conversationId`. New mail and cross-mailbox replies still use `sendMail`.
- Related: #669 used `createReply` plus a draft patch. This path sends the reply in one request and avoids leftover drafts.

## Test plan
- [ ] Compose a new Outlook message from Relaticle. It still posts to `/me/sendMail`.
- [ ] Reply to an inbound Outlook thread. The sent item stays in the same conversation in Outlook and Relaticle.
- [ ] Reply from a different connected mailbox. Sending still succeeds as a new message.
- [ ] Confirm send-retry reconciliation still finds outbound Microsoft mail by RelaticleMessageId.