### PR TITLE
Adopt Microsoft sent rows when Graph assigns canonical ids

### DIFF
--- a/.ai/rules/email-integration.md
+++ b/.ai/rules/email-integration.md
@@ -84,6 +84,13 @@ Los Angeles day window starts at 07:00 UTC, so a September 10 all-day event
 would otherwise appear on the 9th. Timed meetings still use local-day UTC
 bounds.
 
+## Microsoft sent mail must be adopted on import
+
+Graph `/me/sendMail` returns 202 with no body. A successful send stores
+`ms-pending-*` placeholders. The next delta delivers a different Graph id
+and `internetMessageId`. Match the RelaticleMessageId extended property
+and update that SENT row. Creating a new synced row duplicates the send.
+
 ## Authorize composer inline images
 
 `EmailInlineImageEmbedder` copies files named in composer HTML (`data-id` or

--- a/packages/EmailIntegration/src/Actions/StoreEmailAction.php
+++ b/packages/EmailIntegration/src/Actions/StoreEmailAction.php
@@ -9,14 +9,17 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
 use Relaticle\EmailIntegration\Models\Email;
 use Relaticle\EmailIntegration\Models\EmailAttachment;
 use Relaticle\EmailIntegration\Models\EmailLabel;
 use Relaticle\EmailIntegration\Models\EmailParticipant;
 use Relaticle\EmailIntegration\Models\EmailRead;
+use Relaticle\EmailIntegration\Models\EmailThread;
 use Relaticle\EmailIntegration\Services\EmailClassifier;
 use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
+use Relaticle\EmailIntegration\Services\MicrosoftGraphMailService;
 use Symfony\Component\Mime\MimeTypes;
 use Throwable;
 
@@ -30,6 +33,14 @@ final readonly class StoreEmailAction
      */
     public function execute(ConnectedAccount $connectedAccount, FetchedEmailData $data): Email
     {
+        $adopted = $this->adoptPendingSentEmail($connectedAccount, $data);
+
+        if ($adopted instanceof Email) {
+            $this->bumpInitialImportProgress($connectedAccount);
+
+            return $adopted;
+        }
+
         $storedInlinePaths = [];
 
         try {
@@ -187,6 +198,78 @@ final readonly class StoreEmailAction
         $storedInlinePaths[] = $path;
 
         return $path;
+    }
+
+    /**
+     * Graph /me/sendMail returns no id, so a successful send stores ms-pending-*
+     * placeholders. Import must attach the canonical Graph ids to that SENT row.
+     */
+    private function adoptPendingSentEmail(ConnectedAccount $connectedAccount, FetchedEmailData $data): ?Email
+    {
+        $messageIds = array_values(array_unique(array_filter(
+            [$data->reconciliationMessageId, $data->rfcMessageId],
+            fn (?string $id): bool => is_string($id) && $id !== '',
+        )));
+
+        if ($messageIds === []) {
+            return null;
+        }
+
+        return DB::transaction(function () use ($connectedAccount, $data, $messageIds): ?Email {
+            $pending = Email::query()
+                ->where('connected_account_id', $connectedAccount->getKey())
+                ->whereIn('rfc_message_id', $messageIds)
+                ->get()
+                ->first(fn (Email $email): bool => str_starts_with((string) $email->provider_message_id, MicrosoftGraphMailService::PENDING_MESSAGE_ID_PREFIX));
+
+            if (! $pending instanceof Email) {
+                return null;
+            }
+
+            $previousThreadId = $pending->thread_id;
+            $threadId = $data->threadId !== '' ? $data->threadId : $pending->thread_id;
+
+            $pending->update([
+                'provider_message_id' => $data->providerMessageId,
+                'thread_id' => $threadId,
+                'rfc_message_id' => $data->rfcMessageId ?? $pending->rfc_message_id,
+                'status' => EmailStatus::SENT,
+                'folder' => $data->folder ?? $pending->folder,
+            ]);
+
+            if (is_string($threadId) && $threadId !== '') {
+                resolve(SyncEmailThreadAction::class)->execute($connectedAccount, $threadId);
+            }
+
+            $this->forgetPendingThread($connectedAccount, $previousThreadId, $threadId);
+
+            return $pending->refresh();
+        });
+    }
+
+    private function forgetPendingThread(ConnectedAccount $connectedAccount, ?string $previousThreadId, ?string $canonicalThreadId): void
+    {
+        if (! is_string($previousThreadId) || $previousThreadId === $canonicalThreadId) {
+            return;
+        }
+
+        if (! str_starts_with($previousThreadId, MicrosoftGraphMailService::PENDING_THREAD_ID_PREFIX)) {
+            return;
+        }
+
+        $stillUsed = Email::query()
+            ->where('connected_account_id', $connectedAccount->getKey())
+            ->where('thread_id', $previousThreadId)
+            ->exists();
+
+        if ($stillUsed) {
+            return;
+        }
+
+        EmailThread::query()
+            ->where('connected_account_id', $connectedAccount->getKey())
+            ->where('thread_id', $previousThreadId)
+            ->delete();
     }
 
     private function bumpInitialImportProgress(ConnectedAccount $connectedAccount): void

--- a/packages/EmailIntegration/src/Data/FetchedEmailData.php
+++ b/packages/EmailIntegration/src/Data/FetchedEmailData.php
@@ -38,5 +38,6 @@ final readonly class FetchedEmailData
          * back to AI.
          */
         public ?EmailCategory $providerCategory = null,
+        public ?string $reconciliationMessageId = null,
     ) {}
 }

--- a/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
+++ b/packages/EmailIntegration/src/Services/MicrosoftGraphMailService.php
@@ -25,6 +25,10 @@ final class MicrosoftGraphMailService implements MailServiceInterface
     /** Graph message delta is per-folder. These two cover inbound and outbound sync. */
     private const array DELTA_FOLDERS = ['inbox', 'sentitems'];
 
+    public const string PENDING_MESSAGE_ID_PREFIX = 'ms-pending-';
+
+    public const string PENDING_THREAD_ID_PREFIX = 'ms-pending-thread-';
+
     private const string RECONCILIATION_PROPERTY_ID = 'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId';
 
     /**
@@ -115,7 +119,7 @@ final class MicrosoftGraphMailService implements MailServiceInterface
                 '$select' => 'id,internetMessageId,conversationId,subject,bodyPreview,receivedDateTime,sentDateTime,isRead,hasAttachments,parentFolderId,from,toRecipients,ccRecipients,bccRecipients,body',
                 // Pull attachment metadata (not bytes) alongside the message so has-attachment
                 // rows expose a downloadable list; bytes are fetched on demand via downloadAttachment().
-                '$expand' => 'attachments($select=id,name,contentType,size,isInline,contentId)',
+                '$expand' => 'attachments($select=id,name,contentType,size,isInline,contentId),'.$this->reconciliationPropertiesExpand(),
             ])
             ->throw()
             ->json();
@@ -150,7 +154,45 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             bodyHtml: $bodyHtml,
             participants: $participants,
             attachments: $this->mapInboundAttachments($message['attachments'] ?? []),
+            reconciliationMessageId: $this->reconciliationMessageId($message),
         );
+    }
+
+    private function reconciliationPropertiesExpand(): string
+    {
+        return 'singleValueExtendedProperties($filter=id eq \''.self::RECONCILIATION_PROPERTY_ID.'\')';
+    }
+
+    /**
+     * @param  array<string, mixed>  $message
+     */
+    private function reconciliationMessageId(array $message): ?string
+    {
+        $properties = $message['singleValueExtendedProperties'] ?? [];
+
+        if (! is_array($properties)) {
+            return null;
+        }
+
+        foreach ($properties as $property) {
+            if (! is_array($property)) {
+                continue;
+            }
+
+            if (($property['id'] ?? null) !== self::RECONCILIATION_PROPERTY_ID) {
+                continue;
+            }
+
+            $value = $property['value'] ?? null;
+
+            if (! is_string($value) || $value === '') {
+                return null;
+            }
+
+            return $value;
+        }
+
+        return null;
     }
 
     /**
@@ -280,12 +322,12 @@ final class MicrosoftGraphMailService implements MailServiceInterface
             ->throw();
 
         // Graph /me/sendMail returns 202 with no body. Synthesize ids; the next
-        // delta sync will pick up the canonical Graph id + internetMessageId.
+        // delta sync adopts the SENT row and writes the canonical Graph ids.
         $synthetic = (string) Str::ulid();
 
         return [
-            'provider_message_id' => "ms-pending-{$synthetic}",
-            'thread_id' => "ms-pending-thread-{$synthetic}",
+            'provider_message_id' => self::PENDING_MESSAGE_ID_PREFIX.$synthetic,
+            'thread_id' => self::PENDING_THREAD_ID_PREFIX.$synthetic,
             'rfc_message_id' => $data['rfc_message_id'] ?? "<{$synthetic}@graph.microsoft.com>",
         ];
     }

--- a/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
+++ b/tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php
@@ -357,6 +357,44 @@ it('does not treat a custom folder named Drafts as the well-known drafts folder'
         ->and($email->direction)->toBe(EmailDirection::INBOUND);
 });
 
+it('maps a Graph sent message reconciliation property onto FetchedEmailData', function (): void {
+    Http::fake([
+        ...graphWellKnownFolderFakes(),
+        'https://graph.microsoft.com/v1.0/me/messages/AAA1*' => Http::response([
+            'id' => 'AAA1',
+            'internetMessageId' => '<provider-id@example.com>',
+            'conversationId' => 'conversation-1',
+            'subject' => 'Hi',
+            'bodyPreview' => 'Hi',
+            'receivedDateTime' => '2026-01-15T10:00:00Z',
+            'isRead' => true,
+            'hasAttachments' => false,
+            'parentFolderId' => 'sent-folder-id',
+            'from' => ['emailAddress' => ['address' => 'owner@example.com', 'name' => 'Owner']],
+            'toRecipients' => [['emailAddress' => ['address' => 'b@example.com', 'name' => 'B']]],
+            'ccRecipients' => [],
+            'bccRecipients' => [],
+            'body' => ['contentType' => 'html', 'content' => '<p>Hi</p>'],
+            'singleValueExtendedProperties' => [[
+                'id' => 'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId',
+                'value' => '<local-id@example.com>',
+            ]],
+        ]),
+    ]);
+
+    $email = resolve(MicrosoftGraphServiceFactory::class)->make(makeAzureAccount())->fetchMessage('AAA1');
+
+    expect($email->providerMessageId)->toBe('AAA1')
+        ->and($email->rfcMessageId)->toBe('<provider-id@example.com>')
+        ->and($email->reconciliationMessageId)->toBe('<local-id@example.com>')
+        ->and($email->threadId)->toBe('conversation-1')
+        ->and($email->direction)->toBe(EmailDirection::OUTBOUND)
+        ->and($email->folder)->toBe(EmailFolder::Sent);
+
+    Http::assertSent(fn (Request $r): bool => str_contains((string) $r->url(), '/me/messages/AAA1')
+        && str_contains(urldecode((string) $r->url()), 'singleValueExtendedProperties($filter=id eq \'String {00020329-0000-0000-C000-000000000046} Name RelaticleMessageId\')'));
+});
+
 it('maps a Graph message payload to FetchedEmailData', function (): void {
     Http::fake([
         ...graphWellKnownFolderFakes(),
@@ -384,6 +422,7 @@ it('maps a Graph message payload to FetchedEmailData', function (): void {
 
     expect($email->providerMessageId)->toBe('AAA1')
         ->and($email->rfcMessageId)->toBe('<rfc-abc@example.com>')
+        ->and($email->reconciliationMessageId)->toBeNull()
         ->and($email->threadId)->toBe('thread-1')
         ->and($email->subject)->toBe('Hello')
         ->and($email->bodyHtml)->toBe('<p>Hi</p>')

--- a/tests/Feature/EmailIntegration/StoreEmailActionTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailActionTest.php
@@ -57,6 +57,7 @@ function makeFetchedEmailData(array $overrides = []): FetchedEmailData
         ],
         attachments: $overrides['attachments'] ?? [],
         providerCategory: $overrides['providerCategory'] ?? null,
+        reconciliationMessageId: $overrides['reconciliationMessageId'] ?? null,
     );
 }
 
@@ -632,4 +633,114 @@ it('does not bump mailbox import progress after the history cursor is written', 
     resolve(StoreEmailAction::class)->execute($this->account, makeFetchedEmailData());
 
     expect($this->account->fresh()?->initial_sync_imported)->toBe(0);
+});
+
+it('adopts a pending Microsoft sent row instead of creating a duplicate', function (): void {
+    $pendingThreadId = 'ms-pending-thread-01ARZ3NDEKTSV4RRFFQ69G5FAV';
+
+    $sent = Email::factory()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->getKey(),
+        'rfc_message_id' => '<local-id@example.com>',
+        'provider_message_id' => 'ms-pending-01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        'thread_id' => $pendingThreadId,
+        'status' => EmailStatus::SENT,
+        'subject' => 'Hi',
+    ]);
+
+    EmailThread::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->getKey(),
+        'thread_id' => $pendingThreadId,
+        'subject' => 'Hi',
+    ]);
+
+    $email = resolve(StoreEmailAction::class)->execute($this->account, makeFetchedEmailData([
+        'providerMessageId' => 'AAA1',
+        'rfcMessageId' => '<provider-id@example.com>',
+        'reconciliationMessageId' => '<local-id@example.com>',
+        'threadId' => 'conversation-1',
+        'subject' => 'Hi from Graph',
+        'direction' => EmailDirection::OUTBOUND,
+        'folder' => EmailFolder::Sent,
+    ]));
+
+    expect($email->is($sent))->toBeTrue()
+        ->and(Email::query()->where('connected_account_id', $this->account->getKey())->count())->toBe(1);
+
+    expect($email->refresh())
+        ->provider_message_id->toBe('AAA1')
+        ->thread_id->toBe('conversation-1')
+        ->rfc_message_id->toBe('<provider-id@example.com>')
+        ->status->toBe(EmailStatus::SENT)
+        ->subject->toBe('Hi');
+
+    $this->assertDatabaseHas('email_threads', [
+        'connected_account_id' => $this->account->getKey(),
+        'thread_id' => 'conversation-1',
+    ]);
+
+    $this->assertDatabaseMissing('email_threads', [
+        'connected_account_id' => $this->account->getKey(),
+        'thread_id' => $pendingThreadId,
+    ]);
+});
+
+it('adopts a pending Microsoft sent row when Graph keeps the stamped message id', function (): void {
+    $sent = Email::factory()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $this->account->getKey(),
+        'rfc_message_id' => '<local-id@example.com>',
+        'provider_message_id' => 'ms-pending-01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        'thread_id' => 'ms-pending-thread-01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        'status' => EmailStatus::SENT,
+    ]);
+
+    $email = resolve(StoreEmailAction::class)->execute($this->account, makeFetchedEmailData([
+        'providerMessageId' => 'AAA1',
+        'rfcMessageId' => '<local-id@example.com>',
+        'threadId' => 'conversation-1',
+        'direction' => EmailDirection::OUTBOUND,
+        'folder' => EmailFolder::Sent,
+    ]));
+
+    expect($email->is($sent))->toBeTrue()
+        ->and($email->refresh()->provider_message_id)->toBe('AAA1')
+        ->and(Email::query()->where('connected_account_id', $this->account->getKey())->count())->toBe(1);
+});
+
+it('does not adopt a pending Microsoft send that belongs to another mailbox', function (): void {
+    $otherAccount = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+    ]));
+
+    Email::factory()->outbound()->create([
+        'team_id' => $this->team->id,
+        'user_id' => $this->user->id,
+        'connected_account_id' => $otherAccount->getKey(),
+        'rfc_message_id' => '<local-id@example.com>',
+        'provider_message_id' => 'ms-pending-OTHERMAILBOX',
+        'thread_id' => 'ms-pending-thread-OTHERMAILBOX',
+        'status' => EmailStatus::SENT,
+    ]);
+
+    resolve(StoreEmailAction::class)->execute($this->account, makeFetchedEmailData([
+        'providerMessageId' => 'AAA1',
+        'rfcMessageId' => '<provider-id@example.com>',
+        'reconciliationMessageId' => '<local-id@example.com>',
+        'threadId' => 'conversation-1',
+        'direction' => EmailDirection::OUTBOUND,
+        'folder' => EmailFolder::Sent,
+    ]));
+
+    expect(Email::query()->where('connected_account_id', $this->account->getKey())->count())->toBe(1)
+        ->and(Email::query()->where('connected_account_id', $otherAccount->getKey())->count())->toBe(1);
+
+    $this->assertDatabaseHas('emails', [
+        'connected_account_id' => $otherAccount->getKey(),
+        'provider_message_id' => 'ms-pending-OTHERMAILBOX',
+    ]);
 });

--- a/tests/Feature/EmailIntegration/StoreEmailJobTest.php
+++ b/tests/Feature/EmailIntegration/StoreEmailJobTest.php
@@ -8,6 +8,10 @@ use Illuminate\Contracts\Queue\Job as QueueJob;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Relaticle\EmailIntegration\Actions\StoreEmailAction;
+use Relaticle\EmailIntegration\Data\FetchedEmailData;
+use Relaticle\EmailIntegration\Enums\EmailDirection;
+use Relaticle\EmailIntegration\Enums\EmailFolder;
+use Relaticle\EmailIntegration\Enums\EmailStatus;
 use Relaticle\EmailIntegration\Jobs\Concerns\ReleasesOnProviderRateLimit;
 use Relaticle\EmailIntegration\Jobs\StoreEmailJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
@@ -141,6 +145,60 @@ it('still fails when the provider error is not a rate limit', function (): void 
 
     $job->handle($factory, resolve(StoreEmailAction::class));
 })->throws(GoogleServiceException::class, 'Backend Error');
+
+it('adopts a pending Microsoft sent row when the canonical Graph id arrives', function (): void {
+    $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
+        'sync_inbox' => true,
+        'sync_sent' => true,
+    ]));
+
+    $sent = Email::factory()->outbound()->create([
+        'team_id' => $account->team_id,
+        'user_id' => $account->user_id,
+        'connected_account_id' => $account->getKey(),
+        'rfc_message_id' => '<local-id@example.com>',
+        'provider_message_id' => 'ms-pending-01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        'thread_id' => 'ms-pending-thread-01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        'status' => EmailStatus::SENT,
+        'subject' => 'Hi',
+    ]);
+
+    $fetched = new FetchedEmailData(
+        providerMessageId: 'AAA1',
+        rfcMessageId: '<provider-id@example.com>',
+        threadId: 'conversation-1',
+        inReplyTo: null,
+        subject: 'Hi from Graph',
+        snippet: 'Hi',
+        sentAt: now(),
+        direction: EmailDirection::OUTBOUND,
+        folder: EmailFolder::Sent,
+        hasAttachments: false,
+        isRead: true,
+        bodyText: 'Hi',
+        bodyHtml: '<p>Hi</p>',
+        participants: [
+            ['email_address' => 'owner@example.com', 'name' => 'Owner', 'role' => 'from'],
+        ],
+        attachments: [],
+        reconciliationMessageId: '<local-id@example.com>',
+    );
+
+    $service = Mockery::mock(MailServiceInterface::class);
+    $service->shouldReceive('fetchMessage')->once()->with('AAA1')->andReturn($fetched);
+
+    $factory = Mockery::mock(MailServiceFactoryInterface::class);
+    $factory->shouldReceive('make')->once()->andReturn($service);
+
+    $job = new StoreEmailJob($account, 'AAA1');
+    $job->handle($factory, resolve(StoreEmailAction::class));
+
+    expect(Email::query()->where('connected_account_id', $account->id)->count())->toBe(1)
+        ->and($sent->refresh()->provider_message_id)->toBe('AAA1')
+        ->and($sent->thread_id)->toBe('conversation-1')
+        ->and($sent->rfc_message_id)->toBe('<provider-id@example.com>')
+        ->and($sent->status)->toBe(EmailStatus::SENT);
+});
 
 it('releases using the Retry-After header from Microsoft Graph', function (): void {
     $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create());


### PR DESCRIPTION
## Summary
- Graph `/me/sendMail` returns 202 with no body, so a successful send stores `ms-pending-*` ids.
- The next mailbox sync used Graph's canonical id and created a second row.
- Import now matches the RelaticleMessageId extended property and updates the existing SENT row.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/StoreEmailActionTest.php tests/Feature/EmailIntegration/StoreEmailJobTest.php tests/Feature/EmailIntegration/MicrosoftGraphMailServiceTest.php`
- [ ] Send from a Microsoft mailbox, then run incremental sync and confirm one email row
- [ ] Confirm that row's `provider_message_id` is the Graph id, not `ms-pending-*`
- [ ] Confirm a teammate mailbox with the same stamped Message-ID is not adopted