### PR TITLE
Restore Set as default in the mailbox account menu

### DIFF
--- a/packages/EmailIntegration/src/Filament/Concerns/HasConnectedAccountActions.php
+++ b/packages/EmailIntegration/src/Filament/Concerns/HasConnectedAccountActions.php
@@ -74,6 +74,7 @@ trait HasConnectedAccountActions
         // into the mountAction() click handler, which reads getInvokedArguments().
         return ActionGroup::make([
             ...$settingsAction,
+            ($this->setDefaultAction())($arguments),
             ($this->reconnectAction())($arguments),
             ...array_map(fn (Action $action): Action => $action($arguments), $extraActions),
             ($this->disconnectAction())($arguments),

--- a/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
+++ b/tests/Feature/EmailIntegration/EmailAccountsPageTest.php
@@ -179,6 +179,18 @@ it('promotes an account to default and demotes the previous default on setDefaul
         ->and($current->fresh()->is_default)->toBeFalse();
 });
 
+it('renders set as default in the account menu when the mailbox is not default', function (): void {
+    livewire(EmailAccountsPage::class)
+        ->assertSee(__('filament/pages/email-accounts.actions.set_default'));
+});
+
+it('does not render set as default in the account menu when the mailbox is already default', function (): void {
+    $this->account->update(['is_default' => true]);
+
+    livewire(EmailAccountsPage::class)
+        ->assertDontSee(__('filament/pages/email-accounts.actions.set_default'));
+});
+
 it('hides setDefault for the account that is already default', function (): void {
     $default = ConnectedAccount::withoutEvents(fn () => ConnectedAccount::factory()->default()->create([
         'team_id' => $this->team->id,


### PR DESCRIPTION
## Summary
- Puts Set as default back in the connected-account overflow menu on the accounts page and the per-account settings page.
- The action still existed, so tests that called it passed, but the dropdown never rendered it after the menu was slimmed to Manage, Reconnect, and Disconnect.
- Hidden for the mailbox that is already the default.

## Test plan
- [x] `php artisan test --compact tests/Feature/EmailIntegration/EmailAccountsPageTest.php`
- [x] Open Email settings → Accounts with two mailboxes. The non-default overflow menu shows Set as default. The default mailbox does not.
- [x] Approve Set as default on the second mailbox and confirm the Default badge moves.