### PR TITLE
Keep homepage meetings visible during background sync

### DIFF
--- a/app/Livewire/App/Onboarding/ActivationChecklist.php
+++ b/app/Livewire/App/Onboarding/ActivationChecklist.php
@@ -137,7 +137,7 @@ final class ActivationChecklist extends Component
 
     /**
      * Progress for the current user's mailbox import, shown inline on the
-     * sync_email row while the initial backfill or an incremental run is in flight.
+     * sync_email row while the initial history backfill is in flight.
      *
      * @return array{percent: int, showsPercent: bool}|null
      */
@@ -157,7 +157,7 @@ final class ActivationChecklist extends Component
         $syncingAccounts = ConnectedAccount::query()
             ->ownedBy($this->user(), $team)
             ->get()
-            ->filter(fn (ConnectedAccount $account): bool => $account->showsSyncProgress());
+            ->filter(fn (ConnectedAccount $account): bool => $account->isImportingHistory());
 
         if ($syncingAccounts->isEmpty()) {
             return null;

--- a/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
+++ b/packages/EmailIntegration/resources/views/livewire/meetings-home-widget.blade.php
@@ -11,61 +11,63 @@
                 <span class="text-gray-400 dark:text-gray-500">{{ $this->meetings->count() }}</span>
             @endif
         </h2>
-        <div class="flex shrink-0 items-center gap-1">
-            {{-- The prefix is server-rendered and the date comes from the picker's
-                 own state, so a click anywhere on "Today, Sep 10" opens the calendar. --}}
-            <div class="fi-meetings-date flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-                <span
-                    aria-hidden="true"
-                    class="cursor-pointer"
-                    x-on:click="$el.parentElement.querySelector('.fi-meetings-date-trigger')?.click()"
-                >{{ $this->datePrefix() }}</span>
-                {{ $this->getSchema('datePickerSchema') }}
+        @if (! $mailboxSyncing)
+            <div class="flex shrink-0 items-center gap-1">
+                {{-- The prefix is server-rendered and the date comes from the picker's
+                     own state, so a click anywhere on "Today, Sep 10" opens the calendar. --}}
+                <div class="fi-meetings-date flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+                    <span
+                        aria-hidden="true"
+                        class="cursor-pointer"
+                        x-on:click="$el.parentElement.querySelector('.fi-meetings-date-trigger')?.click()"
+                    >{{ $this->datePrefix() }}</span>
+                    {{ $this->getSchema('datePickerSchema') }}
+                </div>
+
+                <x-filament::icon-button
+                    color="gray"
+                    size="xs"
+                    :icon="\Filament\Support\Icons\Heroicon::OutlinedChevronLeft"
+                    :label="__('filament/pages/dashboard.meetings.previous_day')"
+                    wire:click="previousDay"
+                />
+                <x-filament::icon-button
+                    color="gray"
+                    size="xs"
+                    :icon="\Filament\Support\Icons\Heroicon::OutlinedChevronRight"
+                    :label="__('filament/pages/dashboard.meetings.next_day')"
+                    wire:click="nextDay"
+                />
+
+                <x-filament::dropdown placement="bottom-end" teleport>
+                    <x-slot name="trigger">
+                        <x-filament::icon-button
+                            color="gray"
+                            size="sm"
+                            :icon="\Filament\Support\Icons\Heroicon::OutlinedEllipsisVertical"
+                            :label="__('filament/pages/dashboard.meetings.more_actions')"
+                        />
+                    </x-slot>
+
+                    <x-filament::dropdown.list>
+                        <x-filament::dropdown.list.item
+                            :icon="\Filament\Support\Icons\Heroicon::OutlinedCalendarDays"
+                            wire:click="goToToday"
+                        >
+                            {{ __('filament/pages/dashboard.meetings.go_to_today') }}
+                        </x-filament::dropdown.list.item>
+
+                        <x-filament::dropdown.list.item
+                            tag="a"
+                            :icon="\Filament\Support\Icons\Heroicon::OutlinedCog6Tooth"
+                            :href="\Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage::getUrl()"
+                        >
+                            {{ __('filament/pages/dashboard.meetings.calendar_settings') }}
+                        </x-filament::dropdown.list.item>
+                    </x-filament::dropdown.list>
+                </x-filament::dropdown>
             </div>
-
-            <x-filament::icon-button
-                color="gray"
-                size="xs"
-                :icon="\Filament\Support\Icons\Heroicon::OutlinedChevronLeft"
-                :label="__('filament/pages/dashboard.meetings.previous_day')"
-                wire:click="previousDay"
-            />
-            <x-filament::icon-button
-                color="gray"
-                size="xs"
-                :icon="\Filament\Support\Icons\Heroicon::OutlinedChevronRight"
-                :label="__('filament/pages/dashboard.meetings.next_day')"
-                wire:click="nextDay"
-            />
-
-            <x-filament::dropdown placement="bottom-end" teleport>
-                <x-slot name="trigger">
-                    <x-filament::icon-button
-                        color="gray"
-                        size="sm"
-                        :icon="\Filament\Support\Icons\Heroicon::OutlinedEllipsisVertical"
-                        :label="__('filament/pages/dashboard.meetings.more_actions')"
-                    />
-                </x-slot>
-
-                <x-filament::dropdown.list>
-                    <x-filament::dropdown.list.item
-                        :icon="\Filament\Support\Icons\Heroicon::OutlinedCalendarDays"
-                        wire:click="goToToday"
-                    >
-                        {{ __('filament/pages/dashboard.meetings.go_to_today') }}
-                    </x-filament::dropdown.list.item>
-
-                    <x-filament::dropdown.list.item
-                        tag="a"
-                        :icon="\Filament\Support\Icons\Heroicon::OutlinedCog6Tooth"
-                        :href="\Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage::getUrl()"
-                    >
-                        {{ __('filament/pages/dashboard.meetings.calendar_settings') }}
-                    </x-filament::dropdown.list.item>
-                </x-filament::dropdown.list>
-            </x-filament::dropdown>
-        </div>
+        @endif
     </div>
 
     @if ($mailboxSyncing)

--- a/packages/EmailIntegration/src/Console/Commands/IncrementalEmailSyncCommand.php
+++ b/packages/EmailIntegration/src/Console/Commands/IncrementalEmailSyncCommand.php
@@ -10,7 +10,6 @@ use Illuminate\Console\Command;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Jobs\IncrementalEmailSyncJob;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
-use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 #[Description('Dispatch incremental mailbox sync jobs for active accounts.')]
 #[Signature('email:incremental-sync')]
@@ -22,7 +21,6 @@ final class IncrementalEmailSyncCommand extends Command
             ->where('status', EmailAccountStatus::ACTIVE)
             ->whereNotNull('sync_cursor')
             ->each(function (ConnectedAccount $account): void {
-                MailboxSyncTracker::markEmailStarted($account);
                 dispatch(new IncrementalEmailSyncJob($account));
             });
 

--- a/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
+++ b/packages/EmailIntegration/src/Livewire/MeetingsHomeWidget.php
@@ -29,7 +29,6 @@ use Relaticle\EmailIntegration\Models\Meeting;
 use Relaticle\EmailIntegration\Models\Scopes\VisibleMeetingScope;
 use Relaticle\EmailIntegration\Services\ListMeetingsForDay;
 use Relaticle\EmailIntegration\Services\MailboxDisplayNameDirectory;
-use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 use Relaticle\EmailIntegration\Services\MeetingRespondentResolver;
 use Relaticle\EmailIntegration\Services\MeetingTemporalState;
 
@@ -217,24 +216,18 @@ final class MeetingsHomeWidget extends Component implements HasActions, HasSchem
         $rows = [];
 
         foreach ($this->ownedAccounts() as $account) {
-            if (! $account->showsSyncProgress()) {
+            if (! $account->isImportingHistory()) {
                 continue;
             }
-
-            $isInitialImport = $account->isImportingHistory();
 
             $rows[] = [
                 'id' => (string) $account->getKey(),
                 'email' => $account->email_address,
-                'emailsImported' => $isInitialImport
-                    ? $account->syncEmailsProcessedCount()
-                    : ($account->isEmailSyncing() ? MailboxSyncTracker::emailProcessedCount($account) : 0),
-                'meetingsImported' => $isInitialImport
-                    ? $account->syncMeetingsProcessedCount()
-                    : ($account->isCalendarSyncing() ? MailboxSyncTracker::calendarProcessedCount($account) : 0),
+                'emailsImported' => $account->syncEmailsProcessedCount(),
+                'meetingsImported' => $account->syncMeetingsProcessedCount(),
                 'percent' => $account->syncDisplayPercent(),
                 'hasCalendar' => $account->hasCalendar(),
-                'isInitialImport' => $isInitialImport,
+                'isInitialImport' => true,
             ];
         }
 

--- a/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
+++ b/tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php
@@ -7,6 +7,7 @@ use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
+use Relaticle\EmailIntegration\Console\Commands\IncrementalEmailSyncCommand;
 use Relaticle\EmailIntegration\Controllers\CalendarPushWebhookController;
 use Relaticle\EmailIntegration\Enums\EmailAccountStatus;
 use Relaticle\EmailIntegration\Enums\EmailProvider;
@@ -22,6 +23,7 @@ use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 mutates(
     CalendarPushWebhookController::class,
     EnsureCalendarPushChannelJob::class,
+    IncrementalEmailSyncCommand::class,
     MailboxImportStatus::class,
 );
 
@@ -124,7 +126,7 @@ it('ignores microsoft notifications with a forged client state', function (): vo
     Bus::assertNothingDispatched();
 });
 
-it('marks email sync as started when the scheduled command dispatches incremental sync', function (): void {
+it('does not mark email sync as started until the incremental job runs', function (): void {
     Bus::fake([IncrementalEmailSyncJob::class]);
 
     $account = ConnectedAccount::withoutEvents(fn (): ConnectedAccount => ConnectedAccount::factory()->create([
@@ -133,7 +135,7 @@ it('marks email sync as started when the scheduled command dispatches incrementa
 
     $this->artisan('email:incremental-sync')->assertSuccessful();
 
-    expect(MailboxSyncTracker::isEmailSyncing($account))->toBeTrue();
+    expect(MailboxSyncTracker::isEmailSyncing($account))->toBeFalse();
 });
 
 it('retries microsoft push renewal failures instead of replacing the subscription', function (): void {

--- a/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
+++ b/tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php
@@ -85,6 +85,23 @@ it('shows mailbox sync progress inside the meetings section', function (): void 
         ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
 });
 
+it('hides date navigation while mailbox sync is in progress', function (): void {
+    $this->account->update([
+        'sync_cursor' => null,
+        'calendar_sync_cursor' => null,
+        'initial_sync_imported' => 12,
+        'initial_sync_estimated' => 40,
+    ]);
+
+    livewire(MeetingsHomeWidget::class)
+        ->assertDontSee(__('filament/pages/dashboard.meetings.date.today'))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.previous_day'))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.next_day'))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.more_actions'))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.go_to_today'))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.calendar_settings'));
+});
+
 it('shows mailbox sync progress during email-only history import', function (): void {
     $this->account->update([
         'capabilities' => ['email' => true, 'calendar' => false],
@@ -140,7 +157,15 @@ it('hides meetings while calendar sync is in progress', function (): void {
         ->assertDontSee(__('filament/pages/dashboard.meetings.empty.title'));
 });
 
-it('shows reconnect sync progress with percent and new item counts', function (): void {
+it('keeps meetings visible during background incremental sync', function (): void {
+    Meeting::factory()->create([
+        'team_id' => $this->team->id,
+        'connected_account_id' => $this->account->id,
+        'title' => 'Board review',
+        'starts_at' => Date::parse('2026-09-09 16:00:00'),
+        'ends_at' => Date::parse('2026-09-09 17:00:00'),
+    ]);
+
     $this->account->update([
         'capabilities' => ['email' => true, 'calendar' => true],
         'sync_cursor' => 'done',
@@ -157,58 +182,12 @@ it('shows reconnect sync progress with percent and new item counts', function ()
     MailboxSyncTracker::bumpCalendarProcessed($this->account);
 
     livewire(MeetingsHomeWidget::class)
-        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => 25]))
-        ->assertSee(__('filament/pages/dashboard.meetings.syncing.description_update'))
-        ->assertSee(trans_choice('filament/pages/dashboard.meetings.syncing.emails_updated', 2, ['count' => 2]))
-        ->assertSee(trans_choice('filament/pages/dashboard.meetings.syncing.meetings_updated', 1, ['count' => 1]))
-        ->assertSee('aria-valuenow="25"', false);
-});
-
-it('hides zero counts during reconnect sync before new items arrive', function (): void {
-    $this->account->update([
-        'capabilities' => ['email' => true, 'calendar' => true],
-        'sync_cursor' => 'done',
-        'calendar_sync_cursor' => 'done',
-        'initial_sync_imported' => 643,
-        'initial_calendar_sync_imported' => 120,
-    ]);
-
-    MailboxSyncTracker::markEmailStarted($this->account);
-    MailboxSyncTracker::markCalendarStarted($this->account);
-
-    livewire(MeetingsHomeWidget::class)
-        ->assertSee(__('filament/pages/dashboard.meetings.syncing.title'))
-        ->assertSee(__('filament/pages/dashboard.meetings.syncing.description_update'))
-        ->assertDontSee(trans_choice('filament/pages/dashboard.meetings.syncing.emails_processed', 643, ['count' => 643]))
-        ->assertDontSee(trans_choice('filament/pages/dashboard.meetings.syncing.emails_updated', 0, ['count' => 0]))
-        ->assertDontSee('aria-valuenow=', false);
-});
-
-it('shows meetings after calendar sync finishes', function (): void {
-    $this->account->update([
-        'capabilities' => ['email' => true, 'calendar' => true],
-        'calendar_sync_cursor' => 'done',
-    ]);
-
-    Meeting::factory()->create([
-        'team_id' => $this->team->id,
-        'connected_account_id' => $this->account->id,
-        'title' => 'Board review',
-        'starts_at' => Date::parse('2026-09-09 16:00:00'),
-        'ends_at' => Date::parse('2026-09-09 17:00:00'),
-    ]);
-
-    MailboxSyncTracker::markCalendarStarted($this->account);
-
-    $component = livewire(MeetingsHomeWidget::class)
-        ->assertSee('data-testid="meetings-mailbox-sync"', escape: false)
-        ->assertDontSee('Board review');
-
-    MailboxSyncTracker::markCalendarFinished($this->account);
-
-    $component->call('refreshMailboxSync')
+        ->assertSee('Board review')
+        ->assertSee(__('filament/pages/dashboard.meetings.date.today'))
+        ->assertSee(__('filament/pages/dashboard.meetings.more_actions'))
         ->assertDontSee('data-testid="meetings-mailbox-sync"', escape: false)
-        ->assertSee('Board review');
+        ->assertDontSee(__('filament/pages/dashboard.meetings.syncing.description_update'))
+        ->assertDontSee(__('filament/pages/dashboard.meetings.syncing.title_with_percent', ['percent' => 25]));
 });
 
 it('shows mailbox sync progress on the dashboard inside meetings', function (): void {

--- a/tests/Feature/Onboarding/ActivationChecklistTest.php
+++ b/tests/Feature/Onboarding/ActivationChecklistTest.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Str;
 use Laravel\Pennant\Feature;
 use Relaticle\EmailIntegration\Filament\Pages\EmailAccountsPage;
 use Relaticle\EmailIntegration\Models\ConnectedAccount;
+use Relaticle\EmailIntegration\Services\MailboxSyncTracker;
 
 mutates(ActivationChecklist::class, DismissActivationChecklist::class);
 
@@ -123,6 +124,22 @@ it('shows an inline syncing row while the mailbox import is in flight', function
         ->assertSeeHtml('data-testid="activation-email-sync-progress"')
         ->assertSee(__('filament/pages/dashboard.activation.steps.sync_email.syncing'))
         ->assertSee('12%');
+});
+
+it('does not treat background incremental sync as an in-flight mailbox import', function (): void {
+    $account = ConnectedAccount::factory()->create([
+        'team_id' => $this->team->getKey(),
+        'user_id' => $this->owner->getKey(),
+        'sync_cursor' => 'done',
+        'last_synced_at' => now(),
+    ]);
+
+    MailboxSyncTracker::markEmailStarted($account);
+
+    livewire(ActivationChecklist::class)
+        ->assertSeeHtml(stepState('sync_email', true))
+        ->assertDontSeeHtml('data-testid="activation-email-sync-progress"')
+        ->assertDontSee(__('filament/pages/dashboard.activation.steps.sync_email.syncing'));
 });
 
 it('completes the invite step while an invitation is pending', function (): void {


### PR DESCRIPTION
## Summary
- Keep already imported homepage meetings visible while scheduled incremental mailbox and calendar sync runs in the background.
- Show the blocking "Checking for new emails..." overlay only during the initial history import.
- Hide date navigation during that initial import, and stop the scheduler from flipping the syncing flag before the job actually runs.

## Test plan
- [x] `php artisan test --compact tests/Feature/CalendarIntegration/MeetingsHomeWidgetTest.php tests/Feature/CalendarIntegration/CalendarPushAndSyncStatusTest.php tests/Feature/Onboarding/ActivationChecklistTest.php tests/Feature/Commands/EmailIntegrationScheduleTest.php`
- [x] Confirm a connected workspace still shows meetings and date controls while incremental sync is in flight.
- [x] Confirm connecting a new mailbox still shows the initial import overlay in the meetings section.